### PR TITLE
v2 – Fix wrong if when deleting an entry

### DIFF
--- a/src/Wallabag/CoreBundle/Controller/EntryController.php
+++ b/src/Wallabag/CoreBundle/Controller/EntryController.php
@@ -347,7 +347,7 @@ class EntryController extends Controller
         );
 
         // don't redirect user to the deleted entry
-        return $this->redirect($url !== $request->headers->get('referer') ?: $this->generateUrl('homepage'));
+        return $this->redirect($url !== $request->headers->get('referer') ? $request->headers->get('referer') : $this->generateUrl('homepage'));
     }
 
     /**


### PR DESCRIPTION
Bad condition when deleting an entry returned `true` instead of the referer url.

Following #1540