### PR TITLE
SMTP from environment variables

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -85,6 +85,9 @@
             "Sensio\\Bundle\\DistributionBundle\\Composer\\ScriptHandler::clearCache",
             "Sensio\\Bundle\\DistributionBundle\\Composer\\ScriptHandler::installAssets",
             "Sensio\\Bundle\\DistributionBundle\\Composer\\ScriptHandler::installRequirementsFile"
+        ],
+        "build-parameters": [
+            "Incenteev\\ParameterHandler\\ScriptHandler::buildParameters"
         ]
     },
     "extra": {
@@ -92,7 +95,13 @@
         "symfony-web-dir": "web",
         "symfony-assets-install": "relative",
         "incenteev-parameters": {
-            "file": "app/config/parameters.yml"
+            "file": "app/config/parameters.yml",
+            "env-map": {
+                "mailer_host": "WALLABAG_MAILER_HOST",
+                "mailer_user": "WALLABAG_MAILER_USER",
+                "mailer_password": "WALLABAG_MAILER_PASSWORD",
+                "secret": "WALLABAG_SECRET"
+            }
         }
     },
     "autoload": {


### PR DESCRIPTION
Configuring SMTP parameters required to be written in files which is not convenient when using docker containers as the credentials need to be in the filesystem. Created environment parameters override for those parameters. A new build script created in order to generate those parameters right before launching the application.

This allows to build containers without [specifying credentials in the container itself](https://github.com/mathbruyen/home/blob/424542ae568b8c23af8d9585d4390db421cf9ca3/wallabag/Dockerfile) and [use them in kubernetes](https://github.com/mathbruyen/home/blob/424542ae568b8c23af8d9585d4390db421cf9ca3/wallabag-controller.yaml) (I'm also looking at [this PR on kubernetes](https://github.com/kubernetes/kubernetes/issues/4710) for storing the password in a secret out of source control rather than in the replication controller configuration but this is independent of wallabag).

All the parameters are prefixed with `WALLABAG_`. I can also add others like all database configuration if you like the way to do it.