### PR TITLE
Add support for custom http port

### DIFF
--- a/inc/poche/Tools.class.php
+++ b/inc/poche/Tools.class.php
@@ -51,6 +51,7 @@ final class Tools
 
         $serverport = (!isset($_SERVER["SERVER_PORT"])
             || $_SERVER["SERVER_PORT"] == '80'
+            || $_SERVER["SERVER_PORT"] == HTTP_PORT
             || ($https && $_SERVER["SERVER_PORT"] == '443')
             || ($https && $_SERVER["SERVER_PORT"]==SSL_PORT) //Custom HTTPS port detection
             ? '' : ':' . $_SERVER["SERVER_PORT"]);

--- a/inc/poche/config.inc.default.php
+++ b/inc/poche/config.inc.default.php
@@ -24,6 +24,8 @@
 #################################################################################
 # Do not trespass unless you know what you are doing
 #################################################################################
+// Change this if http is running on nonstandard port - i.e is behind cache proxy
+@define ('HTTP_PORT', 80);
 
 // Change this if not using the standart port for SSL - i.e you server is behind sslh
 @define ('SSL_PORT', 443);


### PR DESCRIPTION
Now you can use wallabag behind reverse proxy (i.e Squid or Varnish)
without problem with urls like wallabag.example.com:8080.
