### PR TITLE
Some checks about Redis & RabbitMQ

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -16,6 +16,7 @@
     <php>
         <ini name="error_reporting" value="-1" />
         <server name="KERNEL_DIR" value="app/" />
+        <env name="SYMFONY_DEPRECATIONS_HELPER" value="weak" />
     </php>
 
     <filter>

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.da.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.da.yml
@@ -432,6 +432,9 @@ flashes:
             # failed_on_file: 'Error while processing import. Please verify your import file.'
             # summary: 'Import summary: %imported% imported, %skipped% already saved.'
             # summary_with_queue: 'Import summary: %queued% queued.'
+        error:
+            # redis_enabled_not_installed: Redis is enabled for handle asynchronous import but it looks like <u>we can't connect to it</u>. Please check Redis configuration.
+            # rabbit_enabled_not_installed: RabbitMQ is enabled for handle asynchronous import but it looks like <u>we can't connect to it</u>. Please check RabbitMQ configuration.
     developer:
         notice:
             # client_created: 'New client created.'

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.de.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.de.yml
@@ -432,6 +432,9 @@ flashes:
             failed_on_file: 'Fehler während des Imports. Bitte überprüfe deine Import-Datei.'
             summary: 'Import-Zusammenfassung: %imported% importiert, %skipped% bereits gespeichert.'
             # summary_with_queue: 'Import summary: %queued% queued.'
+        error:
+            # redis_enabled_not_installed: Redis is enabled for handle asynchronous import but it looks like <u>we can't connect to it</u>. Please check Redis configuration.
+            # rabbit_enabled_not_installed: RabbitMQ is enabled for handle asynchronous import but it looks like <u>we can't connect to it</u>. Please check RabbitMQ configuration.
     developer:
         notice:
             client_created: 'Neuer Client erstellt.'

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.en.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.en.yml
@@ -434,6 +434,9 @@ flashes:
             failed_on_file: 'Error while processing import. Please verify your import file.'
             summary: 'Import summary: %imported% imported, %skipped% already saved.'
             summary_with_queue: 'Import summary: %queued% queued.'
+        error:
+            redis_enabled_not_installed: Redis is enabled for handle asynchronous import but it looks like <u>we can't connect to it</u>. Please check Redis configuration.
+            rabbit_enabled_not_installed: RabbitMQ is enabled for handle asynchronous import but it looks like <u>we can't connect to it</u>. Please check RabbitMQ configuration.
     developer:
         notice:
             client_created: 'New client %name% created.'

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.es.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.es.yml
@@ -432,6 +432,9 @@ flashes:
             failed_on_file: 'Se ocurre un error por procesar importación. Por favor verifique su archivo importado.'
             summary: 'Resúmen importado: %importado% importado, %saltados% ya guardado.'
             # summary_with_queue: 'Import summary: %queued% queued.'
+        error:
+            # redis_enabled_not_installed: Redis is enabled for handle asynchronous import but it looks like <u>we can't connect to it</u>. Please check Redis configuration.
+            # rabbit_enabled_not_installed: RabbitMQ is enabled for handle asynchronous import but it looks like <u>we can't connect to it</u>. Please check RabbitMQ configuration.
     developer:
         notice:
             client_created: 'Nuevo cliente creado.'

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.fa.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.fa.yml
@@ -432,6 +432,9 @@ flashes:
             failed_on_file: 'خطا هنگام پردازش پروندهٔ ورودی. آیا پروندهٔ درون‌ریزی شده سالم است؟'
             summary: 'گزارش درون‌ریزی: %imported% وارد شد, %skipped% از قبل ذخیره شده بود.'
             # summary_with_queue: 'Import summary: %queued% queued.'
+        error:
+            # redis_enabled_not_installed: Redis is enabled for handle asynchronous import but it looks like <u>we can't connect to it</u>. Please check Redis configuration.
+            # rabbit_enabled_not_installed: RabbitMQ is enabled for handle asynchronous import but it looks like <u>we can't connect to it</u>. Please check RabbitMQ configuration.
     developer:
         notice:
             # client_created: 'New client created.'

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.fr.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.fr.yml
@@ -434,6 +434,9 @@ flashes:
             failed_on_file: "Erreur lors du traitement de l'import. Vérifier votre fichier."
             summary: "Rapport d'import: %imported% importés, %skipped% déjà présent."
             summary_with_queue: "Rapport d'import: %queued% en cours de traitement."
+        error:
+            redis_enabled_not_installed: Redis est activé pour les imports asynchrones mais <u>impossible de s'y connecter</u>. Vérifier la configuration de Redis.
+            rabbit_enabled_not_installed: RabbitMQ est activé pour les imports asynchrones mais <u>impossible de s'y connecter</u>. Vérifier la configuration de RabbitMQ.
     developer:
         notice:
             client_created: 'Nouveau client %name% créé'

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.it.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.it.yml
@@ -431,6 +431,9 @@ flashes:
             failed_on_file: 'Errore durante la processazione dei dati da importare. Verifica il tuo file di import.'
             summary: 'Sommario di importazione: %imported% importati, %skipped% già salvati.'
             # summary_with_queue: 'Import summary: %queued% queued.'
+        error:
+            # redis_enabled_not_installed: Redis is enabled for handle asynchronous import but it looks like <u>we can't connect to it</u>. Please check Redis configuration.
+            # rabbit_enabled_not_installed: RabbitMQ is enabled for handle asynchronous import but it looks like <u>we can't connect to it</u>. Please check RabbitMQ configuration.
     developer:
         notice:
             client_created: 'Nuovo client creato.'

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.oc.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.oc.yml
@@ -432,6 +432,9 @@ flashes:
             failed_on_file: "Errorr pendent du tractament de l'import. Mercés de verificar vòstre fichièr."
             summary: "Rapòrt d'import: %imported% importats, %skipped% ja presents."
             # summary_with_queue: 'Import summary: %queued% queued.'
+        error:
+            # redis_enabled_not_installed: Redis is enabled for handle asynchronous import but it looks like <u>we can't connect to it</u>. Please check Redis configuration.
+            # rabbit_enabled_not_installed: RabbitMQ is enabled for handle asynchronous import but it looks like <u>we can't connect to it</u>. Please check RabbitMQ configuration.
     developer:
         notice:
             client_created: 'Novèl client creat'

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.pl.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.pl.yml
@@ -432,6 +432,9 @@ flashes:
             failed_on_file: 'Błąd podczas ptrzetwarzania pliku. Sprawdż swój importowany plik.'
             summary: 'Podsumowanie importu: %imported% zaimportowane, %skipped% już zapisane.'
             summary_with_queue: 'Podsumowanie importu: %queued% zakolejkowane.'
+        error:
+            # redis_enabled_not_installed: Redis is enabled for handle asynchronous import but it looks like <u>we can't connect to it</u>. Please check Redis configuration.
+            # rabbit_enabled_not_installed: RabbitMQ is enabled for handle asynchronous import but it looks like <u>we can't connect to it</u>. Please check RabbitMQ configuration.
     developer:
         notice:
             client_created: 'Nowy klient utworzony.'

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.ro.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.ro.yml
@@ -432,6 +432,9 @@ flashes:
             # failed_on_file: 'Error while processing import. Please verify your import file.'
             # summary: 'Import summary: %imported% imported, %skipped% already saved.'
             # summary_with_queue: 'Import summary: %queued% queued.'
+        error:
+            # redis_enabled_not_installed: Redis is enabled for handle asynchronous import but it looks like <u>we can't connect to it</u>. Please check Redis configuration.
+            # rabbit_enabled_not_installed: RabbitMQ is enabled for handle asynchronous import but it looks like <u>we can't connect to it</u>. Please check RabbitMQ configuration.
     developer:
         notice:
             # client_created: 'New client created.'

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.tr.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.tr.yml
@@ -432,6 +432,9 @@ flashes:
             # failed_on_file: 'Error while processing import. Please verify your import file.'
             # summary: 'Import summary: %imported% imported, %skipped% already saved.'
             # summary_with_queue: 'Import summary: %queued% queued.'
+        error:
+            # redis_enabled_not_installed: Redis is enabled for handle asynchronous import but it looks like <u>we can't connect to it</u>. Please check Redis configuration.
+            # rabbit_enabled_not_installed: RabbitMQ is enabled for handle asynchronous import but it looks like <u>we can't connect to it</u>. Please check RabbitMQ configuration.
     developer:
         notice:
             # client_created: 'New client created.'

--- a/src/Wallabag/ImportBundle/Resources/views/Import/check_queue.html.twig
+++ b/src/Wallabag/ImportBundle/Resources/views/Import/check_queue.html.twig
@@ -1,11 +1,23 @@
-{% if nbRedisMessages > 0 %}
+{% if nbRedisMessages is defined and nbRedisMessages > 0 %}
     <script>
         Materialize.toast('Messages in queue: {{ nbRedisMessages }}', 4000);
     </script>
 {% endif %}
 
-{% if nbRabbitMessages > 0 %}
+{% if nbRabbitMessages is defined and nbRabbitMessages > 0 %}
     <script>
         Materialize.toast('Messages in queue: {{ nbRabbitMessages }}', 4000);
     </script>
+{% endif %}
+
+{% if redisNotInstalled is defined and redisNotInstalled  %}
+    <div class="card-panel red darken-1 white-text">
+        {{ 'flashes.import.error.redis_enabled_not_installed'|trans|raw }}
+    </div>
+{% endif %}
+
+{% if rabbitNotInstalled is defined and rabbitNotInstalled  %}
+    <div class="card-panel red darken-1 white-text">
+        {{ 'flashes.import.error.rabbit_enabled_not_installed'|trans|raw }}
+    </div>
 {% endif %}

--- a/tests/Wallabag/CoreBundle/WallabagCoreTestCase.php
+++ b/tests/Wallabag/CoreBundle/WallabagCoreTestCase.php
@@ -80,4 +80,19 @@ abstract class WallabagCoreTestCase extends WebTestCase
 
         throw new \RuntimeException('No logged in User.');
     }
+
+    /**
+     * Check if Redis is installed.
+     * If not, mark test as skip
+     */
+    protected function checkRedis()
+    {
+        try {
+            $this->client->getContainer()->get('wallabag_core.redis.client')->connect();
+        } catch (\Exception $e) {
+            $this->markTestSkipped(
+              'Redis is not installed/activated'
+            );
+        }
+    }
 }

--- a/tests/Wallabag/ImportBundle/Controller/PocketControllerTest.php
+++ b/tests/Wallabag/ImportBundle/Controller/PocketControllerTest.php
@@ -34,6 +34,7 @@ class PocketControllerTest extends WallabagCoreTestCase
 
     public function testImportPocketWithRedisEnabled()
     {
+        $this->checkRedis();
         $this->logInAs('admin');
         $client = $this->getClient();
 

--- a/tests/Wallabag/ImportBundle/Controller/ReadabilityControllerTest.php
+++ b/tests/Wallabag/ImportBundle/Controller/ReadabilityControllerTest.php
@@ -54,6 +54,7 @@ class ReadabilityControllerTest extends WallabagCoreTestCase
 
     public function testImportReadabilityWithRedisEnabled()
     {
+        $this->checkRedis();
         $this->logInAs('admin');
         $client = $this->getClient();
 

--- a/tests/Wallabag/ImportBundle/Controller/WallabagV1ControllerTest.php
+++ b/tests/Wallabag/ImportBundle/Controller/WallabagV1ControllerTest.php
@@ -54,6 +54,7 @@ class WallabagV1ControllerTest extends WallabagCoreTestCase
 
     public function testImportWallabagWithRedisEnabled()
     {
+        $this->checkRedis();
         $this->logInAs('admin');
         $client = $this->getClient();
 

--- a/tests/Wallabag/ImportBundle/Controller/WallabagV2ControllerTest.php
+++ b/tests/Wallabag/ImportBundle/Controller/WallabagV2ControllerTest.php
@@ -54,6 +54,7 @@ class WallabagV2ControllerTest extends WallabagCoreTestCase
 
     public function testImportWallabagWithRedisEnabled()
     {
+        $this->checkRedis();
         $this->logInAs('admin');
         $client = $this->getClient();
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Documentation | no
| Translation   | yes
| Fixed tickets | 
| License       | MIT

- Disable PHPUnit deprecation that fail tests since Twig 1.25.0 (it didn't seems the error come from something we've done)
- Display a message when async import won’t work
 Preview of the error message:
 ![](https://cl.ly/1a1z1F3m1f3t/Image%202016-09-24%20at%207.58.49%20PM.png)
- Avoid failing tests for user who didn’t install Redis (test will be marked as skip)