### PR TITLE
Fix date filter on same day

### DIFF
--- a/app/config/services.yml
+++ b/app/config/services.yml
@@ -4,6 +4,7 @@ parameters:
     security.authentication.provider.dao.class: Wallabag\CoreBundle\Security\Authentication\Provider\WallabagAuthenticationProvider
     security.encoder.digest.class: Wallabag\CoreBundle\Security\Authentication\Encoder\WallabagPasswordEncoder
     security.validator.user_password.class: Wallabag\CoreBundle\Security\Validator\WallabagUserPasswordValidator
+    lexik_form_filter.get_filter.doctrine_orm.class: Wallabag\CoreBundle\Event\Subscriber\CustomDoctrineORMSubscriber
 
 services:
     # used for tests

--- a/src/Wallabag/CoreBundle/Event/Subscriber/CustomDoctrineORMSubscriber.php
+++ b/src/Wallabag/CoreBundle/Event/Subscriber/CustomDoctrineORMSubscriber.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Wallabag\CoreBundle\Event\Subscriber;
+
+use Lexik\Bundle\FormFilterBundle\Event\Subscriber\DoctrineORMSubscriber;
+use Lexik\Bundle\FormFilterBundle\Event\GetFilterConditionEvent;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+/**
+ * This custom class override the default behavior of LexikFilterBundle on `filter_date_range`
+ * It converts a date_range to date_time_range to add hour to be able to grab a whole day (from 00:00:00 to 23:59:59)
+ */
+class CustomDoctrineORMSubscriber extends DoctrineORMSubscriber implements EventSubscriberInterface
+{
+    /**
+     * @param GetFilterConditionEvent $event
+     */
+    public function filterDateRange(GetFilterConditionEvent $event)
+    {
+        $expr   = $event->getFilterQuery()->getExpressionBuilder();
+        $values = $event->getValues();
+        $value  = $values['value'];
+
+        // left date should start at midnight
+        if (isset($value['left_date'][0]) && $value['left_date'][0] instanceOf \DateTime) {
+            $value['left_date'][0]->setTime(0, 0, 0);
+        }
+
+        // right adte should end one second before midnight
+        if (isset($value['right_date'][0]) && $value['right_date'][0] instanceOf \DateTime) {
+            $value['right_date'][0]->setTime(23, 59, 59);
+        }
+
+        if (isset($value['left_date'][0]) || isset($value['right_date'][0])) {
+            $event->setCondition($expr->dateTimeInRange($event->getField(), $value['left_date'][0], $value['right_date'][0]));
+        }
+    }
+}

--- a/src/Wallabag/CoreBundle/Event/Subscriber/CustomDoctrineORMSubscriber.php
+++ b/src/Wallabag/CoreBundle/Event/Subscriber/CustomDoctrineORMSubscriber.php
@@ -8,7 +8,7 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 /**
  * This custom class override the default behavior of LexikFilterBundle on `filter_date_range`
- * It converts a date_range to date_time_range to add hour to be able to grab a whole day (from 00:00:00 to 23:59:59)
+ * It converts a date_range to date_time_range to add hour to be able to grab a whole day (from 00:00:00 to 23:59:59).
  */
 class CustomDoctrineORMSubscriber extends DoctrineORMSubscriber implements EventSubscriberInterface
 {
@@ -17,17 +17,17 @@ class CustomDoctrineORMSubscriber extends DoctrineORMSubscriber implements Event
      */
     public function filterDateRange(GetFilterConditionEvent $event)
     {
-        $expr   = $event->getFilterQuery()->getExpressionBuilder();
+        $expr = $event->getFilterQuery()->getExpressionBuilder();
         $values = $event->getValues();
-        $value  = $values['value'];
+        $value = $values['value'];
 
         // left date should start at midnight
-        if (isset($value['left_date'][0]) && $value['left_date'][0] instanceOf \DateTime) {
+        if (isset($value['left_date'][0]) && $value['left_date'][0] instanceof \DateTime) {
             $value['left_date'][0]->setTime(0, 0, 0);
         }
 
         // right adte should end one second before midnight
-        if (isset($value['right_date'][0]) && $value['right_date'][0] instanceOf \DateTime) {
+        if (isset($value['right_date'][0]) && $value['right_date'][0] instanceof \DateTime) {
             $value['right_date'][0]->setTime(23, 59, 59);
         }
 

--- a/src/Wallabag/CoreBundle/Filter/EntryFilterType.php
+++ b/src/Wallabag/CoreBundle/Filter/EntryFilterType.php
@@ -27,8 +27,9 @@ class EntryFilterType extends AbstractType
                         ),
                         'format' => 'dd/MM/yyyy',
                         'widget' => 'single_text',
-                ),
-            ))
+                    ),
+                )
+            )
             ->add('domainName', 'filter_text', array(
                 'apply_filter' => function (QueryInterface $filterQuery, $field, $values) {
                         $value = $values['value'];

--- a/src/Wallabag/CoreBundle/Tests/Controller/EntryControllerTest.php
+++ b/src/Wallabag/CoreBundle/Tests/Controller/EntryControllerTest.php
@@ -279,6 +279,15 @@ class EntryControllerTest extends WallabagCoreTestCase
         $this->assertCount(5, $crawler->filter('div[class=entry]'));
 
         $data = array(
+            'entry_filter[createdAt][left_date]' => date('d/m/Y'),
+            'entry_filter[createdAt][right_date]' => date('d/m/Y'),
+        );
+
+        $crawler = $client->submit($form, $data);
+
+        $this->assertCount(5, $crawler->filter('div[class=entry]'));
+
+        $data = array(
             'entry_filter[createdAt][left_date]' => '01/01/1970',
             'entry_filter[createdAt][right_date]' => '01/01/1970',
         );


### PR DESCRIPTION
I override the default behavior of the filter_date_range to add time and allow filter for a single day

Fix #1379