### PR TITLE
Create config even if user is disabled

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,31 +41,11 @@ env:
 matrix:
     fast_finish: true
     include:
-        # driver for PostgreSQL currently unsupported by HHVM, requires 3rd party dependency
-        - php: hhvm-3.12
-          sudo: required
-          dist: trusty
-          group: edge
-          env: DB=mysql
-          addons:
-            apt:
-                packages:
-                    - mysql-server-5.6
-                    - mysql-client-core-5.6
-                    - mysql-client-5.6
-          services:
-            - mysql
-        - php: hhvm-3.12
-          sudo: required
-          dist: trusty
-          group: edge
-          env: DB=sqlite
         - php: 7.0
           env: CS_FIXER=run VALIDATE_TRANSLATION_FILE=run DB=sqlite
         - php: 7.0
           env: DB=sqlite ASSETS=build
     allow_failures:
-        - php: hhvm-3.12
         - php: 7.1
         - php: nightly
 

--- a/src/Wallabag/UserBundle/EventListener/CreateConfigListener.php
+++ b/src/Wallabag/UserBundle/EventListener/CreateConfigListener.php
@@ -45,10 +45,6 @@ class CreateConfigListener implements EventSubscriberInterface
 
     public function createConfig(UserEvent $event, $eventName = null, EventDispatcherInterface $eventDispatcher = null)
     {
-        if (!$event->getUser()->isEnabled()) {
-            return;
-        }
-
         $config = new Config($event->getUser());
         $config->setTheme($this->theme);
         $config->setItemsPerPage($this->itemsOnPage);

--- a/tests/Wallabag/UserBundle/EventListener/CreateConfigListenerTest.php
+++ b/tests/Wallabag/UserBundle/EventListener/CreateConfigListenerTest.php
@@ -41,26 +41,6 @@ class CreateConfigListenerTest extends \PHPUnit_Framework_TestCase
         $this->response = Response::create();
     }
 
-    public function testWithInvalidUser()
-    {
-        $user = new User();
-        $user->setEnabled(false);
-
-        $event = new FilterUserResponseEvent(
-            $user,
-            $this->request,
-            $this->response
-        );
-
-        $this->em->expects($this->never())->method('persist');
-        $this->em->expects($this->never())->method('flush');
-
-        $this->dispatcher->dispatch(
-            FOSUserEvents::REGISTRATION_COMPLETED,
-            $event
-        );
-    }
-
     public function testWithValidUser()
     {
         $user = new User();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes|no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Documentation | no
| Translation   | no
| Fixed tickets | https://github.com/wallabag/wallabag/issues/2357
| License       | MIT

Should fix https://github.com/wallabag/wallabag/issues/2357

When a user register itself AND the wallabag instance is configured to send a confirmation email, the user is disabled when the listener (which create the config) receive the event.
There were a check (don't know why) if the user is enabled we create the config. But the user is disabled when confirmation email is actived.