### PR TITLE
Change wording for create a new user

### DIFF
--- a/src/Wallabag/CoreBundle/Command/InstallCommand.php
+++ b/src/Wallabag/CoreBundle/Command/InstallCommand.php
@@ -180,7 +180,7 @@ class InstallCommand extends ContainerAwareCommand
         $this->defaultOutput->writeln('<info><comment>Step 3 of 4.</comment> Administration setup.</info>');
 
         $questionHelper = $this->getHelperSet()->get('question');
-        $question = new ConfirmationQuestion('Would you like to create a new user ? (y/N)', false);
+        $question = new ConfirmationQuestion('Would you like to create a new admin user (recommended) ? (y/N)', true);
 
         if (!$questionHelper->ask($this->defaultInput, $this->defaultOutput, $question)) {
             return $this;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      |no
| New feature?  |no
| BC breaks?    |no
| Deprecations? |no
| Tests pass?   | yes
| Documentation |no
| Translation   |no
| Fixed tickets | 
| License       | MIT

Since https://github.com/wallabag/wallabag/pull/1652 user created while installing wallabag is now admin. I think it's better to say that information to the user.
Also, I've switched the default answer to `true` so, hitting <kbd>enter</kbd> all the way will create an admin.