### PR TITLE
[RSS] introducing query param 'limit' for max items in RSS feed

### DIFF
--- a/inc/poche/Poche.class.php
+++ b/inc/poche/Poche.class.php
@@ -784,10 +784,11 @@ class Poche
      *
      * @param $token
      * @param $user_id
-     * @param $tag_id
-     * @param string $type
+     * @param $tag_id if $type is 'tag', the id of the tag to generate feed for
+     * @param string $type the type of feed to generate
+     * @param int $limit the maximum number of items (0 means all)
      */
-    public function generateFeeds($token, $user_id, $tag_id, $type = 'home')
+    public function generateFeeds($token, $user_id, $tag_id, $type = 'home', $limit = 0)
     {
         $allowed_types = array('home', 'fav', 'archive', 'tag');
         $config = $this->store->getConfigUser($user_id);
@@ -814,8 +815,13 @@ class Poche
             $entries = $this->store->getEntriesByView($type, $user_id);
         }
 
+        // if $limit is set to zero, use all entries
+        if (0 == $limit) {
+            $limit = count($entries);
+        }
         if (count($entries) > 0) {
-            foreach ($entries as $entry) {
+            for ($i = 0; $i < min(count($entries), $limit); $i++) {
+                $entry = $entries[$i];
                 $newItem = $feed->createNewItem();
                 $newItem->setTitle($entry['title']);
                 $newItem->setSource(Tools::getPocheUrl() . '?view=view&amp;id=' . $entry['id']);

--- a/inc/poche/Routing.class.php
+++ b/inc/poche/Routing.class.php
@@ -102,7 +102,8 @@ class Routing
         	$this->wallabag->login($this->referer);
         } elseif (isset($_GET['feed']) && isset($_GET['user_id'])) {
             $tag_id = (isset($_GET['tag_id']) ? intval($_GET['tag_id']) : 0);
-            $this->wallabag->generateFeeds($_GET['token'], filter_var($_GET['user_id'],FILTER_SANITIZE_NUMBER_INT), $tag_id, $_GET['type']);
+            $limit = (isset($_GET['limit']) ? intval($_GET['limit']) : 0);
+            $this->wallabag->generateFeeds($_GET['token'], filter_var($_GET['user_id'],FILTER_SANITIZE_NUMBER_INT), $tag_id, $_GET['type'], $limit);
         }
         
         //allowed ONLY to logged in user


### PR DESCRIPTION
As asked in issue #553 I introduced a 'limit' query parameter to control how many items should be displayed in the feed at most. It should also address a part of issue #1000.

So far the limit should be set manually, by default all items are displayed.