### PR TITLE
Corrected Regex for lighttpd rewrite

### DIFF
--- a/docs/en/user/installation.rst
+++ b/docs/en/user/installation.rst
@@ -226,7 +226,7 @@ Assuming you install wallabag in the /var/www/wallabag folder, here's the recipe
     dir-listing.activate = "disable"
 
     url.rewrite-if-not-file = (
-        "^/([^?])(?:\?(.))?" => "/app.php?$1&$2",
+        "^/([^?]*)(?:\?(.*))?" => "/app.php?$1&$2",
         "^/([^?]*)" => "/app.php?=$1",
     )
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Documentation | yes
| Translation   | no
| Fixed tickets | -
| License       | MIT


I am using Wallabag with lighttpd and noticed that the regex for the rewrite doesn't work as it's missing quantifier. I've added them.

I tested it using https://regex101.com/


