### PR TITLE
Fix issue #2296: epub export with special chars in the title.

### DIFF
--- a/src/Wallabag/CoreBundle/Helper/EntriesExport.php
+++ b/src/Wallabag/CoreBundle/Helper/EntriesExport.php
@@ -163,8 +163,12 @@ class EntriesExport
                 $book->setSubject($tag['value']);
             }
 
+            // the reader in Kobo Devices doesn't likes special caracters
+            // in filenames, we limit to A-z/0-9
+            $filename = preg_replace('/[^A-Za-z0-9\-]/', '', $entry->getTitle());
+
             $chapter = $content_start.$entry->getContent().$bookEnd;
-            $book->addChapter($entry->getTitle(), htmlspecialchars($entry->getTitle()).'.html', $chapter, true, EPub::EXTERNAL_REF_ADD);
+            $book->addChapter($entry->getTitle(), htmlspecialchars($filename).'.html', $chapter, true, EPub::EXTERNAL_REF_ADD);
         }
 
         return Response::create(


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Documentation | no
| Translation   | no
| Fixed tickets | #2296 
| License       | MIT

I removed all special chars from the filename of an epub chapter, in case other characters break the file (not only `+`).