### PR TITLE
Instead of selecting the whole data, just count it

### DIFF
--- a/src/Wallabag/CoreBundle/Controller/DeveloperController.php
+++ b/src/Wallabag/CoreBundle/Controller/DeveloperController.php
@@ -49,7 +49,7 @@ class DeveloperController extends Controller
 
             $this->get('session')->getFlashBag()->add(
                 'notice',
-                $this->get('translator')->trans('flashes.developer.notice.client_created', array('%name%' => $client->getName()))
+                $this->get('translator')->trans('flashes.developer.notice.client_created', ['%name%' => $client->getName()])
             );
 
             return $this->render('WallabagCoreBundle:Developer:client_parameters.html.twig', [
@@ -81,7 +81,7 @@ class DeveloperController extends Controller
 
         $this->get('session')->getFlashBag()->add(
             'notice',
-            $this->get('translator')->trans('flashes.developer.notice.client_deleted', array('%name%' => $client->getName()))
+            $this->get('translator')->trans('flashes.developer.notice.client_deleted', ['%name%' => $client->getName()])
         );
 
         return $this->redirect($this->generateUrl('developer'));

--- a/src/Wallabag/CoreBundle/Resources/views/themes/material/layout.html.twig
+++ b/src/Wallabag/CoreBundle/Resources/views/themes/material/layout.html.twig
@@ -35,16 +35,16 @@
             {% set currentRoute = app.request.attributes.get('_route') %}
 
             <li class="bold {% if currentRoute == 'unread' or currentRoute == 'homepage' %}active{% endif %}">
-                <a class="waves-effect" href="{{ path('unread') }}">{{ 'menu.left.unread'|trans }} <span class="numberItems grey-text">{{ unreadEntries }}</span></a>
+                <a class="waves-effect" href="{{ path('unread') }}">{{ 'menu.left.unread'|trans }} <span class="numberItems grey-text">{{ count_entries('unread') }}</span></a>
             </li>
             <li class="bold {% if currentRoute == 'starred' %}active{% endif %}">
-                <a class="waves-effect" href="{{ path('starred') }}">{{ 'menu.left.starred'|trans }} <span class="numberItems grey-text">{{ starredEntries }}</span></a>
+                <a class="waves-effect" href="{{ path('starred') }}">{{ 'menu.left.starred'|trans }} <span class="numberItems grey-text">{{ count_entries('starred') }}</span></a>
             </li>
             <li class="bold {% if currentRoute == 'archive' %}active{% endif %}">
-                <a class="waves-effect" href="{{ path('archive') }}">{{ 'menu.left.archive'|trans }} <span class="numberItems grey-text">{{ archivedEntries }}</span></a>
+                <a class="waves-effect" href="{{ path('archive') }}">{{ 'menu.left.archive'|trans }} <span class="numberItems grey-text">{{ count_entries('archive') }}</span></a>
             </li>
             <li class="bold border-bottom {% if currentRoute == 'all' %}active{% endif %}">
-                <a class="waves-effect" href="{{ path('all') }}">{{ 'menu.left.all_articles'|trans }} <span class="numberItems grey-text">{{ allEntries }}</span></a>
+                <a class="waves-effect" href="{{ path('all') }}">{{ 'menu.left.all_articles'|trans }} <span class="numberItems grey-text">{{ count_entries('all') }}</span></a>
             </li>
             <li class="bold border-bottom {% if currentRoute == 'tags' %}active{% endif %}">
                 <a class="waves-effect" href="{{ path('tag') }}">{{ 'menu.left.tags'|trans }}</a>

--- a/src/Wallabag/CoreBundle/Twig/WallabagExtension.php
+++ b/src/Wallabag/CoreBundle/Twig/WallabagExtension.php
@@ -33,31 +33,31 @@ class WallabagExtension extends \Twig_Extension implements \Twig_Extension_Globa
         $user = $this->tokenStorage->getToken() ? $this->tokenStorage->getToken()->getUser() : null;
 
         if (null === $user || !is_object($user)) {
-            return array();
+            return [];
         }
 
         $unreadEntries = $this->repository->enableCache(
-            $this->repository->getBuilderForUnreadByUser($user->getId())->getQuery()
+            $this->repository->getBuilderForUnreadByUser($user->getId())->select('COUNT(e.id)')->getQuery()
         );
 
         $starredEntries = $this->repository->enableCache(
-            $this->repository->getBuilderForStarredByUser($user->getId())->getQuery()
+            $this->repository->getBuilderForStarredByUser($user->getId())->select('COUNT(e.id)')->getQuery()
         );
 
         $archivedEntries = $this->repository->enableCache(
-            $this->repository->getBuilderForArchiveByUser($user->getId())->getQuery()
+            $this->repository->getBuilderForArchiveByUser($user->getId())->select('COUNT(e.id)')->getQuery()
         );
 
         $allEntries = $this->repository->enableCache(
-            $this->repository->getBuilderForAllByUser($user->getId())->getQuery()
+            $this->repository->getBuilderForAllByUser($user->getId())->select('COUNT(e.id)')->getQuery()
         );
 
-        return array(
-            'unreadEntries' => count($unreadEntries->getResult()),
-            'starredEntries' => count($starredEntries->getResult()),
-            'archivedEntries' => count($archivedEntries->getResult()),
-            'allEntries' => count($allEntries->getResult()),
-        );
+        return [
+            'unreadEntries' => $unreadEntries->getSingleScalarResult(),
+            'starredEntries' => $starredEntries->getSingleScalarResult(),
+            'archivedEntries' => $archivedEntries->getSingleScalarResult(),
+            'allEntries' => $allEntries->getSingleScalarResult(),
+        ];
     }
 
     public function getName()

--- a/src/Wallabag/CoreBundle/Twig/WallabagExtension.php
+++ b/src/Wallabag/CoreBundle/Twig/WallabagExtension.php
@@ -36,9 +36,9 @@ class WallabagExtension extends \Twig_Extension implements \Twig_Extension_Globa
     }
 
     /**
-     * Return number of entries depending of the type (unread, archive, starred or all)
+     * Return number of entries depending of the type (unread, archive, starred or all).
      *
-     * @param  string $type Type of entries to count
+     * @param string $type Type of entries to count
      *
      * @return int
      */
@@ -78,7 +78,7 @@ class WallabagExtension extends \Twig_Extension implements \Twig_Extension_Globa
             ->groupBy('e.id')
             ->getQuery();
 
-        $data =$this->repository
+        $data = $this->repository
             ->enableCache($query)
             ->getArrayResult();
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Documentation | no
| Translation   | no
| Fixed tickets |
| License       | MIT

Instead of performing a complex select (to retrieve all data for entry, etc...) just select the counter and retrieve it.

Down from ~50ms to ~30ms on the unread page (with 500 items)