### PR TITLE
API: ability to export entry in all available format (epub, pdf, etc...)

### DIFF
--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -130,6 +130,8 @@ fos_rest:
 nelmio_api_doc:
     sandbox:
         enabled: false
+    cache:
+        enabled: true
     name: wallabag API documentation
 
 nelmio_cors:

--- a/src/Wallabag/ApiBundle/Controller/WallabagRestController.php
+++ b/src/Wallabag/ApiBundle/Controller/WallabagRestController.php
@@ -127,10 +127,17 @@ class WallabagRestController extends FOSRestController
      *
      * @return JsonResponse
      */
-    public function getEntryAction(Entry $entry)
+    public function getEntryAction(Entry $entry, $_format)
     {
         $this->validateAuthentication();
         $this->validateUserAccess($entry->getUser()->getId());
+
+        if ($_format === 'epub') {
+            return $this->get('wallabag_core.helper.entries_export')
+                ->setEntries($entry)
+                ->updateTitle('entry')
+                ->exportAs($_format);
+        }
 
         $json = $this->get('serializer')->serialize($entry, 'json');
 

--- a/src/Wallabag/ApiBundle/Resources/config/routing_rest.yml
+++ b/src/Wallabag/ApiBundle/Resources/config/routing_rest.yml
@@ -1,6 +1,4 @@
-entries:
-  type: rest
-  resource:     "WallabagApiBundle:WallabagRest"
-  name_prefix:  api_
-  requirements:
-    _format: xml|json|html|epub
+api:
+    type: rest
+    resource: "WallabagApiBundle:WallabagRest"
+    name_prefix:  api_

--- a/src/Wallabag/ApiBundle/Resources/config/routing_rest.yml
+++ b/src/Wallabag/ApiBundle/Resources/config/routing_rest.yml
@@ -2,3 +2,5 @@ entries:
   type: rest
   resource:     "WallabagApiBundle:WallabagRest"
   name_prefix:  api_
+  requirements:
+    _format: xml|json|html|epub


### PR DESCRIPTION
Following discussions on Twitter - see https://twitter.com/wallabagapp/status/783608582323462144 - here's kind of a *draft* PR.

There is an endpoint in the API to get an entry as a JSON string: `/api/entries/123.json`
The returned JSON string contains an HTML version of the entry's content, but this is not well suited for offline reading, especially as it doesn't contain the images of the entry.

Instead of this HTML version of the entry's content, I'd rather use an EPUB version: one file to download, embeds the images, and many reading engines exist (like on ereader devices ;-) ), as it's a well-known format.
Great thing is: wallabag already has a "download as EPUB" feature, which is currently not exposed by the API.

So: this PR is a draft (no test included for now -- seems to work on my server, but I haven't used this feature much) of an idea to **add EPUB export to the API**.

I re-used the existing endpoint to get one entry, but used the format information in the URL: instead of always returning a JSON string, this endpoint can now return EPUB content if called with the corresponding extension: `/api/entries/123.epub`

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | N/A
| Documentation | no
| Translation   | no
| Fixed tickets | https://github.com/wallabag/wallabag/issues/2311
| License       | MIT
