### PR TITLE
Docker : install PHP 'gd' extension

### DIFF
--- a/docker/php/Dockerfile
+++ b/docker/php/Dockerfile
@@ -4,9 +4,10 @@ FROM php:fpm
 ARG timezone='Europe/Paris'
 
 RUN apt-get update && apt-get install -y \
-        libmcrypt-dev libicu-dev libpq-dev libxml2-dev \
+        libmcrypt-dev libicu-dev libpq-dev libxml2-dev libpng12-dev libjpeg-dev \
+    && /usr/local/bin/docker-php-ext-configure gd --with-jpeg-dir=/usr/include \
     && docker-php-ext-install \
-        iconv mcrypt mbstring intl pdo pdo_mysql pdo_pgsql
+        iconv mcrypt mbstring intl pdo pdo_mysql pdo_pgsql gd
 
 RUN echo "date.timezone="$timezone > /usr/local/etc/php/conf.d/date_timezone.ini
 

--- a/docs/de/developer/docker.rst
+++ b/docs/de/developer/docker.rst
@@ -44,7 +44,7 @@ wallabag laufen lassen
    Eigenschaften mit den kommentierten zu ersetzen (mit Werten
    mit ``env.`` Präfix)
 #. ``composer install`` die Projektabhängigkeiten
-#. ``php app/console wallabag:install``, um das Schema zu erstellen
+#. ``php bin/console wallabag:install``, um das Schema zu erstellen
 #. ``docker-compose up`` um die Container laufen zu lassen
 #. Schließlich öffne http://localhost:8080/, um dein frisch
    installiertes wallabag zu finden.

--- a/docs/en/developer/docker.rst
+++ b/docs/en/developer/docker.rst
@@ -40,7 +40,7 @@ Run wallabag
 #. Edit ``app/config/parameters.yml`` to replace ``database_*``
    properties with commented ones (with values prefixed by ``env.``)
 #. ``composer install`` the project dependencies
-#. ``php app/console wallabag:install`` to create the schema
+#. ``php bin/console wallabag:install`` to create the schema
 #. ``docker-compose up`` to run the containers
 #. Finally, browse to http://localhost:8080/ to find your freshly
    installed wallabag.

--- a/docs/fr/developer/docker.rst
+++ b/docs/fr/developer/docker.rst
@@ -39,7 +39,7 @@ Exécuter wallabag
 #. Editer ``app/config/parameters.yml`` pour remplacer les propriétés ``database_*``
     par les lignes commentées (celles avec des valeurs préfixées par ``env.``)
 #. ``composer install`` pour installer les dépendances
-#. ``php app/console wallabag:install`` pour créer le schéma de la BDD
+#. ``php bin/console wallabag:install`` pour créer le schéma de la BDD
 #. ``docker-compose up`` pour démarrer les conteneurs
 #. Enfin, se rendre sur http://localhost:8080/ pour accéder à une installation
     tout propre de wallabag.


### PR DESCRIPTION
To be able to export an entry as an EPUB file, we need the `gd` extension.
=> Add it to docker

I also fixed a small error in the docs: `console` is in `bin/` and not in `app/.`

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | 
| Documentation | yes
| Translation   | yes
| Fixed tickets | 
| License       | MIT
