### PR TITLE
Previous toolbar design for WP7

### DIFF
--- a/inc/poche/Poche.class.php
+++ b/inc/poche/Poche.class.php
@@ -428,6 +428,9 @@ class Poche
                         $content = $tidy->value;
                     }
 
+                    # Just for WP, see issue #258 (yeah, sorry)
+                    $isIE9WP7Browser = (preg_match("#IEMobile/9.0#", $_SERVER["HTTP_USER_AGENT"])) ? (true) : (false);
+
                     # flattr checking
                     $flattr = new FlattrItem();
                     $flattr->checkItem($entry['url'],$entry['id']);
@@ -435,7 +438,8 @@ class Poche
                     $tpl_vars = array(
                     'entry' => $entry,
                     'content' => $content,
-                    'flattr' => $flattr
+                    'flattr' => $flattr,
+                    'isIE9WP7Browser' => $isIE9WP7Browser,
                     );
                 }
                 else {

--- a/themes/default/_head.twig
+++ b/themes/default/_head.twig
@@ -7,4 +7,5 @@
         <link rel="stylesheet" href="{{ poche_url }}/themes/{{ theme }}/css/style-{{ theme }}.css" media="all" title="{{ theme }} theme">
         <link rel="stylesheet" href="{{ poche_url }}/themes/{{ constant('DEFAULT_THEME') }}/css/messages.css" media="all">
         <link rel="stylesheet" href="{{ poche_url }}/themes/{{ constant('DEFAULT_THEME') }}/css/print.css" media="print">
+        {% if isIE9WP7Browser %}<link rel="stylesheet" href="{{ poche_url }}/themes/{{ constant('DEFAULT_THEME') }}/css/style-WP.css" media="all">{% endif %}
         <script src="{{ poche_url }}/themes/{{ constant('DEFAULT_THEME') }}/js/jquery-2.0.3.min.js"></script>

--- a/themes/default/css/style-WP.css
+++ b/themes/default/css/style-WP.css
@@ -1,0 +1,5 @@
+#article_toolbar {
+    position: relative !important;
+    width: 100% !important;
+    text-align: justify !important;
+}

--- a/themes/default/view.twig
+++ b/themes/default/view.twig
@@ -1,6 +1,14 @@
 {% extends "layout.twig" %}
 {% block title %}{{ entry.title|raw }} ({{ entry.url | e | getDomain }}){% endblock %}
 {% block content %}
+        <div id="article">
+            <header class="mbm">
+                <h1>{{ entry.title|raw }}</h1>
+            </header>
+            <article>
+                {{ content | raw }}
+            </article>
+        </div>
         <div id="article_toolbar">
             <ul>
                 <li><a href="./" title="{% trans "back to home" %}" class="tool back"><span>{% trans "back to home" %}</span></a></li>
@@ -15,14 +23,6 @@
                 {% if constant('FLATTR') == 1 %}{% if flattr.status == constant('FLATTRABLE') %}<li><a href="http://flattr.com/submit/auto?url={{ entry.url }}" class="tool flattr" target="_blank" title="{% trans "flattr" %}"><span>{% trans "flattr" %}</span></a></li>{% elseif flattr.status == constant('FLATTRED') %}<li><a href="{{ flattr.flattrItemURL }}" class="tool flattr" target="_blank" title="{% trans "flattr" %}"><span>{% trans "flattr" %}</span>{{ flattr.numflattrs }}</a></li>{% endif %}{% endif %}
                 <li><a href="mailto:support@inthepoche.com?subject=Wrong%20display%20in%20poche&amp;body={{ entry.url|url_encode }}" title="{% trans "this article appears wrong?" %}" class="tool bad-display"><span>{% trans "this article appears wrong?" %}</span></a></li>
             </ul>
-        </div>
-        <div id="article">
-            <header class="mbm">
-                <h1>{{ entry.title|raw }}</h1>
-            </header>
-            <article>
-                {{ content | raw }}
-            </article>
         </div>
         <script src="{{ poche_url }}/themes/{{ constant('DEFAULT_THEME') }}/js/restoreScroll.js"></script>
         <script type="text/javascript">


### PR DESCRIPTION
Fixes #258.
IE9 for WP7 Phones didn't supported fixed element like the new toolbar.
This fix detects the user-agent from WP7 phones and shows the regular
toolbar at the bottom of the page.
