### PR TITLE
Fix #1643: fix the way to load the HTML template in 2factor auth

### DIFF
--- a/src/Wallabag/CoreBundle/Tests/Controller/SettingsControllerTest.php
+++ b/src/Wallabag/CoreBundle/Tests/Controller/SettingsControllerTest.php
@@ -6,7 +6,7 @@ use Wallabag\CoreBundle\Tests\WallabagCoreTestCase;
 
 /**
  * The controller `SettingsController` does not exist.
- * This test cover security against the internal settings page managed by CraueConfigBundle
+ * This test cover security against the internal settings page managed by CraueConfigBundle.
  */
 class SettingsControllerTest extends WallabagCoreTestCase
 {

--- a/src/Wallabag/UserBundle/Mailer/AuthCodeMailer.php
+++ b/src/Wallabag/UserBundle/Mailer/AuthCodeMailer.php
@@ -48,7 +48,7 @@ class AuthCodeMailer implements AuthCodeMailerInterface
     private $supportUrl;
 
     /**
-     * Url for the wallabag instance (only used for image in the HTML email template)
+     * Url for the wallabag instance (only used for image in the HTML email template).
      *
      * @var string
      */
@@ -80,7 +80,7 @@ class AuthCodeMailer implements AuthCodeMailerInterface
      */
     public function sendAuthCode(TwoFactorInterface $user)
     {
-        $template = $this->twig->loadTemplate('@WallabagUserBundle/Resources/views/TwoFactor/email_auth_code.html.twig');
+        $template = $this->twig->loadTemplate('WallabagUserBundle:TwoFactor:email_auth_code.html.twig');
 
         $subject = $template->renderBlock('subject', array());
         $bodyHtml = $template->renderBlock('body_html', [

--- a/src/Wallabag/UserBundle/Tests/Mailer/AuthCodeMailerTest.php
+++ b/src/Wallabag/UserBundle/Tests/Mailer/AuthCodeMailerTest.php
@@ -43,7 +43,7 @@ class AuthCodeMailerTest extends \PHPUnit_Framework_TestCase
 {% block body_text %}text body {{ support_url }}{% endblock %}
 TWIG;
 
-        $this->twig = new \Twig_Environment(new \Twig_Loader_Array(array('@WallabagUserBundle/Resources/views/TwoFactor/email_auth_code.html.twig' => $twigTemplate)));
+        $this->twig = new \Twig_Environment(new \Twig_Loader_Array(array('WallabagUserBundle:TwoFactor:email_auth_code.html.twig' => $twigTemplate)));
 
         $this->config = $this->getMockBuilder('Craue\ConfigBundle\Util\Config')
             ->disableOriginalConstructor()


### PR DESCRIPTION
Fix #1643 due to https://github.com/symfony/symfony/pull/15272