### PR TITLE
Fix reading speed not defined when user was created via config page

### DIFF
--- a/src/Wallabag/CoreBundle/Controller/ConfigController.php
+++ b/src/Wallabag/CoreBundle/Controller/ConfigController.php
@@ -140,6 +140,7 @@ class ConfigController extends Controller
             $config->setItemsPerPage($this->getParameter('wallabag_core.items_on_page'));
             $config->setRssLimit($this->getParameter('wallabag_core.rss_limit'));
             $config->setLanguage($this->getParameter('wallabag_core.language'));
+            $config->setReadingSpeed($this->getParameter('wallabag_core.reading_speed'));
 
             $em->persist($config);
 

--- a/src/Wallabag/CoreBundle/Tests/Controller/ConfigControllerTest.php
+++ b/src/Wallabag/CoreBundle/Tests/Controller/ConfigControllerTest.php
@@ -355,6 +355,11 @@ class ConfigControllerTest extends WallabagCoreTestCase
 
         $this->assertTrue(false !== $user);
         $this->assertTrue($user->isEnabled());
+        $this->assertEquals('material', $user->getConfig()->getTheme());
+        $this->assertEquals(12, $user->getConfig()->getItemsPerPage());
+        $this->assertEquals(50, $user->getConfig()->getRssLimit());
+        $this->assertEquals('en', $user->getConfig()->getLanguage());
+        $this->assertEquals(1, $user->getConfig()->getReadingSpeed());
     }
 
     public function testRssUpdateResetToken()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Documentation | no
| Translation   | no
| Fixed tickets | #2004 
| License       | MIT

Fix #2004

About tests, I need your opinion.