### PR TITLE
Force prod env on project creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Keep in mind it's an **unstable** branch, everything can be broken :)
 If you don't have it yet, please [install composer](https://getcomposer.org/download/). Then you can install wallabag by executing the following commands:
 
 ```
-composer create-project wallabag/wallabag wallabag 2.0.*@alpha
+SYMFONY_ENV=prod composer create-project wallabag/wallabag wallabag 2.0.*alpha --no-dev
 php bin/console wallabag:install
 php bin/console server:run
 ```


### PR DESCRIPTION
So the only solution I found so far is to force the `prod` env when create the project with composer.
There is other solution.

Since the `cache:clear` task is using `dev` env by default, so it tries to load dev bundle, which aren't there since we specify `--no-dev`.

----

Fix #1617 

/ping @bdunogier 
/see https://github.com/sensiolabs/SensioDistributionBundle/pull/140