### PR TITLE
Fixed typo in entry:notice:entry_saved

### DIFF
--- a/src/Wallabag/CoreBundle/Resources/translations/messages.de.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.de.yml
@@ -396,7 +396,7 @@ flashes:
     entry:
         notice:
             entry_already_saved: 'Eintrag bereits am %date% gespeichert'
-            entry_saved: 'Eintag gespeichert'
+            entry_saved: 'Eintrag gespeichert'
             # entry_saved_failed: 'Failed to save entry'
             entry_updated: 'Eintrag aktualisiert'
             entry_reloaded: 'Eintrag neugeladen'


### PR DESCRIPTION
"Eintag" to "Eintrag"