### PR TITLE
Change Permissions in pochePictures.php

### DIFF
--- a/inc/poche/pochePictures.php
+++ b/inc/poche/pochePictures.php
@@ -84,12 +84,12 @@ function create_assets_directory($id)
 {
     $assets_path = ABS_PATH;
     if(!is_dir($assets_path)) {
-        mkdir($assets_path, 0705);
+        mkdir($assets_path, 0715);
     }
 
     $article_directory = $assets_path . $id;
     if(!is_dir($article_directory)) {
-        mkdir($article_directory, 0705);
+        mkdir($article_directory, 0715);
     }
 
     return $article_directory;


### PR DESCRIPTION
Stored Pictures are not accessible (on my server), when permission is set to 0705, but instead, when using 0755 (or for example to 0715) all is working as expected. So maybe it would be good, considering in changing the permission of created directories in the assets directory
