### PR TITLE
Remove ability to change username

### DIFF
--- a/src/Wallabag/CoreBundle/Controller/ConfigController.php
+++ b/src/Wallabag/CoreBundle/Controller/ConfigController.php
@@ -9,7 +9,7 @@ use Symfony\Component\HttpFoundation\JsonResponse;
 use Wallabag\CoreBundle\Entity\Config;
 use Wallabag\CoreBundle\Entity\User;
 use Wallabag\CoreBundle\Form\Type\ChangePasswordType;
-use Wallabag\CoreBundle\Form\Type\UserType;
+use Wallabag\CoreBundle\Form\Type\UserInformationType;
 use Wallabag\CoreBundle\Form\Type\NewUserType;
 use Wallabag\CoreBundle\Form\Type\RssType;
 use Wallabag\CoreBundle\Tools\Utils;
@@ -65,7 +65,7 @@ class ConfigController extends Controller
         }
 
         // handle changing user information
-        $userForm = $this->createForm(new UserType(), $user);
+        $userForm = $this->createForm(new UserInformationType(), $user);
         $userForm->handleRequest($request);
 
         if ($userForm->isValid()) {

--- a/src/Wallabag/CoreBundle/Entity/User.php
+++ b/src/Wallabag/CoreBundle/Entity/User.php
@@ -4,6 +4,7 @@ namespace Wallabag\CoreBundle\Entity;
 
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\ORM\Mapping as ORM;
+use Symfony\Bridge\Doctrine\Validator\Constraints\UniqueEntity;
 use Symfony\Component\Security\Core\User\UserInterface;
 use Symfony\Component\Security\Core\User\AdvancedUserInterface;
 use Symfony\Component\Validator\Constraints as Assert;
@@ -17,6 +18,9 @@ use JMS\Serializer\Annotation\Expose;
  * @ORM\Entity(repositoryClass="Wallabag\CoreBundle\Repository\UserRepository")
  * @ORM\HasLifecycleCallbacks()
  * @ExclusionPolicy("all")
+ *
+ * @UniqueEntity("email")
+ * @UniqueEntity("username")
  */
 class User implements AdvancedUserInterface, \Serializable
 {

--- a/src/Wallabag/CoreBundle/Form/Type/UserInformationType.php
+++ b/src/Wallabag/CoreBundle/Form/Type/UserInformationType.php
@@ -5,12 +5,11 @@ use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolverInterface;
 
-class UserType extends AbstractType
+class UserInformationType extends AbstractType
 {
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
         $builder
-            ->add('username', 'text')
             ->add('name', 'text')
             ->add('email', 'text')
             ->add('save', 'submit')
@@ -26,6 +25,6 @@ class UserType extends AbstractType
 
     public function getName()
     {
-        return 'user';
+        return 'update_user';
     }
 }

--- a/src/Wallabag/CoreBundle/Resources/views/Config/index.html.twig
+++ b/src/Wallabag/CoreBundle/Resources/views/Config/index.html.twig
@@ -86,14 +86,6 @@
 
         <fieldset class="w500p inline">
             <div class="row">
-                {{ form_label(form.user.username) }}
-                {{ form_errors(form.user.username) }}
-                {{ form_widget(form.user.username) }}
-            </div>
-        </fieldset>
-
-        <fieldset class="w500p inline">
-            <div class="row">
                 {{ form_label(form.user.name) }}
                 {{ form_errors(form.user.name) }}
                 {{ form_widget(form.user.name) }}

--- a/src/Wallabag/CoreBundle/Tests/Controller/ConfigControllerTest.php
+++ b/src/Wallabag/CoreBundle/Tests/Controller/ConfigControllerTest.php
@@ -27,7 +27,7 @@ class ConfigControllerTest extends WallabagTestCase
 
         $this->assertCount(1, $crawler->filter('button[id=config_save]'));
         $this->assertCount(1, $crawler->filter('button[id=change_passwd_save]'));
-        $this->assertCount(1, $crawler->filter('button[id=user_save]'));
+        $this->assertCount(1, $crawler->filter('button[id=update_user_save]'));
         $this->assertCount(1, $crawler->filter('button[id=new_user_save]'));
         $this->assertCount(1, $crawler->filter('button[id=rss_config_save]'));
     }
@@ -189,25 +189,15 @@ class ConfigControllerTest extends WallabagTestCase
         return array(
             array(
                 array(
-                    'user[username]' => '',
-                    'user[name]' => '',
-                    'user[email]' => '',
+                    'update_user[name]' => '',
+                    'update_user[email]' => '',
                 ),
                 'This value should not be blank.',
             ),
             array(
                 array(
-                    'user[username]' => 'ad',
-                    'user[name]' => '',
-                    'user[email]' => '',
-                ),
-                'This value is too short.',
-            ),
-            array(
-                array(
-                    'user[username]' => 'admin',
-                    'user[name]' => '',
-                    'user[email]' => 'test',
+                    'update_user[name]' => '',
+                    'update_user[email]' => 'test',
                 ),
                 'This value is not a valid email address.',
             ),
@@ -226,7 +216,7 @@ class ConfigControllerTest extends WallabagTestCase
 
         $this->assertEquals(200, $client->getResponse()->getStatusCode());
 
-        $form = $crawler->filter('button[id=user_save]')->form();
+        $form = $crawler->filter('button[id=update_user_save]')->form();
 
         $crawler = $client->submit($form, $data);
 
@@ -245,12 +235,11 @@ class ConfigControllerTest extends WallabagTestCase
 
         $this->assertEquals(200, $client->getResponse()->getStatusCode());
 
-        $form = $crawler->filter('button[id=user_save]')->form();
+        $form = $crawler->filter('button[id=update_user_save]')->form();
 
         $data = array(
-            'user[username]' => 'admin',
-            'user[name]' => 'new name',
-            'user[email]' => 'admin@wallabag.io',
+            'update_user[name]' => 'new name',
+            'update_user[email]' => 'admin@wallabag.io',
         );
 
         $client->submit($form, $data);
@@ -297,6 +286,14 @@ class ConfigControllerTest extends WallabagTestCase
                     'new_user[email]' => 'wallace@wallace.me',
                 ),
                 'Password should by at least',
+            ),
+            array(
+                array(
+                    'new_user[username]' => 'admin',
+                    'new_user[password]' => 'wallacewallace',
+                    'new_user[email]' => 'wallace@wallace.me',
+                ),
+                'This value is already used',
             ),
         );
     }


### PR DESCRIPTION
Since password are linked to username it was hard to change username while checking that the password is the good one.

Instead of doing crazy things to achieve that, I act that user won't be able to update username.

Also, username (and email) must be unique, since people logged in using username and can request a new password using email.

This should fix #1149