### PR TITLE
Enabled created user from Config

### DIFF
--- a/src/Wallabag/CoreBundle/Controller/ConfigController.php
+++ b/src/Wallabag/CoreBundle/Controller/ConfigController.php
@@ -98,6 +98,8 @@ class ConfigController extends Controller
 
         // handle adding new user
         $newUser = new User();
+        // enable created user by default
+        $newUser->setEnabled(true);
         $newUserForm = $this->createForm(new NewUserType(), $newUser, array('validation_groups' => array('Profile')));
         $newUserForm->handleRequest($request);
 

--- a/src/Wallabag/CoreBundle/Tests/Controller/ConfigControllerTest.php
+++ b/src/Wallabag/CoreBundle/Tests/Controller/ConfigControllerTest.php
@@ -337,6 +337,14 @@ class ConfigControllerTest extends WallabagCoreTestCase
 
         $this->assertGreaterThan(1, $alert = $crawler->filter('div.messages.success')->extract(array('_text')));
         $this->assertContains('User "wallace" added', $alert[0]);
+
+        $em = $client->getContainer()->get('doctrine.orm.entity_manager');
+        $user = $em
+            ->getRepository('WallabagCoreBundle:User')
+            ->findOneByUsername('wallace');
+
+        $this->assertTrue(false !== $user);
+        $this->assertTrue($user->isEnabled());
     }
 
     public function testRssUpdateResetToken()


### PR DESCRIPTION
By default, creating user with FOSUser are disabled by default.

Fix #1423