### PR TITLE
Translation for Persian

### DIFF
--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -35,6 +35,7 @@ wallabag_core:
         fr: 'Français'
         de: 'Deutsch'
         tr: 'Türkçe'
+        fa: 'فارسی'
     items_on_page: 12
     theme: material
     language: en

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.fa.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.fa.yml
@@ -1,0 +1,129 @@
+#Login
+Keep me logged in: 'مرا به خاطر بسپار'
+Forgot your password?: ' رمزتان را گم کرده‌اید؟'
+Login: 'ورود'
+Back to login: 'بازگشت به صفحهٔ ورود'
+Send: 'بفرست'
+"Enter your email address below and we'll send you password reset instructions.": "نشانی ایمیل خود را بنویسید تا راهنمای تغییر رمز را برایتان بفرستیم."
+
+# Menu
+unread: 'خوانده‌نشده'
+starred: 'برگزیده'
+archive: 'بایگانی'
+all: 'همه'
+tags: 'برچسب‌ها'
+config: 'پیکربندی'
+howto: 'خودآموز'
+logout: 'خروج'
+Filtered: 'فیلترشده'
+About: 'درباره'
+
+# Header
+Back to unread articles: 'بازگشت به خوانده‌نشده‌ها'
+Add a new entry: 'افزودن مقالهٔ تازه'
+Search: 'جستجو'
+Filter entries: 'فیلترکردن مقاله‌ها'
+Enter your search here: 'جستجوی خود را این‌جا بنویسید:'
+Save new entry: 'ذخیرهٔ مقالهٔ تازه'
+
+# Config screen
+Settings: 'تنظیمات'
+User information: 'اطلاعات کاربر'
+Password: 'رمز'
+RSS: 'آر-اس-اس'
+Add a user: 'افزودن کاربر'
+Theme: 'پوسته'
+Items per page: 'تعداد مقاله در هر صفحه'
+Language: 'زبان'
+Save: 'ذخیره'
+RSS token: 'کد آر-اس-اس'
+Name: 'نام'
+Email: 'نشانی ایمیل'
+No token: 'بدون کد'
+Reset your token: 'بازنشانی کد'
+Create your token: 'کد خود را بسازید'
+Rss limit: 'محدودیت آر-اس-اس'
+RSS links: 'پیوند آر-اس-اس'
+'RSS feeds provided by wallabag allow you to read your saved articles with your favourite RSS reader. You need to generate a token first.': 'با خوراک آر-اس-اس که wallabag در اختیارتان می‌گذارد، می‌توانید مقاله‌های ذخیره‌شده را در نرم‌افزار آر-اس-اس دلخواه خود بخوانید. برای این کار نخست باید یک کد بسازید.'
+Old password: 'رمز قدیمی'
+New password: 'رمز تازه'
+Repeat new password: 'رمز تازه را دوباره بنویسید'
+Username: 'نام کاربری'
+
+# Entries
+'estimated reading time': 'زمان تخمینی برای خواندن'
+original: اصلی
+Toggle mark as read: 'خوانده‌شده/خوانده‌نشده'
+Toggle favorite: 'برگزیده/نابرگزیده'
+Delete: 'پاک کردن'
+
+# Filters
+Filters: 'فیلتر'
+Status: 'وضعیت'
+Archived: 'بایگانی‌شده'
+Starred: 'برگزیده'
+Preview picture: 'پیش‌نمایش عکس'
+Has a preview picture: 'دارای عکس پیش‌نمایش'
+Reading time in minutes: 'زمان خواندن به دقیقه'
+from: 'از'
+to: 'تا'
+website.com: 'website.com'
+Domain name: 'نام دامنه'
+Creation date: 'زمان ساخت'
+dd/mm/yyyy: 'dd.mm.yyyy'
+Clear: 'از نو'
+Filter: 'فیلتر'
+
+# About
+Who is behind wallabag: "سازندگان wallabag"
+Getting help: "گرفتن کمک"
+Helping wallabag: "کمک‌کردن به wallabag"
+Developed by: "ساختهٔ"
+website: "وب‌گاه"
+And many others contributors ♥: "و بسیاری دیگر از مشارکت‌کنندگان ♥"
+on GitHub: "روی GitHub"
+Project website: "وب‌گاه پروژه"
+License: "پروانه"
+Version: "نسخه"
+Documentation: "راهنما"
+Bug reports: "گزارش اشکال‌ها"
+On our support website: "در وب‌گاه پشتیبانی"
+or: "یا"
+"wallabag is free and opensource. You can help us:": "wallabag رایگان، آزاد، و متن‌باز است. شما می‌توانید به ما کمک کنید:"
+"by contributing to the project:": "با مشارکت در پروژه:"
+an issue lists all our needs: "فهرست نیازمندی‌های ما در این صفحه است:"
+via Paypal: "از راه PayPal"
+
+# Howto
+Form: فرم
+Thanks to this form: "به کمک این فرم"
+Browser addons: "افزونه برای مرورگرها"
+Mobile apps: "برنامه‌های موبایل"
+Bookmarklet: "ابزار علامت‌گذاری صفحه‌ها"
+Standard Firefox Add-On: "افزونهٔ فایرفاکس"
+Chrome Extension: "افزونهٔ کروم"
+download the application: "برنامه را باربگیرید"
+"Drag &amp; drop this link to your bookmarks bar:": "این پیوند را به نوار بوک‌مارک مرورگرتان بکشید:"
+
+# Flash messages
+Information updated: "اطلاعات به‌روز شد"
+"Config saved. Some parameters will be considered after disconnection.": "پیکربندی ذخیره شد. برخی از تنظیمات پس از این که قطع شدید اعمال می‌شود."
+RSS information updated: "اطلاعات آر-اس-اس به‌روز شد"
+Password updated: "رمز به‌روز شد"
+Entry starred: "مقاله برگزیده شد"
+Entry unstarred: "مقاله نابرگزیده شد"
+Entry archived: "مقاله بایگانی شد"
+Entry unarchived: "مقاله از بایگانی درآمد"
+Entry deleted: "مقاله پاک شد"
+
+# Entry
+Mark as read: 'خوانده‌شده'
+Favorite: 'برگزیده'
+back: 'بازگشت'
+original article: 'مقالهٔ اصلی'
+Add a tag: 'افزودن برچسب'
+Share: 'هم‌رسانی'
+Download: 'بارگیری'
+Does this article appear wrong?: "آیا مقاله نادرست نشان داده شده؟"
+Problems?: 'مشکلات؟'
+Edit title: "ویرایش عنوان"


### PR DESCRIPTION
Translation file for the 'Persian' language. Also recognized by fa_IR. Also known (in the Persian language) as Farsi. Also written like فارسی in Persian. All said, please call the language just 'Persian'.