### PR TITLE
fix of  _SESSION - indefined variable

### DIFF
--- a/inc/3rdparty/class.messages.php
+++ b/inc/3rdparty/class.messages.php
@@ -59,6 +59,7 @@ class Messages {
 		$this->msgId = md5(uniqid());
 		
 		// Create the session array if it doesnt already exist
+		settype($_SESSION, 'array');
 		if( !array_key_exists('flash_messages', $_SESSION) ) $_SESSION['flash_messages'] = array();
 		
 	}


### PR DESCRIPTION
this will fix problem with undefined session variable.
I find, however, that our entire process of session handling is bad. For example, we try to logout user even if he is not logged in, logout is done via destroying of session and a lot of more small or larger bad ideas. Maybe it's now time to freeze list of features we want to add into v.1, do it all and concentrate on v.2.
