### PR TITLE
Force download on poche export

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -1,0 +1,8 @@
+Options +FollowSymlinks
+RewriteEngine On
+RewriteRule ^dl/export_poche.json$ ?export [L]
+
+# Force download
+RewriteCond %{QUERY_STRING} =export
+RewriteRule ([^/]*)$ - [L,E=dl:$1]
+Header onsuccess set Content-disposition "attachment; filename=%{dl}e" env=dl


### PR DESCRIPTION
I think it would be better to force download when clicking on the export link.
And I've also changed the path of this link (see [poche-temes#21](https://github.com/inthepoche/poche-themes/pull/21)) to understand that it returns a file.
