### PR TITLE
Handle only upper or only lower reading filter

### DIFF
--- a/src/Wallabag/CoreBundle/Form/Type/EntryFilterType.php
+++ b/src/Wallabag/CoreBundle/Form/Type/EntryFilterType.php
@@ -45,10 +45,10 @@ class EntryFilterType extends AbstractType
                     if (null === $lower && null === $upper) {
                         // no value? no filter
                         return;
-                    } else if (null === $lower && null !== $upper) {
+                    } elseif (null === $lower && null !== $upper) {
                         // only lower value is defined: query all entries with reading LOWER THAN this value
                         $expression = $filterQuery->getExpr()->lte($field, $max);
-                    } else if (null !== $lower && null === $upper) {
+                    } elseif (null !== $lower && null === $upper) {
                         // only upper value is defined: query all entries with reading GREATER THAN this value
                         $expression = $filterQuery->getExpr()->gte($field, $min);
                     } else {

--- a/tests/Wallabag/CoreBundle/Controller/EntryControllerTest.php
+++ b/tests/Wallabag/CoreBundle/Controller/EntryControllerTest.php
@@ -499,6 +499,42 @@ class EntryControllerTest extends WallabagCoreTestCase
         $this->assertCount(1, $crawler->filter('div[class=entry]'));
     }
 
+    public function testFilterOnReadingTimeOnlyUpper()
+    {
+        $this->logInAs('admin');
+        $client = $this->getClient();
+
+        $crawler = $client->request('GET', '/unread/list');
+
+        $form = $crawler->filter('button[id=submit-filter]')->form();
+
+        $data = [
+            'entry_filter[readingTime][right_number]' => 22,
+        ];
+
+        $crawler = $client->submit($form, $data);
+
+        $this->assertCount(2, $crawler->filter('div[class=entry]'));
+    }
+
+    public function testFilterOnReadingTimeOnlyLower()
+    {
+        $this->logInAs('admin');
+        $client = $this->getClient();
+
+        $crawler = $client->request('GET', '/unread/list');
+
+        $form = $crawler->filter('button[id=submit-filter]')->form();
+
+        $data = [
+            'entry_filter[readingTime][left_number]' => 22,
+        ];
+
+        $crawler = $client->submit($form, $data);
+
+        $this->assertCount(4, $crawler->filter('div[class=entry]'));
+    }
+
     public function testFilterOnUnreadStatus()
     {
         $this->logInAs('admin');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | ?
| Documentation | no
| Translation   | no
| Fixed tickets | https://github.com/wallabag/wallabag/issues/2077
| License       | MIT

When we select only one value in the reading time filter, we need to perform a query with only one value (greater than OR lower than).

Should fix https://github.com/wallabag/wallabag/issues/2077