### PR TITLE
fix pictures display when DOWNLOAD_PICTURES is enabled

### DIFF
--- a/inc/poche/pochePictures.php
+++ b/inc/poche/pochePictures.php
@@ -33,7 +33,7 @@ final class Picture
                 }
 
                 if (self::_downloadPictures($absolute_path, $fullpath) === true) {
-                    $content = str_replace($matches[$i][2], $fullpath, $content);
+                    $content = str_replace($matches[$i][2], Tools::getPocheUrl() . $fullpath, $content);
                 }
 
                 $processing_pictures[] = $absolute_path;


### PR DESCRIPTION
Simple fix, should fix both https://github.com/wallabag/android-app/issues/32 and https://github.com/wallabag/wallabag/issues/804 issues.
