### PR TITLE
fix bug on regex components

### DIFF
--- a/inc/poche/pochePictures.php
+++ b/inc/poche/pochePictures.php
@@ -20,8 +20,8 @@ final class Picture
         $processing_pictures = array(); // list of processing image to avoid processing the same pictures twice
         preg_match_all('#<\s*(img)[^>]+src="([^"]*)"[^>]*>#Si', $content, $matches, PREG_SET_ORDER);
         foreach($matches as $i => $link) {
-            $link[1] = trim($link[1]);
-            if (!preg_match('#^(([a-z]+://)|(\#))#', $link[1])) {
+            $link[2] = trim($link[2]);
+            if (!preg_match('#^(([a-z]+://)|(\#))#', $link[2])) {
                 $absolute_path = self::_getAbsoluteLink($link[2], $url);
                 $filename = basename(parse_url($absolute_path, PHP_URL_PATH));
                 $directory = self::_createAssetsDirectory($id);


### PR DESCRIPTION
The trim and preg_match function were using $link[1] as argument, which, according to the previous regex, always contains a string with value "img". I changed it to $link[2] which actually contains the image url and I guess was the original author intent.
(same pull request as #959, but this one targets the right branch)