### PR TITLE
Avoid ".git" option in themes list of config page

### DIFF
--- a/inc/poche/Poche.class.php
+++ b/inc/poche/Poche.class.php
@@ -255,7 +255,7 @@ class Poche
         while (($theme = readdir($handle)) !== false) {
             # Themes are stored in a directory, so all directory names are themes
             # @todo move theme installation data to database
-            if (! is_dir(THEME . '/' . $theme) || in_array($theme, array('..', '.'))) {
+            if (! is_dir(THEME . '/' . $theme) || in_array($theme, array('..', '.', '.git'))) {
                 continue;
             }
             


### PR DESCRIPTION
In a nutshell git directory was not filtered in themes select.
