### PR TITLE
composer: min PHP 5.3 added

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,6 +23,7 @@
         "issues": "https://github.com/wallabag/wallabag/issues"
     },
     "require": {
+        "php": ">=5.3.3",
         "twig/twig": "1.*",
         "twig/extensions": "1.0.*",
         "umpirsky/twig-gettext-extractor": "1.1.*"


### PR DESCRIPTION
Composer should contain min supported PHP version.

Should be 5.3.3 according to https://github.com/wallabag/wallabag/blob/4b1fa4c2febc7abbc6da3d65e4e760949a55843c/check_essentials.php#L5