### PR TITLE
don't call flattr if flattr is disabled

### DIFF
--- a/inc/poche/Poche.class.php
+++ b/inc/poche/Poche.class.php
@@ -405,9 +405,12 @@ class Poche
                     }
 
                     # flattr checking
-                    $flattr = new FlattrItem();
-                    $flattr->checkItem($entry['url'], $entry['id']);
-
+                    $flattr = NULL;
+                    if (FLATTR) {
+                        $flattr = new FlattrItem();
+                        $flattr->checkItem($entry['url'], $entry['id']);
+                    }
+                    
                     # tags
                     $tags = $this->store->retrieveTagsByEntry($entry['id']);
 


### PR DESCRIPTION
This should prevent calls to Flattr API when Flattr isn't activated. So it should show pages faster.

Please test (I tested this offline only)
