### PR TITLE
Fix #1717: Change remove tag icon in entry view with material theme

### DIFF
--- a/src/Wallabag/CoreBundle/Resources/views/themes/material/Entry/entry.html.twig
+++ b/src/Wallabag/CoreBundle/Resources/views/themes/material/Entry/entry.html.twig
@@ -189,7 +189,7 @@ main {
             <div id="list">
                 {% for tag in entry.tags %}
                     <div class="chip">
-                    {{ tag.label }} <a href="{{ path('remove_tag', { 'entry': entry.id, 'tag': tag.id }) }}"><i class="mdi-navigation-close"></i></a>
+                    {{ tag.label }} <a href="{{ path('remove_tag', { 'entry': entry.id, 'tag': tag.id }) }}"><i class="mdi-action-delete"></i></a>
                     </div>
                 {% endfor %}
             </div>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Documentation | no
| Translation   | no
| Fixed tickets | #1717
| License       | MIT

We now have a trash icon instead of a cross. 
The cross is already used to close some div (new link form, etc.) and has some js behaviors.
