### PR TITLE
Use friendsofphp instead of fabpot

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -88,7 +88,7 @@
         "sensio/generator-bundle": "^3.0",
         "phpunit/phpunit": "~4.4",
         "symfony/phpunit-bridge": "^2.7",
-        "fabpot/php-cs-fixer": "~1.9"
+        "friendsofphp/php-cs-fixer": "~1.9"
     },
     "scripts": {
         "post-cmd": [


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Documentation | no
| Translation   | no
| Fixed tickets | https://github.com/wallabag/wallabag/issues/2141
| License       | MIT

The fabpot's one is now depreacted
Fix https://github.com/wallabag/wallabag/issues/2141