### PR TITLE
Fix form user display when 2FA is disabled

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,7 @@ php:
     - 5.5
     - 5.6
     - 7.0
+    - 7.1
     - nightly
     - hhvm
 
@@ -38,6 +39,7 @@ matrix:
           env: DB=pgsql  # driver for PostgreSQL currently unsupported by HHVM, requires 3rd party dependency
     allow_failures:
         - php: hhvm
+        - php: nightly
 
 # exclude v1 branches
 branches:
@@ -46,7 +48,8 @@ branches:
 
 before_script:
     - if [[ $TRAVIS_PHP_VERSION != hhvm ]]; then echo "memory_limit=-1" >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini; fi;
-    - if [[ $TRAVIS_PHP_VERSION != hhvm ]]; then phpenv config-rm xdebug.ini; fi;
+    # xdebug isn't enable for PHP 7.1
+    - if [[ $TRAVIS_PHP_VERSION != '7.1' && $TRAVIS_PHP_VERSION != 'hhvm' ]]; then phpenv config-rm xdebug.ini; fi
     - composer self-update --no-progress
     - if [[ "$DB" = "pgsql" ]]; then psql -c 'create database wallabag_test;' -U postgres; fi;
 

--- a/src/Wallabag/CoreBundle/Form/DataTransformer/StringToListTransformer.php
+++ b/src/Wallabag/CoreBundle/Form/DataTransformer/StringToListTransformer.php
@@ -16,7 +16,7 @@ class StringToListTransformer implements DataTransformerInterface
     private $separator;
 
     /**
-     * @param string $separator The separator used in the list.
+     * @param string $separator The separator used in the list
      */
     public function __construct($separator = ',')
     {

--- a/src/Wallabag/CoreBundle/Form/Type/ConfigType.php
+++ b/src/Wallabag/CoreBundle/Form/Type/ConfigType.php
@@ -21,7 +21,9 @@ class ConfigType extends AbstractType
     {
         $this->themes = array_combine(
             $themes,
-            array_map(function ($s) { return ucwords(strtolower(str_replace('-', ' ', $s))); }, $themes)
+            array_map(function ($s) {
+                return ucwords(strtolower(str_replace('-', ' ', $s)));
+            }, $themes)
         );
 
         $this->languages = $languages;

--- a/src/Wallabag/CoreBundle/Helper/RuleBasedTagger.php
+++ b/src/Wallabag/CoreBundle/Helper/RuleBasedTagger.php
@@ -25,7 +25,7 @@ class RuleBasedTagger
     /**
      * Add tags from rules defined by the user.
      *
-     * @param Entry $entry Entry to tag.
+     * @param Entry $entry Entry to tag
      */
     public function tag(Entry $entry)
     {
@@ -49,7 +49,7 @@ class RuleBasedTagger
      *
      * @param User $user
      *
-     * @return array<Entry> A list of modified entries.
+     * @return array<Entry> A list of modified entries
      */
     public function tagAllForUser(User $user)
     {
@@ -75,7 +75,7 @@ class RuleBasedTagger
     /**
      * Fetch a tag.
      *
-     * @param string $label The tag's label.
+     * @param string $label The tag's label
      *
      * @return Tag
      */

--- a/src/Wallabag/CoreBundle/Resources/views/themes/baggy/Config/index.html.twig
+++ b/src/Wallabag/CoreBundle/Resources/views/themes/baggy/Config/index.html.twig
@@ -134,7 +134,8 @@
         </fieldset>
         {% endif %}
 
-        {{ form_rest(form.user) }}
+        {{ form_widget(form.user._token) }}
+        {{ form_widget(form.user.save) }}
     </form>
 
     <h2>{{ 'config.tab_menu.password'|trans }}</h2>

--- a/src/Wallabag/CoreBundle/Resources/views/themes/material/Config/index.html.twig
+++ b/src/Wallabag/CoreBundle/Resources/views/themes/material/Config/index.html.twig
@@ -158,7 +158,7 @@
                             {% endif %}
 
                             {{ form_widget(form.user.save, {'attr': {'class': 'btn waves-effect waves-light'}}) }}
-                            {{ form_rest(form.user) }}
+                            {{ form_widget(form.user._token) }}
                         </form>
                     </div>
 

--- a/tests/Wallabag/CoreBundle/Command/InstallCommandTest.php
+++ b/tests/Wallabag/CoreBundle/Command/InstallCommandTest.php
@@ -28,16 +28,32 @@ class InstallCommandTest extends WallabagCoreTestCase
              *
              * http://stackoverflow.com/a/14374832/569101
              */
-            $this->markTestSkipped('PostgreSQL spotted: can find a good way to drop current database, skipping.');
+            $this->markTestSkipped('PostgreSQL spotted: can\'t find a good way to drop current database, skipping.');
         }
     }
 
+    /**
+     * Ensure next tests will have a clean database
+     */
     public static function tearDownAfterClass()
     {
         $application = new Application(static::$kernel);
         $application->setAutoExit(false);
 
-        $code = $application->run(new ArrayInput([
+        $application->run(new ArrayInput([
+            'command' => 'doctrine:schema:drop',
+            '--no-interaction' => true,
+            '--force' => true,
+            '--env' => 'test',
+        ]), new NullOutput());
+
+        $application->run(new ArrayInput([
+            'command' => 'doctrine:schema:create',
+            '--no-interaction' => true,
+            '--env' => 'test',
+        ]), new NullOutput());
+
+        $application->run(new ArrayInput([
             'command' => 'doctrine:fixtures:load',
             '--no-interaction' => true,
             '--env' => 'test',


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Documentation | no
| Translation   | no
| Fixed tickets | N/A
| License       | MIT

When Two factor authentication is disabled, the `form_rest` displayed the label of the 2FA field, see below 

![capture d ecran 2016-05-18 a 14 59 32](https://cloud.githubusercontent.com/assets/121870/15359442/a8a65e12-1d09-11e6-95d4-12c2c25bc6c0.png)
