### PR TITLE
Update select theme filter and sort names

### DIFF
--- a/inc/poche/Poche.class.php
+++ b/inc/poche/Poche.class.php
@@ -271,6 +271,7 @@ class Poche
             $themes[] = array('name' => $theme, 'current' => $current);
         }
         
+        sort($themes);
         return $themes;
     }
 


### PR DESCRIPTION
Hi,

Since the poche-themes repo has been deleted, there is no need to filter ".git" folder in the themes list.
Moreover I've noticed that this list is not always sort alphabetically (check demo). I've changed that!
