### PR TITLE
Add an exists endpoint in API

### DIFF
--- a/src/Wallabag/ApiBundle/Controller/WallabagRestController.php
+++ b/src/Wallabag/ApiBundle/Controller/WallabagRestController.php
@@ -23,7 +23,7 @@ class WallabagRestController extends FOSRestController
     }
 
     /**
-     * Check if an entry exist by url
+     * Check if an entry exist by url.
      *
      * @ApiDoc(
      *       parameters={

--- a/src/Wallabag/ApiBundle/Controller/WallabagRestController.php
+++ b/src/Wallabag/ApiBundle/Controller/WallabagRestController.php
@@ -23,6 +23,38 @@ class WallabagRestController extends FOSRestController
     }
 
     /**
+     * Check if an entry exist by url
+     *
+     * @ApiDoc(
+     *       parameters={
+     *          {"name"="url", "dataType"="string", "required"=true, "format"="An url", "description"="Url to check if it exists"}
+     *       }
+     * )
+     *
+     * @return JsonResponse
+     */
+    public function getEntriesExistsAction(Request $request)
+    {
+        $this->validateAuthentication();
+
+        $url = $request->query->get('url', '');
+
+        if (empty($url)) {
+            throw $this->createAccessDeniedException('URL is empty?, logged user id: '.$user->getId());
+        }
+
+        $res = $this->getDoctrine()
+            ->getRepository('WallabagCoreBundle:Entry')
+            ->findByUrlAndUserId($url, $this->getUser()->getId());
+
+        $exists = false === $res ? false : true;
+
+        $json = $this->get('serializer')->serialize(['exists' => $exists], 'json');
+
+        return (new JsonResponse())->setJson($json);
+    }
+
+    /**
      * Retrieve all entries. It could be filtered by many options.
      *
      * @ApiDoc(

--- a/tests/Wallabag/ApiBundle/Controller/WallabagRestControllerTest.php
+++ b/tests/Wallabag/ApiBundle/Controller/WallabagRestControllerTest.php
@@ -695,4 +695,15 @@ class WallabagRestControllerTest extends WallabagApiTestCase
 
         $this->assertEquals(true, $content['exists']);
     }
+
+    public function testGetEntriesExistsWhichDoesNotExists()
+    {
+        $this->client->request('GET', '/api/entries/exists?url=http://google.com/entry2');
+
+        $this->assertEquals(200, $this->client->getResponse()->getStatusCode());
+
+        $content = json_decode($this->client->getResponse()->getContent(), true);
+
+        $this->assertEquals(false, $content['exists']);
+    }
 }

--- a/tests/Wallabag/ApiBundle/Controller/WallabagRestControllerTest.php
+++ b/tests/Wallabag/ApiBundle/Controller/WallabagRestControllerTest.php
@@ -684,4 +684,15 @@ class WallabagRestControllerTest extends WallabagApiTestCase
 
         $this->assertEquals(true, $content['is_starred']);
     }
+
+    public function testGetEntriesExists()
+    {
+        $this->client->request('GET', '/api/entries/exists?url=http://0.0.0.0/entry2');
+
+        $this->assertEquals(200, $this->client->getResponse()->getStatusCode());
+
+        $content = json_decode($this->client->getResponse()->getContent(), true);
+
+        $this->assertEquals(true, $content['exists']);
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Documentation | no
| Translation   | no
| Fixed tickets | https://github.com/wallabag/wallabag/issues/1796
| License       | MIT

Should fix https://github.com/wallabag/wallabag/issues/1796
It should allow third party to check if an url was already saved by a user

![](https://cl.ly/3t2L092B041O/Image%202016-10-01%20at%205.16.43%20PM.png)