### PR TITLE
Move setup config outside setupAdmin

### DIFF
--- a/src/Wallabag/CoreBundle/Command/InstallCommand.php
+++ b/src/Wallabag/CoreBundle/Command/InstallCommand.php
@@ -60,6 +60,7 @@ class InstallCommand extends ContainerAwareCommand
             ->checkRequirements()
             ->setupDatabase()
             ->setupAdmin()
+            ->setupConfig()
             ->setupAsset()
         ;
 
@@ -69,7 +70,7 @@ class InstallCommand extends ContainerAwareCommand
 
     protected function checkRequirements()
     {
-        $this->defaultOutput->writeln('<info><comment>Step 1 of 4.</comment> Checking system requirements.</info>');
+        $this->defaultOutput->writeln('<info><comment>Step 1 of 5.</comment> Checking system requirements.</info>');
 
         $fulfilled = true;
 
@@ -119,7 +120,7 @@ class InstallCommand extends ContainerAwareCommand
 
     protected function setupDatabase()
     {
-        $this->defaultOutput->writeln('<info><comment>Step 2 of 4.</comment> Setting up database.</info>');
+        $this->defaultOutput->writeln('<info><comment>Step 2 of 5.</comment> Setting up database.</info>');
 
         // user want to reset everything? Don't care about what is already here
         if (true === $this->defaultInput->getOption('reset')) {
@@ -190,7 +191,7 @@ class InstallCommand extends ContainerAwareCommand
 
     protected function setupAdmin()
     {
-        $this->defaultOutput->writeln('<info><comment>Step 3 of 4.</comment> Administration setup.</info>');
+        $this->defaultOutput->writeln('<info><comment>Step 3 of 5.</comment> Administration setup.</info>');
 
         $questionHelper = $this->getHelperSet()->get('question');
         $question = new ConfirmationQuestion('Would you like to create a new admin user (recommended) ? (Y/n)', true);
@@ -226,6 +227,16 @@ class InstallCommand extends ContainerAwareCommand
         $config->setLanguage($this->getContainer()->getParameter('wallabag_core.language'));
 
         $em->persist($config);
+
+        $this->defaultOutput->writeln('');
+
+        return $this;
+    }
+
+    protected function setupConfig()
+    {
+        $this->defaultOutput->writeln('<info><comment>Step 4 of 5.</comment> Config setup.</info>');
+        $em = $this->getContainer()->get('doctrine.orm.entity_manager');
 
         // cleanup before insert new stuff
         $em->createQuery('DELETE FROM CraueConfigBundle:Setting')->execute();
@@ -365,7 +376,7 @@ class InstallCommand extends ContainerAwareCommand
 
     protected function setupAsset()
     {
-        $this->defaultOutput->writeln('<info><comment>Step 4 of 4.</comment> Installing assets.</info>');
+        $this->defaultOutput->writeln('<info><comment>Step 5 of 5.</comment> Installing assets.</info>');
 
         $this
             ->runCommand('assets:install')

--- a/src/Wallabag/CoreBundle/Tests/Command/InstallCommandTest.php
+++ b/src/Wallabag/CoreBundle/Tests/Command/InstallCommandTest.php
@@ -67,10 +67,11 @@ class InstallCommandTest extends WallabagCoreTestCase
             'command' => $command->getName(),
         ));
 
-        $this->assertContains('Step 1 of 4. Checking system requirements.', $tester->getDisplay());
-        $this->assertContains('Step 2 of 4. Setting up database.', $tester->getDisplay());
-        $this->assertContains('Step 3 of 4. Administration setup.', $tester->getDisplay());
-        $this->assertContains('Step 4 of 4. Installing assets.', $tester->getDisplay());
+        $this->assertContains('Checking system requirements.', $tester->getDisplay());
+        $this->assertContains('Setting up database.', $tester->getDisplay());
+        $this->assertContains('Administration setup.', $tester->getDisplay());
+        $this->assertContains('Config setup.', $tester->getDisplay());
+        $this->assertContains('Installing assets.', $tester->getDisplay());
     }
 
     public function testRunInstallCommandWithReset()
@@ -97,11 +98,12 @@ class InstallCommandTest extends WallabagCoreTestCase
             '--reset' => true,
         ));
 
-        $this->assertContains('Step 1 of 4. Checking system requirements.', $tester->getDisplay());
-        $this->assertContains('Step 2 of 4. Setting up database.', $tester->getDisplay());
+        $this->assertContains('Checking system requirements.', $tester->getDisplay());
+        $this->assertContains('Setting up database.', $tester->getDisplay());
         $this->assertContains('Droping database, creating database and schema, clearing the cache', $tester->getDisplay());
-        $this->assertContains('Step 3 of 4. Administration setup.', $tester->getDisplay());
-        $this->assertContains('Step 4 of 4. Installing assets.', $tester->getDisplay());
+        $this->assertContains('Administration setup.', $tester->getDisplay());
+        $this->assertContains('Config setup.', $tester->getDisplay());
+        $this->assertContains('Installing assets.', $tester->getDisplay());
 
         // we force to reset everything
         $this->assertContains('Droping database, creating database and schema, clearing the cache', $tester->getDisplay());
@@ -142,10 +144,11 @@ class InstallCommandTest extends WallabagCoreTestCase
             'command' => $command->getName(),
         ));
 
-        $this->assertContains('Step 1 of 4. Checking system requirements.', $tester->getDisplay());
-        $this->assertContains('Step 2 of 4. Setting up database.', $tester->getDisplay());
-        $this->assertContains('Step 3 of 4. Administration setup.', $tester->getDisplay());
-        $this->assertContains('Step 4 of 4. Installing assets.', $tester->getDisplay());
+        $this->assertContains('Checking system requirements.', $tester->getDisplay());
+        $this->assertContains('Setting up database.', $tester->getDisplay());
+        $this->assertContains('Administration setup.', $tester->getDisplay());
+        $this->assertContains('Config setup.', $tester->getDisplay());
+        $this->assertContains('Installing assets.', $tester->getDisplay());
 
         // the current database doesn't already exist
         $this->assertContains('Creating database and schema, clearing the cache', $tester->getDisplay());
@@ -179,10 +182,11 @@ class InstallCommandTest extends WallabagCoreTestCase
             'command' => $command->getName(),
         ));
 
-        $this->assertContains('Step 1 of 4. Checking system requirements.', $tester->getDisplay());
-        $this->assertContains('Step 2 of 4. Setting up database.', $tester->getDisplay());
-        $this->assertContains('Step 3 of 4. Administration setup.', $tester->getDisplay());
-        $this->assertContains('Step 4 of 4. Installing assets.', $tester->getDisplay());
+        $this->assertContains('Checking system requirements.', $tester->getDisplay());
+        $this->assertContains('Setting up database.', $tester->getDisplay());
+        $this->assertContains('Administration setup.', $tester->getDisplay());
+        $this->assertContains('Config setup.', $tester->getDisplay());
+        $this->assertContains('Installing assets.', $tester->getDisplay());
 
         $this->assertContains('Droping schema and creating schema', $tester->getDisplay());
     }
@@ -233,10 +237,11 @@ class InstallCommandTest extends WallabagCoreTestCase
             'command' => $command->getName(),
         ));
 
-        $this->assertContains('Step 1 of 4. Checking system requirements.', $tester->getDisplay());
-        $this->assertContains('Step 2 of 4. Setting up database.', $tester->getDisplay());
-        $this->assertContains('Step 3 of 4. Administration setup.', $tester->getDisplay());
-        $this->assertContains('Step 4 of 4. Installing assets.', $tester->getDisplay());
+        $this->assertContains('Checking system requirements.', $tester->getDisplay());
+        $this->assertContains('Setting up database.', $tester->getDisplay());
+        $this->assertContains('Administration setup.', $tester->getDisplay());
+        $this->assertContains('Config setup.', $tester->getDisplay());
+        $this->assertContains('Installing assets.', $tester->getDisplay());
 
         $this->assertContains('Creating schema', $tester->getDisplay());
     }
@@ -265,9 +270,10 @@ class InstallCommandTest extends WallabagCoreTestCase
             '--no-interaction' => true,
         ));
 
-        $this->assertContains('Step 1 of 4. Checking system requirements.', $tester->getDisplay());
-        $this->assertContains('Step 2 of 4. Setting up database.', $tester->getDisplay());
-        $this->assertContains('Step 3 of 4. Administration setup.', $tester->getDisplay());
-        $this->assertContains('Step 4 of 4. Installing assets.', $tester->getDisplay());
+        $this->assertContains('Checking system requirements.', $tester->getDisplay());
+        $this->assertContains('Setting up database.', $tester->getDisplay());
+        $this->assertContains('Administration setup.', $tester->getDisplay());
+        $this->assertContains('Config setup.', $tester->getDisplay());
+        $this->assertContains('Installing assets.', $tester->getDisplay());
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Documentation | no
| Translation   | no
| Fixed tickets | #1881
| License       | MIT

If user doesn't want to create a new admin (even if it's recommended) the internal config weren't created resulting in error when using the interface.