### PR TITLE
Doc: fix typo in php-hash ext name

### DIFF
--- a/docs/en/user/installation.rst
+++ b/docs/en/user/installation.rst
@@ -11,7 +11,7 @@ You'll need the following extensions for wallabag to work. Some of these may alr
 - php-session
 - php-ctype
 - php-dom
-- pĥp-hash
+- php-hash
 - php-simplexml
 - php-json
 - php-gd


### PR DESCRIPTION
Hi,

There was a typo in the installation part of the documentation: a php extension was `pĥp-hash` instead of `php-hash`. This PR fixes that.

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Documentation | yes
| Translation   | yes
| Fixed tickets | 
| License       | MIT

Didn't know what to put for "translation": 

- Yes there already is a translation for that part, and the french version is correct
- No, this PR doesn't change anything in the translation