### PR TITLE
Implemented additional check for using the 'X-Forwarded-Port' header.

### DIFF
--- a/inc/poche/Tools.class.php
+++ b/inc/poche/Tools.class.php
@@ -54,6 +54,10 @@ final class Tools
             || ($https && $_SERVER["SERVER_PORT"] == '443')
             || ($https && $_SERVER["SERVER_PORT"]==SSL_PORT) //Custom HTTPS port detection
             ? '' : ':' . $_SERVER["SERVER_PORT"]);
+        
+        if (isset($_SERVER["HTTP_X_FORWARDED_PORT"])) {
+            $serverport = ':' . $_SERVER["HTTP_X_FORWARDED_PORT"];
+        }
 
         $scriptname = str_replace('/index.php', '/', $_SERVER["SCRIPT_NAME"]);
 


### PR DESCRIPTION
This PR contains an additional check for the `X-FORWARDED-PORT` header. If this is set, it will used in `getPocheUrl()` for constructing the Wallabag URL
