### PR TITLE
Use translator interface instead of final class

### DIFF
--- a/src/Wallabag/CoreBundle/Repository/EntryRepository.php
+++ b/src/Wallabag/CoreBundle/Repository/EntryRepository.php
@@ -255,7 +255,7 @@ class EntryRepository extends EntityRepository
      *
      * @param int $userId
      *
-     * @return integer
+     * @return int
      */
     public function countAllEntriesByUsername($userId)
     {

--- a/src/Wallabag/UserBundle/Mailer/AuthCodeMailer.php
+++ b/src/Wallabag/UserBundle/Mailer/AuthCodeMailer.php
@@ -4,7 +4,7 @@ namespace Wallabag\UserBundle\Mailer;
 
 use Scheb\TwoFactorBundle\Model\Email\TwoFactorInterface;
 use Scheb\TwoFactorBundle\Mailer\AuthCodeMailerInterface;
-use Symfony\Component\Translation\DataCollectorTranslator;
+use Symfony\Component\Translation\TranslatorInterface;
 
 /**
  * Custom mailer for TwoFactorBundle email.
@@ -22,7 +22,7 @@ class AuthCodeMailer implements AuthCodeMailerInterface
     /**
      * Translator for email content.
      *
-     * @var DataCollectorTranslator
+     * @var TranslatorInterface
      */
     private $translator;
 
@@ -50,13 +50,13 @@ class AuthCodeMailer implements AuthCodeMailerInterface
     /**
      * Initialize the auth code mailer with the SwiftMailer object.
      *
-     * @param \Swift_Mailer           $mailer
-     * @param DataCollectorTranslator $translator
-     * @param string                  $senderEmail
-     * @param string                  $senderName
-     * @param string                  $supportUrl
+     * @param \Swift_Mailer       $mailer
+     * @param TranslatorInterface $translator
+     * @param string              $senderEmail
+     * @param string              $senderName
+     * @param string              $supportUrl
      */
-    public function __construct(\Swift_Mailer $mailer, DataCollectorTranslator $translator, $senderEmail, $senderName, $supportUrl)
+    public function __construct(\Swift_Mailer $mailer, TranslatorInterface $translator, $senderEmail, $senderName, $supportUrl)
     {
         $this->mailer = $mailer;
         $this->translator = $translator;

--- a/src/Wallabag/UserBundle/Tests/Mailer/AuthCodeMailerTest.php
+++ b/src/Wallabag/UserBundle/Tests/Mailer/AuthCodeMailerTest.php
@@ -6,7 +6,6 @@ use Wallabag\UserBundle\Entity\User;
 use Wallabag\UserBundle\Mailer\AuthCodeMailer;
 use Symfony\Component\Translation\Translator;
 use Symfony\Component\Translation\Loader\ArrayLoader;
-use Symfony\Component\Translation\DataCollectorTranslator;
 
 /**
  * @see https://www.pmg.com/blog/integration-testing-swift-mailer/
@@ -28,7 +27,7 @@ class AuthCodeMailerTest extends \PHPUnit_Framework_TestCase
 {
     protected $mailer;
     protected $spool;
-    protected $dataCollector;
+    protected $translator;
 
     protected function setUp()
     {
@@ -39,14 +38,12 @@ class AuthCodeMailerTest extends \PHPUnit_Framework_TestCase
         );
         $this->mailer = new \Swift_Mailer($transport);
 
-        $translator = new Translator('en');
-        $translator->addLoader('array', new ArrayLoader());
-        $translator->addResource('array', array(
+        $this->translator = new Translator('en');
+        $this->translator->addLoader('array', new ArrayLoader());
+        $this->translator->addResource('array', array(
             'auth_code.mailer.subject' => 'auth_code subject',
             'auth_code.mailer.body' => 'Hi %user%, here is the code: %code% and the support: %support%',
         ), 'en', 'wallabag_user');
-
-        $this->dataCollector = new DataCollectorTranslator($translator);
     }
 
     public function testSendEmail()
@@ -59,7 +56,7 @@ class AuthCodeMailerTest extends \PHPUnit_Framework_TestCase
 
         $authCodeMailer = new AuthCodeMailer(
             $this->mailer,
-            $this->dataCollector,
+            $this->translator,
             'nobody@test.io',
             'wallabag test',
             'http://0.0.0.0'


### PR DESCRIPTION
Symfony use a different class when in dev mode and prod mode.

Prod loads `Symfony\Bundle\FrameworkBundle\Translation\Translator`.
Dev loads `Symfony\Component\Translation\DataCollectorTranslator` to gather information for the debug bar.

Fix #1585