### PR TITLE
Remove extra definition

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,7 +45,7 @@ before_script:
     - if [[ $TRAVIS_PHP_VERSION != hhvm ]]; then phpenv config-rm xdebug.ini; fi;
     - composer self-update --no-progress
     - if [ -n "$GH_TOKEN" ]; then composer config github-oauth.github.com ${GH_TOKEN}; fi;
-    - if [[ "$DB" = "pgsql" ]]; then psql -c 'create database wallabag;' -U postgres; fi;
+    - if [[ "$DB" = "pgsql" ]]; then psql -c 'create database wallabag_test;' -U postgres; fi;
 
 before_install:
     - if [[ $TRAVIS_REPO_SLUG = wallabag/wallabag ]]; then cp .composer-auth.json ~/.composer/auth.json; fi;

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,7 +44,6 @@ before_script:
     - if [[ $TRAVIS_PHP_VERSION != hhvm ]]; then echo "memory_limit=-1" >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini; fi;
     - if [[ $TRAVIS_PHP_VERSION != hhvm ]]; then phpenv config-rm xdebug.ini; fi;
     - composer self-update --no-progress
-    - if [ -n "$GH_TOKEN" ]; then composer config github-oauth.github.com ${GH_TOKEN}; fi;
     - if [[ "$DB" = "pgsql" ]]; then psql -c 'create database wallabag_test;' -U postgres; fi;
 
 before_install:

--- a/src/Wallabag/CoreBundle/Command/InstallCommand.php
+++ b/src/Wallabag/CoreBundle/Command/InstallCommand.php
@@ -193,7 +193,7 @@ class InstallCommand extends ContainerAwareCommand
         $this->defaultOutput->writeln('<info><comment>Step 3 of 4.</comment> Administration setup.</info>');
 
         $questionHelper = $this->getHelperSet()->get('question');
-        $question = new ConfirmationQuestion('Would you like to create a new admin user (recommended) ? (y/N)', true);
+        $question = new ConfirmationQuestion('Would you like to create a new admin user (recommended) ? (Y/n)', true);
 
         if (!$questionHelper->ask($this->defaultInput, $this->defaultOutput, $question)) {
             return $this;

--- a/src/Wallabag/CoreBundle/Tests/Command/InstallCommandTest.php
+++ b/src/Wallabag/CoreBundle/Tests/Command/InstallCommandTest.php
@@ -14,6 +14,24 @@ use Wallabag\CoreBundle\Tests\WallabagCoreTestCase;
 
 class InstallCommandTest extends WallabagCoreTestCase
 {
+    public function setUp()
+    {
+        parent::setUp();
+
+        if ($this->getClient()->getContainer()->get('doctrine')->getConnection()->getDriver() instanceof \Doctrine\DBAL\Driver\PDOPgSql\Driver) {
+            /*
+             * LOG:  statement: CREATE DATABASE "wallabag"
+             * ERROR:  source database "template1" is being accessed by other users
+             * DETAIL:  There is 1 other session using the database.
+             * STATEMENT:  CREATE DATABASE "wallabag"
+             * FATAL:  database "wallabag" does not exist
+             *
+             * http://stackoverflow.com/a/14374832/569101
+             */
+            $this->markTestSkipped('PostgreSQL spotted: can find a good way to drop current database, skipping.');
+        }
+    }
+
     public static function tearDownAfterClass()
     {
         $application = new Application(static::$kernel);
@@ -91,19 +109,6 @@ class InstallCommandTest extends WallabagCoreTestCase
 
     public function testRunInstallCommandWithDatabaseRemoved()
     {
-        if ($this->getClient()->getContainer()->get('doctrine')->getConnection()->getDriver() instanceof \Doctrine\DBAL\Driver\PDOPgSql\Driver) {
-            /*
-             * LOG:  statement: CREATE DATABASE "wallabag"
-             * ERROR:  source database "template1" is being accessed by other users
-             * DETAIL:  There is 1 other session using the database.
-             * STATEMENT:  CREATE DATABASE "wallabag"
-             * FATAL:  database "wallabag" does not exist
-             *
-             * http://stackoverflow.com/a/14374832/569101
-             */
-            $this->markTestSkipped('PostgreSQL spotted: can find a good way to drop current database, skipping.');
-        }
-
         $application = new Application($this->getClient()->getKernel());
         $application->add(new DropDatabaseDoctrineCommand());
 
@@ -184,13 +189,6 @@ class InstallCommandTest extends WallabagCoreTestCase
 
     public function testRunInstallCommandChooseNothing()
     {
-        if ($this->getClient()->getContainer()->get('doctrine')->getConnection()->getDriver() instanceof \Doctrine\DBAL\Driver\PDOPgSql\Driver) {
-            /*
-             * @see testRunInstallCommandWithDatabaseRemoved
-             */
-            $this->markTestSkipped('PostgreSQL spotted: can find a good way to drop current database, skipping.');
-        }
-
         $application = new Application($this->getClient()->getKernel());
         $application->add(new InstallCommand());
         $application->add(new DropDatabaseDoctrineCommand());

--- a/src/Wallabag/UserBundle/Resources/config/services.yml
+++ b/src/Wallabag/UserBundle/Resources/config/services.yml
@@ -1,9 +1,4 @@
 services:
-    # might be fixed in the symfony release
-    # https://github.com/FriendsOfSymfony/FOSUserBundle/issues/2048
-    fos_user.doctrine_registry:
-        alias: doctrine
-
     wallabag_user.auth_code_mailer:
         class: Wallabag\UserBundle\Mailer\AuthCodeMailer
         arguments:


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Documentation | no
| Translation   | no
| Fixed tickets | 
| License       | MIT

Since Symfony 3.0.3 has been released, we can remove this hardcoded alias.