### PR TITLE
Add the number of results next to pager

### DIFF
--- a/inc/poche/Poche.class.php
+++ b/inc/poche/Poche.class.php
@@ -262,6 +262,7 @@ class Poche
                 $tpl_vars = array(
                     'entries' => '',
                     'page_links' => '',
+                    'nb_results' => '',
                 );
                 if (count($entries) > 0) {
                     $this->pagination->set_total(count($entries));
@@ -269,6 +270,7 @@ class Poche
                     $datas = $this->store->getEntriesByView($view, $this->user->getId(), $this->pagination->get_limit());
                     $tpl_vars['entries'] = $datas;
                     $tpl_vars['page_links'] = $page_links;
+                    $tpl_vars['nb_results'] = count($entries);
                 }
                 Tools::logm('display ' . $view . ' view');
                 break;

--- a/tpl/css/style.css
+++ b/tpl/css/style.css
@@ -98,6 +98,10 @@ a, a:hover, a:visited {
 #main #content .entrie {
     border-bottom: 1px dashed #222;
 }
+/* First entry */
+#main #content .results + .entrie {
+    clear: both;
+}
 
 #main .entrie .tools {
     list-style-type: none;
@@ -189,11 +193,22 @@ a, a:hover, a:visited {
 }
 
 
-/* Pagination */
-.pagination {
-    clear: both;
+.results {
+    overflow: hidden;
     padding-bottom: 20px;
     padding-top: 10px;
+}
+
+.nb-results {
+    float: left;
+    font-size: 0.9em;
+    line-height: 24px;
+    vertical-align: middle;
+}
+
+/* Pagination */
+.pagination {
+    float: right;
     text-align: right;
 }
 .pagination a {

--- a/tpl/home.twig
+++ b/tpl/home.twig
@@ -18,10 +18,17 @@
             </ul>
 {% endblock %}
 {% block content %}
-            {{ page_links | raw }}
             {% if entries is empty %}
             <div class="messages warning"><p>{% trans "No link available here!" %}</p></div>
             {% else %}
+                {% block pager %}
+                    {% if nb_results > 1 %}
+                <div class="results">
+                    <div class="nb-results">{{ nb_results }} {% trans "results" %}</div>
+                        {{ page_links | raw }}
+                </div>
+                    {% endif %}
+                {% endblock %}
                 {% for entry in entries %}
             <div id="entry-{{ entry.id|e }}" class="entrie">
                 <h2><a href="index.php?view=view&amp;id={{ entry.id|e }}">{{ entry.title|raw }}</a></h2>
@@ -36,5 +43,5 @@
             </div>
                 {% endfor %}
             {% endif %}
-            {{ page_links | raw }}
+            {{ block('pager') }}
 {% endblock %}


### PR DESCRIPTION
We can browse results with the pager links but we don't know how many entries are available.
Therefore I've added this number in a new block and reuse it at the bottom of the page.

This new wording is displayed when there is at least 2 entries. I thought it's useless when we see only one link.
