### PR TITLE
Proposed fix for #773

### DIFF
--- a/check_essentials.php
+++ b/check_essentials.php
@@ -1,0 +1,14 @@
+<?php
+
+// PHP 5.3 minimum
+if (version_compare(PHP_VERSION, '5.3.3', '<')) {
+    die('This software require PHP 5.3.3 minimum');
+}
+
+// Short tags must be enabled for PHP < 5.4
+if (version_compare(PHP_VERSION, '5.4.0', '<')) {
+
+    if (! ini_get('short_open_tag')) {
+        die('This software require to have short tags enabled, check your php.ini => "short_open_tag = On"');
+    }
+}

--- a/check_setup.php
+++ b/check_setup.php
@@ -1,25 +1,12 @@
 <?php
 
-// PHP 5.3 minimum
-if (version_compare(PHP_VERSION, '5.3.3', '<')) {
-    die('This software require PHP 5.3.3 minimum');
-}
-
-// Short tags must be enabled for PHP < 5.4
-if (version_compare(PHP_VERSION, '5.4.0', '<')) {
-
-    if (! ini_get('short_open_tag')) {
-        die('This software require to have short tags enabled, check your php.ini => "short_open_tag = On"');
-    }
-}
-
 // Check if /cache is writeable
 if (! is_writable('cache')) {
     die('The directory "cache" must be writeable by your web server user');
 }
 
 // Check if /db is writeable
-if (! is_writable('db')) {
+if (! is_writable('db') && STORAGE === 'sqlite') {
     die('The directory "db" must be writeable by your web server user');
 }
 

--- a/index.php
+++ b/index.php
@@ -9,8 +9,9 @@
  */
 
 define ('POCHE', '1.7.1');
-require 'check_setup.php';
+require 'check_essentials.php';
 require_once 'inc/poche/global.inc.php';
+require 'check_setup.php';
 
 # Set error reporting level
 if (defined('ERROR_REPORTING')) {


### PR DESCRIPTION
Split up check_setup.php to do a check for the bare essentials (e.g. PHP version) first, then load the config files, etc. and do less important checks which may require access to config variables in the original check_setup.php. Patch fixes #773

Not sure if you like the way this is done, yet it seems to be a good way to get a hold of the configuration constants needed for the check.
