### PR TITLE
Fixing menu hiding behavior when switching from mobile width to desktop width

### DIFF
--- a/themes/baggy/css/main.css
+++ b/themes/baggy/css/main.css
@@ -987,7 +987,7 @@ pre code {
     height: auto;
     padding-top: 3em;
   }
-  #links.open {
+  #links.menu--open {
     display: block;
   }
   footer  {

--- a/themes/baggy/js/init.js
+++ b/themes/baggy/js/init.js
@@ -8,7 +8,7 @@ $.fn.ready(function() {
      ========================================================================== */
 
   $("#menu").click(function(){
-    $("#links").toggleClass('open');
+    $("#links").toggleClass('menu--open');
     if ($('#content').hasClass('opacity03')) {
         $('#content').removeClass('opacity03');
     }


### PR DESCRIPTION
If the viewport is narrow enough to show the "mobile" view, and the menu is opened and then closed, and then the viewport is widened to show the "desktop" view, the menu will be `display:none;`. This shouldn't happen, and this PR fixes this behavior.
