### PR TITLE
Fixed typo

### DIFF
--- a/themes/default/_head.twig
+++ b/themes/default/_head.twig
@@ -8,4 +8,4 @@
         <link rel="stylesheet" href="{{ poche_url }}/themes/{{ constant('DEFAULT_THEME') }}/css/messages.css" media="all">
         <link rel="stylesheet" href="{{ poche_url }}/themes/{{ constant('DEFAULT_THEME') }}/css/print.css" media="print">
         <link href='//fonts.googleapis.com/css?family=Roboto' rel='stylesheet' type='text/css'>
-        <script src="href="{{ poche_url }}/themes/{{ constant('DEFAULT_THEME') }/js/jquery-2.0.3.min.js"></script>
+        <script src="href="{{ poche_url }}/themes/{{ constant('DEFAULT_THEME') }}/js/jquery-2.0.3.min.js"></script>


### PR DESCRIPTION
Related to https://github.com/inthepoche/poche/pull/264

Fixed a stupid typo (missing '}') in themes/default/_head.twig.

My bad, sorry for that.
