### PR TITLE
Add simple stats in footer

### DIFF
--- a/app/config/services.yml
+++ b/app/config/services.yml
@@ -21,6 +21,7 @@ services:
             - "@wallabag_core.tag_repository"
             - "@security.token_storage"
             - "%wallabag_core.cache_lifetime%"
+            - "@translator"
         tags:
             - { name: twig.extension }
 

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.da.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.da.yml
@@ -45,6 +45,7 @@ footer:
         # social: 'Social'
         # powered_by: 'powered by'
         about: 'Om'
+    # stats: Since %user_creation% you read %nb_archives% articles. That is about %per_day% a day!
 
 config:
     page_title: 'Opsætning'

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.de.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.de.yml
@@ -45,6 +45,7 @@ footer:
         social: 'Soziales'
         powered_by: 'angetrieben von'
         about: 'Über'
+    # stats: Since %user_creation% you read %nb_archives% articles. That is about %per_day% a day!
 
 config:
     page_title: 'Einstellungen'

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.en.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.en.yml
@@ -45,6 +45,7 @@ footer:
         social: 'Social'
         powered_by: 'powered by'
         about: 'About'
+    stats: Since %user_creation% you read %nb_archives% articles. That is about %per_day% a day!
 
 config:
     page_title: 'Config'

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.es.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.es.yml
@@ -45,6 +45,7 @@ footer:
         social: 'Social'
         powered_by: 'funciona por'
         about: 'Acerca de'
+    # stats: Since %user_creation% you read %nb_archives% articles. That is about %per_day% a day!
 
 config:
     page_title: 'Configuración'

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.fa.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.fa.yml
@@ -45,6 +45,7 @@ footer:
         social: 'شبکه‌های اجتماعی'
         powered_by: 'توانمند با'
         about: 'درباره'
+    # stats: Since %user_creation% you read %nb_archives% articles. That is about %per_day% a day!
 
 config:
     page_title: 'پیکربندی'

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.fr.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.fr.yml
@@ -45,6 +45,7 @@ footer:
         social: 'Social'
         powered_by: 'propulsé par'
         about: 'À propos'
+    stats: Depuis le %user_creation% vous avez lu %nb_archives% articles. Ce qui fait %per_day% par jour !
 
 config:
     page_title: 'Configuration'

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.it.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.it.yml
@@ -45,6 +45,7 @@ footer:
         social: 'Social'
         powered_by: 'powered by'
         about: 'About'
+    # stats: Since %user_creation% you read %nb_archives% articles. That is about %per_day% a day!
 
 config:
     page_title: 'Configurazione'

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.oc.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.oc.yml
@@ -45,9 +45,10 @@ footer:
         social: 'Social'
         powered_by: 'propulsat per'
         about: 'A prepaus'
-    page_title: 'Configuracion'
+    # stats: Since %user_creation% you read %nb_archives% articles. That is about %per_day% a day!
 
 config:
+    page_title: 'Configuracion'
     tab_menu:
         settings: 'Paramètres'
         rss: 'RSS'

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.pl.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.pl.yml
@@ -45,6 +45,7 @@ footer:
         social: 'Społeczność'
         powered_by: 'Kontrolowany przez'
         about: 'O nas'
+    # stats: Since %user_creation% you read %nb_archives% articles. That is about %per_day% a day!
 
 config:
     page_title: 'Konfiguracja'

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.ro.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.ro.yml
@@ -45,6 +45,7 @@ footer:
         # social: 'Social'
         # powered_by: 'powered by'
         about: 'Despre'
+    # stats: Since %user_creation% you read %nb_archives% articles. That is about %per_day% a day!
 
 config:
     page_title: 'Configurație'

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.tr.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.tr.yml
@@ -45,6 +45,7 @@ footer:
         social: 'Sosyal'
         powered_by: 'powered by'
         about: 'Hakkımızda'
+    # stats: Since %user_creation% you read %nb_archives% articles. That is about %per_day% a day!
 
 config:
     page_title: 'Yapılandırma'

--- a/src/Wallabag/CoreBundle/Resources/views/themes/material/layout.html.twig
+++ b/src/Wallabag/CoreBundle/Resources/views/themes/material/layout.html.twig
@@ -122,8 +122,19 @@
     <footer class="page-footer cyan darken-2">
         <div class="footer-copyright">
             <div class="container">
-                <p>{{ 'footer.wallabag.powered_by'|trans }} <a target="_blank" href="https://wallabag.org" class="grey-text text-lighten-4">wallabag</a></p>
-                <a class="grey-text text-lighten-4 right" href="{{ path('about') }}">{{ 'footer.wallabag.about'|trans }}</a>
+                <div class="row">
+                    <div class="col s8">
+                        <p>
+                            {{ display_stats() }}
+                        </p>
+                    </div>
+                    <div class="col s4">
+                        <p>
+                            {{ 'footer.wallabag.powered_by'|trans }} <a target="_blank" href="https://wallabag.org" class="grey-text text-lighten-4">wallabag</a> –
+                            <a class="grey-text text-lighten-4" href="{{ path('about') }}">{{ 'footer.wallabag.about'|trans|lower }}</a>
+                        </p>
+                    </div>
+                </div>
             </div>
         </div>
     </footer>

--- a/tests/Wallabag/CoreBundle/Twig/WallabagExtensionTest.php
+++ b/tests/Wallabag/CoreBundle/Twig/WallabagExtensionTest.php
@@ -8,7 +8,23 @@ class WallabagExtensionTest extends \PHPUnit_Framework_TestCase
 {
     public function testRemoveWww()
     {
-        $extension = new WallabagExtension();
+        $entryRepository = $this->getMockBuilder('Wallabag\CoreBundle\Repository\EntryRepository')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $tagRepository = $this->getMockBuilder('Wallabag\CoreBundle\Repository\TagRepository')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $tokenStorage = $this->getMockBuilder('Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $translator = $this->getMockBuilder('Symfony\Component\Translation\TranslatorInterface')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $extension = new WallabagExtension($entryRepository, $tagRepository, $tokenStorage, 0, $translator);
 
         $this->assertEquals('lemonde.fr', $extension->removeWww('www.lemonde.fr'));
         $this->assertEquals('lemonde.fr', $extension->removeWww('lemonde.fr'));


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Documentation | no
| Translation   | yes
| Fixed tickets | 
| License       | MIT

Related to https://github.com/wallabag/wallabag/issues/1638

It display a single line in the footer with some stats.

![](https://cl.ly/2Y3Q093E4247/Image%202016-10-01%20at%203.49.52%20PM.png)