### PR TITLE
error reporting level set in E_ALL & ~E_NOTICE by default, can be overriden in config

### DIFF
--- a/inc/3rdparty/makefulltextfeed.php
+++ b/inc/3rdparty/makefulltextfeed.php
@@ -28,7 +28,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 // Request this file passing it a web page or feed URL in the querystring: makefulltextfeed.php?url=example.org/article
 // For more request parameters, see http://help.fivefilters.org/customer/portal/articles/226660-usage
 
-error_reporting(E_ALL ^ E_NOTICE);
+//error_reporting(E_ALL ^ E_NOTICE);
 ini_set("display_errors", 1);
 @set_time_limit(120);
 

--- a/inc/poche/Tools.class.php
+++ b/inc/poche/Tools.class.php
@@ -18,8 +18,6 @@ class Tools
             die(_('Oops, it seems you don\'t have PHP 5.'));
         }
 
-        error_reporting(E_ALL);
-
         function stripslashesDeep($value) {
             return is_array($value)
                 ? array_map('stripslashesDeep', $value)
@@ -64,7 +62,7 @@ class Tools
         if (strpos($host, ':') !== false) {
             $serverport = '';
         }
-        
+
         return 'http' . ($https ? 's' : '') . '://'
             . $host . $serverport . $scriptname;
     }

--- a/inc/poche/config.inc.default.php
+++ b/inc/poche/config.inc.default.php
@@ -30,6 +30,10 @@
 
 @define ('MODE_DEMO', FALSE);
 @define ('DEBUG_POCHE', FALSE);
+
+//default level of error reporting in application. Developers should override it in their config.inc.php: set to E_ALL.
+@define ('ERROR_REPORTING', E_ALL & ~E_NOTICE);
+
 @define ('DOWNLOAD_PICTURES', FALSE); # This can slow down the process of adding articles
 @define ('REGENERATE_PICTURES_QUALITY', 75);
 @define ('CONVERT_LINKS_FOOTNOTES', FALSE);

--- a/index.php
+++ b/index.php
@@ -12,6 +12,11 @@ define ('POCHE', '1.7.0');
 require 'check_setup.php';
 require_once 'inc/poche/global.inc.php';
 
+# Set error reporting level
+if (defined('ERROR_REPORTING')) {
+	error_reporting(ERROR_REPORTING);
+}
+
 # Start session
 Session::$sessionName = 'poche';
 Session::init();


### PR DESCRIPTION
as discussed here: #714
