### PR TITLE
Feature: Filter unread entries

### DIFF
--- a/src/Wallabag/CoreBundle/Form/Type/EntryFilterType.php
+++ b/src/Wallabag/CoreBundle/Form/Type/EntryFilterType.php
@@ -87,6 +87,18 @@ class EntryFilterType extends AbstractType
             ->add('isStarred', CheckboxFilterType::class, [
                 'label' => 'entry.filters.starred_label',
             ])
+            ->add('isUnread', CheckboxFilterType::class, [
+                'label' => 'entry.filters.unread_label',
+                'apply_filter' => function (QueryInterface $filterQuery, $field, $values) {
+                    if(false === $values['value']) {
+                        return;
+                    }
+
+                    $expression = $filterQuery->getExpr()->eq('e.isArchived', 'false');
+
+                    return $filterQuery->createCondition($expression);
+                }
+            ])
             ->add('previewPicture', CheckboxFilterType::class, [
                 'apply_filter' => function (QueryInterface $filterQuery, $field, $values) {
                     if (false === $values['value']) {

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.da.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.da.yml
@@ -154,6 +154,7 @@ entry:
         status_label: 'Status'
         archived_label: 'Arkiveret'
         starred_label: 'Favorit'
+        unread_label: 'Ulæst'
         preview_picture_label: 'Har et vist billede'
         preview_picture_help: 'Forhåndsvis billede'
         language_label: 'Sprog'

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.de.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.de.yml
@@ -154,6 +154,7 @@ entry:
         status_label: 'Status'
         archived_label: 'Archiviert'
         starred_label: 'Favorisiert'
+        unread_label: 'Ungelesene'
         preview_picture_label: 'Vorschaubild vorhanden'
         preview_picture_help: 'Vorschaubild'
         language_label: 'Sprache'

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.en.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.en.yml
@@ -154,6 +154,7 @@ entry:
         status_label: 'Status'
         archived_label: 'Archived'
         starred_label: 'Starred'
+        unread_label: 'Unread'
         preview_picture_label: 'Has a preview picture'
         preview_picture_help: 'Preview picture'
         language_label: 'Language'

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.es.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.es.yml
@@ -154,6 +154,7 @@ entry:
         status_label: 'Estatus'
         archived_label: 'Archivado'
         starred_label: 'Favorito'
+        unread_label: 'Sin leer'
         preview_picture_label: 'Hay una foto'
         preview_picture_help: 'Foto de preview'
         language_label: 'Idioma'

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.fa.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.fa.yml
@@ -154,6 +154,7 @@ entry:
         status_label: 'وضعیت'
         archived_label: 'بایگانی‌شده'
         starred_label: 'برگزیده'
+        unread_label: 'خوانده‌نشده'
         preview_picture_label: 'دارای عکس پیش‌نمایش'
         preview_picture_help: 'پیش‌نمایش عکس'
         language_label: 'زبان'

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.fr.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.fr.yml
@@ -154,6 +154,7 @@ entry:
         status_label: 'Status'
         archived_label: 'Lus'
         starred_label: 'Favoris'
+        unread_label: 'Non lus'
         preview_picture_label: 'A une photo'
         preview_picture_help: 'Photo'
         language_label: 'Langue'

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.oc.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.oc.yml
@@ -154,6 +154,7 @@ entry:
         status_label: 'Estatus'
         archived_label: 'Legits'
         starred_label: 'Favorits'
+        unread_label: 'Pas legits'
         preview_picture_label: 'A una fotò'
         preview_picture_help: 'Fotò'
         language_label: 'Lenga'

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.pl.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.pl.yml
@@ -154,6 +154,7 @@ entry:
         status_label: 'Status'
         archived_label: 'Zarchiwizowane'
         starred_label: 'Oznaczone gwiazdką'
+        unread_label: 'Nieprzeczytane'
         preview_picture_label: 'Posiada podgląd obrazu'
         preview_picture_help: 'Podgląd obrazu'
         language_label: 'Język'

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.ro.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.ro.yml
@@ -154,6 +154,7 @@ entry:
         status_label: 'Status'
         archived_label: 'Arhivat'
         starred_label: 'Steluțe'
+        unread_label: 'Necitite'
         preview_picture_label: 'Are o imagine de previzualizare'
         preview_picture_help: 'Previzualizare imagine'
         language_label: 'Limbă'

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.tr.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.tr.yml
@@ -154,6 +154,7 @@ entry:
         status_label: 'Durum'
         archived_label: 'Arşiv'
         starred_label: 'Favori'
+        unread_label: 'Okunmayan'
         preview_picture_label: 'Resim önizlemesi varsa'
         preview_picture_help: 'Resim önizlemesi'
         language_label: 'Dil'

--- a/src/Wallabag/CoreBundle/Resources/views/themes/baggy/Entry/entries.html.twig
+++ b/src/Wallabag/CoreBundle/Resources/views/themes/baggy/Entry/entries.html.twig
@@ -54,6 +54,11 @@
                 </div>
 
                 <div class="input-field">
+                    {{ form_widget(form.isUnread) }}
+                    {{ form_label(form.isUnread) }}
+                </div>
+
+                <div class="input-field">
                     {{ form_widget(form.previewPicture) }}
                     {{ form_label(form.previewPicture) }}
                 </div>

--- a/src/Wallabag/CoreBundle/Resources/views/themes/material/Entry/entries.html.twig
+++ b/src/Wallabag/CoreBundle/Resources/views/themes/material/Entry/entries.html.twig
@@ -126,6 +126,11 @@
                     {{ form_label(form.isStarred) }}
                 </div>
 
+                <div class="input-field col s6 with-checkbox">
+                    {{ form_widget(form.isUnread) }}
+                    {{ form_label(form.isUnread) }}
+                </div>
+
                 <div class="col s12">
                     <label>{{ 'entry.filters.preview_picture_help'|trans }}</label>
                 </div>


### PR DESCRIPTION
## New feature: Filter Unread
This PR allows users to filter their entries and requiring items to be "unread".

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes*
| Documentation | no
| Translation   | yes
| Fixed tickets | #2031
| License       | MIT

_* I'm getting a couple of PHPUnit test errors/failures, but they also exist on versions without this change._

----

### Possible Issues
There is some coupling caused by the SQL query that might cause future issues if the schema/Doctrine design changes.

Currently in [EntryFilterType.php](https://github.com/wallabag/wallabag/blob/6be103cd39e90849ab614d65bc8ad09f3507a206/src/Wallabag/CoreBundle/Form/Type/EntryFilterType.php#L83) the column for finding the read/unread status is also the archived status column. This uses the same logic as the "Unread" page view.

However, in the query you can see that the field `e.isArchived` is hard-coded and won't change if/when the Doctrine models' parameters do.

If there is a better way to design this please let me know, this solution works but it doesn't seem the best design to me.