### PR TITLE
FIX image inside a figure element max-width

### DIFF
--- a/src/Wallabag/CoreBundle/Resources/public/themes/baggy/css/ratatouille.css
+++ b/src/Wallabag/CoreBundle/Resources/public/themes/baggy/css/ratatouille.css
@@ -64,7 +64,7 @@ pre {
   max-width: 61.25em;/*980px*/
 }
 
-table, img {
+table, img, figure {
   max-width: 100%;
   height :auto;
 }

--- a/src/Wallabag/CoreBundle/Resources/public/themes/material/css/main.css
+++ b/src/Wallabag/CoreBundle/Resources/public/themes/material/css/main.css
@@ -345,7 +345,8 @@ main ul.row {
     max-width: 40em;
 }
 
-#article img {
+#article img,
+#article figure {
     max-width: 100%;
     height: auto;
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Documentation | no
| Translation   | no
| Fixed tickets |
| License       | MIT

Hi,
This is fixing the issue with images inside a figure element that are bigger than expected.