### PR TITLE
Remove tag relation when removing an entry

### DIFF
--- a/src/Wallabag/CoreBundle/Entity/Entry.php
+++ b/src/Wallabag/CoreBundle/Entity/Entry.php
@@ -168,7 +168,7 @@ class Entry
     private $user;
 
     /**
-     * @ORM\ManyToMany(targetEntity="Tag", inversedBy="entries", cascade={"persist"})
+     * @ORM\ManyToMany(targetEntity="Tag", inversedBy="entries", cascade={"persist", "remove"})
      * @ORM\JoinTable
      *
      * @Groups({"entries_for_user", "export_all"})


### PR DESCRIPTION
Fix #1453

When removing an entry, it'll also remove all associated tag and avoid crazy stuff like defined in the previous issue.