### PR TITLE
fix of #115 - stay connected and session livetime

### DIFF
--- a/inc/poche/Poche.class.php
+++ b/inc/poche/Poche.class.php
@@ -61,8 +61,6 @@ class Poche
     private function init() 
     {
         Tools::initPhp();
-        Session::$sessionName = 'poche'; 
-        Session::init();
 
         if (isset($_SESSION['poche_user']) && $_SESSION['poche_user'] != array()) {
             $this->user = $_SESSION['poche_user'];

--- a/index.php
+++ b/index.php
@@ -12,6 +12,12 @@ define ('POCHE', '1.5.3');
 require 'check_setup.php';
 require_once 'inc/poche/global.inc.php';
 
+# Start session
+Session::$sessionName = 'poche';
+if ( !isset($_GET['login']) ) {
+    Session::init();
+}
+
 # Start Poche
 $poche = new Poche();
 $notInstalledMessage = $poche -> getNotInstalledMessage();


### PR DESCRIPTION
this can be treated as a quick fix of the problem.
all is now working as expected: in "stay signed" is not checked, session will expire at the end of browser session or after 1 hour of inactivity. if checked - after 90 days.
Tested for session autostart = true and also for false, so all should be ok in various environments.
However, I think, we may require deeper refactoring of session handling in near future.
