### PR TITLE
use utf8 instead of utf8mb4

### DIFF
--- a/inc/poche/Database.class.php
+++ b/inc/poche/Database.class.php
@@ -33,7 +33,7 @@ class Database {
             case 'mysql':
                 $db_path = 'mysql:host=' . STORAGE_SERVER . ';dbname=' . STORAGE_DB . ';charset=utf8mb4';
                 $this->handle = new PDO($db_path, STORAGE_USER, STORAGE_PASSWORD, array(
-                    PDO::MYSQL_ATTR_INIT_COMMAND => 'SET NAMES utf8mb4',
+                    PDO::MYSQL_ATTR_INIT_COMMAND => 'SET NAMES utf8',
                 ));
                 break;
             case 'postgres':


### PR DESCRIPTION
`utf8mb4` is a superset of `utf8` but was introduced in mysql `5.5.3` or so (it breaks wallabag if the mysql server version is older (e.g. `5.1`)).
