### PR TITLE
fix restart of import

### DIFF
--- a/inc/poche/Routing.class.php
+++ b/inc/poche/Routing.class.php
@@ -141,7 +141,7 @@ class Routing
                 $pdf->producePDF();
             } elseif (isset($_GET['import'])) {
                 $import = $this->wallabag->import();
-                $tplVars = array_merge($this->vars, $import);
+                $this->vars = array_merge($this->vars, $import);
             } elseif (isset($_GET['empty-cache'])) {
                 Tools::emptyCache();
             } elseif (isset($_GET['export'])) {


### PR DESCRIPTION
The import returns some variables needed in the template (I know, it's not logical). 
But when we refactor routing, we forgot to set these values into `$this->vars`: the import only ran once, whereas it should restart automatically (every `IMPORT_DELAY` seconds).