### PR TITLE
Wrong installation instructions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,9 @@ If you don't have it yet, please [install composer](https://getcomposer.org/down
 
 ```
 SYMFONY_ENV=prod composer create-project wallabag/wallabag wallabag "2.0.*@alpha" --no-dev
-php bin/console wallabag:install --env=prod
-php bin/console server:run --env=prod
+cd wallabag
+php app/console wallabag:install --env=prod
+php app/console server:run --env=prod
 ```
 
 ## License


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Documentation | yes
| License       | MIT

 * composer is creating a subdirectory
 * console file is in app folder, not bin

**Sidenote**
After installing linked [composer installation doc](https://getcomposer.org/download/), I got a local `composer.phar` file, not a `composer` command (but I am not familiar with the program)