### PR TITLE
Add a check for the database connection

### DIFF
--- a/src/Wallabag/CoreBundle/Command/InstallCommand.php
+++ b/src/Wallabag/CoreBundle/Command/InstallCommand.php
@@ -72,8 +72,10 @@ class InstallCommand extends ContainerAwareCommand
     {
         $this->defaultOutput->writeln('<info><comment>Step 1 of 5.</comment> Checking system requirements.</info>');
 
-        $fulfilled = true;
+        $rows = [];
 
+        // testing if database driver exists
+        $fulfilled = true;
         $label = '<comment>PDO Driver</comment>';
         $status = '<info>OK!</info>';
         $help = '';
@@ -84,7 +86,21 @@ class InstallCommand extends ContainerAwareCommand
             $help = 'Database driver "'.$this->getContainer()->getParameter('database_driver').'" is not installed.';
         }
 
-        $rows = [];
+        $rows[] = [$label, $status, $help];
+
+        // testing if connection to the database can be etablished
+        $label = '<comment>Database connection</comment>';
+        $status = '<info>OK!</info>';
+        $help = '';
+
+        try {
+            $this->getContainer()->get('doctrine')->getManager()->getConnection()->connect();
+        } catch (\Exception $e) {
+            $fulfilled = false;
+            $status = '<error>ERROR!</error>';
+            $help = 'Can\'t connect to the database: '.$e->getMessage();
+        }
+
         $rows[] = [$label, $status, $help];
 
         foreach ($this->functionExists as $functionRequired) {

--- a/src/Wallabag/CoreBundle/Command/InstallCommand.php
+++ b/src/Wallabag/CoreBundle/Command/InstallCommand.php
@@ -96,7 +96,7 @@ class InstallCommand extends ContainerAwareCommand
         try {
             $this->getContainer()->get('doctrine')->getManager()->getConnection()->connect();
         } catch (\Exception $e) {
-            if (false === strpos($e->getMessage(), "Unknown database")) {
+            if (false === strpos($e->getMessage(), 'Unknown database')) {
                 $fulfilled = false;
                 $status = '<error>ERROR!</error>';
                 $help = 'Can\'t connect to the database: '.$e->getMessage();

--- a/src/Wallabag/CoreBundle/Command/InstallCommand.php
+++ b/src/Wallabag/CoreBundle/Command/InstallCommand.php
@@ -96,9 +96,11 @@ class InstallCommand extends ContainerAwareCommand
         try {
             $this->getContainer()->get('doctrine')->getManager()->getConnection()->connect();
         } catch (\Exception $e) {
-            $fulfilled = false;
-            $status = '<error>ERROR!</error>';
-            $help = 'Can\'t connect to the database: '.$e->getMessage();
+            if (false === strpos($e->getMessage(), "Unknown database")) {
+                $fulfilled = false;
+                $status = '<error>ERROR!</error>';
+                $help = 'Can\'t connect to the database: '.$e->getMessage();
+            }
         }
 
         $rows[] = [$label, $status, $help];
@@ -472,7 +474,7 @@ class InstallCommand extends ContainerAwareCommand
         }
 
         // custom verification for sqlite, since `getListDatabasesSQL` doesn't work for sqlite
-        if ('sqlite' == $schemaManager->getDatabasePlatform()->getName()) {
+        if ('sqlite' === $schemaManager->getDatabasePlatform()->getName()) {
             $params = $this->getContainer()->get('doctrine.dbal.default_connection')->getParams();
 
             if (isset($params['path']) && file_exists($params['path'])) {

--- a/tests/Wallabag/CoreBundle/Command/InstallCommandTest.php
+++ b/tests/Wallabag/CoreBundle/Command/InstallCommandTest.php
@@ -127,6 +127,12 @@ class InstallCommandTest extends WallabagCoreTestCase
 
     public function testRunInstallCommandWithDatabaseRemoved()
     {
+        // skipped SQLite check when database is removed because while testing for the connection,
+        // the driver will create the file (so the database) before testing if database exist
+        if ($this->getClient()->getContainer()->get('doctrine')->getConnection()->getDriver() instanceof \Doctrine\DBAL\Driver\PDOSqlite\Driver) {
+            $this->markTestSkipped('SQLite spotted: can\'t test with database removed.');
+        }
+
         $application = new Application($this->getClient()->getKernel());
         $application->add(new DropDatabaseDoctrineCommand());
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes/no
| New feature?  | yes/no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Documentation | no
| Translation   | no
| Fixed tickets | fix #2251
| License       | MIT

Checking for the driver isn't enough.
We are now checking if we can etablish a connection to the database before trying to do anything.
By displaying the error from the Exception (in case of error) we hope to reduce issues overload about people getting error with the database