### PR TITLE
Entries height with short description

### DIFF
--- a/tpl/css/style.css
+++ b/tpl/css/style.css
@@ -103,6 +103,10 @@ a, a:hover, a:visited {
     list-style-type: none;
 }
 
+#main .entrie .tools + p {
+    min-height: 5.5em;
+}
+
 /*
 #main .entrie .tools li {
     display: inline;


### PR DESCRIPTION
If the description of an entrie is short, its display is broken, the "original" link is positioned on the left of tools list instead of under.
You can see it with this example: "A simple test : &gt; "test"".

Therefore, I've set a min-height on its container.
