### PR TITLE
Force user-agent for iansommerville.com

### DIFF
--- a/src/Wallabag/CoreBundle/Resources/config/services.yml
+++ b/src/Wallabag/CoreBundle/Resources/config/services.yml
@@ -39,7 +39,22 @@ services:
     wallabag_core.graby:
         class: Graby\Graby
         arguments:
-            - { error_message: "wallabag can't retrieve contents for this article. Please report this issue to us." }
+            -
+                error_message: "wallabag can't retrieve contents for this article. Please report this issue to us."
+                http_client:
+                    user_agents:
+                        'lifehacker.com': 'PHP/5.2'
+                        'gawker.com': 'PHP/5.2'
+                        'deadspin.com': 'PHP/5.2'
+                        'kotaku.com': 'PHP/5.2'
+                        'jezebel.com': 'PHP/5.2'
+                        'io9.com': 'PHP/5.2'
+                        'jalopnik.com': 'PHP/5.2'
+                        'gizmodo.com': 'PHP/5.2'
+                        '.wikipedia.org': 'Mozilla/5.2'
+                        '.fok.nl': 'Googlebot/2.1'
+                        'getpocket.com': 'PHP/5.2'
+                        'iansommerville.com': 'PHP/5.2'
         calls:
             - [ setLogger, [ "@logger" ] ]
         tags:


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Documentation | no
| Translation   | no
| Fixed tickets | #1801
| License       | MIT

When using the default User Agent, the website returns a 403. By forcing the User Agent for this domain, we got the proper behavior: a 200

Since we can't _append_ new user agent to the default graby configuration, we need to rewrite all the default config + the new one.