### PR TITLE
Use full size of the panel for domain-filtering

### DIFF
--- a/src/Wallabag/CoreBundle/Resources/views/themes/material/Entry/entries.html.twig
+++ b/src/Wallabag/CoreBundle/Resources/views/themes/material/Entry/entries.html.twig
@@ -93,7 +93,7 @@
                     <label for="entry_filter_readingTime_right_number">{% trans %}to{% endtrans %}</label>
                 </div>
 
-                <div class="input-field col 12">
+                <div class="input-field col s12">
                     {{ form_widget(form.domainName, {'type': 'text', 'attr' : {'placeholder': 'website.com'} }) }}
                     <label for="entry_filter_domainName">{% trans %}Domain name{% endtrans %}</label>
                 </div>

--- a/src/Wallabag/CoreBundle/Resources/views/themes/material/Entry/entries.html.twig
+++ b/src/Wallabag/CoreBundle/Resources/views/themes/material/Entry/entries.html.twig
@@ -93,7 +93,7 @@
                     <label for="entry_filter_readingTime_right_number">{% trans %}to{% endtrans %}</label>
                 </div>
 
-                <div class="input-field col s6">
+                <div class="input-field col 12">
                     {{ form_widget(form.domainName, {'type': 'text', 'attr' : {'placeholder': 'website.com'} }) }}
                     <label for="entry_filter_domainName">{% trans %}Domain name{% endtrans %}</label>
                 </div>


### PR DESCRIPTION
For longer domains, use all the space.

![domain-filter-fullsize](https://cloud.githubusercontent.com/assets/2197836/9481215/a349c560-4b88-11e5-84c1-2afb2daaa6a3.png)

