### PR TITLE
Add rudimentary add API that responds with minimal JSON

### DIFF
--- a/api.php
+++ b/api.php
@@ -1,0 +1,48 @@
+<?php
+/**
+ * wallabag, self hostable application allowing you to not miss any content anymore
+ *
+ * @category   wallabag
+ * @author     
+ * @copyright  2014
+ * @license    http://www.wtfpl.net/ see COPYING file
+ */
+
+define ('POCHE', '1.6.1');
+require 'check_setup.php';
+require_once 'inc/poche/global.inc.php';
+
+# Start session
+Session::$sessionName = 'poche';
+Session::init();
+
+# Start Poche
+$poche = new Poche();
+$notInstalledMessage = $poche -> getNotInstalledMessage();
+
+# Parse GET & REFERER vars
+$referer = empty($_SERVER['HTTP_REFERER']) ? '' : $_SERVER['HTTP_REFERER'];
+$uname = empty($_POST['login']) ? '' : $_POST['login'];
+$upass = empty($_POST['password']) ? '' : $_POST['password'];
+$url = new Url((isset($_POST['url'])) ? $_POST['url'] : '');
+
+$xobj = new stdClass();
+$xobj->status = 1;
+$xobj->message = 'Invalid Username or Password';
+
+#Tools::logm('User: ' . $uname . ', password: ' . $upass . ', url: ' . $url->getUrl());
+
+$user = $poche->store->login($uname, Tools::encodeString($upass . $uname), false);
+if ($user != array()) {
+	Session::login($user['username'], $user['password'], $uname, $upass, false, array('poche_user' => new User($user)));
+	$poche->user = new User($user);
+	$poche->actionOnly = true;
+	#
+	# One could add an action parameter to the post, but I'm only supporting
+	# add operations here...
+	#
+	$poche->action('add', $url, $user['id']);
+	$xobj->status = 0;
+	$xobj->message = 'OK: added '.$url->getUrl();
+}
+Tools::renderJson($xobj);

--- a/inc/poche/Poche.class.php
+++ b/inc/poche/Poche.class.php
@@ -18,6 +18,7 @@ class Poche
     public $tpl;
     public $messages;
     public $pagination;
+    public $actionOnly;
 
     private $currentTheme = '';
     private $currentLanguage = '';
@@ -97,6 +98,7 @@ class Poche
         }
 
         $this->currentLanguage = $languageDirectory;
+	$this->actionOnly = false;
     }
 
     public function configFileIsAvailable() {
@@ -462,11 +464,13 @@ class Poche
                     Tools::logm('error during insertion : the link wasn\'t added ' . $url->getUrl());
                 }
 
+		if (!$this->actionOnly) {
                 if ($autoclose == TRUE) {
                   Tools::redirect('?view=home');
                 } else {
                   Tools::redirect('?view=home&closewin=true');
                 }
+		}
                 break;
             case 'delete':
                 $msg = 'delete link #' . $id;


### PR DESCRIPTION
 Instead of waiting for v2, I thought I'd add this "quick and dirty" and minimal change patch to support an "API". Basically, it supports adding urls and simulates as much of a session necessary to do so.

There are corresponding changes to the android app which support this method of posting urls.

<!---
@huboard:{"milestone_order":646.75}
-->
