### PR TITLE
Adding .htaccess files to prohibit access to critical directories, e.g.,...

### DIFF
--- a/cache/.gitignore
+++ b/cache/.gitignore
@@ -1,0 +1,1 @@
+!.htaccess

--- a/cache/.htaccess
+++ b/cache/.htaccess
@@ -1,0 +1,2 @@
+Order deny,allow
+Deny from all

--- a/db/.htaccess
+++ b/db/.htaccess
@@ -1,0 +1,2 @@
+Order deny,allow
+Deny from all

--- a/inc/.htaccess
+++ b/inc/.htaccess
@@ -1,0 +1,2 @@
+Order deny,allow
+Deny from all

--- a/locale/.htaccess
+++ b/locale/.htaccess
@@ -1,0 +1,2 @@
+Order deny,allow
+Deny from all


### PR DESCRIPTION
This commit would fix a critical security hole that allows anyone to access the sqlite database file by simply pointing their browser to: https://DOMAINNAME/wallabag/db/wallabag.sqlite (previously https://DOMAINNAME/poche/db/poche.sqlite).
See: http://invisibletower.de/2014/wallabag-auf-dem-uberspace/ and http://classmplanet.de/poche-on-uberspace/
