### PR TITLE
Customize errors templates

### DIFF
--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -64,6 +64,7 @@ twig:
     strict_variables: "%kernel.debug%"
     form_themes:
         - "LexikFormFilterBundle:Form:form_div_layout.html.twig"
+    exception_controller: wallabag_core.exception_controller:showAction
 
 # Doctrine Configuration
 doctrine:

--- a/src/Wallabag/CoreBundle/Controller/ExceptionController.php
+++ b/src/Wallabag/CoreBundle/Controller/ExceptionController.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Wallabag\CoreBundle\Controller;
+
+use Symfony\Bundle\TwigBundle\Controller\ExceptionController as BaseExceptionController;
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * This controller allow us to customize the error template.
+ * The only modified line from the parent template is for "WallabagCoreBundle".
+ */
+class ExceptionController extends BaseExceptionController
+{
+    protected function findTemplate(Request $request, $format, $code, $showException)
+    {
+        $name = $showException ? 'exception' : 'error';
+        if ($showException && 'html' == $format) {
+            $name = 'exception_full';
+        }
+
+        // For error pages, try to find a template for the specific HTTP status code and format
+        if (!$showException) {
+            $template = sprintf('WallabagCoreBundle:Exception:%s.%s.twig', $name, $format);
+            if ($this->templateExists($template)) {
+                return $template;
+            }
+        }
+
+        // try to find a template for the given format
+        $template = sprintf('@Twig/Exception/%s.%s.twig', $name, $format);
+        if ($this->templateExists($template)) {
+            return $template;
+        }
+
+        // default to a generic HTML exception
+        $request->setRequestFormat('html');
+
+        return sprintf('@Twig/Exception/%s.html.twig', $showException ? 'exception_full' : $name);
+    }
+}

--- a/src/Wallabag/CoreBundle/ParamConverter/UsernameRssTokenConverter.php
+++ b/src/Wallabag/CoreBundle/ParamConverter/UsernameRssTokenConverter.php
@@ -49,7 +49,7 @@ class UsernameRssTokenConverter implements ParamConverterInterface
         $em = $this->registry->getManagerForClass($configuration->getClass());
 
         // Check, if class name is what we need
-        if ('Wallabag\UserBundle\Entity\User' !== $em->getClassMetadata($configuration->getClass())->getName()) {
+        if (null !== $em && 'Wallabag\UserBundle\Entity\User' !== $em->getClassMetadata($configuration->getClass())->getName()) {
             return false;
         }
 
@@ -69,9 +69,8 @@ class UsernameRssTokenConverter implements ParamConverterInterface
         $username = $request->attributes->get('username');
         $rssToken = $request->attributes->get('token');
 
-        // Check, if route attributes exists
-        if (null === $username || null === $rssToken) {
-            throw new \InvalidArgumentException('Route attribute is missing');
+        if (!$request->attributes->has('username') || !$request->attributes->has('token')) {
+            return false;
         }
 
         // Get actual entity manager for class

--- a/src/Wallabag/CoreBundle/Resources/config/services.yml
+++ b/src/Wallabag/CoreBundle/Resources/config/services.yml
@@ -133,3 +133,9 @@ services:
                 host: '%redis_host%'
                 port: '%redis_port%'
                 schema: tcp
+
+    wallabag_core.exception_controller:
+        class: Wallabag\CoreBundle\Controller\ExceptionController
+        arguments:
+            - '@twig'
+            - '%kernel.debug%'

--- a/src/Wallabag/CoreBundle/Resources/views/themes/baggy/Exception/error.html.twig
+++ b/src/Wallabag/CoreBundle/Resources/views/themes/baggy/Exception/error.html.twig
@@ -1,0 +1,24 @@
+{% extends "WallabagCoreBundle::layout.html.twig" %}
+
+{% block title %}{{ 'error.page_title'|trans }}{% endblock %}
+
+{% block body_class %}login{% endblock %}
+
+{% block menu %}{% endblock %}
+{% block messages %}{% endblock %}
+{% block header %}{% endblock %}
+
+{% block content %}
+<main class="valign-wrapper">
+    <div class="valign row">
+        <div class="card sw">
+            <div class="center"><img src="{{ asset('bundles/wallabagcore/themes/_global/img/logo-w.png') }}" alt="wallabag logo" /></div>
+            <h2>{{ status_code }}: {{ status_text }}</h2>
+            <p>{{ exception.message }}</p>
+        </div>
+    </div>
+</main>
+{% endblock %}
+
+{% block footer %}
+{% endblock %}

--- a/src/Wallabag/CoreBundle/Resources/views/themes/material/Exception/error.html.twig
+++ b/src/Wallabag/CoreBundle/Resources/views/themes/material/Exception/error.html.twig
@@ -1,0 +1,30 @@
+{% extends "WallabagCoreBundle::layout.html.twig" %}
+
+{% block title %}{{ 'error.page_title'|trans }}{% endblock %}
+
+{% block body_class %}login{% endblock %}
+
+{% block menu %}{% endblock %}
+{% block messages %}{% endblock %}
+
+{% block content %}
+<main class="valign-wrapper">
+    <div class="valign row">
+        <div class="card sw">
+            <div class="center"><img src="{{ asset('bundles/wallabagcore/themes/_global/img/logo-other_themes.png') }}" alt="wallabag logo" /></div>
+            <div class="card-content">
+                <div class="row">
+                    <h5>{{ status_code }}: {{ status_text }}</h5>
+                    <p>{{ exception.message }}</p>
+                    {# {% for trace in exception.trace %}
+                        <p>{{ trace.class }} - {{ trace.type }} - {{ trace.file }} - {{ trace.line }}</p>
+                    {% endfor %} #}
+                </div>
+            </div>
+        </div>
+    </div>
+</main>
+{% endblock %}
+
+{% block footer %}
+{% endblock %}

--- a/tests/Wallabag/CoreBundle/ParamConverter/UsernameRssTokenConverterTest.php
+++ b/tests/Wallabag/CoreBundle/ParamConverter/UsernameRssTokenConverterTest.php
@@ -125,16 +125,14 @@ class UsernameRssTokenConverterTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue($converter->supports($params));
     }
 
-    /**
-     * @expectedException InvalidArgumentException
-     * @expectedExceptionMessage Route attribute is missing
-     */
     public function testApplyEmptyRequest()
     {
         $params = new ParamConverter([]);
         $converter = new UsernameRssTokenConverter();
 
-        $converter->apply(new Request(), $params);
+        $res = $converter->apply(new Request(), $params);
+
+        $this->assertFalse($res);
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Documentation | no
| Translation   | yes
| Fixed tickets | https://github.com/wallabag/wallabag/issues/1570
| License       | MIT

All error goes to the same template which only display the error message and the status code.

Should (finally) fix https://github.com/wallabag/wallabag/issues/1570

On material:

![](https://cl.ly/2Q3V2d0U1426/Image%202016-10-01%20at%203.45.36%20PM.png)

On baggy:

![](https://cl.ly/0C02332D3x3U/Image%202016-10-01%20at%203.45.08%20PM.png)