### PR TITLE
Simplify build system

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,9 +26,9 @@
 /web/bundles/
 /web/uploads/
 
-# PHPUnit
-/app/phpunit.xml
-/phpunit.xml
+# Build
+/app/build
+/build
 
 # Composer PHAR
 /composer.phar

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,5 +14,5 @@ before_script:
   - echo 'date.timezone = "Europe/Paris"' >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini
 
 script:
-  - ant -f app/build.xml prepare
-  - phpunit -c app  --coverage-text
+  - ant prepare
+  - phpunit --coverage-text

--- a/build.xml
+++ b/build.xml
@@ -11,31 +11,30 @@
             <arg value="install"/>
             <arg value="--no-interaction"/>
             <arg value="--no-progress"/>
-            <arg value="--working-dir=.."/>
         </exec>
         <exec executable="php">
-            <arg value="${basedir}/../app/console"/>
+            <arg value="${basedir}/app/console"/>
             <arg value="doctrine:database:drop"/>
             <arg value="--force"/>
             <arg value="--env=test"/>
         </exec>
         <exec executable="php">
-            <arg value="${basedir}/../app/console"/>
+            <arg value="${basedir}/app/console"/>
             <arg value="doctrine:database:create"/>
             <arg value="--env=test"/>
         </exec>
         <exec executable="php">
-            <arg value="${basedir}/../app/console"/>
+            <arg value="${basedir}/app/console"/>
             <arg value="doctrine:schema:create"/>
             <arg value="--env=test"/>
         </exec>
         <exec executable="php">
-            <arg value="${basedir}/../app/console"/>
+            <arg value="${basedir}/app/console"/>
             <arg value="cache:clear"/>
             <arg value="--env=test"/>
         </exec>
         <exec executable="php">
-            <arg value="${basedir}/../app/console"/>
+            <arg value="${basedir}/app/console"/>
             <arg value="doctrine:fixtures:load"/>
             <arg value="--no-interaction"/>
             <arg value="--env=test"/>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -9,23 +9,27 @@
          processIsolation="false"
          stopOnFailure="false"
          syntaxCheck="false"
-         bootstrap="bootstrap.php.cache"
+         bootstrap="app/bootstrap.php.cache"
         >
 
     <testsuites>
         <testsuite name="wallabag Test Suite">
-            <directory>../src/Wallabag/CoreBundle/Tests</directory>
+            <directory>./src/Wallabag/*Bundle/Tests</directory>
         </testsuite>
     </testsuites>
 
+    <php>
+        <server name="KERNEL_DIR" value="./app/" />
+    </php>
+
     <filter>
         <whitelist>
-            <directory>../src</directory>
+            <directory>./src</directory>
             <exclude>
-                <directory>../vendor</directory>
-                <directory>../src/Wallabag/CoreBundle/Resources</directory>
-                <directory>../src/Wallabag/CoreBundle/Tests</directory>
-                <directory>../src/Wallabag/CoreBundle/DataFixtures</directory>
+                <directory>./vendor</directory>
+                <directory>./src/Wallabag/*Bundle/Resources</directory>
+                <directory>./src/Wallabag/*Bundle/Tests</directory>
+                <directory>./src/Wallabag/*Bundle/DataFixtures</directory>
             </exclude>
         </whitelist>
     </filter>


### PR DESCRIPTION
Instead of launching the tests suite using:

```
ant -f app/build.xml prepare && phpunit -c app
```

It will be more simple:
```
ant prepare && phpunit
```