### PR TITLE
Remove SMTP configuration environment overrides

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -90,11 +90,8 @@
         "fabpot/php-cs-fixer": "~1.9"
     },
     "scripts": {
-        "build-parameters": [
-            "Incenteev\\ParameterHandler\\ScriptHandler::buildParameters"
-        ],
         "post-cmd": [
-            "@build-parameters",
+            "Incenteev\\ParameterHandler\\ScriptHandler::buildParameters",
             "Sensio\\Bundle\\DistributionBundle\\Composer\\ScriptHandler::buildBootstrap",
             "Sensio\\Bundle\\DistributionBundle\\Composer\\ScriptHandler::clearCache",
             "Sensio\\Bundle\\DistributionBundle\\Composer\\ScriptHandler::installAssets",
@@ -116,13 +113,7 @@
         "symfony-tests-dir": "tests",
         "symfony-assets-install": "relative",
         "incenteev-parameters": {
-            "file": "app/config/parameters.yml",
-            "env-map": {
-                "mailer_host": "WALLABAG_MAILER_HOST",
-                "mailer_user": "WALLABAG_MAILER_USER",
-                "mailer_password": "WALLABAG_MAILER_PASSWORD",
-                "secret": "WALLABAG_SECRET"
-            }
+            "file": "app/config/parameters.yml"
         }
     },
     "autoload": {

--- a/docs/en/user/installation.rst
+++ b/docs/en/user/installation.rst
@@ -62,6 +62,11 @@ To start php's build-in server and test if everything did install correctly, you
 
 And access wallabag at http://yourserverip:8000
 
+.. note::
+
+    To define parameters with environment variables, you have to set these variables with ``SYMFONY__`` prefix. For example, ``SYMFONY__DATABASE_DRIVER``. You can have a look to the  `Symfony documentation
+<http://symfony.com/doc/current/cookbook/configuration/external_parameters.html>`__.
+
 Installing on Apache
 --------------------
 

--- a/docs/fr/user/installation.rst
+++ b/docs/fr/user/installation.rst
@@ -60,6 +60,11 @@ Pour démarrer le serveur interne à php et vérifier que tout s'est installé c
 
 Et accéder wallabag à l'adresse http://lipdevotreserveur:8000
 
+.. note::
+
+    Pour définir des paramètres via des variables d'environnement, vous pouvez les spécifier avec le préfixe ``SYMFONY__``. Par exemple, ``SYMFONY__DATABASE_DRIVER``. Vous pouvez lire `documentation Symfony
+<http://symfony.com/doc/current/cookbook/configuration/external_parameters.html>`__ pour en savoir plus. 
+
 Installation avec Apache
 ------------------------
 


### PR DESCRIPTION
Previously, here #1725 (by @mathbruyen) ... 

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | yes (previous overrides no longer work)
| Deprecations? | no
| Tests pass?   | yes
| Documentation | no
| Translation   | no
| License       | MIT

SMTP configuration has been added in #1518 to use ParameterHandle's `env-map`. But Symfony actually has a native way of allowing parameters to be overriden from environment so rather than having to define a mapping for each possible parameter, users can define any override in `parameters.yml`:

> parameters:
>     database_host: %WALLABAG_DB_HOST%

and define an environment variable `SYMFONY__WALLABAG_DB_HOST`.

Links:
* [env-map](https://github.com/Incenteev/ParameterHandler#using-environment-variables-to-set-the-parameters)
* [Symfony external parameters](http://symfony.com/doc/current/cookbook/configuration/external_parameters.html)