### PR TITLE
Add CLI import for wallabag v2 files

### DIFF
--- a/docs/en/user/migration.rst
+++ b/docs/en/user/migration.rst
@@ -24,29 +24,6 @@ After creating an user account on your new wallabag v2 instance, you must head o
    :alt: Import from wallabag v1
    :align: center
 
-Import via command-line interface (CLI)
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-If you have a CLI access on your web server, you can execute this command to import your wallabag v1 export:
-
-::
-
-    bin/console wallabag:import-v1 1 ~/Downloads/wallabag-export-1-2016-04-05.json --env=prod
-
-Please replace values:
-
-* ``1`` is the user identifier in database (The ID of the first user created on wallabag is 1)
-* ``~/Downloads/wallabag-export-1-2016-04-05.json`` is the path of your wallabag v1 export
-
-You'll have this in return:
-
-::
-
-    Start : 05-04-2016 11:36:07 ---
-    403 imported
-    0 already saved
-    End : 05-04-2016 11:36:09 ---
-
 From wallabag 2.x
 -----------------
 
@@ -60,3 +37,30 @@ From your new wallabag instance, create your user account and click on the link 
 
 .. note::
     If you encounter issues during the export or the import, don't hesitate to `ask for support <https://www.wallabag.org/pages/support.html>`__.
+
+Import via command-line interface (CLI)
+---------------------------------------
+
+If you have a CLI access on your web server, you can execute this command to import your wallabag v1 export:
+
+::
+
+    bin/console wallabag:import 1 ~/Downloads/wallabag-export-1-2016-04-05.json --env=prod
+
+Please replace values:
+
+* ``1`` is the user identifier in database (The ID of the first user created on wallabag is 1)
+* ``~/Downloads/wallabag-export-1-2016-04-05.json`` is the path of your wallabag v1 export
+
+If you want to mark all these entries as read, you can add the ``--markAsRead=yes`` option.
+
+To import a wallabag v2 file, you need to add the option ``--importer=v2``.
+
+You'll have this in return:
+
+::
+
+    Start : 05-04-2016 11:36:07 ---
+    403 imported
+    0 already saved
+    End : 05-04-2016 11:36:09 ---

--- a/docs/en/user/migration.rst
+++ b/docs/en/user/migration.rst
@@ -52,7 +52,7 @@ Please replace values:
 * ``1`` is the user identifier in database (The ID of the first user created on wallabag is 1)
 * ``~/Downloads/wallabag-export-1-2016-04-05.json`` is the path of your wallabag v1 export
 
-If you want to mark all these entries as read, you can add the ``--markAsRead=yes`` option.
+If you want to mark all these entries as read, you can add the ``--markAsRead`` option.
 
 To import a wallabag v2 file, you need to add the option ``--importer=v2``.
 

--- a/docs/fr/user/migration.rst
+++ b/docs/fr/user/migration.rst
@@ -38,8 +38,8 @@ Depuis votre nouvelle instance de wallabag, créez votre compte utilisateur puis
 .. note::
     S'il vous arrive des problèmes durant l'export ou l'import, n'hésitez pas à `demander de l'aide <https://www.wallabag.org/pages/support.html>`__.
 
-Import via via la ligne de commande (CLI)
------------------------------------------
+Import via la ligne de commande (CLI)
+-------------------------------------
 
 Si vous avez accès à la ligne de commandes de votre serveur web, vous pouvez exécuter cette commande pour import votre fichier wallabag v1 :
 
@@ -52,7 +52,7 @@ Remplacez les valeurs :
 * ``1`` est l'identifiant de votre utilisateur en base (l'ID de votre premier utilisateur créé sur wallabag est 1)
 * ``~/Downloads/wallabag-export-1-2016-04-05.json`` est le chemin de votre export wallabag v1
 
-Si vous voulez marquer tous ces articles comme lus, vous pouvez ajouter l'option ``--markAsRead=yes``.
+Si vous voulez marquer tous ces articles comme lus, vous pouvez ajouter l'option ``--markAsRead``.
 
 Pour importer un fichier wallabag v2, vous devez ajouter l'option ``--importer=v2``.
 

--- a/docs/fr/user/migration.rst
+++ b/docs/fr/user/migration.rst
@@ -24,29 +24,6 @@ Une fois que vous avez créé un compte utilisateur sur votre nouvelle instance 
    :alt: Import depuis wallabag v1
    :align: center
 
-Import via via la ligne de commande (CLI)
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-Si vous avez accès à la ligne de commandes de votre serveur web, vous pouvez exécuter cette commande pour import votre fichier wallabag v1 :
-
-::
-
-    bin/console wallabag:import-v1 1 ~/Downloads/wallabag-export-1-2016-04-05.json --env=prod
-
-Remplacez les valeurs :
-
-* ``1`` est l'identifiant de votre utilisateur en base (l'ID de votre premier utilisateur créé sur wallabag est 1)
-* ``~/Downloads/wallabag-export-1-2016-04-05.json`` est le chemin de votre export wallabag v1
-
-Vous obtiendrez :
-
-::
-
-    Start : 05-04-2016 11:36:07 ---
-    403 imported
-    0 already saved
-    End : 05-04-2016 11:36:09 ---
-
 Depuis wallabag 2.x
 -------------------
 
@@ -60,3 +37,30 @@ Depuis votre nouvelle instance de wallabag, créez votre compte utilisateur puis
 
 .. note::
     S'il vous arrive des problèmes durant l'export ou l'import, n'hésitez pas à `demander de l'aide <https://www.wallabag.org/pages/support.html>`__.
+
+Import via via la ligne de commande (CLI)
+-----------------------------------------
+
+Si vous avez accès à la ligne de commandes de votre serveur web, vous pouvez exécuter cette commande pour import votre fichier wallabag v1 :
+
+::
+
+    bin/console wallabag:import 1 ~/Downloads/wallabag-export-1-2016-04-05.json --env=prod
+
+Remplacez les valeurs :
+
+* ``1`` est l'identifiant de votre utilisateur en base (l'ID de votre premier utilisateur créé sur wallabag est 1)
+* ``~/Downloads/wallabag-export-1-2016-04-05.json`` est le chemin de votre export wallabag v1
+
+Si vous voulez marquer tous ces articles comme lus, vous pouvez ajouter l'option ``--markAsRead=yes``.
+
+Pour importer un fichier wallabag v2, vous devez ajouter l'option ``--importer=v2``.
+
+Vous obtiendrez :
+
+::
+
+    Start : 05-04-2016 11:36:07 ---
+    403 imported
+    0 already saved
+    End : 05-04-2016 11:36:09 ---

--- a/src/Wallabag/ImportBundle/Command/ImportCommand.php
+++ b/src/Wallabag/ImportBundle/Command/ImportCommand.php
@@ -13,10 +13,12 @@ class ImportCommand extends ContainerAwareCommand
     protected function configure()
     {
         $this
-            ->setName('wallabag:import-v1')
+            ->setName('wallabag:import')
             ->setDescription('Import entries from a JSON export from a wallabag v1 instance')
             ->addArgument('userId', InputArgument::REQUIRED, 'User ID to populate')
             ->addArgument('filepath', InputArgument::REQUIRED, 'Path to the JSON file')
+            ->addOption('importer', null, InputArgument::OPTIONAL, 'The importer to use: v1 or v2', 'v1')
+            ->addOption('markAsRead', null, InputArgument::OPTIONAL, 'Mark all entries as read: true/false', false)
         ;
     }
 
@@ -35,6 +37,15 @@ class ImportCommand extends ContainerAwareCommand
         }
 
         $wallabag = $this->getContainer()->get('wallabag_import.wallabag_v1.import');
+
+        if ('v2' === $input->getOption('importer')) {
+            $wallabag = $this->getContainer()->get('wallabag_import.wallabag_v2.import');
+        }
+
+        if ('yes' === $input->getOption('markAsRead')) {
+            $wallabag->setMarkAsRead(true);
+        }
+
         $res = $wallabag
             ->setUser($user)
             ->setFilepath($input->getArgument('filepath'))

--- a/src/Wallabag/ImportBundle/Command/ImportCommand.php
+++ b/src/Wallabag/ImportBundle/Command/ImportCommand.php
@@ -18,7 +18,7 @@ class ImportCommand extends ContainerAwareCommand
             ->addArgument('userId', InputArgument::REQUIRED, 'User ID to populate')
             ->addArgument('filepath', InputArgument::REQUIRED, 'Path to the JSON file')
             ->addOption('importer', null, InputArgument::OPTIONAL, 'The importer to use: v1 or v2', 'v1')
-            ->addOption('markAsRead', null, InputArgument::OPTIONAL, 'Mark all entries as read: true/false', false)
+            ->addOption('markAsRead', null, InputArgument::OPTIONAL, 'Mark all entries as read', false)
         ;
     }
 
@@ -42,9 +42,7 @@ class ImportCommand extends ContainerAwareCommand
             $wallabag = $this->getContainer()->get('wallabag_import.wallabag_v2.import');
         }
 
-        if ('yes' === $input->getOption('markAsRead')) {
-            $wallabag->setMarkAsRead(true);
-        }
+        $wallabag->setMarkAsRead($input->getOption('markAsRead'));
 
         $res = $wallabag
             ->setUser($user)


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | yes
| Deprecations? | no
| Tests pass?   | yes
| Documentation | yes
| Translation   | yes
| Fixed tickets | N/A
| License       | MIT

* Add CLI import for wallabag v2 with the ``--importer=v2`` option
* Add *mark all as read** support with the ``--markAsRead=yes`` option
* BC breaks with old importer because I change the command name
* No tests on this command because we only use v1/v2 importers which are already tested.
