### PR TITLE
Convert the MySQL charset to utf8mb4 to support the full range of unicode

### DIFF
--- a/inc/poche/Database.class.php
+++ b/inc/poche/Database.class.php
@@ -31,8 +31,10 @@ class Database {
                 $this->handle = new PDO($db_path);
                 break;
             case 'mysql':
-                $db_path = 'mysql:host=' . STORAGE_SERVER . ';dbname=' . STORAGE_DB;
-                $this->handle = new PDO($db_path, STORAGE_USER, STORAGE_PASSWORD);
+                $db_path = 'mysql:host=' . STORAGE_SERVER . ';dbname=' . STORAGE_DB . ';charset=utf8mb4';
+                $this->handle = new PDO($db_path, STORAGE_USER, STORAGE_PASSWORD, array(
+                    PDO::MYSQL_ATTR_INIT_COMMAND => 'SET NAMES utf8mb4',
+                ));
                 break;
             case 'postgres':
                 $db_path = 'pgsql:host=' . STORAGE_SERVER . ';dbname=' . STORAGE_DB;

--- a/install/index.php
+++ b/install/index.php
@@ -101,12 +101,14 @@ else if (isset($_POST['install'])) {
                 $content = file_get_contents('inc/poche/config.inc.php');
 
                 if ($_POST['db_engine'] == 'mysql') {
-                    $db_path = 'mysql:host=' . $_POST['mysql_server'] . ';dbname=' . $_POST['mysql_database'];
+                    $db_path = 'mysql:host=' . $_POST['mysql_server'] . ';dbname=' . $_POST['mysql_database'] . ';charset=utf8mb4';
                     $content = str_replace("define ('STORAGE_SERVER', 'localhost');", "define ('STORAGE_SERVER', '".$_POST['mysql_server']."');", $content);
                     $content = str_replace("define ('STORAGE_DB', 'poche');", "define ('STORAGE_DB', '".$_POST['mysql_database']."');", $content);
                     $content = str_replace("define ('STORAGE_USER', 'poche');", "define ('STORAGE_USER', '".$_POST['mysql_user']."');", $content);
                     $content = str_replace("define ('STORAGE_PASSWORD', 'poche');", "define ('STORAGE_PASSWORD', '".$_POST['mysql_password']."');", $content);
-                    $handle = new PDO($db_path, $_POST['mysql_user'], $_POST['mysql_password']); 
+                    $handle = new PDO($db_path, $_POST['mysql_user'], $_POST['mysql_password'], array(
+                        PDO::MYSQL_ATTR_INIT_COMMAND => 'SET NAMES utf8mb4',
+                    ));
 
                     $sql_structure = file_get_contents('install/mysql.sql');
                 }

--- a/install/mysql.sql
+++ b/install/mysql.sql
@@ -3,7 +3,7 @@ CREATE TABLE IF NOT EXISTS `config` (
   `name` varchar(255) NOT NULL,
   `value` varchar(255) NOT NULL,
   PRIMARY KEY (`id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 CREATE TABLE IF NOT EXISTS `entries` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
@@ -14,7 +14,7 @@ CREATE TABLE IF NOT EXISTS `entries` (
   `content` blob NOT NULL,
   `user_id` int(11) NOT NULL,
   PRIMARY KEY (`id`)
-) ENGINE=InnoDB  DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB  DEFAULT CHARSET=utf8mb4;
 
 CREATE TABLE IF NOT EXISTS `users` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
@@ -23,7 +23,7 @@ CREATE TABLE IF NOT EXISTS `users` (
   `name` varchar(255) NOT NULL,
   `email` varchar(255) NOT NULL,
   PRIMARY KEY (`id`)
-) ENGINE=InnoDB  DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB  DEFAULT CHARSET=utf8mb4;
 
 CREATE TABLE IF NOT EXISTS `users_config` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
@@ -31,13 +31,13 @@ CREATE TABLE IF NOT EXISTS `users_config` (
   `name` varchar(255) NOT NULL,
   `value` varchar(255) NOT NULL,
   PRIMARY KEY (`id`)
-) ENGINE=InnoDB  DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB  DEFAULT CHARSET=utf8mb4;
 
 CREATE TABLE IF NOT EXISTS `tags` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `value` varchar(255) NOT NULL,
   PRIMARY KEY (`id`)
-) ENGINE=InnoDB  DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB  DEFAULT CHARSET=utf8mb4;
 
 CREATE TABLE IF NOT EXISTS `tags_entries` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
@@ -46,4 +46,4 @@ CREATE TABLE IF NOT EXISTS `tags_entries` (
   FOREIGN KEY(entry_id) REFERENCES entries(id) ON DELETE CASCADE,
   FOREIGN KEY(tag_id) REFERENCES tags(id) ON DELETE CASCADE,
   PRIMARY KEY (`id`)
-) ENGINE=InnoDB  DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB  DEFAULT CHARSET=utf8mb4;


### PR DESCRIPTION
MySQL with charset utf8 only supports Unicode-characters which fit in 4-bytes. If you try to store Unicode-text with characters which don't fit in 4-bytes, MySQL will truncate everything after that character. In MySQL 5.5.3 the `utf8mb4` charset has been added which implements full UTF8 support.

These articles explains it pretty good:
- https://mathiasbynens.be/notes/mysql-utf8mb4
- http://geoff.greer.fm/2012/08/12/character-encoding-bugs-are-𝒜wesome/

When I add the second link to Wallabag, everything after the '𝒜'-character is truncated by MySQL. Which results in this:
![2014-09-18_213825](https://cloud.githubusercontent.com/assets/279664/4326228/2411b816-3f6d-11e4-9dde-91dbce715077.png)

With this simple fix:
![2014-09-18_213647](https://cloud.githubusercontent.com/assets/279664/4326231/28990786-3f6d-11e4-9e2b-9c0ca6c67462.png)

To convert an existing database you canrun the following queries:

``` sql
ALTER TABLE `wallabag`.`config` CONVERT TO CHARACTER SET utf8mb4;
ALTER TABLE `wallabag`.`entries` CONVERT TO CHARACTER SET utf8mb4;
ALTER TABLE `wallabag`.`tags` CONVERT TO CHARACTER SET utf8mb4;
ALTER TABLE `wallabag`.`tag_entries` CONVERT TO CHARACTER SET utf8mb4;
ALTER TABLE `wallabag`.`users` CONVERT TO CHARACTER SET utf8mb4;
ALTER TABLE `wallabag`.`users_config` CONVERT TO CHARACTER SET utf8mb4;
```
