### PR TITLE
Exporttxt

### DIFF
--- a/app/config/parameters.yml.dist
+++ b/app/config/parameters.yml.dist
@@ -43,4 +43,5 @@ parameters:
 
     # fosuser stuff
     fosuser_confirmation: true
+
     from_email: no-reply@wallabag.org

--- a/app/config/parameters.yml.dist
+++ b/app/config/parameters.yml.dist
@@ -43,5 +43,4 @@ parameters:
 
     # fosuser stuff
     fosuser_confirmation: true
-
     from_email: no-reply@wallabag.org

--- a/src/Wallabag/CoreBundle/Helper/EntriesExport.php
+++ b/src/Wallabag/CoreBundle/Helper/EntriesExport.php
@@ -6,6 +6,7 @@ use JMS\Serializer;
 use JMS\Serializer\SerializationContext;
 use JMS\Serializer\SerializerBuilder;
 use PHPePub\Core\EPub;
+use Html2Text\Html2Text;
 use PHPePub\Core\Structure\OPF\DublinCore;
 use Symfony\Component\HttpFoundation\Response;
 use Craue\ConfigBundle\Util\Config;
@@ -99,6 +100,8 @@ class EntriesExport
 
             case 'xml':
                 return $this->produceXML();
+            case 'txt':
+                return $this->produceTXT();
         }
 
         throw new \InvalidArgumentException(sprintf('The format "%s" is not yet supported.', $format));
@@ -358,6 +361,25 @@ class EntriesExport
             )
         )->send();
     }
+
+    private function produceTXT()
+    {
+        $content = '';
+        foreach ($this->entries as $entry) {
+            $content .= $entry->getTitle();
+            $content .= strip_tags($entry->getContent());
+        }
+        return Response::create(
+            $content,
+            200,
+            array(
+                'Content-type' => 'text/plain',
+                'Content-Disposition' => 'attachment; filename="'.$this->title.'.txt"',
+                'Content-Transfer-Encoding' => 'UTF-8',
+            )
+        )->send();
+    }
+
 
     /**
      * Return a Serializer object for producing processes that need it (JSON & XML).

--- a/src/Wallabag/CoreBundle/Helper/EntriesExport.php
+++ b/src/Wallabag/CoreBundle/Helper/EntriesExport.php
@@ -366,8 +366,8 @@ class EntriesExport
     {
         $content = '';
         foreach ($this->entries as $entry) {
-            $content .= $entry->getTitle();
-            $content .= strip_tags($entry->getContent());
+            $content .= "\n\n" . str_repeat("=",100) . "\n\n" . $entry->getTitle() . "\n\n" . str_repeat("=",100) . "\n\n";
+            $content .= trim(preg_replace('/\s+/S', ' ', strip_tags($entry->getContent()))) . "\n\n";
         }
         return Response::create(
             $content,

--- a/src/Wallabag/CoreBundle/Helper/EntriesExport.php
+++ b/src/Wallabag/CoreBundle/Helper/EntriesExport.php
@@ -6,7 +6,6 @@ use JMS\Serializer;
 use JMS\Serializer\SerializationContext;
 use JMS\Serializer\SerializerBuilder;
 use PHPePub\Core\EPub;
-use Html2Text\Html2Text;
 use PHPePub\Core\Structure\OPF\DublinCore;
 use Symfony\Component\HttpFoundation\Response;
 use Craue\ConfigBundle\Util\Config;

--- a/src/Wallabag/CoreBundle/Helper/EntriesExport.php
+++ b/src/Wallabag/CoreBundle/Helper/EntriesExport.php
@@ -364,8 +364,9 @@ class EntriesExport
     private function produceTXT()
     {
         $content = '';
+        $bar = str_repeat("=",100);
         foreach ($this->entries as $entry) {
-            $content .= "\n\n" . str_repeat("=",100) . "\n\n" . $entry->getTitle() . "\n\n" . str_repeat("=",100) . "\n\n";
+            $content .= "\n\n" . $bar . "\n\n" . $entry->getTitle() . "\n\n" . $bar . "\n\n";
             $content .= trim(preg_replace('/\s+/S', ' ', strip_tags($entry->getContent()))) . "\n\n";
         }
         return Response::create(

--- a/src/Wallabag/CoreBundle/Helper/EntriesExport.php
+++ b/src/Wallabag/CoreBundle/Helper/EntriesExport.php
@@ -364,11 +364,12 @@ class EntriesExport
     private function produceTXT()
     {
         $content = '';
-        $bar = str_repeat("=",100);
+        $bar = str_repeat('=', 100);
         foreach ($this->entries as $entry) {
-            $content .= "\n\n" . $bar . "\n\n" . $entry->getTitle() . "\n\n" . $bar . "\n\n";
-            $content .= trim(preg_replace('/\s+/S', ' ', strip_tags($entry->getContent()))) . "\n\n";
+            $content .= "\n\n".$bar."\n\n".$entry->getTitle()."\n\n".$bar."\n\n";
+            $content .= trim(preg_replace('/\s+/S', ' ', strip_tags($entry->getContent())))."\n\n";
         }
+
         return Response::create(
             $content,
             200,
@@ -379,7 +380,6 @@ class EntriesExport
             )
         )->send();
     }
-
 
     /**
      * Return a Serializer object for producing processes that need it (JSON & XML).

--- a/src/Wallabag/CoreBundle/Resources/views/themes/material/Entry/entries.html.twig
+++ b/src/Wallabag/CoreBundle/Resources/views/themes/material/Entry/entries.html.twig
@@ -101,13 +101,13 @@
     {% endif %}
         <h4 class="center">{% trans %}Export{% endtrans %}</h4>
         <ul>
-            {% if craue_setting('export_epub') %}<li class="bold"><a class="waves-effect" href="{{ path('export_entries', { 'category': currentRoute, 'format': 'epub' }) }}">{% trans %}EPUB{% endtrans %}</a></li>{% endif %}
-            {% if craue_setting('export_mobi') %}<li class="bold"><a class="waves-effect" href="{{ path('export_entries', { 'category': currentRoute, 'format': 'mobi' }) }}">{% trans %}MOBI{% endtrans %}</a></li>{% endif %}
-            {% if craue_setting('export_pdf') %}<li class="bold"><a class="waves-effect" href="{{ path('export_entries', { 'category': currentRoute, 'format': 'pdf' }) }}">{% trans %}PDF{% endtrans %}</a></li>{% endif %}
-            {% if craue_setting('export_xml') %}<li class="bold"><a class="waves-effect" href="{{ path('export_entries', { 'category': currentRoute, 'format': 'xml' }) }}">{% trans %}XML{% endtrans %}</a></li>{% endif %}
-            {% if craue_setting('export_csv') %}<li class="bold"><a class="waves-effect" href="{{ path('export_entries', { 'category': currentRoute, 'format': 'json' }) }}">{% trans %}JSON{% endtrans %}</a></li>{% endif %}
-            {% if craue_setting('export_json') %}<li class="bold"><a class="waves-effect" href="{{ path('export_entries', { 'category': currentRoute, 'format': 'csv' }) }}">{% trans %}CSV{% endtrans %}</a></li>{% endif %}
-            {% if craue_setting('export_txt') %}<li class="bold"><a class="waves-effect" href="{{ path('export_entries', { 'category': currentRoute, 'format': 'txt' }) }}">{% trans %}TXT{% endtrans %}</a></li>{% endif %}
+            {% if craue_setting('export_epub') %}<li class="bold"><a class="waves-effect" href="{{ path('export_entries', { 'category': currentRoute, 'format': 'epub' }) }}">EPUB</a></li>{% endif %}
+            {% if craue_setting('export_mobi') %}<li class="bold"><a class="waves-effect" href="{{ path('export_entries', { 'category': currentRoute, 'format': 'mobi' }) }}">MOBI</a></li>{% endif %}
+            {% if craue_setting('export_pdf') %}<li class="bold"><a class="waves-effect" href="{{ path('export_entries', { 'category': currentRoute, 'format': 'pdf' }) }}">PDF</a></li>{% endif %}
+            {% if craue_setting('export_csv') %}<li class="bold"><a class="waves-effect" href="{{ path('export_entries', { 'category': currentRoute, 'format': 'json' }) }}">JSON</a></li>{% endif %}
+            {% if craue_setting('export_json') %}<li class="bold"><a class="waves-effect" href="{{ path('export_entries', { 'category': currentRoute, 'format': 'csv' }) }}">CSV</a></li>{% endif %}
+            {% if craue_setting('export_txt') %}<li class="bold"><a class="waves-effect" href="{{ path('export_entries', { 'category': currentRoute, 'format': 'txt' }) }}">TXT</a></li>{% endif %}
+            {% if craue_setting('export_xml') %}<li class="bold"><a class="waves-effect" href="{{ path('export_entries', { 'category': currentRoute, 'format': 'xml' }) }}">XML</a></li>{% endif %}
         </ul>
     </div>
 

--- a/src/Wallabag/CoreBundle/Resources/views/themes/material/Entry/entries.html.twig
+++ b/src/Wallabag/CoreBundle/Resources/views/themes/material/Entry/entries.html.twig
@@ -107,7 +107,7 @@
             {% if craue_setting('export_xml') %}<li class="bold"><a class="waves-effect" href="{{ path('export_entries', { 'category': currentRoute, 'format': 'xml' }) }}">{% trans %}XML{% endtrans %}</a></li>{% endif %}
             {% if craue_setting('export_csv') %}<li class="bold"><a class="waves-effect" href="{{ path('export_entries', { 'category': currentRoute, 'format': 'json' }) }}">{% trans %}JSON{% endtrans %}</a></li>{% endif %}
             {% if craue_setting('export_json') %}<li class="bold"><a class="waves-effect" href="{{ path('export_entries', { 'category': currentRoute, 'format': 'csv' }) }}">{% trans %}CSV{% endtrans %}</a></li>{% endif %}
-            {% if craue_setting('export_txt') %}<li class="bold"><del><a class="waves-effect" href="{{ path('export_entries', { 'category': currentRoute, 'format': 'txt' }) }}">{% trans %}TXT{% endtrans %}</a></del></li>{% endif %}
+            {% if craue_setting('export_txt') %}<li class="bold"><a class="waves-effect" href="{{ path('export_entries', { 'category': currentRoute, 'format': 'txt' }) }}">{% trans %}TXT{% endtrans %}</a></li>{% endif %}
         </ul>
     </div>
 

--- a/src/Wallabag/CoreBundle/Resources/views/themes/material/Entry/entry.html.twig
+++ b/src/Wallabag/CoreBundle/Resources/views/themes/material/Entry/entry.html.twig
@@ -118,7 +118,7 @@
                     {% if craue_setting('export_pdf') %}<li><a href="{{ path('export_entry', { 'id': entry.id, 'format': 'pdf' }) }}" title="Generate PDF file">PDF</a></li>{% endif %}
                     {% if craue_setting('export_csv') %}<li><a href="{{ path('export_entry', { 'id': entry.id, 'format': 'csv' }) }}" title="Generate CSV file">CSV</a></li>{% endif %}
                     {% if craue_setting('export_json') %}<li><a href="{{ path('export_entry', { 'id': entry.id, 'format': 'json' }) }}" title="Generate JSON file">JSON</a></li>{% endif %}
-                    {% if craue_setting('export_txt') %}<li><del><a href="{{ path('export_entry', { 'id': entry.id, 'format': 'txt' }) }}" title="Generate TXT file">TXT</a></del></li>{% endif %}
+                    {% if craue_setting('export_txt') %}<li><a href="{{ path('export_entry', { 'id': entry.id, 'format': 'txt' }) }}" title="Generate TXT file">TXT</a></li>{% endif %}
                     {% if craue_setting('export_xml') %}<li><a href="{{ path('export_entry', { 'id': entry.id, 'format': 'xml' }) }}" title="Generate XML file">XML</a></li>{% endif %}
                 </ul>
             </div>

--- a/src/Wallabag/CoreBundle/Tests/Controller/ExportControllerTest.php
+++ b/src/Wallabag/CoreBundle/Tests/Controller/ExportControllerTest.php
@@ -41,7 +41,7 @@ class ExportControllerTest extends WallabagCoreTestCase
         $this->logInAs('admin');
         $client = $this->getClient();
 
-        $client->request('GET', '/export/unread.txt');
+        $client->request('GET', '/export/unread.doc');
         $this->assertEquals(404, $client->getResponse()->getStatusCode());
 
         $content = $client->getContainer()
@@ -49,7 +49,7 @@ class ExportControllerTest extends WallabagCoreTestCase
             ->getRepository('WallabagCoreBundle:Entry')
             ->findOneByUsernameAndNotArchived('admin');
 
-        $client->request('GET', '/export/'.$content->getId().'.txt');
+        $client->request('GET', '/export/'.$content->getId().'.doc');
         $this->assertEquals(404, $client->getResponse()->getStatusCode());
     }
 
@@ -117,6 +117,23 @@ class ExportControllerTest extends WallabagCoreTestCase
         $this->assertEquals('application/pdf', $headers->get('content-type'));
         $this->assertEquals('attachment; filename="All articles.pdf"', $headers->get('content-disposition'));
         $this->assertEquals('binary', $headers->get('content-transfer-encoding'));
+    }
+
+    public function testTxtExport()
+    {
+        $this->logInAs('admin');
+        $client = $this->getClient();
+
+        ob_start();
+        $crawler = $client->request('GET', '/export/all.txt');
+        ob_end_clean();
+
+        $this->assertEquals(200, $client->getResponse()->getStatusCode());
+
+        $headers = $client->getResponse()->headers;
+        $this->assertEquals('text/plain; charset=UTF-8', $headers->get('content-type'));
+        $this->assertEquals('attachment; filename="All articles.txt"', $headers->get('content-disposition'));
+        $this->assertEquals('UTF-8', $headers->get('content-transfer-encoding'));
     }
 
     public function testCsvExport()


### PR DESCRIPTION
Adds txt export.
As the html saved is quite dirty, to avoid multiples spaces everywhere I strip everything, therefore all the article is displayed on one line.
Maybe I can start by replacing all `<p>` by new lines inside every article.