### PR TITLE
Fix #1622: parameter for FosUser confirmation

### DIFF
--- a/app/Resources/CraueConfigBundle/translations/CraueConfigBundle.en.yml
+++ b/app/Resources/CraueConfigBundle/translations/CraueConfigBundle.en.yml
@@ -9,7 +9,7 @@ export_json: Enable JSON export
 export_txt: Enable TXT export
 export_xml: Enable XML export
 pocket_consumer_key: Consumer key for Pocket to import contents (https://getpocket.com/developer/docs/authentication)
-shaarli_url: URL de Shaarli, if the service is enabled
+shaarli_url: Shaarli URL, if the service is enabled
 share_diaspora: Enable share to Diaspora
 share_mail: Enable share by email
 share_shaarli: Enable share to Shaarli

--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -168,7 +168,7 @@ fos_user:
     user_class: Wallabag\UserBundle\Entity\User
     registration:
         confirmation:
-            enabled: true
+            enabled: %fosuser_confirmation%
     from_email:
         address:        %from_email%
         sender_name:    wallabag

--- a/app/config/parameters.yml.dist
+++ b/app/config/parameters.yml.dist
@@ -40,6 +40,8 @@ parameters:
     # two factor stuff
     twofactor_auth: true
     twofactor_sender: no-reply@wallabag.org
+
+    # fosuser stuff
     fosuser_confirmation: true
 
     from_email: no-reply@wallabag.org

--- a/app/config/parameters.yml.dist
+++ b/app/config/parameters.yml.dist
@@ -40,5 +40,6 @@ parameters:
     # two factor stuff
     twofactor_auth: true
     twofactor_sender: no-reply@wallabag.org
+    fosuser_confirmation: true
 
     from_email: no-reply@wallabag.org

--- a/app/config/tests/parameters.yml.dist.mysql
+++ b/app/config/tests/parameters.yml.dist.mysql
@@ -30,6 +30,8 @@ parameters:
     # two factor stuff
     twofactor_auth: true
     twofactor_sender: no-reply@wallabag.org
+
+    # fosuser stuff
     fosuser_confirmation: true
 
     from_email: no-reply@wallabag.org

--- a/app/config/tests/parameters.yml.dist.mysql
+++ b/app/config/tests/parameters.yml.dist.mysql
@@ -30,5 +30,6 @@ parameters:
     # two factor stuff
     twofactor_auth: true
     twofactor_sender: no-reply@wallabag.org
+    fosuser_confirmation: true
 
     from_email: no-reply@wallabag.org

--- a/app/config/tests/parameters.yml.dist.pgsql
+++ b/app/config/tests/parameters.yml.dist.pgsql
@@ -30,6 +30,8 @@ parameters:
     # two factor stuff
     twofactor_auth: true
     twofactor_sender: no-reply@wallabag.org
+
+    # fosuser stuff
     fosuser_confirmation: true
 
     from_email: no-reply@wallabag.org

--- a/app/config/tests/parameters.yml.dist.pgsql
+++ b/app/config/tests/parameters.yml.dist.pgsql
@@ -30,5 +30,6 @@ parameters:
     # two factor stuff
     twofactor_auth: true
     twofactor_sender: no-reply@wallabag.org
+    fosuser_confirmation: true
 
     from_email: no-reply@wallabag.org

--- a/app/config/tests/parameters.yml.dist.sqlite
+++ b/app/config/tests/parameters.yml.dist.sqlite
@@ -30,6 +30,8 @@ parameters:
     # two factor stuff
     twofactor_auth: true
     twofactor_sender: no-reply@wallabag.org
+
+    # fosuser stuff
     fosuser_confirmation: true
 
     from_email: no-reply@wallabag.org

--- a/app/config/tests/parameters.yml.dist.sqlite
+++ b/app/config/tests/parameters.yml.dist.sqlite
@@ -30,5 +30,6 @@ parameters:
     # two factor stuff
     twofactor_auth: true
     twofactor_sender: no-reply@wallabag.org
+    fosuser_confirmation: true
 
     from_email: no-reply@wallabag.org

--- a/src/Wallabag/CoreBundle/Tests/Controller/SettingsControllerTest.php
+++ b/src/Wallabag/CoreBundle/Tests/Controller/SettingsControllerTest.php
@@ -6,7 +6,7 @@ use Wallabag\CoreBundle\Tests\WallabagCoreTestCase;
 
 /**
  * The controller `SettingsController` does not exist.
- * This test cover security against the internal settings page managed by CraueConfigBundle
+ * This test cover security against the internal settings page managed by CraueConfigBundle.
  */
 class SettingsControllerTest extends WallabagCoreTestCase
 {

--- a/src/Wallabag/UserBundle/Mailer/AuthCodeMailer.php
+++ b/src/Wallabag/UserBundle/Mailer/AuthCodeMailer.php
@@ -48,7 +48,7 @@ class AuthCodeMailer implements AuthCodeMailerInterface
     private $supportUrl;
 
     /**
-     * Url for the wallabag instance (only used for image in the HTML email template)
+     * Url for the wallabag instance (only used for image in the HTML email template).
      *
      * @var string
      */


### PR DESCRIPTION
Fix #1622. 
It's now possible to enable/disable email confirmation for user registration via the parameters. 