### PR TITLE
Force server version to avoid connexion error

### DIFF
--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -82,6 +82,7 @@ doctrine:
         password: "%database_password%"
         charset:  UTF8
         path:     "%database_path%"
+        server_version: 5.6
 
     orm:
         auto_generate_proxy_classes: "%kernel.debug%"

--- a/src/Wallabag/CoreBundle/Command/InstallCommand.php
+++ b/src/Wallabag/CoreBundle/Command/InstallCommand.php
@@ -455,7 +455,13 @@ class InstallCommand extends ContainerAwareCommand
             return false;
         }
 
-        return in_array($databaseName, $schemaManager->listDatabases());
+        try {
+            return in_array($databaseName, $schemaManager->listDatabases());
+        } catch (\Doctrine\DBAL\Exception\ConnectionException $e) {
+            // it means we weren't able to get database list, assume the database doesn't exist
+
+            return false;
+        }
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Documentation | no
| Translation   | no
| Fixed tickets | #1769 
| License       | MIT

When installing a new project with MySQL, if the database doesn't exist before installation will fail because DBAL will try to get the server version by querying it.
And since this query is done using the default database connexion and since the database doesn't exist, DBAL can't connect to the server.

Following #1773
See http://blog.insight.sensiolabs.com/2014/12/22/making-symfony-bootable-with-dbal-2-5.html