### PR TITLE
v2 – Add custom email for 2FA

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,6 @@ matrix:
         - php: hhvm
           env: DB=pgsql  # driver for PostgreSQL currently unsupported by HHVM, requires 3rd party dependency
     allow_failures:
-        - php: 7.0
         - php: hhvm
 
 branches:

--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -198,6 +198,7 @@ scheb_two_factor:
         sender_email: %twofactor_sender%
         digits: 6
         template: WallabagUserBundle:Authentication:form.html.twig
+        mailer: wallabag_user.auth_code_mailer
 
 kphoen_rulerz:
     executors:

--- a/app/config/parameters.yml.dist
+++ b/app/config/parameters.yml.dist
@@ -52,10 +52,11 @@ parameters:
     export_mobi: true
     export_pdf: true
     wallabag_url: http://v2.wallabag.org
+    wallabag_support_url: 'https://www.wallabag.org/pages/support.html'
 
     # default user config
     items_on_page: 12
     theme: material
-    language: en_US
+    language: en
     from_email: no-reply@wallabag.org
     rss_limit: 50

--- a/app/config/tests/parameters.yml.dist.mysql
+++ b/app/config/tests/parameters.yml.dist.mysql
@@ -52,6 +52,7 @@ parameters:
     export_mobi: true
     export_pdf: true
     wallabag_url: http://v2.wallabag.org
+    wallabag_support_url: 'https://www.wallabag.org/pages/support.html'
 
     # default user config
     items_on_page: 12

--- a/app/config/tests/parameters.yml.dist.pgsql
+++ b/app/config/tests/parameters.yml.dist.pgsql
@@ -52,6 +52,7 @@ parameters:
     export_mobi: true
     export_pdf: true
     wallabag_url: http://v2.wallabag.org
+    wallabag_support_url: 'https://www.wallabag.org/pages/support.html'
 
     # default user config
     items_on_page: 12

--- a/app/config/tests/parameters.yml.dist.sqlite
+++ b/app/config/tests/parameters.yml.dist.sqlite
@@ -52,6 +52,7 @@ parameters:
     export_mobi: true
     export_pdf: true
     wallabag_url: http://v2.wallabag.org
+    wallabag_support_url: 'https://www.wallabag.org/pages/support.html'
 
     # default user config
     items_on_page: 12

--- a/src/Wallabag/CoreBundle/DataFixtures/ORM/LoadConfigData.php
+++ b/src/Wallabag/CoreBundle/DataFixtures/ORM/LoadConfigData.php
@@ -25,7 +25,7 @@ class LoadConfigData extends AbstractFixture implements OrderedFixtureInterface
 
         $adminConfig->setTheme('material');
         $adminConfig->setItemsPerPage(30);
-        $adminConfig->setLanguage('en_US');
+        $adminConfig->setLanguage('en');
 
         $manager->persist($adminConfig);
 
@@ -34,7 +34,7 @@ class LoadConfigData extends AbstractFixture implements OrderedFixtureInterface
         $bobConfig = new Config($this->getReference('bob-user'));
         $bobConfig->setTheme('default');
         $bobConfig->setItemsPerPage(10);
-        $bobConfig->setLanguage('fr_FR');
+        $bobConfig->setLanguage('fr');
 
         $manager->persist($bobConfig);
 

--- a/src/Wallabag/CoreBundle/Resources/views/themes/baggy/Config/index.html.twig
+++ b/src/Wallabag/CoreBundle/Resources/views/themes/baggy/Config/index.html.twig
@@ -40,6 +40,10 @@
     {{ form_start(form.rss) }}
         {{ form_errors(form.rss) }}
 
+        <div class="row">
+            {% trans %}RSS feeds provided by wallabag allow you to read your saved articles with your favourite RSS reader.{% endtrans %}
+        </div>
+
         <fieldset class="w500p inline">
             <div class="row">
                 <label>Rss token</label>
@@ -101,6 +105,10 @@
         </fieldset>
 
         {% if twofactor_auth %}
+        <div class="row">
+            {% trans %}Enabling two factor authentication means you'll receive an email with a code on every new untrusted connexion{% endtrans %}
+        </div>
+
         <fieldset class="w500p inline">
             <div class="row">
                 {{ form_label(form.user.twoFactorAuthentication) }}

--- a/src/Wallabag/CoreBundle/Resources/views/themes/material/Config/index.html.twig
+++ b/src/Wallabag/CoreBundle/Resources/views/themes/material/Config/index.html.twig
@@ -133,6 +133,12 @@
                             {% if twofactor_auth %}
                             <div class="row">
                                 <div class="input-field col s12">
+                                    {% trans %}Enabling two factor authentication means you'll receive an email with a code on every new untrusted connexion{% endtrans %}
+                                </div>
+                            </div>
+
+                            <div class="row">
+                                <div class="input-field col s12">
                                     {{ form_widget(form.user.twoFactorAuthentication) }}
                                     {{ form_label(form.user.twoFactorAuthentication) }}
                                     {{ form_errors(form.user.twoFactorAuthentication) }}

--- a/src/Wallabag/CoreBundle/Tests/Controller/ConfigControllerTest.php
+++ b/src/Wallabag/CoreBundle/Tests/Controller/ConfigControllerTest.php
@@ -44,7 +44,7 @@ class ConfigControllerTest extends WallabagCoreTestCase
         $form = $crawler->filter('button[id=config_save]')->form();
 
         $data = array(
-            'config[theme]' => 0,
+            'config[theme]' => 'baggy',
             'config[items_per_page]' => '30',
             'config[language]' => 'en',
         );
@@ -63,7 +63,7 @@ class ConfigControllerTest extends WallabagCoreTestCase
     {
         return array(
             array(array(
-                'config[theme]' => 0,
+                'config[theme]' => 'baggy',
                 'config[items_per_page]' => '',
                 'config[language]' => 'en',
             )),

--- a/src/Wallabag/UserBundle/DependencyInjection/Configuration.php
+++ b/src/Wallabag/UserBundle/DependencyInjection/Configuration.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Wallabag\UserBundle\DependencyInjection;
+
+use Symfony\Component\Config\Definition\Builder\TreeBuilder;
+use Symfony\Component\Config\Definition\ConfigurationInterface;
+
+class Configuration implements ConfigurationInterface
+{
+    public function getConfigTreeBuilder()
+    {
+        $treeBuilder = new TreeBuilder();
+        $rootNode = $treeBuilder->root('wallabag_user');
+
+        return $treeBuilder;
+    }
+}

--- a/src/Wallabag/UserBundle/DependencyInjection/WallabagUserExtension.php
+++ b/src/Wallabag/UserBundle/DependencyInjection/WallabagUserExtension.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Wallabag\UserBundle\DependencyInjection;
+
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\Config\FileLocator;
+use Symfony\Component\HttpKernel\DependencyInjection\Extension;
+use Symfony\Component\DependencyInjection\Loader;
+
+class WallabagUserExtension extends Extension
+{
+    public function load(array $configs, ContainerBuilder $container)
+    {
+        $configuration = new Configuration();
+        $config = $this->processConfiguration($configuration, $configs);
+
+        $loader = new Loader\YamlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
+        $loader->load('services.yml');
+    }
+
+    public function getAlias()
+    {
+        return 'wallabag_user';
+    }
+}

--- a/src/Wallabag/UserBundle/Mailer/AuthCodeMailer.php
+++ b/src/Wallabag/UserBundle/Mailer/AuthCodeMailer.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace Wallabag\UserBundle\Mailer;
+
+use Scheb\TwoFactorBundle\Model\Email\TwoFactorInterface;
+use Scheb\TwoFactorBundle\Mailer\AuthCodeMailerInterface;
+use Symfony\Component\Translation\DataCollectorTranslator;
+
+/**
+ * Custom mailer for TwoFactorBundle email.
+ * It adds a custom template to the email so user won't get a lonely authentication code but a complete email.
+ */
+class AuthCodeMailer implements AuthCodeMailerInterface
+{
+    /**
+     * SwiftMailer.
+     *
+     * @var \Swift_Mailer
+     */
+    private $mailer;
+
+    /**
+     * Translator for email content.
+     *
+     * @var DataCollectorTranslator
+     */
+    private $translator;
+
+    /**
+     * Sender email address.
+     *
+     * @var string
+     */
+    private $senderEmail;
+
+    /**
+     * Sender name.
+     *
+     * @var string
+     */
+    private $senderName;
+
+    /**
+     * Support URL to report any bugs.
+     *
+     * @var string
+     */
+    private $supportUrl;
+
+    /**
+     * Initialize the auth code mailer with the SwiftMailer object.
+     *
+     * @param \Swift_Mailer           $mailer
+     * @param DataCollectorTranslator $translator
+     * @param string                  $senderEmail
+     * @param string                  $senderName
+     * @param string                  $supportUrl
+     */
+    public function __construct(\Swift_Mailer $mailer, DataCollectorTranslator $translator, $senderEmail, $senderName, $supportUrl)
+    {
+        $this->mailer = $mailer;
+        $this->translator = $translator;
+        $this->senderEmail = $senderEmail;
+        $this->senderName = $senderName;
+        $this->supportUrl = $supportUrl;
+    }
+
+    /**
+     * Send the auth code to the user via email.
+     *
+     * @param TwoFactorInterface $user
+     */
+    public function sendAuthCode(TwoFactorInterface $user)
+    {
+        $message = new \Swift_Message();
+        $message
+            ->setTo($user->getEmail())
+            ->setFrom($this->senderEmail, $this->senderName)
+            ->setSubject($this->translator->trans('auth_code.mailer.subject', array(), 'wallabag_user'))
+            ->setBody($this->translator->trans(
+                'auth_code.mailer.body',
+                [
+                    '%user%' => $user->getName(),
+                    '%code%' => $user->getEmailAuthCode(),
+                    '%support%' => $this->supportUrl,
+                ],
+                'wallabag_user'
+            ))
+        ;
+
+        $this->mailer->send($message);
+    }
+}

--- a/src/Wallabag/UserBundle/Resources/config/services.yml
+++ b/src/Wallabag/UserBundle/Resources/config/services.yml
@@ -1,0 +1,9 @@
+services:
+    wallabag_user.auth_code_mailer:
+        class: Wallabag\UserBundle\Mailer\AuthCodeMailer
+        arguments:
+            - "@mailer"
+            - "@translator"
+            - "%scheb_two_factor.email.sender_email%"
+            - "%scheb_two_factor.email.sender_name%"
+            - "%wallabag_support_url%"

--- a/src/Wallabag/UserBundle/Resources/translations/wallabag_user.en.yml
+++ b/src/Wallabag/UserBundle/Resources/translations/wallabag_user.en.yml
@@ -1,0 +1,10 @@
+# Two factor mail
+auth_code.mailer.subject: 'Wallabag authentication Code'
+auth_code.mailer.body: |
+    Hi %user%,
+
+    Since you enable two factor authentication on your wallabag account and you just logged in from a new device (computer, phone, etc.), we send you a code to validate your connection.
+    Here is the code: %code%
+
+    Please don't hesitate to contact us if you have any problems: %support%
+    The wallabag team

--- a/src/Wallabag/UserBundle/Resources/translations/wallabag_user.fr.yml
+++ b/src/Wallabag/UserBundle/Resources/translations/wallabag_user.fr.yml
@@ -1,0 +1,10 @@
+# Two factor mail
+auth_code.mailer.subject: "Code d'authentification wallabag"
+auth_code.mailer.body: |
+    Bonjour %user%,
+
+    Comme vous avez activé la double authentification sur votre compte wallabag et que vous venez de vous connecter depuis un nouvel appareil (ordinateur, téléphone, etc.), nous vous envoyons un code pour valider votre connexion.
+    Voici le code à renseigner: %code%
+
+    Si vous avez un problème de connexion, n'hésitez pas à contacter le support: %support%
+    L'équipe wallabag

--- a/src/Wallabag/UserBundle/Tests/Mailer/AuthCodeMailerTest.php
+++ b/src/Wallabag/UserBundle/Tests/Mailer/AuthCodeMailerTest.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace Wallabag\UserBundle\Tests\Mailer;
+
+use Wallabag\UserBundle\Entity\User;
+use Wallabag\UserBundle\Mailer\AuthCodeMailer;
+use Symfony\Component\Translation\Translator;
+use Symfony\Component\Translation\Loader\ArrayLoader;
+use Symfony\Component\Translation\DataCollectorTranslator;
+
+/**
+ * @see https://www.pmg.com/blog/integration-testing-swift-mailer/
+ */
+final class CountableMemorySpool extends \Swift_MemorySpool implements \Countable
+{
+    public function count()
+    {
+        return count($this->messages);
+    }
+
+    public function getMessages()
+    {
+        return $this->messages;
+    }
+}
+
+class AuthCodeMailerTest extends \PHPUnit_Framework_TestCase
+{
+    protected $mailer;
+    protected $spool;
+    protected $dataCollector;
+
+    protected function setUp()
+    {
+        $this->spool = new CountableMemorySpool();
+        $transport = new \Swift_Transport_SpoolTransport(
+            new \Swift_Events_SimpleEventDispatcher(),
+            $this->spool
+        );
+        $this->mailer = new \Swift_Mailer($transport);
+
+        $translator = new Translator('en');
+        $translator->addLoader('array', new ArrayLoader());
+        $translator->addResource('array', array(
+            'auth_code.mailer.subject' => 'auth_code subject',
+            'auth_code.mailer.body' => 'Hi %user%, here is the code: %code% and the support: %support%',
+        ), 'en', 'wallabag_user');
+
+        $this->dataCollector = new DataCollectorTranslator($translator);
+    }
+
+    public function testSendEmail()
+    {
+        $user = new User();
+        $user->setTwoFactorAuthentication(true);
+        $user->setEmailAuthCode(666666);
+        $user->setEmail('test@wallabag.io');
+        $user->setName('Bob');
+
+        $authCodeMailer = new AuthCodeMailer(
+            $this->mailer,
+            $this->dataCollector,
+            'nobody@test.io',
+            'wallabag test',
+            'http://0.0.0.0'
+        );
+
+        $authCodeMailer->sendAuthCode($user);
+
+        $this->assertCount(1, $this->spool);
+
+        $msg = $this->spool->getMessages()[0];
+        $this->assertArrayHasKey('test@wallabag.io', $msg->getTo());
+        $this->assertEquals(array('nobody@test.io' => 'wallabag test'), $msg->getFrom());
+        $this->assertEquals('auth_code subject', $msg->getSubject());
+        $this->assertContains('Hi Bob, here is the code: 666666 and the support: http://0.0.0.0', $msg->toString());
+    }
+}


### PR DESCRIPTION
Related #1490 

Here is the email template:

> Hi Jeremy,
>
> Since you enable two factor authentication on your wallabag account and you just logged in from a new device (computer, phone, etc.), we send you a code to validate your connection.
>Here is the code: 412585
>
>Please don't hesitate to contact us if you have any problems: https://www.wallabag.org/pages/support.html
>The wallabag team
