### PR TITLE
update heise.de.txt

### DIFF
--- a/inc/3rdparty/site_config/standard/heise.de.txt
+++ b/inc/3rdparty/site_config/standard/heise.de.txt
@@ -1,7 +1,9 @@
-single_page_link: //p[@class='news_option']/a
+#second part of single_page_link for telepolis-articles (desktop-version of site)
+single_page_link: //p[@class='news_option']/a | //a[@id='tp-druckversion']
 
 date: //p[@class='news_datum']
 title: //h1
 body: //div[@class='meldung_wrapper']
 
 test_url: http://www.heise.de/newsticker/meldung/Europa-soll-Grundrechteschutz-im-Netz-staerken-1392664.html
+test_url: http://www.heise.de/tp/artikel/42/42579/1.html


### PR DESCRIPTION
Multi-page Telepolis-articles (www.heise.de/tp/...) are not fetched correctly atm. My addition to the single_page_link makes it work (tested with http://www.heise.de/tp/artikel/42/42579/1.html).
