### PR TITLE
Fix: stops multiplication, in database, of a same user config item

### DIFF
--- a/inc/poche/Database.class.php
+++ b/inc/poche/Database.class.php
@@ -193,7 +193,7 @@ class Database {
     public function updateUserConfig($userId, $key, $value) {
         $config = $this->getConfigUser($userId);
         
-        if (!isset ($user_config[$key])) {
+        if (! isset($config[$key])) {
             $sql = "INSERT INTO users_config (value, user_id, name) VALUES (?, ?, ?)";
         }
         else {


### PR DESCRIPTION
A simple error of variable name which causes multiplication of user config items in the database, considering they are always new items.
