### PR TITLE
Add message in web server log in case of authentication failure

### DIFF
--- a/inc/poche/Poche.class.php
+++ b/inc/poche/Poche.class.php
@@ -798,6 +798,8 @@ class Poche
                 Tools::redirect($referer);
             }
             $this->messages->add('e', _('login failed: bad login or password'));
+            // log login failure in web server log to allow fail2ban usage
+            error_log('user '.$login.' authentication failure');
             Tools::logm('login failed');
             Tools::redirect();
         }


### PR DESCRIPTION
This patch add an error message in case of login failure attempt.
The purpose of this message is to enable the usage of fail2ban to block any brute force attack on the login page.

The fail2ban filter definition to take advantage of this log message (named apache-auth-wallabag.conf):

``` ini
[INCLUDES]
before = apache-common.conf
[Definition]
failregex = ^%(_apache_error_client)s user .* (authentication failure|not found|password mismatch).*$
ignoreregex =
```

Anf the jail definition:

``` ini
[apache-auth-custo]
enabled = true
port = http,https
filter = apache-auth-wallabag
logpath = /var/log/apache2/*error.log
maxretry = 1
```

Those examples are tested on Ubuntu.

**remark**: the change on line 1068 and after is only the automatic removal of ^M at the end of the line by my text editor.
