### PR TITLE
Fix for 2.1 installation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -91,8 +91,8 @@ before_install:
     - if [[ $TRAVIS_REPO_SLUG = wallabag/wallabag ]]; then cp .composer-auth.json ~/.composer/auth.json; fi;
 
 script:
-    - travis_wait bash install.sh
+    - travis_wait bash install_dev.sh
     - ant prepare-$DB
-    - phpunit -v
+    - if [[ $VALIDATE_TRANSLATION_FILE = '' ]]; then phpunit -v ; fi;
     - if [[ $CS_FIXER = run ]]; then php bin/php-cs-fixer fix src/ --verbose --dry-run ; fi;
     - if [[ $VALIDATE_TRANSLATION_FILE = run ]]; then php bin/console lint:yaml src/Wallabag/CoreBundle/Resources/translations -v ; fi;

--- a/docs/de/user/installation.rst
+++ b/docs/de/user/installation.rst
@@ -56,6 +56,7 @@ Um wallabag selbst zu installieren, musst du die folgenden Kommandos ausführen:
     cd wallabag
     git checkout 2.1.0
     ASSETS=build ./install.sh
+    php bin/console wallabag:install --env=prod
 
 Um PHPs eingebauten Server zu starten und zu testen, ob alles korrekt installiert wurde, kannst du folgendes Kommando ausführen:
 

--- a/docs/de/user/upgrade-2.0.x-2.0.y.rst
+++ b/docs/de/user/upgrade-2.0.x-2.0.y.rst
@@ -8,6 +8,7 @@ Das neueste Release ist auf https://www.wallabag.org/pages/download-wallabag.htm
 
 ::
 
+    rm -rf var/cache/*
     git fetch origin
     git fetch --tags
     git checkout 2.0.8

--- a/docs/de/user/upgrade-2.0.x-2.1.y.rst
+++ b/docs/de/user/upgrade-2.0.x-2.1.y.rst
@@ -11,6 +11,7 @@ Das neueste Release ist auf https://www.wallabag.org/pages/download-wallabag.htm
 
 ::
 
+    rm -rf var/cache/*
     git fetch origin
     git fetch --tags
     git checkout 2.1.0

--- a/docs/en/user/installation.rst
+++ b/docs/en/user/installation.rst
@@ -55,6 +55,7 @@ To install wallabag itself, you must run the following commands:
     cd wallabag
     git checkout 2.1.0
     ASSETS=build ./install.sh
+    php bin/console wallabag:install --env=prod
 
 To start PHP's build-in server and test if everything did install correctly, you can do:
 

--- a/docs/en/user/upgrade-2.0.x-2.0.y.rst
+++ b/docs/en/user/upgrade-2.0.x-2.0.y.rst
@@ -8,6 +8,7 @@ The last release is published on https://www.wallabag.org/pages/download-wallaba
 
 ::
 
+    rm -rf var/cache/*
     git fetch origin
     git fetch --tags
     git checkout 2.0.8

--- a/docs/en/user/upgrade-2.0.x-2.1.y.rst
+++ b/docs/en/user/upgrade-2.0.x-2.1.y.rst
@@ -11,6 +11,7 @@ The last release is published on https://www.wallabag.org/pages/download-wallaba
 
 ::
 
+    rm -rf var/cache/*
     git fetch origin
     git fetch --tags
     git checkout 2.1.0

--- a/docs/fr/user/installation.rst
+++ b/docs/fr/user/installation.rst
@@ -53,6 +53,7 @@ Pour installer wallabag, vous devez exécuter ces commandes :
     cd wallabag
     git checkout 2.1.0
     ASSETS=build ./install.sh
+    php bin/console wallabag:install --env=prod
 
 Pour démarrer le serveur interne à php et vérifier que tout s'est installé correctement, vous pouvez exécuter :
 

--- a/docs/fr/user/upgrade-2.0.x-2.0.y.rst
+++ b/docs/fr/user/upgrade-2.0.x-2.0.y.rst
@@ -8,6 +8,7 @@ La dernière version de wallabag est publiée à cette adresse : https://www.wal
 
 ::
 
+    rm -rf var/cache/*
     git fetch origin
     git fetch --tags
     git checkout 2.0.8

--- a/docs/fr/user/upgrade-2.0.x-2.1.y.rst
+++ b/docs/fr/user/upgrade-2.0.x-2.1.y.rst
@@ -11,6 +11,7 @@ La dernière version de wallabag est publiée à cette adresse : https://www.wal
 
 ::
 
+    rm -rf var/cache/*
     git fetch origin
     git fetch --tags
     git checkout 2.1.0

--- a/install.sh
+++ b/install.sh
@@ -1,15 +1,13 @@
 #! /usr/bin/env bash
 
-if [[ $ASSETS == 'build' ]]; then
-    echo "Installing PHP dependencies through Composer..."
-    composer install --no-interaction --no-progress --prefer-dist -o
+echo " > Installing PHP dependencies through Composer..."
+composer install --no-interaction --no-progress --prefer-dist -o --no-dev
 
-    chmod ugo+x vendor/mouf/nodejs-installer/bin/local/npm
-    echo "Downloading librairies through npm..."
-    vendor/mouf/nodejs-installer/bin/local/npm install
+chmod ugo+x vendor/mouf/nodejs-installer/bin/local/npm
+echo " > Downloading librairies through npm..."
+vendor/mouf/nodejs-installer/bin/local/npm install
 
-    echo "Concat, minify and installing assets..."
-    node_modules/grunt/bin/grunt
-else
-    composer install --no-interaction --no-progress --prefer-dist -o
-fi
+echo " > Concat, minify and installing assets..."
+node_modules/grunt/bin/grunt
+
+echo " > Install finished"

--- a/install_dev.sh
+++ b/install_dev.sh
@@ -1,13 +1,14 @@
 #! /usr/bin/env bash
 
-echo "Installing PHP dependencies (including dev) through Composer..."
-composer install
+echo " > Installing PHP dependencies (including dev) through Composer..."
+composer install -o  --no-interaction --no-progress --prefer-dist
 
-echo "Downloading librairies through npm..."
-npm install
+if [[ $ASSETS == 'build' || $TRAVIS_BUILD_DIR == '' ]]; then
+    echo " > Downloading librairies through npm..."
+    npm install
 
-echo "Concat, minify and installing assets..."
-grunt
+    echo " > Concat, minify and installing assets..."
+    grunt
+fi
 
-echo "Installing wallabag..."
-php bin/console wallabag:install
+echo " > Install finished"


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Documentation | yes
| Translation   | yes
| Fixed tickets | 
| License       | MIT


We removed too much stuff in the installation part. Re-add `wallabag:install`

Also use `install_dev.sh` for Travis and `install.sh` for final user.
Add `--no-dev` to `composer install` for prod env

Also, the translations build won't run PHPUnit now (so it'll be faster)