### PR TITLE
fix #981: add filter on domain name

### DIFF
--- a/src/Wallabag/CoreBundle/Filter/EntryFilterType.php
+++ b/src/Wallabag/CoreBundle/Filter/EntryFilterType.php
@@ -5,6 +5,8 @@ namespace Wallabag\CoreBundle\Filter;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
+use Lexik\Bundle\FormFilterBundle\Filter\FilterOperands;
+use Lexik\Bundle\FormFilterBundle\Filter\Query\QueryInterface;
 
 class EntryFilterType extends AbstractType
 {
@@ -24,7 +26,18 @@ class EntryFilterType extends AbstractType
                             'placeholder' => 'dd/mm/yyyy'),
                         'format' => 'dd/MM/yyyy',
                         'widget' => 'single_text'
-                    )));
+                )))
+            ->add('domainName', 'filter_text', array(
+                'apply_filter' => function (QueryInterface $filterQuery, $field, $values)
+                    {
+                        $value = $values['value'];
+                        if (strlen($value) <= 3 || empty($value)) {
+                            return null;
+                        }
+                        $expression = $filterQuery->getExpr()->like($field, $filterQuery->getExpr()->literal('%'.$value.'%'));
+                        return $filterQuery->createCondition($expression);
+                    }
+            ));
     }
 
     public function getName()

--- a/src/Wallabag/CoreBundle/Resources/views/themes/material/Entry/entries.html.twig
+++ b/src/Wallabag/CoreBundle/Resources/views/themes/material/Entry/entries.html.twig
@@ -77,8 +77,16 @@
                     <label for="entry_filter_readingTime_right_number">{% trans %}to{% endtrans %}</label>
                 </div>
 
+
                 <div class="col s12">
+
                     <label>{% trans %}Create at{% endtrans %}</label>
+
+                    <label>{% trans %}Domain name{% endtrans %}</label>
+                </div>
+                <div class="input-field col s6">
+                    {{ form_widget(form.domainName, {'type': 'text'}) }}
+                    <label for="entry_filter_domainName">{% trans %}www.website.com{% endtrans %}</label>
                 </div>
 
                 <div class="input-field col s6">

--- a/src/Wallabag/CoreBundle/Tests/Controller/EntryControllerTest.php
+++ b/src/Wallabag/CoreBundle/Tests/Controller/EntryControllerTest.php
@@ -293,7 +293,6 @@ class EntryControllerTest extends WallabagCoreTestCase
     {
         $this->logInAs('admin');
         $client = $this->getClient();
-
         $crawler = $client->request('GET', '/config');
 
         $form = $crawler->filter('button[id=config_save]')->form();
@@ -309,5 +308,28 @@ class EntryControllerTest extends WallabagCoreTestCase
         $crawler = $client->request('GET', 'unread/list'.$parameters);
 
         $this->assertContains($parameters, $client->getResponse()->getContent());
+    }
+
+    public function testFilterOnDomainName()
+    {
+        $this->logInAs('admin');
+        $client = $this->getClient();
+
+        $crawler = $client->request('GET', '/unread/list');
+        $form = $crawler->filter('button[id=submit-filter]')->form();
+        $data = array(
+            'entry_filter[domainName]' => 'monde'
+        );
+
+        $crawler = $client->submit($form, $data);
+        $this->assertCount(1, $crawler->filter('div[class=entry]'));
+
+        $form = $crawler->filter('button[id=submit-filter]')->form();
+        $data = array(
+            'entry_filter[domainName]' => 'wallabag'
+        );
+
+        $crawler = $client->submit($form, $data);
+        $this->assertCount(0, $crawler->filter('div[class=entry]'));
     }
 }


### PR DESCRIPTION
I put a field text which looks for the domain names who contain the term (%term% in fact). I disabled the availibity to have a select list with these options: starts with, ends with, contains, is exactly. 
@j0k3r, @tcitworld Tell me if it's good for you.

After this PR is merged, @modos189 needs to enhance it with some JS and CSS :-) 