### PR TITLE
fix api properties and typo

### DIFF
--- a/src/Wallabag/ApiBundle/Controller/WallabagRestController.php
+++ b/src/Wallabag/ApiBundle/Controller/WallabagRestController.php
@@ -126,9 +126,13 @@ class WallabagRestController extends FOSRestController
             $this->get('wallabag_core.content_proxy')->assignTagsToEntry($entry, $tags);
         }
 
-        $entry->setStarred((bool) $isStarred);
+        if (!is_null($isStarred)) {
+            $entry->setStarred((bool) $isStarred);
+        }
 
-        $entry->setArchived((bool) $isArchived);
+        if (!is_null($isArchived)) {
+            $entry->setArchived((bool) $isArchived);
+        }
 
         $em = $this->getDoctrine()->getManager();
         $em->persist($entry);

--- a/src/Wallabag/ApiBundle/Controller/WallabagRestController.php
+++ b/src/Wallabag/ApiBundle/Controller/WallabagRestController.php
@@ -126,11 +126,11 @@ class WallabagRestController extends FOSRestController
             $this->get('wallabag_core.content_proxy')->assignTagsToEntry($entry, $tags);
         }
 
-        if (true === (bool) $isStarred) {
+        if ($isStarred === 'true') {
             $entry->setStarred(true);
         }
 
-        if (true === (bool) $isArchived) {
+        if ($isArchived  === 'true') {
             $entry->setArchived(true);
         }
 

--- a/src/Wallabag/ApiBundle/Controller/WallabagRestController.php
+++ b/src/Wallabag/ApiBundle/Controller/WallabagRestController.php
@@ -27,13 +27,13 @@ class WallabagRestController extends FOSRestController
      *
      * @ApiDoc(
      *       parameters={
-     *          {"name"="archive", "dataType"="boolean", "required"=false, "format"="true or false, all entries by default", "description"="filter by archived status."},
-     *          {"name"="star", "dataType"="boolean", "required"=false, "format"="true or false, all entries by default", "description"="filter by starred status."},
+     *          {"name"="archive", "dataType"="integer", "required"=false, "format"="1 or 0, all entries by default", "description"="filter by archived status."},
+     *          {"name"="starred", "dataType"="integer", "required"=false, "format"="1 or 0, all entries by default", "description"="filter by starred status."},
      *          {"name"="sort", "dataType"="string", "required"=false, "format"="'created' or 'updated', default 'created'", "description"="sort entries by date."},
      *          {"name"="order", "dataType"="string", "required"=false, "format"="'asc' or 'desc', default 'desc'", "description"="order of sort."},
      *          {"name"="page", "dataType"="integer", "required"=false, "format"="default '1'", "description"="what page you want."},
      *          {"name"="perPage", "dataType"="integer", "required"=false, "format"="default'30'", "description"="results per page."},
-     *          {"name"="tags", "dataType"="string", "required"=false, "format"="api%2Crest", "description"="a list of tags url encoded. Will returns entries that matches ALL tags."},
+     *          {"name"="tags", "dataType"="string", "required"=false, "format"="api,rest", "description"="a list of tags url encoded. Will returns entries that matches ALL tags."},
      *       }
      * )
      *
@@ -43,8 +43,8 @@ class WallabagRestController extends FOSRestController
     {
         $this->validateAuthentication();
 
-        $isArchived = $request->query->get('archive');
-        $isStarred = $request->query->get('star');
+        $isArchived = (int) $request->query->get('archive');
+        $isStarred = (int) $request->query->get('starred');
         $sort = $request->query->get('sort', 'created');
         $order = $request->query->get('order', 'desc');
         $page = (int) $request->query->get('page', 1);
@@ -52,7 +52,7 @@ class WallabagRestController extends FOSRestController
 
         $pager = $this->getDoctrine()
             ->getRepository('WallabagCoreBundle:Entry')
-            ->findEntries($this->getUser()->getId(), $isArchived, $isStarred, $sort, $order);
+            ->findEntries($this->getUser()->getId(), (bool) $isArchived, (bool) $isStarred, $sort, $order);
 
         $pager->setCurrentPage($page);
         $pager->setMaxPerPage($perPage);
@@ -97,8 +97,8 @@ class WallabagRestController extends FOSRestController
      *          {"name"="url", "dataType"="string", "required"=true, "format"="http://www.test.com/article.html", "description"="Url for the entry."},
      *          {"name"="title", "dataType"="string", "required"=false, "description"="Optional, we'll get the title from the page."},
      *          {"name"="tags", "dataType"="string", "required"=false, "format"="tag1,tag2,tag3", "description"="a comma-separated list of tags."},
-     *          {"name"="starred", "dataType"="boolean", "required"=false, "format"="true or false", "description"="entry already starred"},
-     *          {"name"="archive", "dataType"="boolean", "required"=false, "format"="true or false", "description"="entry already archived"},
+     *          {"name"="starred", "dataType"="integer", "required"=false, "format"="1 or 0", "description"="entry already starred"},
+     *          {"name"="archive", "dataType"="integer", "required"=false, "format"="1 or 0", "description"="entry already archived"},
      *       }
      * )
      *
@@ -109,8 +109,8 @@ class WallabagRestController extends FOSRestController
         $this->validateAuthentication();
 
         $url = $request->request->get('url');
-        $isArchived = $request->request->get('archive');
-        $isStarred = $request->request->get('starred');
+        $isArchived = (int) $request->request->get('archive');
+        $isStarred = (int) $request->request->get('starred');
 
         $entry = $this->get('wallabag_core.entry_repository')->findByUrlAndUserId($url, $this->getUser()->getId());
 
@@ -126,11 +126,11 @@ class WallabagRestController extends FOSRestController
             $this->get('wallabag_core.content_proxy')->assignTagsToEntry($entry, $tags);
         }
 
-        if ($isStarred === 'true') {
+        if (true === (bool) $isStarred) {
             $entry->setStarred(true);
         }
 
-        if ($isArchived  === 'true') {
+        if (true === (bool) $isArchived) {
             $entry->setArchived(true);
         }
 
@@ -154,8 +154,8 @@ class WallabagRestController extends FOSRestController
      *      parameters={
      *          {"name"="title", "dataType"="string", "required"=false},
      *          {"name"="tags", "dataType"="string", "required"=false, "format"="tag1,tag2,tag3", "description"="a comma-separated list of tags."},
-     *          {"name"="archive", "dataType"="boolean", "required"=false, "format"="true or false", "description"="archived the entry."},
-     *          {"name"="star", "dataType"="boolean", "required"=false, "format"="true or false", "description"="starred the entry."},
+     *          {"name"="archive", "dataType"="integer", "required"=false, "format"="1 or 0", "description"="archived the entry."},
+     *          {"name"="starred", "dataType"="integer", "required"=false, "format"="1 or 0", "description"="starred the entry."},
      *      }
      * )
      *
@@ -167,19 +167,19 @@ class WallabagRestController extends FOSRestController
         $this->validateUserAccess($entry->getUser()->getId());
 
         $title = $request->request->get('title');
-        $isArchived = $request->request->get('archive');
-        $isStarred = $request->request->get('star');
+        $isArchived = (int) $request->request->get('archive');
+        $isStarred = (int) $request->request->get('starred');
 
         if (!is_null($title)) {
             $entry->setTitle($title);
         }
 
         if (!is_null($isArchived)) {
-            $entry->setArchived($isArchived);
+            $entry->setArchived((bool) $isArchived);
         }
 
         if (!is_null($isStarred)) {
-            $entry->setStarred($isStarred);
+            $entry->setStarred((bool) $isStarred);
         }
 
         $tags = $request->request->get('tags', '');

--- a/src/Wallabag/ApiBundle/Controller/WallabagRestController.php
+++ b/src/Wallabag/ApiBundle/Controller/WallabagRestController.php
@@ -126,13 +126,9 @@ class WallabagRestController extends FOSRestController
             $this->get('wallabag_core.content_proxy')->assignTagsToEntry($entry, $tags);
         }
 
-        if (true === (bool) $isStarred) {
-            $entry->setStarred(true);
-        }
+        $entry->setStarred((bool) $isStarred);
 
-        if (true === (bool) $isArchived) {
-            $entry->setArchived(true);
-        }
+        $entry->setArchived((bool) $isArchived);
 
         $em = $this->getDoctrine()->getManager();
         $em->persist($entry);

--- a/src/Wallabag/ApiBundle/Tests/Controller/WallabagRestControllerTest.php
+++ b/src/Wallabag/ApiBundle/Tests/Controller/WallabagRestControllerTest.php
@@ -188,8 +188,8 @@ class WallabagRestControllerTest extends WallabagApiTestCase
     {
         $this->client->request('POST', '/api/entries.json', array(
             'url' => 'http://www.lemonde.fr/idees/article/2016/02/08/preserver-la-liberte-d-expression-sur-les-reseaux-sociaux_4861503_3232.html',
-            'archive' => true,
-            'starred' => true,
+            'archive' => 'true',
+            'starred' => 'true',
         ));
 
         $this->assertEquals(200, $this->client->getResponse()->getStatusCode());

--- a/src/Wallabag/ApiBundle/Tests/Controller/WallabagRestControllerTest.php
+++ b/src/Wallabag/ApiBundle/Tests/Controller/WallabagRestControllerTest.php
@@ -188,8 +188,8 @@ class WallabagRestControllerTest extends WallabagApiTestCase
     {
         $this->client->request('POST', '/api/entries.json', array(
             'url' => 'http://www.lemonde.fr/idees/article/2016/02/08/preserver-la-liberte-d-expression-sur-les-reseaux-sociaux_4861503_3232.html',
-            'archive' => 'true',
-            'starred' => 'true',
+            'archive' => '1',
+            'starred' => '1',
         ));
 
         $this->assertEquals(200, $this->client->getResponse()->getStatusCode());
@@ -220,8 +220,8 @@ class WallabagRestControllerTest extends WallabagApiTestCase
         $this->client->request('PATCH', '/api/entries/'.$entry->getId().'.json', array(
             'title' => 'New awesome title',
             'tags' => 'new tag '.uniqid(),
-            'star' => true,
-            'archive' => false,
+            'starred' => '1',
+            'archive' => '0',
         ));
 
         $this->assertEquals(200, $this->client->getResponse()->getStatusCode());

--- a/src/Wallabag/CoreBundle/Controller/DeveloperController.php
+++ b/src/Wallabag/CoreBundle/Controller/DeveloperController.php
@@ -43,7 +43,7 @@ class DeveloperController extends Controller
         $clientForm->handleRequest($request);
 
         if ($clientForm->isValid()) {
-            $client->setAllowedGrantTypes(array('token', 'authorization_code', 'password','refresh_token'));
+            $client->setAllowedGrantTypes(array('token', 'authorization_code', 'password', 'refresh_token'));
             $em->persist($client);
             $em->flush();
 

--- a/src/Wallabag/CoreBundle/Entity/Entry.php
+++ b/src/Wallabag/CoreBundle/Entity/Entry.php
@@ -59,6 +59,8 @@ class Entry
     /**
      * @var bool
      *
+     * @Exclude
+     *
      * @ORM\Column(name="is_archived", type="boolean")
      *
      * @Groups({"entries_for_user", "export_all"})
@@ -67,6 +69,8 @@ class Entry
 
     /**
      * @var bool
+     *
+     * @Exclude
      *
      * @ORM\Column(name="is_starred", type="boolean")
      *
@@ -271,6 +275,16 @@ class Entry
         return $this->isArchived;
     }
 
+    /**
+     * @VirtualProperty
+     * @SerializedName("is_archived")
+     * @Groups({"entries_for_user", "export_all"})
+     */
+    public function is_Archived()
+    {
+        return (int) $this->isArchived();
+    }
+
     public function toggleArchive()
     {
         $this->isArchived = $this->isArchived() ^ 1;
@@ -300,6 +314,16 @@ class Entry
     public function isStarred()
     {
         return $this->isStarred;
+    }
+
+    /**
+     * @VirtualProperty
+     * @SerializedName("is_starred")
+     * @Groups({"entries_for_user", "export_all"})
+     */
+    public function is_Starred()
+    {
+        return (int) $this->isStarred();
     }
 
     public function toggleStar()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Documentation | no
| Translation   | no
| Fixed tickets | #1780, #1784
| License       | MIT

Yeah, because a (bool) string is always true... 
Also, cs.