### PR TITLE
fix of conflict of s shortcat and entering s in input fields

### DIFF
--- a/themes/baggy/js/init.js
+++ b/themes/baggy/js/init.js
@@ -60,14 +60,17 @@ $.fn.ready(function() {
      ========================================================================== */
 
   $(window).keydown(function(e){
-    switch (e.keyCode) {
-      // s letter
-      case 83:
-        $bagitForm.toggle();
-      break;
-      case 27:
-        $bagitForm.hide();
-      break;
+    if ( e.target.tagName.toLowerCase() !== 'input' ) {
+      switch (e.keyCode) {
+        // s letter
+        case 83:
+          $bagitForm.toggle();
+          return false;
+        break;
+        case 27:
+          $bagitForm.hide();
+        break;
+      }
     }
   })
 


### PR DESCRIPTION
this will fix conflict of "s" shortcat in input field, see comments in pull request #540.
Note: I havn't added texarea or dropdown fix because it's extra as for now: only input control is used in wallabag for the moment.
