### PR TITLE
Don't add entry through API if it already exists

### DIFF
--- a/src/Wallabag/ApiBundle/Controller/WallabagRestController.php
+++ b/src/Wallabag/ApiBundle/Controller/WallabagRestController.php
@@ -112,10 +112,14 @@ class WallabagRestController extends FOSRestController
         $isArchived = $request->request->get('archive');
         $isStarred = $request->request->get('starred');
 
-        $entry = $this->get('wallabag_core.content_proxy')->updateEntry(
-            new Entry($this->getUser()),
-            $url
-        );
+        $entry = $this->get('wallabag_core.entry_repository')->findByUrlAndUserId($url, $this->getUser()->getId());
+
+        if (false === $entry) {
+            $entry = $this->get('wallabag_core.content_proxy')->updateEntry(
+                new Entry($this->getUser()),
+                $url
+            );
+        }
 
         $tags = $request->request->get('tags', '');
         if (!empty($tags)) {

--- a/src/Wallabag/ApiBundle/Tests/Controller/WallabagRestControllerTest.php
+++ b/src/Wallabag/ApiBundle/Tests/Controller/WallabagRestControllerTest.php
@@ -166,6 +166,24 @@ class WallabagRestControllerTest extends WallabagApiTestCase
         $this->assertCount(1, $content['tags']);
     }
 
+    public function testPostSameEntry()
+    {
+        $this->client->request('POST', '/api/entries.json', array(
+            'url' => 'http://www.lemonde.fr/pixels/article/2015/03/28/plongee-dans-l-univers-d-ingress-le-jeu-de-google-aux-frontieres-du-reel_4601155_4408996.html',
+            'archive' => '1',
+        ));
+
+        $this->assertEquals(200, $this->client->getResponse()->getStatusCode());
+
+        $content = json_decode($this->client->getResponse()->getContent(), true);
+
+        $this->assertGreaterThan(0, $content['id']);
+        $this->assertEquals('http://www.lemonde.fr/pixels/article/2015/03/28/plongee-dans-l-univers-d-ingress-le-jeu-de-google-aux-frontieres-du-reel_4601155_4408996.html', $content['url']);
+        $this->assertEquals(true, $content['is_archived']);
+        $this->assertEquals(false, $content['is_starred']);
+        $this->assertCount(1, $content['tags']);
+    }
+
     public function testPostArchivedAndStarredEntry()
     {
         $this->client->request('POST', '/api/entries.json', array(


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Documentation | no
| Translation   | no
| Fixed tickets | 
| License       | MIT

If an entry was with the same URL was re-sent a second time, a second article was created in DB. This fixes it.

Note that all metadata (archived, starred, tags, ...) associated with the second call to API will be applied to the original entry.

Also, checkout #1796