### PR TITLE
Ability to check multiple urls in API

### DIFF
--- a/tests/Wallabag/ApiBundle/Controller/WallabagRestControllerTest.php
+++ b/tests/Wallabag/ApiBundle/Controller/WallabagRestControllerTest.php
@@ -794,6 +794,22 @@ class WallabagRestControllerTest extends WallabagApiTestCase
         $this->assertEquals(true, $content['exists']);
     }
 
+    public function testGetEntriesExistsWithManyUrls()
+    {
+        $url1 = 'http://0.0.0.0/entry2';
+        $url2 = 'http://0.0.0.0/entry10';
+        $this->client->request('GET', '/api/entries/exists?urls[]='.$url1.'&urls[]='.$url2);
+
+        $this->assertEquals(200, $this->client->getResponse()->getStatusCode());
+
+        $content = json_decode($this->client->getResponse()->getContent(), true);
+
+        $this->assertArrayHasKey($url1, $content);
+        $this->assertArrayHasKey($url2, $content);
+        $this->assertEquals(true, $content[$url1]);
+        $this->assertEquals(false, $content[$url2]);
+    }
+
     public function testGetEntriesExistsWhichDoesNotExists()
     {
         $this->client->request('GET', '/api/entries/exists?url=http://google.com/entry2');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes (little one)
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Documentation | no
| Translation   | no
| Fixed tickets | https://github.com/wallabag/wallabag/issues/1796
| License       | MIT

This is the end of https://github.com/wallabag/wallabag/pull/2325
We can now check multiple urls at once using: 

```
/api/entries/exists?urls[]=http://...&urls[]=http://...
```

I don't know if we should put a limitation to avoid receiving hundred of urls at once ?