### PR TITLE
Check selected PDO driver on install

### DIFF
--- a/src/Wallabag/CoreBundle/Command/InstallCommand.php
+++ b/src/Wallabag/CoreBundle/Command/InstallCommand.php
@@ -73,13 +73,14 @@ class InstallCommand extends ContainerAwareCommand
 
         $fulfilled = true;
 
-        $label = '<comment>PDO Drivers</comment>';
+        $label = '<comment>PDO Driver</comment>';
         $status = '<info>OK!</info>';
         $help = '';
-        if (!(extension_loaded('pdo_sqlite') || extension_loaded('pdo_mysql') || extension_loaded('pdo_pgsql'))) {
+
+        if (!extension_loaded($this->getContainer()->getParameter('database_driver'))) {
             $fulfilled = false;
             $status = '<error>ERROR!</error>';
-            $help = 'Needs one of sqlite, mysql or pgsql PDO drivers';
+            $help = 'Database driver "'.$this->getContainer()->getParameter('database_driver').'" is not installed.';
         }
 
         $rows = [];


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Documentation | no
| Translation   | no
| Fixed tickets | https://github.com/wallabag/wallabag/issues/1830
| License       | MIT

Instead of checking that one of the DB driver is installed we retrieve the selected driver (in parameters) and see if the extension exists.