### PR TITLE
Make call to FTRSS silent to avoid warnings which can break import

### DIFF
--- a/inc/poche/Tools.class.php
+++ b/inc/poche/Tools.class.php
@@ -342,7 +342,10 @@ final class Tools
             return $json;
         };
 
-        $json = $scope("inc/3rdparty/makefulltextfeed.php", array("url" => $url));
+	// Silence $scope function to avoid
+	// issues with FTRSS when error_reporting is to high
+	// FTRSS generates PHP warnings which break output
+        $json = @$scope("inc/3rdparty/makefulltextfeed.php", array("url" => $url));
 
         // Clearing and restoring context
         foreach ($GLOBALS as $key => $value) {


### PR DESCRIPTION
Amongst other things, the way FTRSS is called can break multipage, because FTRSS sometimes produces PHP Warnings.
Making this call silent solve the issue
