### PR TITLE
Remove keyboard shortcut and add tagging rule panel in baggy

### DIFF
--- a/src/Wallabag/CoreBundle/Resources/public/themes/baggy/js/saveLink.js
+++ b/src/Wallabag/CoreBundle/Resources/public/themes/baggy/js/saveLink.js
@@ -79,19 +79,6 @@ $.fn.ready(function() {
   });
 
   /* ==========================================================================
-   Keyboard gestion
-   ========================================================================== */
-
-  $(window).keydown(function(e){
-    if ( ( e.target.tagName.toLowerCase() !== 'input' && e.keyCode == 83 ) || (e.keyCode == 27 && $bagitForm.is(':visible') ) ) {
-      $bagit.removeClass("current");
-      $("#bagit-arrow").removeClass("arrow-down");
-      toggleSaveLinkForm();
-      return false;
-    }
-  });
-
-  /* ==========================================================================
    Process all links inside an article
    ========================================================================== */
 

--- a/src/Wallabag/CoreBundle/Resources/views/themes/baggy/Config/index.html.twig
+++ b/src/Wallabag/CoreBundle/Resources/views/themes/baggy/Config/index.html.twig
@@ -49,7 +49,7 @@
 
     <h2>{{ 'config.tab_menu.rss'|trans }}</h2>
 
-    {{ form_start(form.rss) }}
+        {{ form_start(form.rss) }}
         {{ form_errors(form.rss) }}
 
         <div class="row">
@@ -169,7 +169,7 @@
         {{ form_rest(form.pwd) }}
     </form>
 
-    <h2>{{ 'config.tab_menu.rules'|trans }}}</h2>
+    <h2>{{ 'config.tab_menu.rules'|trans }}</h2>
 
     <ul>
         {% for tagging_rule in app.user.config.taggingRules %}
@@ -183,7 +183,7 @@
         {% endfor %}
     </ul>
 
-    {{ form_start(form.new_tagging_rule) }}
+        {{ form_start(form.new_tagging_rule) }}
         {{ form_errors(form.new_tagging_rule) }}
 
         <fieldset class="w500p inline">
@@ -204,6 +204,91 @@
 
         {{ form_rest(form.new_tagging_rule) }}
     </form>
+
+    <div class="row">
+        <div class="input-field col s12">
+            <h3>{{ 'config.form_rules.faq.title'|trans }}</h3>
+
+            <h4>{{ 'config.form_rules.faq.tagging_rules_definition_title'|trans }}</h4>
+            <p class="help">{{ 'config.form_rules.faq.tagging_rules_definition_description'|trans|raw }}</p>
+
+            <h4>{{ 'config.form_rules.faq.how_to_use_them_title'|trans }}</h4>
+            <p class="help">{{ 'config.form_rules.faq.how_to_use_them_description'|trans|raw }}</p>
+
+            <h4>{{ 'config.form_rules.faq.variables_available_title'|trans }}</h4>
+            <p class="help">
+                {{ 'config.form_rules.faq.variables_available_description'|trans }}
+            </p>
+
+            <table class="bordered">
+                <thead>
+                <tr>
+                    <th>{{ 'config.form_rules.faq.variable_description.label'|trans }}</th>
+                    <th>{{ 'config.form_rules.faq.meaning'|trans }}</th>
+                    <th>{{ 'config.form_rules.faq.operator_description.label'|trans }}</th>
+                    <th>{{ 'config.form_rules.faq.meaning'|trans }}</th>
+                </tr>
+                </thead>
+
+                <tbody>
+                <tr>
+                    <td>title</td>
+                    <td>{{ 'config.form_rules.faq.variable_description.title'|trans }}</td>
+                    <td>&lt;=</td>
+                    <td>{{ 'config.form_rules.faq.operator_description.less_than'|trans }}</td>
+                </tr>
+                <tr>
+                    <td>url</td>
+                    <td>{{ 'config.form_rules.faq.variable_description.url'|trans }}</td>
+                    <td>&lt;</td>
+                    <td>{{ 'config.form_rules.faq.operator_description.strictly_less_than'|trans }}</td>
+                </tr>
+                <tr>
+                    <td>isArchived</td>
+                    <td>{{ 'config.form_rules.faq.variable_description.isArchived'|trans }}</td>
+                    <td>=&gt;</td>
+                    <td>{{ 'config.form_rules.faq.operator_description.greater_than'|trans }}</td>
+                </tr>
+                <tr>
+                    <td>isStarred</td>
+                    <td>{{ 'config.form_rules.faq.variable_description.isStarred'|trans }}</td>
+                    <td>&gt;</td>
+                    <td>{{ 'config.form_rules.faq.operator_description.strictly_greater_than'|trans }}</td>
+                </tr>
+                <tr>
+                    <td>content</td>
+                    <td>{{ 'config.form_rules.faq.variable_description.content'|trans }}</td>
+                    <td>=</td>
+                    <td>{{ 'config.form_rules.faq.operator_description.equal_to'|trans }}</td>
+                </tr>
+                <tr>
+                    <td>language</td>
+                    <td>{{ 'config.form_rules.faq.variable_description.language'|trans }}</td>
+                    <td>!=</td>
+                    <td>{{ 'config.form_rules.faq.operator_description.not_equal_to'|trans }}</td>
+                </tr>
+                <tr>
+                    <td>mimetype</td>
+                    <td>{{ 'config.form_rules.faq.variable_description.mimetype'|trans }}</td>
+                    <td>OR</td>
+                    <td>{{ 'config.form_rules.faq.operator_description.or'|trans }}</td>
+                </tr>
+                <tr>
+                    <td>readingTime</td>
+                    <td>{{ 'config.form_rules.faq.variable_description.readingTime'|trans }}</td>
+                    <td>AND</td>
+                    <td>{{ 'config.form_rules.faq.operator_description.and'|trans }}</td>
+                </tr>
+                <tr>
+                    <td>domainName</td>
+                    <td>{{ 'config.form_rules.faq.variable_description.domainName'|trans }}</td>
+                    <td>matches</td>
+                    <td>{{ 'config.form_rules.faq.operator_description.matches'|trans|raw }}</td>
+                </tr>
+                </tbody>
+            </table>
+        </div>
+    </div>
 
     {% if is_granted('ROLE_SUPER_ADMIN') %}
     <h2>{{ 'config.tab_menu.new_user'|trans }}</h2>

--- a/src/Wallabag/CoreBundle/Resources/views/themes/material/Config/index.html.twig
+++ b/src/Wallabag/CoreBundle/Resources/views/themes/material/Config/index.html.twig
@@ -250,75 +250,75 @@
                                 <h5>{{ 'config.form_rules.faq.variables_available_title'|trans }}</h5>
                                 <p class="help">
                                     {{ 'config.form_rules.faq.variables_available_description'|trans }}
-
-                                    <table class="bordered">
-                                        <thead>
-                                            <tr>
-                                                <th>{{ 'config.form_rules.faq.variable_description.label'|trans }}</th>
-                                                <th>{{ 'config.form_rules.faq.meaning'|trans }}</th>
-                                                <th>{{ 'config.form_rules.faq.operator_description.label'|trans }}</th>
-                                                <th>{{ 'config.form_rules.faq.meaning'|trans }}</th>
-                                            </tr>
-                                        </thead>
-
-                                        <tbody>
-                                            <tr>
-                                                <td>title</td>
-                                                <td>{{ 'config.form_rules.faq.variable_description.title'|trans }}</td>
-                                                <td>&lt;=</td>
-                                                <td>{{ 'config.form_rules.faq.operator_description.less_than'|trans }}</td>
-                                            </tr>
-                                            <tr>
-                                                <td>url</td>
-                                                <td>{{ 'config.form_rules.faq.variable_description.url'|trans }}</td>
-                                                <td>&lt;</td>
-                                                <td>{{ 'config.form_rules.faq.operator_description.strictly_less_than'|trans }}</td>
-                                            </tr>
-                                            <tr>
-                                                <td>isArchived</td>
-                                                <td>{{ 'config.form_rules.faq.variable_description.isArchived'|trans }}</td>
-                                                <td>=&gt;</td>
-                                                <td>{{ 'config.form_rules.faq.operator_description.greater_than'|trans }}</td>
-                                            </tr>
-                                            <tr>
-                                                <td>isStarred</td>
-                                                <td>{{ 'config.form_rules.faq.variable_description.isStarred'|trans }}</td>
-                                                <td>&gt;</td>
-                                                <td>{{ 'config.form_rules.faq.operator_description.strictly_greater_than'|trans }}</td>
-                                            </tr>
-                                            <tr>
-                                                <td>content</td>
-                                                <td>{{ 'config.form_rules.faq.variable_description.content'|trans }}</td>
-                                                <td>=</td>
-                                                <td>{{ 'config.form_rules.faq.operator_description.equal_to'|trans }}</td>
-                                            </tr>
-                                            <tr>
-                                                <td>language</td>
-                                                <td>{{ 'config.form_rules.faq.variable_description.language'|trans }}</td>
-                                                <td>!=</td>
-                                                <td>{{ 'config.form_rules.faq.operator_description.not_equal_to'|trans }}</td>
-                                            </tr>
-                                            <tr>
-                                                <td>mimetype</td>
-                                                <td>{{ 'config.form_rules.faq.variable_description.mimetype'|trans }}</td>
-                                                <td>OR</td>
-                                                <td>{{ 'config.form_rules.faq.operator_description.or'|trans }}</td>
-                                            </tr>
-                                            <tr>
-                                                <td>readingTime</td>
-                                                <td>{{ 'config.form_rules.faq.variable_description.readingTime'|trans }}</td>
-                                                <td>AND</td>
-                                                <td>{{ 'config.form_rules.faq.operator_description.and'|trans }}</td>
-                                            </tr>
-                                            <tr>
-                                                <td>domainName</td>
-                                                <td>{{ 'config.form_rules.faq.variable_description.domainName'|trans }}</td>
-                                                <td>matches</td>
-                                                <td>{{ 'config.form_rules.faq.operator_description.matches'|trans|raw }}</td>
-                                            </tr>
-                                        </tbody>
-                                    </table>
                                 </p>
+
+                                <table class="bordered">
+                                    <thead>
+                                        <tr>
+                                            <th>{{ 'config.form_rules.faq.variable_description.label'|trans }}</th>
+                                            <th>{{ 'config.form_rules.faq.meaning'|trans }}</th>
+                                            <th>{{ 'config.form_rules.faq.operator_description.label'|trans }}</th>
+                                            <th>{{ 'config.form_rules.faq.meaning'|trans }}</th>
+                                        </tr>
+                                    </thead>
+
+                                    <tbody>
+                                        <tr>
+                                            <td>title</td>
+                                            <td>{{ 'config.form_rules.faq.variable_description.title'|trans }}</td>
+                                            <td>&lt;=</td>
+                                            <td>{{ 'config.form_rules.faq.operator_description.less_than'|trans }}</td>
+                                        </tr>
+                                        <tr>
+                                            <td>url</td>
+                                            <td>{{ 'config.form_rules.faq.variable_description.url'|trans }}</td>
+                                            <td>&lt;</td>
+                                            <td>{{ 'config.form_rules.faq.operator_description.strictly_less_than'|trans }}</td>
+                                        </tr>
+                                        <tr>
+                                            <td>isArchived</td>
+                                            <td>{{ 'config.form_rules.faq.variable_description.isArchived'|trans }}</td>
+                                            <td>=&gt;</td>
+                                            <td>{{ 'config.form_rules.faq.operator_description.greater_than'|trans }}</td>
+                                        </tr>
+                                        <tr>
+                                            <td>isStarred</td>
+                                            <td>{{ 'config.form_rules.faq.variable_description.isStarred'|trans }}</td>
+                                            <td>&gt;</td>
+                                            <td>{{ 'config.form_rules.faq.operator_description.strictly_greater_than'|trans }}</td>
+                                        </tr>
+                                        <tr>
+                                            <td>content</td>
+                                            <td>{{ 'config.form_rules.faq.variable_description.content'|trans }}</td>
+                                            <td>=</td>
+                                            <td>{{ 'config.form_rules.faq.operator_description.equal_to'|trans }}</td>
+                                        </tr>
+                                        <tr>
+                                            <td>language</td>
+                                            <td>{{ 'config.form_rules.faq.variable_description.language'|trans }}</td>
+                                            <td>!=</td>
+                                            <td>{{ 'config.form_rules.faq.operator_description.not_equal_to'|trans }}</td>
+                                        </tr>
+                                        <tr>
+                                            <td>mimetype</td>
+                                            <td>{{ 'config.form_rules.faq.variable_description.mimetype'|trans }}</td>
+                                            <td>OR</td>
+                                            <td>{{ 'config.form_rules.faq.operator_description.or'|trans }}</td>
+                                        </tr>
+                                        <tr>
+                                            <td>readingTime</td>
+                                            <td>{{ 'config.form_rules.faq.variable_description.readingTime'|trans }}</td>
+                                            <td>AND</td>
+                                            <td>{{ 'config.form_rules.faq.operator_description.and'|trans }}</td>
+                                        </tr>
+                                        <tr>
+                                            <td>domainName</td>
+                                            <td>{{ 'config.form_rules.faq.variable_description.domainName'|trans }}</td>
+                                            <td>matches</td>
+                                            <td>{{ 'config.form_rules.faq.operator_description.matches'|trans|raw }}</td>
+                                        </tr>
+                                    </tbody>
+                                </table>
                             </div>
                         </div>
                     </div>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| Tests pass?   | yes
| Fixed tickets | #1673
| License       | MIT

Fix #1673 
I don't think that we have to work many hours on baggy theme. Baggy is still here and must be readable for articles, but for config screens, we only have to do the minimum.
