### PR TITLE
Disable zappr approvals

### DIFF
--- a/.zappr.yaml
+++ b/.zappr.yaml
@@ -1,16 +1,17 @@
 # see https://zappr.opensource.zalan.do/
 autobranch: false
 commit: false
-approvals:
-  minimum: 1
-  ignore: pr_opener
-  pattern: "^(:\\+1:|👍)$"
-  veto:
-    pattern: "^(:\\-1:|👎)$"
-  from:
-    orgs:
-      - wallabag
-    collaborators: true
+approvals: false
+#approvals:
+#  minimum: 1
+#  ignore: pr_opener
+#  pattern: "^(:\\+1:|👍)$"
+#  veto:
+#    pattern: "^(:\\-1:|👎)$"
+#  from:
+#    orgs:
+#      - wallabag
+#    collaborators: true
 specification:
   title:
     minimum-length:


### PR DESCRIPTION
We are going to use the built-in function by Github (while waiting for "review" to be part of zappr)