### PR TITLE
Docker timezone

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,6 +15,7 @@ services:
         build:
             context: docker/php
             args:
+                # Set here your timezone using one of this: http://php.net/manual/en/timezones.php
                 timezone: 'Europe/Monaco'
         ports:
             - "9000:9000"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,42 +1,47 @@
-nginx:
-    image: nginx
-    ports:
-        - "8080:80"
-    volumes:
-        - ./docker/nginx/nginx.conf:/nginx.conf
-        - ./docker/logs/nginx:/var/log/nginx
-        - .:/var/www/html
-    links:
-        - php:php
-    command: nginx -c /nginx.conf
-php:
-    build: docker/php
-    ports:
-        - "9000:9000"
-    volumes:
-        - .:/var/www/html
-    #links:
-        # - "postgres:rdbms"
-        # - "mariadb:rdbms"
-    env_file:
-        - ./docker/php/env
-        # Comment non-used DBMS lines
-        # If all DBMS are commented out, sqlite will be used as default
-        # - ./docker/postgres/env
-        # - ./docker/mariadb/env
-#postgres:
-#    image: postgres:9
-#    ports:
-#        - "5432:5432"
-#    volumes:
-#        - ./docker/data/pgsql:/var/lib/postgresql/data
-#    env_file:
-#        - ./docker/postgres/env
-#mariadb:
-#    image: mariadb:10
-#    ports:
-#        - "3306:3306"
-#    volumes:
-#        - ./docker/data/mariadb:/var/lib/mysql
-#    env_file:
-#        - ./docker/mariadb/env
+version: '2'
+services:
+    nginx:
+        image: nginx
+        ports:
+            - "8080:80"
+        volumes:
+            - ./docker/nginx/nginx.conf:/nginx.conf
+            - ./docker/logs/nginx:/var/log/nginx
+            - .:/var/www/html
+        links:
+            - php:php
+        command: nginx -c /nginx.conf
+    php:
+        build:
+            context: docker/php
+            args:
+                timezone: 'Europe/Monaco'
+        ports:
+            - "9000:9000"
+        volumes:
+            - .:/var/www/html
+        #links:
+            # - "postgres:rdbms"
+            # - "mariadb:rdbms"
+        env_file:
+            - ./docker/php/env
+            # Comment non-used DBMS lines
+            # If all DBMS are commented out, sqlite will be used as default
+            # - ./docker/postgres/env
+            # - ./docker/mariadb/env
+    #postgres:
+    #    image: postgres:9
+    #    ports:
+    #        - "5432:5432"
+    #    volumes:
+    #        - ./docker/data/pgsql:/var/lib/postgresql/data
+    #    env_file:
+    #        - ./docker/postgres/env
+    #mariadb:
+    #    image: mariadb:10
+    #    ports:
+    #        - "3306:3306"
+    #    volumes:
+    #        - ./docker/data/mariadb:/var/lib/mysql
+    #    env_file:
+    #        - ./docker/mariadb/env

--- a/docker/php/Dockerfile
+++ b/docker/php/Dockerfile
@@ -1,11 +1,13 @@
 FROM php:fpm
 
+ARG timezone='Europe/Paris'
+
 RUN apt-get update && apt-get install -y \
         libmcrypt-dev libicu-dev libpq-dev libxml2-dev \
     && docker-php-ext-install \
         iconv mcrypt mbstring intl pdo pdo_mysql pdo_pgsql
 
-RUN echo "date.timezone=Europe/Paris" > /usr/local/etc/php/conf.d/date_timezone.ini
+RUN echo "date.timezone="$timezone > /usr/local/etc/php/conf.d/date_timezone.ini
 
 RUN usermod -u 1000 www-data
 

--- a/docker/php/Dockerfile
+++ b/docker/php/Dockerfile
@@ -1,5 +1,6 @@
 FROM php:fpm
 
+# Default timezone. To change it, use the argument in the docker-compose.yml file
 ARG timezone='Europe/Paris'
 
 RUN apt-get update && apt-get install -y \

--- a/docker/php/Dockerfile
+++ b/docker/php/Dockerfile
@@ -5,6 +5,8 @@ RUN apt-get update && apt-get install -y \
     && docker-php-ext-install \
         iconv mcrypt mbstring intl pdo pdo_mysql pdo_pgsql
 
+RUN echo "date.timezone=Europe/Paris" > /usr/local/etc/php/conf.d/date_timezone.ini
+
 RUN usermod -u 1000 www-data
 
 CMD ["php-fpm"]


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?|  no
| BC breaks?   | no
| Deprecations? |no
| Tests pass?   | yes|no
| Documentation | yes|no
| Translation   | yes|no
| Fixed tickets | #1726
| License       | MIT


Docker-compose should be upgraded to v1.6 to use the argument of the docker-compose.yml file.
In this sample, the argument is different from the default to show that it's the one from compose which is taken.

Following #1749

Kudos to @DjayDev