### PR TITLE
Fixed two-factor checkbox display in user admin panel

### DIFF
--- a/src/Wallabag/UserBundle/Resources/views/Manage/edit.html.twig
+++ b/src/Wallabag/UserBundle/Resources/views/Manage/edit.html.twig
@@ -68,7 +68,7 @@
                                 <br/>
 
                                 {{ form_widget(edit_form.save, {'attr': {'class': 'btn waves-effect waves-light'}}) }}
-                                {{ form_rest(edit_form) }}
+                                {{ form_widget(edit_form._token) }}
                             </form>
                             <p>
                                 {{ form_start(delete_form) }}

--- a/tests/Wallabag/UserBundle/Controller/ManageControllerTest.php
+++ b/tests/Wallabag/UserBundle/Controller/ManageControllerTest.php
@@ -23,7 +23,7 @@ class ManageControllerTest extends WallabagCoreTestCase
 
         // Create a new user in the database
         $crawler = $client->request('GET', '/users/');
-        $this->assertEquals(200, $client->getResponse()->getStatusCode(), "Unexpected HTTP status code for GET /users/");
+        $this->assertEquals(200, $client->getResponse()->getStatusCode(), 'Unexpected HTTP status code for GET /users/');
         $crawler = $client->click($crawler->selectLink('user.list.create_new_one')->link());
 
         // Fill in the form and submit it


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Documentation | no
| Translation   | no
| Fixed tickets | #2380
| License       | MIT

Fix #2380

When 2FA is enabled: 

![](https://d17oy1vhnax1f7.cloudfront.net/items/3s0p2V471G1F011k2J12/Capture%20d%E2%80%99e%CC%81cran%202016-10-07%20a%CC%80%2014.55.49.png?v=cea4c5e2)

When it's disabled: 
![](https://d17oy1vhnax1f7.cloudfront.net/items/1r350B1b0p1k3Q2a2j2j/Capture%20d%E2%80%99e%CC%81cran%202016-10-07%20a%CC%80%2014.54.55.png?v=7dafc468)
