### PR TITLE
Remove error message when creating ePub versions

### DIFF
--- a/src/Wallabag/CoreBundle/Helper/EntriesExport.php
+++ b/src/Wallabag/CoreBundle/Helper/EntriesExport.php
@@ -25,7 +25,7 @@ class EntriesExport
     private $footerTemplate = '<div style="text-align:center;">
         <p>Produced by wallabag with %EXPORT_METHOD%</p>
         <p>Please open <a href="https://github.com/wallabag/wallabag/issues">an issue</a> if you have trouble with the display of this E-Book on your device.</p>
-        </div';
+        </div>';
 
     /**
      * @param Config $craueConfig CraueConfig instance to get wallabag instance url from database


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes|no
| New feature?  | yes|no
| BC breaks?    | yes|no
| Deprecations? | yes|no
| Tests pass?   | yes|no
| Documentation | yes|no
| Translation   | yes|no
| Fixed tickets | comma-separated list of tickets fixed by the PR, if any
| License       | MIT

Trying to create a ePub version, the first page shows a message of a
“missing >”. This change solve this problem (and, for sure, in any
download version that’s use HTML).