### PR TITLE
duplicate check added. fix of issue #400

### DIFF
--- a/inc/poche/Database.class.php
+++ b/inc/poche/Database.class.php
@@ -241,6 +241,22 @@ class Database {
         return isset($entry[0]) ? $entry[0] : null;
     }
 
+    public function retrieveOneByURL($url, $user_id) {
+        $entry  = NULL;
+        $sql    = "SELECT * FROM entries WHERE url=? AND user_id=?";
+        $params = array($url, $user_id);
+        $query  = $this->executeQuery($sql, $params);
+        $entry  = $query->fetchAll();
+
+        return isset($entry[0]) ? $entry[0] : null;
+    }
+
+    public function reassignTags($old_entry_id, $new_entry_id) {
+        $sql    = "UPDATE tags_entries SET entry_id=? WHERE entry_id=?";
+        $params = array($new_entry_id, $old_entry_id);
+        $query  = $this->executeQuery($sql, $params);
+    }
+
     public function getEntriesByView($view, $user_id, $limit = '') {
         switch ($_SESSION['sort'])
         {


### PR DESCRIPTION
this is a fix of  issue #400 (duplicate check). 
If duplicate is detected (by URL), old one is deleted but favorite status and tags are preserved.
Reason for removing of old record is need to move updated article to the top of list. 
