### PR TITLE
quick fix of issue #750: mulipage content for politico.com/magazine articles

### DIFF
--- a/inc/3rdparty/site_config/standard/politico.com.txt
+++ b/inc/3rdparty/site_config/standard/politico.com.txt
@@ -4,10 +4,14 @@ body://div[contains(@class,"story-text")]
 # Why doesn't this work? next_page_link://ul[contains(@class,"pagination")]/li/a[@rel="next"]
 
 next_page_link://ul[contains(@class,"pagination")]/li[contains(@class, "current")]/following-sibling::node()/a
+next_page_link://div[contains(@class,"pagination")]/ol/li[contains(@class, "current")]/following-sibling::node()/a
 date://meta[@name="publish_date"]/@content
 
 strip://div[contains(@class, "breadcrumbs")]
 strip://a[contains(@class, "hidden")]
 strip://div[contains(@class, "story-embed")]
 strip://div[contains(@class, "story-text")]//p/a[contains(text(), "Also on POLITICO:")]/..
+strip://div[contains(@class, "story-interrupt")]
+strip://footer[contains(@class, "author-bio")]
+
 test_url: http://www.politico.com/news/stories/0712/78105.html


### PR DESCRIPTION
this is quick fix, a bit dirty: image and article annotation are included for every page as for now. Hope, a bit later will add cleanup workaround. 
