### PR TITLE
Changed Flattr Caching System

### DIFF
--- a/inc/3rdparty/FlattrItem.class.php
+++ b/inc/3rdparty/FlattrItem.class.php
@@ -9,9 +9,10 @@ class FlattrItem {
     public $flattrItemURL;
     public $numflattrs;
 
-    public function checkItem($urltoflattr) {
-        $this->cacheflattrfile($urltoflattr);
-        $flattrResponse = file_get_contents(CACHE . "/flattr/".md5($urltoflattr).".cache");
+    public function checkItem($urltoflattr,$id) {
+        $this->cacheflattrfile($urltoflattr, $id);
+        $flattrResponse = file_get_contents(CACHE . "/flattr/".$id.".cache");
+        print_r($flattrResponse);
         if($flattrResponse != FALSE) {
             $result = json_decode($flattrResponse);
             if (isset($result->message)){
@@ -33,15 +34,15 @@ class FlattrItem {
         }
     }
 
-    private function cacheflattrfile($urltoflattr) {
+    private function cacheflattrfile($urltoflattr, $id) {
         if (!is_dir(CACHE . '/flattr')) {
             mkdir(CACHE . '/flattr', 0777);
         }
 
         // if a cache flattr file for this url already exists and it's been less than one day than it have been updated, see in /cache
-        if ((!file_exists(CACHE . "/flattr/".md5($urltoflattr).".cache")) || (time() - filemtime(CACHE . "/flattr/".md5($urltoflattr).".cache") > 86400)) {
+        if ((!file_exists(CACHE . "/flattr/".$id.".cache")) || (time() - filemtime(CACHE . "/flattr/".$id.".cache") > 86400)) {
             $askForFlattr = Tools::getFile(FLATTR_API . $urltoflattr);
-            $flattrCacheFile = fopen(CACHE . "/flattr/".md5($urltoflattr).".cache", 'w+');
+            $flattrCacheFile = fopen(CACHE . "/flattr/".$id.".cache", 'w+');
             fwrite($flattrCacheFile, $askForFlattr);
             fclose($flattrCacheFile);
         }

--- a/inc/poche/Poche.class.php
+++ b/inc/poche/Poche.class.php
@@ -385,7 +385,7 @@ class Poche
 
                     # flattr checking
                     $flattr = new FlattrItem();
-                    $flattr->checkItem($entry['url']);
+                    $flattr->checkItem($entry['url'],$entry['id']);
 
                     $tpl_vars = array(
                     'entry' => $entry,


### PR DESCRIPTION
Fixes Issue #243.
Uses directly id of article for the name of the flattr information cache file, rather than it's url (hashed, base64, etc.).
