### PR TITLE
Do not specify language in Firefox addon link

### DIFF
--- a/src/Wallabag/CoreBundle/Resources/views/themes/material/layout.html.twig
+++ b/src/Wallabag/CoreBundle/Resources/views/themes/material/layout.html.twig
@@ -134,7 +134,7 @@
                         <a target="_blank" class="grey-text text-lighten-3" href="https://itunes.apple.com/app/id828331015" title="iOS">
                             <span class="icon-apple"></span>
                         </a>
-                        <a target="_blank" class="grey-text text-lighten-3" href="https://addons.mozilla.org/ru/firefox/addon/wallabag/" title="Firefox">
+                        <a target="_blank" class="grey-text text-lighten-3" href="https://addons.mozilla.org/firefox/addon/wallabag/" title="Firefox">
                             <span class="icon-firefox"></span>
                         </a>
                         <a target="_blank" class="grey-text text-lighten-3" href="https://chrome.google.com/webstore/detail/wallabagit/peehlcgckcnclnjlndmoddifcicdnabm" title="Chrome">


### PR DESCRIPTION
This PR fixes the link to the Firefox addon page displayed in the footer. I chose to remove the language from the link so that we let Mozilla Addons site handle it.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | no
| Documentation | no
| Translation   | no
| Fixed tickets | #2037
| License       | MIT