### PR TITLE
Send postMessage to opener before autoclose

### DIFF
--- a/themes/_global/js/autoClose.js
+++ b/themes/_global/js/autoClose.js
@@ -1,6 +1,26 @@
 $(document).ready(function() {
 	current_url = window.location.href
 	if (current_url.match("&closewin=true")) {
+		if (opener) {
+			var msgDiv = $("div.messages");
+			var msg = msgDiv.children("p").text();
+			var status = msgDiv.hasClass("success") ?
+				'success' : 'unknown';
+			/* TODO
+			 * I would also like to send the link back
+			 * but the first link e.g. $(".tool.link")[0]
+			 * may not be the right way to find it:
+			 * We also get a "success" when the item is
+			 * already stored. In this case the item
+			 * will be sorted to the top.
+			 * Are there other cases where we get a
+			 * success but the url is not on top?!
+			*/
+			var url = $(".tool.link")[0].href;
+			opener.postMessage({"wallabag-status": status,
+				"wallabag-msg": msg,
+				"wallabag-url": url }, "*");
+		}
 		window.close();
 	}
 });

--- a/themes/_global/js/autoClose.js
+++ b/themes/_global/js/autoClose.js
@@ -1,23 +1,12 @@
 $(document).ready(function() {
-	current_url = window.location.href
-	if (current_url.match("&closewin=true")) {
-		if (opener) {
+  if (location.search.match("&closewin=true")) {
+		if (window.opener) {
 			var msgDiv = $("div.messages");
 			var msg = msgDiv.children("p").text();
 			var status = msgDiv.hasClass("success") ?
 				'success' : 'unknown';
-			/* TODO
-			 * I would also like to send the link back
-			 * but the first link e.g. $(".tool.link")[0]
-			 * may not be the right way to find it:
-			 * We also get a "success" when the item is
-			 * already stored. In this case the item
-			 * will be sorted to the top.
-			 * Are there other cases where we get a
-			 * success but the url is not on top?!
-			*/
 			var url = $(".tool.link")[0].href;
-			opener.postMessage({"wallabag-status": status,
+			window.opener.postMessage({"wallabag-status": status,
 				"wallabag-msg": msg,
 				"wallabag-url": url }, "*");
 		}


### PR DESCRIPTION
This patch comes in handy when using another webapp that uses window.open to delegate adding to the wallabag site. I'm needing this for the upcoming Firefox OS app that I'm working on: https://github.com/freddyb/wallabag-fxos/

The patch apply cleanly on the dev branch as well as 1.9 (where I'm using it).


cc @tcitworld