### PR TITLE
[proof-of-concept] restricted content access implementation

### DIFF
--- a/app/config/parameters.yml.dist
+++ b/app/config/parameters.yml.dist
@@ -59,3 +59,7 @@ parameters:
     language: en_US
     from_email: no-reply@wallabag.org
     rss_limit: 50
+
+    # login to external sites
+    mediapart_login: ~
+    mediapart_password: ~

--- a/app/config/tests/parameters.yml.dist.mysql
+++ b/app/config/tests/parameters.yml.dist.mysql
@@ -59,3 +59,7 @@ parameters:
     language: en_US
     from_email: no-reply@wallabag.org
     rss_limit: 50
+
+    # login to external sites
+    mediapart_login: ~
+    mediapart_password: ~

--- a/app/config/tests/parameters.yml.dist.pgsql
+++ b/app/config/tests/parameters.yml.dist.pgsql
@@ -59,3 +59,7 @@ parameters:
     language: en_US
     from_email: no-reply@wallabag.org
     rss_limit: 50
+
+    # login to external sites
+    mediapart_login: ~
+    mediapart_password: ~

--- a/app/config/tests/parameters.yml.dist.sqlite
+++ b/app/config/tests/parameters.yml.dist.sqlite
@@ -59,3 +59,7 @@ parameters:
     language: en_US
     from_email: no-reply@wallabag.org
     rss_limit: 50
+
+    # login to external sites
+    mediapart_login: ~
+    mediapart_password: ~

--- a/src/Wallabag/CoreBundle/Authenticator/FileCookieJarFactory.php
+++ b/src/Wallabag/CoreBundle/Authenticator/FileCookieJarFactory.php
@@ -1,0 +1,27 @@
+<?php
+
+/**
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+
+namespace Wallabag\CoreBundle\Authenticator;
+
+use GuzzleHttp\Cookie\FileCookieJar;
+
+class FileCookieJarFactory
+{
+    private $cookieFilePathName;
+
+    public function __construct($cookieFilePathName)
+    {
+        $this->cookieFilePathName = $cookieFilePathName;
+    }
+
+    /**
+     * @return \GuzzleHttp\Cookie\CookieJar
+     */
+    public function createCookieJar()
+    {
+        return new FileCookieJar($this->cookieFilePathName);
+    }
+}

--- a/src/Wallabag/CoreBundle/Helper/ContentProxy/Authenticator/AbstractFormBasedAuthenticator.php
+++ b/src/Wallabag/CoreBundle/Helper/ContentProxy/Authenticator/AbstractFormBasedAuthenticator.php
@@ -1,0 +1,101 @@
+<?php
+
+namespace Wallabag\CoreBundle\Helper\ContentProxy\Authenticator;
+
+use Wallabag\CoreBundle\Helper\ContentProxy\Authenticator\Exception\AuthenticatorException;
+use Wallabag\CoreBundle\Helper\ContentProxy\Authenticator\WebsiteAuthenticator\CookieBased;
+use Wallabag\CoreBundle\Helper\ContentProxy\Authenticator\WebsiteAuthenticator\CredentialsBased;
+use Wallabag\CoreBundle\Helper\ContentProxy\Authenticator\WebsiteAuthenticator\FormBased;
+use Wallabag\CoreBundle\Helper\ContentProxy\Authenticator\WebsiteAuthenticator\UrlBased;
+use GuzzleHttp\Client;
+use GuzzleHttp\Cookie\CookieJar;
+
+abstract class AbstractFormBasedAuthenticator implements CredentialsBased, UrlBased, FormBased, CookieBased
+{
+    /** @var CookieJar */
+    private $cookieJar = true;
+
+    /** @var string */
+    private $username;
+
+    /** @var string */
+    private $password;
+
+    /** @var string */
+    private $uri;
+
+    /** @var \GuzzleHttp\Client */
+    protected $guzzle;
+
+    public function setGuzzleClient(Client $guzzle)
+    {
+        $this->guzzle = $guzzle;
+    }
+
+    public function setCredentials($username, $password)
+    {
+        $this->username = $username;
+        $this->password = $password;
+    }
+
+    public function setCookieJar(CookieJar $cookieJar)
+    {
+        $this->cookieJar = $cookieJar;
+    }
+
+    public function getUsername()
+    {
+        return $this->username;
+    }
+
+    public function getPassword()
+    {
+        return $this->password;
+    }
+
+    public function setUri($uri)
+    {
+        $this->uri = $uri;
+    }
+
+    public function getUri()
+    {
+        return $this->uri;
+    }
+
+    public function login()
+    {
+        $postFields = [
+            $this->getUsernameFieldName() => $this->getUsername(),
+            $this->getPasswordFieldName() => $this->getPassword(),
+        ] + $this->getExtraFormFields();
+
+        $this->guzzle->post(
+            $this->getUri(),
+            ['body' => $postFields, 'allow_redirects' => true, 'cookies' => $this->getCookieJar(), 'verify' => false]
+        );
+
+        $this->verifyCookies($this->getCookieJar());
+    }
+
+    /**
+     * @return CookieJar
+     */
+    public function getCookieJar()
+    {
+        return $this->cookieJar;
+    }
+
+    public function isLoggedIn()
+    {
+        if ($this->cookieJar instanceof CookieJar) {
+            try {
+                return $this->verifyCookies($this->cookieJar);
+            } catch (AuthenticatorException $e) {
+                return false;
+            }
+        }
+
+        return false;
+    }
+}

--- a/src/Wallabag/CoreBundle/Helper/ContentProxy/Authenticator/Exception/AuthenticatorException.php
+++ b/src/Wallabag/CoreBundle/Helper/ContentProxy/Authenticator/Exception/AuthenticatorException.php
@@ -1,0 +1,17 @@
+<?php
+
+/**
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+
+namespace Wallabag\CoreBundle\Helper\ContentProxy\Authenticator\Exception;
+
+use Exception;
+
+class AuthenticatorException extends Exception
+{
+    public function __construct($message, $uri = 'n/a')
+    {
+        parent::__construct($message.'. Uri: '.$uri, 0);
+    }
+}

--- a/src/Wallabag/CoreBundle/Helper/ContentProxy/Authenticator/Site/MediapartAuthenticator.php
+++ b/src/Wallabag/CoreBundle/Helper/ContentProxy/Authenticator/Site/MediapartAuthenticator.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Wallabag\CoreBundle\Helper\ContentProxy\Authenticator\Site;
+
+use Wallabag\CoreBundle\Helper\ContentProxy\Authenticator\AbstractFormBasedAuthenticator;
+use Wallabag\CoreBundle\Helper\ContentProxy\Authenticator\Exception\AuthenticatorException;
+use Wallabag\CoreBundle\Helper\ContentProxy\Authenticator\WebsiteAuthenticator;
+use Wallabag\CoreBundle\Helper\ContentProxy\Authenticator\WebsiteAuthenticator\CookieBased;
+use Wallabag\CoreBundle\Helper\ContentProxy\Authenticator\WebsiteAuthenticator\CredentialsBased;
+use Wallabag\CoreBundle\Helper\ContentProxy\Authenticator\WebsiteAuthenticator\FormBased;
+use Wallabag\CoreBundle\Helper\ContentProxy\Authenticator\WebsiteAuthenticator\UrlBased;
+use GuzzleHttp\Cookie\CookieJar;
+use GuzzleHttp\Cookie\SetCookie;
+
+class MediapartAuthenticator
+    extends AbstractFormBasedAuthenticator
+    implements WebsiteAuthenticator, UrlBased, CredentialsBased, FormBased, CookieBased
+{
+    public function getUsernameFieldName()
+    {
+        return 'name';
+    }
+
+    public function getPasswordFieldName()
+    {
+        return 'password';
+    }
+
+    public function getExtraFormFields()
+    {
+        return ['op' => 'ok'];
+    }
+
+    public function verifyCookies(CookieJar $cookieJar)
+    {
+        /** @var SetCookie $cookie */
+        foreach ($cookieJar as $cookie) {
+            if ($cookie->getDomain() === '.mediapart.fr' && $cookie->getName() == 'MPSESSID') {
+                return true;
+            }
+        }
+
+        throw new AuthenticatorException($this->getUri());
+    }
+
+    public function requiresAuth($html)
+    {
+        // we use the length since the restricted access text gets filtered by Graby
+        return strlen($html) < 1000;
+    }
+}

--- a/src/Wallabag/CoreBundle/Helper/ContentProxy/Authenticator/WebsiteAuthenticator.php
+++ b/src/Wallabag/CoreBundle/Helper/ContentProxy/Authenticator/WebsiteAuthenticator.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Wallabag\CoreBundle\Helper\ContentProxy\Authenticator;
+
+interface WebsiteAuthenticator
+{
+    /**
+     * Logs the configured user, and returns the session cookie string.
+     */
+    public function login();
+
+    public function setCredentials($username, $password);
+
+    /**
+     * Checks if we are logged into the site, but without calling the server (e.g. do we have a Cookie).
+     *
+     * @return bool
+     */
+    public function isLoggedIn();
+
+    /**
+     * Checks from the HTML of a page if authentication is requested by a grabbed page.
+     *
+     * @param string $html
+     *
+     * @return bool
+     */
+    public function requiresAuth($html);
+}

--- a/src/Wallabag/CoreBundle/Helper/ContentProxy/Authenticator/WebsiteAuthenticator/CookieBased.php
+++ b/src/Wallabag/CoreBundle/Helper/ContentProxy/Authenticator/WebsiteAuthenticator/CookieBased.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Wallabag\CoreBundle\Helper\ContentProxy\Authenticator\WebsiteAuthenticator;
+
+use GuzzleHttp\Cookie\CookieJar;
+use Wallabag\CoreBundle\Helper\ContentProxy\Authenticator\Exception\AuthenticatorException;
+
+interface CookieBased
+{
+    /**
+     * Verifies the contents of the cookie jar after login.
+     *
+     * @param \GuzzleHttp\Cookie\CookieJar $cookieJar
+     *
+     * @throws AuthenticatorException If login failed
+     */
+    public function verifyCookies(CookieJar $cookieJar);
+
+    public function getCookieJar();
+}

--- a/src/Wallabag/CoreBundle/Helper/ContentProxy/Authenticator/WebsiteAuthenticator/CredentialsBased.php
+++ b/src/Wallabag/CoreBundle/Helper/ContentProxy/Authenticator/WebsiteAuthenticator/CredentialsBased.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Wallabag\CoreBundle\Helper\ContentProxy\Authenticator\WebsiteAuthenticator;
+
+interface CredentialsBased
+{
+    public function setCredentials($username, $password);
+
+    public function getUsername();
+
+    public function getPassword();
+}

--- a/src/Wallabag/CoreBundle/Helper/ContentProxy/Authenticator/WebsiteAuthenticator/FormBased.php
+++ b/src/Wallabag/CoreBundle/Helper/ContentProxy/Authenticator/WebsiteAuthenticator/FormBased.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Wallabag\CoreBundle\Helper\ContentProxy\Authenticator\WebsiteAuthenticator;
+
+interface FormBased
+{
+    public function getUsernameFieldName();
+
+    public function getPasswordFieldName();
+
+    public function getExtraFormFields();
+}

--- a/src/Wallabag/CoreBundle/Helper/ContentProxy/Authenticator/WebsiteAuthenticator/UrlBased.php
+++ b/src/Wallabag/CoreBundle/Helper/ContentProxy/Authenticator/WebsiteAuthenticator/UrlBased.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Wallabag\CoreBundle\Helper\ContentProxy\Authenticator\WebsiteAuthenticator;
+
+interface UrlBased
+{
+    public function setUri($uri);
+
+    public function getUri();
+}

--- a/src/Wallabag/CoreBundle/Resources/config/services.yml
+++ b/src/Wallabag/CoreBundle/Resources/config/services.yml
@@ -53,7 +53,12 @@ services:
     wallabag_core.http_client:
         class: GuzzleHttp\Client
         arguments:
-            - {"defaults": {"cookies": @wallabag_core.authenticator.cookie_jar}}
+            -
+                "defaults": {"cookies": @wallabag_core.authenticator.cookie_jar}
+                "handler": @wallabag_core.http_client.safe_curl_handler
+
+    wallabag_core.http_client.safe_curl_handler:
+        class: Graby\Ring\Client\SafeCurlHandler
 
     wallabag_core.authenticator.cookie_jar:
         class: GuzzleHttp\Cookie\CookieJar
@@ -71,6 +76,7 @@ services:
             - @wallabag_core.graby
             - @wallabag_core.rule_based_tagger
             - @logger
+            - @wallabag_core.authenticator.mediapart
 
     wallabag_core.rule_based_tagger:
         class: Wallabag\CoreBundle\Helper\RuleBasedTagger
@@ -117,3 +123,11 @@ services:
         class: Wallabag\CoreBundle\Operator\Doctrine\Matches
         tags:
             - { name: rulerz.operator, executor: rulerz.executor.doctrine, operator: matches, inline: true }
+
+    wallabag_core.authenticator.mediapart:
+        class: Wallabag\CoreBundle\Helper\ContentProxy\Authenticator\Site\MediapartAuthenticator
+        calls:
+            - [setUri, ['https://www.mediapart.fr/login_check']]
+            - [setCredentials, [%mediapart_login%, %mediapart_password%]]
+            - [setGuzzleClient, [@wallabag_core.http_client]]
+            - [setCookieJar, [@wallabag_core.authenticator.cookie_jar]]

--- a/src/Wallabag/CoreBundle/Resources/config/services.yml
+++ b/src/Wallabag/CoreBundle/Resources/config/services.yml
@@ -44,10 +44,26 @@ services:
         class: Graby\Graby
         arguments:
             - { error_message: false }
+            - @wallabag_core.http_client
         calls:
             - [ setLogger, [ @logger ] ]
         tags:
             - { name: monolog.logger, channel: graby }
+
+    wallabag_core.http_client:
+        class: GuzzleHttp\Client
+        arguments:
+            - {"defaults": {"cookies": @wallabag_core.authenticator.cookie_jar}}
+
+    wallabag_core.authenticator.cookie_jar:
+        class: GuzzleHttp\Cookie\CookieJar
+        factory_service: wallabag_core.authenticator.cookie_jar_factory
+        factory_method: createCookieJar
+
+    wallabag_core.authenticator.cookie_jar_factory:
+        class: Wallabag\CoreBundle\Authenticator\FileCookieJarFactory
+        arguments:
+            - "%kernel.cache_dir%/cookiejar.json"
 
     wallabag_core.content_proxy:
         class: Wallabag\CoreBundle\Helper\ContentProxy


### PR DESCRIPTION
> Proof of concept of site authentication

Based on a discussion with @j0k3r on gitter, and a comment I made on #438. Interested in feedback. Should work with mediapart.fr, with login & password in `parameters.yml`.

### Session handling
Introduces a guzzle client service, injected into Graby. This service uses a `CookieJar` that stores cookies to `app/cache/env/cookiejar.json` (will be created if it doesn't exist). Relevant cookies will be sent with the request, meaning that if the session is valid, authenticated content can be grabbed.

`cookiejar.json` example:

```json
[
    {
        "Discard": false,
        "Domain": ".mediapart.fr",
        "Expires": 1451314010,
        "HttpOnly": false,
        "Max-Age": "604800",
        "Name": "MPSESSID",
        "Path": "/",
        "Secure": true,
        "Value": "foobar"
    }
]
```

### Authenticator
An authenticator service is added to the `ContentProxy`. It is used to login to the site if required.

Currently hardcoded to the `MediapartAuthenticator`. Needs to be changed to a dispatcher of some sorts, probably using the uri / site name (or let authenticators test the uri, `supports($uri)`.

#### Site handlers
Added one for mediapart. Also have one for monde-diplomatique.fr, I'll add it.

### Question: does it belong here or in Graby ?
The CookieJar part could very well be part of graby. It would avoid the raw HTML thing, and would probably make more sense. The CookieJar could still be maintained from wallabag itself. Graby could support the basic FileCookieJar, while Wallabag could use one based on the database.

### TODO
- [ ] Move some of the logic to Graby instead.