### PR TITLE
Remove SMTP configuration environment overrides

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -89,11 +89,8 @@
         "symfony/phpunit-bridge": "^2.7"
     },
     "scripts": {
-        "build-parameters": [
-            "Incenteev\\ParameterHandler\\ScriptHandler::buildParameters"
-        ],
         "post-cmd": [
-            "@build-parameters",
+            "Incenteev\\ParameterHandler\\ScriptHandler::buildParameters",
             "Sensio\\Bundle\\DistributionBundle\\Composer\\ScriptHandler::buildBootstrap",
             "Sensio\\Bundle\\DistributionBundle\\Composer\\ScriptHandler::clearCache",
             "Sensio\\Bundle\\DistributionBundle\\Composer\\ScriptHandler::installAssets",
@@ -115,13 +112,7 @@
         "symfony-tests-dir": "tests",
         "symfony-assets-install": "relative",
         "incenteev-parameters": {
-            "file": "app/config/parameters.yml",
-            "env-map": {
-                "mailer_host": "WALLABAG_MAILER_HOST",
-                "mailer_user": "WALLABAG_MAILER_USER",
-                "mailer_password": "WALLABAG_MAILER_PASSWORD",
-                "secret": "WALLABAG_SECRET"
-            }
+            "file": "app/config/parameters.yml"
         }
     },
     "autoload": {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | yes (previous overrides no longer work)
| Deprecations? | no
| Tests pass?   | yes
| Documentation | no
| Translation   | no
| License       | MIT

SMTP configuration has been added in #1518 to use ParameterHandle's `env-map`. But Symfony actually has a native way of allowing parameters to be overriden from environment so rather than having to define a mapping for each possible parameter, users can define any override in `parameters.yml`:

> parameters:
>     database_host: %WALLABAG_DB_HOST%

and define an environment variable `SYMFONY__WALLABAG_DB_HOST`.

Links:
* [env-map](https://github.com/Incenteev/ParameterHandler#using-environment-variables-to-set-the-parameters)
* [Symfony external parameters](http://symfony.com/doc/current/cookbook/configuration/external_parameters.html)