### PR TITLE
Allow failure for PHP 7.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -54,6 +54,7 @@ matrix:
           env: CS_FIXER=run VALIDATE_TRANSLATION_FILE=run DB=sqlite
     allow_failures:
         - php: hhvm-3.12
+        - php: 7.1
         - php: nightly
 
 # exclude v1 branches


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Documentation | no
| Translation   | no
| Fixed tickets | 
| License       | MIT

Got tired of `EE/home/travis/build.sh: line 45:  4445 Segmentation fault      (core dumped) phpunit -v` using PHP 7.1.0beta3