### PR TITLE
Add ability to use socket

### DIFF
--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -77,6 +77,7 @@ doctrine:
         password: "%database_password%"
         charset: UTF8
         path: "%database_path%"
+        unix_socket: "%database_socket%"
         server_version: 5.6
 
     orm:

--- a/app/config/parameters.yml.dist
+++ b/app/config/parameters.yml.dist
@@ -18,6 +18,7 @@ parameters:
     database_password: ~
     database_path: "%kernel.root_dir%/../data/db/wallabag.sqlite"
     database_table_prefix: wallabag_
+    database_socket: null
 
     mailer_transport:  smtp
     mailer_host:       127.0.0.1
@@ -48,5 +49,7 @@ parameters:
     rabbitmq_password: guest
 
     # Redis processing
+    redis_scheme: tcp
     redis_host: localhost
     redis_port: 6379
+    redis_path: null

--- a/src/Wallabag/CoreBundle/Resources/config/services.yml
+++ b/src/Wallabag/CoreBundle/Resources/config/services.yml
@@ -119,9 +119,10 @@ services:
         class: Predis\Client
         arguments:
             -
+                scheme: '%redis_scheme%'
                 host: '%redis_host%'
                 port: '%redis_port%'
-                schema: tcp
+                path: '%redis_path%'
 
     wallabag_core.exception_controller:
         class: Wallabag\CoreBundle\Controller\ExceptionController


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | yes (new parameters)
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Documentation | no
| Translation   | no
| Fixed tickets | #2143 & #2391
| License       | MIT

Should fix #2143 #2391
Add ability to use socket for Redis & MySQL.

Should we wait for 2.2.0 or can this be added to 2.1.2? Because we added information in `parameters.yml` that must be set to run wallabag (even if defined at null).