### PR TITLE
Ignore composer.lock

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ data/db/wallabag*.sqlite
 # Docker container logs and data
 docker/logs/
 docker/data/
+
+# To avoid crazy stuff on some PR, we must manually FORCE ADD IT on each new release
+composer.lock

--- a/build.xml
+++ b/build.xml
@@ -11,7 +11,7 @@
 
     <target name="composer" description="Install deps using Composer">
         <exec executable="composer">
-            <arg value="install"/>
+            <arg value="up"/>
             <arg value="--no-interaction"/>
             <arg value="--no-progress"/>
         </exec>


### PR DESCRIPTION
Having a big composer.lock on a final project can have side effect on incoming PR that add a new vendor.
Mostly because conflict are too frequent.

By ignoring composer.lock we ease the PR submission and rebase.

BUT we need to be careful when we release a new version of wallabag. We should manually `git add -f composer.lock` to update it.

Since composer.lock will no longer be commited I switch the `composer install` to a `composer up` in the travis configuration.

/ping @bdunogier what do you think?