### PR TITLE
v2 – 	Avoid multiple tag creation

### DIFF
--- a/src/Wallabag/CoreBundle/DataFixtures/ORM/LoadTaggingRuleData.php
+++ b/src/Wallabag/CoreBundle/DataFixtures/ORM/LoadTaggingRuleData.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Wallabag\CoreBundle\DataFixtures\ORM;
+
+use Doctrine\Common\DataFixtures\AbstractFixture;
+use Doctrine\Common\DataFixtures\OrderedFixtureInterface;
+use Doctrine\Common\Persistence\ObjectManager;
+use Wallabag\CoreBundle\Entity\TaggingRule;
+
+class LoadTaggingRuleData extends AbstractFixture implements OrderedFixtureInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function load(ObjectManager $manager)
+    {
+        $tr1 = new TaggingRule();
+        $tr1->setRule('content matches "spurs"');
+        $tr1->setTags(array('sport'));
+        $tr1->setConfig($this->getReference('admin-config'));
+
+        $manager->persist($tr1);
+
+        $tr2 = new TaggingRule();
+        $tr2->setRule('content matches "basket"');
+        $tr2->setTags(array('sport'));
+        $tr2->setConfig($this->getReference('admin-config'));
+
+        $manager->persist($tr2);
+
+        $manager->flush();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getOrder()
+    {
+        return 40;
+    }
+}

--- a/src/Wallabag/CoreBundle/Entity/Entry.php
+++ b/src/Wallabag/CoreBundle/Entity/Entry.php
@@ -462,6 +462,14 @@ class Entry
             return;
         }
 
+        // check if tag already exist but has not yet be persisted
+        // it seems that the previous condition with `contains()` doesn't check that case
+        foreach ($this->tags as $existingTag) {
+            if ($existingTag->getUser() !== $tag->getUser() || $existingTag->getLabel() === $tag->getLabel()) {
+                return;
+            }
+        }
+
         $this->tags[] = $tag;
         $tag->addEntry($this);
     }

--- a/src/Wallabag/CoreBundle/Helper/RuleBasedTagger.php
+++ b/src/Wallabag/CoreBundle/Helper/RuleBasedTagger.php
@@ -65,7 +65,6 @@ class RuleBasedTagger
                     $tag = $this->getTag($user, $label);
 
                     $entry->addTag($tag);
-                    $entries[] = $entry;
                 }
             }
         }

--- a/src/Wallabag/CoreBundle/Tests/Helper/RuleBasedTaggerTest.php
+++ b/src/Wallabag/CoreBundle/Tests/Helper/RuleBasedTaggerTest.php
@@ -121,6 +121,26 @@ class RuleBasedTaggerTest extends \PHPUnit_Framework_TestCase
         $this->assertSame($tag, $tags[0]);
     }
 
+    public function testSameTagWithDifferentfMatchingRules()
+    {
+        $taggingRule = $this->getTaggingRule('bla bla', array('hey'));
+        $otherTaggingRule = $this->getTaggingRule('rule as string', array('hey'));
+
+        $user = $this->getUser([$taggingRule, $otherTaggingRule]);
+        $entry = new Entry($user);
+
+        $this->rulerz
+            ->method('satisfies')
+            ->willReturn(true);
+
+        $this->tagger->tag($entry);
+
+        $this->assertFalse($entry->getTags()->isEmpty());
+
+        $tags = $entry->getTags();
+        $this->assertCount(1, $tags);
+    }
+
     private function getUser(array $taggingRules = [])
     {
         $user = new User();

--- a/src/Wallabag/CoreBundle/Tests/Helper/RuleBasedTaggerTest.php
+++ b/src/Wallabag/CoreBundle/Tests/Helper/RuleBasedTaggerTest.php
@@ -141,6 +141,32 @@ class RuleBasedTaggerTest extends \PHPUnit_Framework_TestCase
         $this->assertCount(1, $tags);
     }
 
+    public function testTagAllEntriesForAUser()
+    {
+        $taggingRule = $this->getTaggingRule('bla bla', array('hey'));
+
+        $user = $this->getUser([$taggingRule]);
+
+        $this->rulerz
+            ->method('satisfies')
+            ->willReturn(true);
+
+        $this->rulerz
+            ->method('filter')
+            ->willReturn(array(new Entry($user), new Entry($user)));
+
+        $entries = $this->tagger->tagAllForUser($user);
+
+        $this->assertCount(2, $entries);
+
+        foreach ($entries as $entry) {
+            $tags = $entry->getTags();
+
+            $this->assertCount(1, $tags);
+            $this->assertEquals('hey', $tags[0]->getLabel());
+        }
+    }
+
     private function getUser(array $taggingRules = [])
     {
         $user = new User();


### PR DESCRIPTION
When a new tag is created but not yet persisted, it can be duplicated.
It could happen when multiple rules match the content and at least 2 of them should attach same new tag.

Fix #1528