### PR TITLE
store Content-Type in database

### DIFF
--- a/src/Wallabag/CoreBundle/Entity/Entry.php
+++ b/src/Wallabag/CoreBundle/Entity/Entry.php
@@ -265,6 +265,8 @@ class Entry
     public function setContent($content)
     {
         $this->content = $content;
+        $headers = get_headers($this->url, 1);
+        $this->mimetype = $headers['Content-Type'];
         $this->readingTime = Tools::getReadingTime($content);
 
         return $this;


### PR DESCRIPTION
As you can see below, mimetype is stored, but sometimes, we've got charset. 

What can I do? 

![mimetype](https://lut.im/VsMeLOMO/bY9VOFJ7)