### PR TITLE
Remove binary from repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,9 @@
 /var/sessions/*
 !var/sessions/.gitkeep
 !var/SymfonyRequirements.php
+/bin/*
+!/bin/console
+!/bin/symfony_requirements
 
 # Parameters
 /app/config/parameters.yml

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ More informations on our website: [wallabag.org](https://wallabag.org)
 
 # Install wallabag
 
-If you don't have it yet, please [install composer](https://getcomposer.org/download/).
+If you don't have it yet, please [install composer](https://getcomposer.org/download/) or be sure to use Composer 1.2 (`composer selfupdate` can help you about that).
 Then you can install wallabag by executing the following commands:
 
 ```

--- a/bin/doctrine
+++ b/bin/doctrine
@@ -1,1 +1,0 @@
-../vendor/doctrine/orm/bin/doctrine

--- a/bin/doctrine-dbal
+++ b/bin/doctrine-dbal
@@ -1,1 +1,0 @@
-../vendor/doctrine/dbal/bin/doctrine-dbal

--- a/bin/doctrine-migrations
+++ b/bin/doctrine-migrations
@@ -1,1 +1,0 @@
-../vendor/doctrine/migrations/bin/doctrine-migrations

--- a/bin/doctrine.php
+++ b/bin/doctrine.php
@@ -1,1 +1,0 @@
-../vendor/doctrine/orm/bin/doctrine.php

--- a/bin/php-cs-fixer
+++ b/bin/php-cs-fixer
@@ -1,1 +1,0 @@
-../vendor/friendsofphp/php-cs-fixer/php-cs-fixer

--- a/bin/security-checker
+++ b/bin/security-checker
@@ -1,1 +1,0 @@
-../vendor/sensiolabs/security-checker/security-checker

--- a/docs/en/user/installation.rst
+++ b/docs/en/user/installation.rst
@@ -37,7 +37,7 @@ Installation
 On a dedicated web server (recommended way)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-wallabag uses a large number of libraries in order to function. These libraries must be installed with a tool called Composer. You need to install it if you have not already done so.
+wallabag uses a large number of libraries in order to function. These libraries must be installed with a tool called Composer. You need to install it if you have not already done so and be sure to use the 1.2 version (if you already have Composer, run a ``composer selfupdate``).
 
 Install Composer:
 

--- a/docs/fr/user/installation.rst
+++ b/docs/fr/user/installation.rst
@@ -35,7 +35,7 @@ Installation
 Sur un serveur dédié (méthode conseillée)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-wallabag utilise un grand nombre de bibliothèques pour fonctionner. Ces bibliothèques doivent être installées à l'aide d'un outil nommé Composer. Vous devez l'installer si ce n'est déjà fait.
+wallabag utilise un grand nombre de bibliothèques pour fonctionner. Ces bibliothèques doivent être installées à l'aide d'un outil nommé Composer. Vous devez l'installer si ce n'est déjà fait et vous assurer que vous utilisez bien la version 1.2 (si vous avez déjà Composer, faite un ``composer selfupdate``).
 
 Installation de Composer :
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Documentation | yes
| Translation   | no
| Fixed tickets | 
| License       | MIT

Since Composer 1.2, binaries are re-installed from vendors if there aren't found.
This avoid us to commit binaries vendors into the repo.

:warning: You have to update your Composer to the 1.2 (`composer selfupdate`)