### PR TITLE
Correct readability return when no content found

### DIFF
--- a/inc/Readability.php
+++ b/inc/Readability.php
@@ -185,6 +185,7 @@ class Readability
 			$articleContent = $this->dom->createElement('div');
 			$articleContent->setAttribute('id', 'readability-content');
 			$articleContent->innerHTML = '<p>Sorry, Readability was unable to parse this page for content.</p>';		
+			return $this->success;
 		}
 		
 		$overlay->setAttribute('id', 'readOverlay');


### PR DESCRIPTION
When no content found, Readability return success=false early.
