### PR TITLE
Don't cut entries title in card view

### DIFF
--- a/src/Wallabag/CoreBundle/Resources/views/themes/material/Entry/entries.html.twig
+++ b/src/Wallabag/CoreBundle/Resources/views/themes/material/Entry/entries.html.twig
@@ -35,7 +35,7 @@
                                 <i class="card-title grey-text text-darken-4 activator mdi-navigation-more-horiz right"></i>
                             {% endif %}
 
-                            <span class="card-title"><a href="{{ path('view', { 'id': entry.id }) }}" title="{{ entry.title|raw }}">{{ entry.title|striptags|slice(0, 42)|raw }}</a></span>
+                            <span class="card-title"><a href="{{ path('view', { 'id': entry.id }) }}" title="{{ entry.title|raw }}">{{ entry.title|striptags|raw }}</a></span>
 
                             <div class="estimatedTime grey-text">
                                 <span class="tool reading-time">


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Documentation | no
| Translation   | no
| Fixed tickets | #2055 
| License       | MIT

Stop cutting titles arbitrary at character 42.

I hope the fix is not better than the bug in case with really long titles. Indeed I guess the complement fix is to cut the title using CSS, I don't know about CSS but it seems `text-overflow` is the way to go.