### PR TITLE
#763 fix to display the login successful message with the translation

### DIFF
--- a/inc/poche/Poche.class.php
+++ b/inc/poche/Poche.class.php
@@ -877,6 +877,14 @@ class Poche
                 $longlastingsession = isset($_POST['longlastingsession']);
                 $passwordTest = ($isauthenticated) ? $user['password'] : Tools::encodeString($password . $login);
                 Session::login($user['username'], $user['password'], $login, $passwordTest, $longlastingsession, array('poche_user' => new User($user)));
+
+                # reload l10n
+                $language = $user['config']['language'];
+                @putenv('LC_ALL=' . $language);
+                setlocale(LC_ALL, $language);
+                bindtextdomain($language, LOCALE);
+                textdomain($language);
+
                 $this->messages->add('s', _('welcome to your wallabag'));
                 Tools::logm('login successful');
                 Tools::redirect($referer);


### PR DESCRIPTION
I'm not it's the better way. @tcitworld / @mariroz, what do you think? 

fix for #763 

<!---
@huboard:{"order":513.75,"milestone_order":744.5,"custom_state":""}
-->
