### PR TITLE
 Fix #1708: typos in french documentation

### DIFF
--- a/docs/fr/user/create_account.rst
+++ b/docs/fr/user/create_account.rst
@@ -27,7 +27,7 @@ Votre compte est maintenant actif.
 Foire aux questions
 -------------------
 
-Je ne veux pas valider le formulaire de création de compte
+Je ne peux pas valider le formulaire de création de compte
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Soyez sur d'avoir bien renseigné tous les champs :

--- a/docs/fr/user/installation.rst
+++ b/docs/fr/user/installation.rst
@@ -11,7 +11,7 @@ Vous aurez besoin des extensions suivantes pour que wallabag fonctionne. Il est 
 - php-session
 - php-ctype
 - php-dom
-- pĥp-hash
+- php-hash
 - php-simplexml
 - php-json
 - php-gd


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Documentation | yes
| Translation   | yes
| Fixed tickets | #1708
| License       | MIT
