### PR TITLE
Ensure orphan tag are remove in API

### DIFF
--- a/src/Wallabag/ApiBundle/Controller/WallabagRestController.php
+++ b/src/Wallabag/ApiBundle/Controller/WallabagRestController.php
@@ -400,6 +400,8 @@ class WallabagRestController extends FOSRestController
             ->getRepository('WallabagCoreBundle:Entry')
             ->removeTag($this->getUser()->getId(), $tag);
 
+        $this->cleanOrphanTag($tag);
+
         $json = $this->get('serializer')->serialize($tag, 'json');
 
         return (new JsonResponse())->setJson($json);
@@ -440,6 +442,8 @@ class WallabagRestController extends FOSRestController
             ->getRepository('WallabagCoreBundle:Entry')
             ->removeTags($this->getUser()->getId(), $tags);
 
+        $this->cleanOrphanTag($tags);
+
         $json = $this->get('serializer')->serialize($tags, 'json');
 
         return (new JsonResponse())->setJson($json);
@@ -464,6 +468,8 @@ class WallabagRestController extends FOSRestController
             ->getRepository('WallabagCoreBundle:Entry')
             ->removeTag($this->getUser()->getId(), $tag);
 
+        $this->cleanOrphanTag($tag);
+
         $json = $this->get('serializer')->serialize($tag, 'json');
 
         return (new JsonResponse())->setJson($json);
@@ -483,6 +489,28 @@ class WallabagRestController extends FOSRestController
         $json = $this->get('serializer')->serialize($version, 'json');
 
         return (new JsonResponse())->setJson($json);
+    }
+
+    /**
+     * Remove orphan tag in case no entries are associated to it.
+     *
+     * @param Tag|array $tags
+     */
+    private function cleanOrphanTag($tags)
+    {
+        if (!is_array($tags)) {
+            $tags = [$tags];
+        }
+
+        $em = $this->getDoctrine()->getManager();
+
+        foreach ($tags as $tag) {
+            if (count($tag->getEntries()) === 0) {
+                $em->remove($tag);
+            }
+        }
+
+        $em->flush();
     }
 
     /**

--- a/src/Wallabag/CoreBundle/Controller/TagController.php
+++ b/src/Wallabag/CoreBundle/Controller/TagController.php
@@ -63,10 +63,12 @@ class TagController extends Controller
         $entry->removeTag($tag);
         $em = $this->getDoctrine()->getManager();
         $em->flush();
-        if (count($tag->getEntries()) == 0) {
+
+        // remove orphan tag in case no entries are associated to it
+        if (count($tag->getEntries()) === 0) {
             $em->remove($tag);
+            $em->flush();
         }
-        $em->flush();
 
         $redirectUrl = $this->get('wallabag_core.helper.redirect')->to($request->headers->get('referer'));
 

--- a/src/Wallabag/CoreBundle/Resources/config/services.yml
+++ b/src/Wallabag/CoreBundle/Resources/config/services.yml
@@ -29,7 +29,7 @@ services:
         arguments:
             - "@doctrine"
 
-    wallabag_core.table_prefix_subscriber:
+    wallabag_core.subscriber.table_prefix:
         class: Wallabag\CoreBundle\Subscriber\TablePrefixSubscriber
         arguments:
             - "%database_table_prefix%"

--- a/tests/Wallabag/ApiBundle/Controller/WallabagRestControllerTest.php
+++ b/tests/Wallabag/ApiBundle/Controller/WallabagRestControllerTest.php
@@ -561,6 +561,8 @@ class WallabagRestControllerTest extends WallabagApiTestCase
      */
     public function testDeleteUserTag($tag)
     {
+        $tagName = $tag['label'];
+
         $this->client->request('DELETE', '/api/tags/'.$tag['id'].'.json');
 
         $this->assertEquals(200, $this->client->getResponse()->getStatusCode());
@@ -577,6 +579,13 @@ class WallabagRestControllerTest extends WallabagApiTestCase
             ->findAllByTagId($this->user->getId(), $tag['id']);
 
         $this->assertCount(0, $entries);
+
+        $tag = $this->client->getContainer()
+            ->get('doctrine.orm.entity_manager')
+            ->getRepository('WallabagCoreBundle:Tag')
+            ->findOneByLabel($tagName);
+
+        $this->assertNull($tag, $tagName.' was removed because it begun an orphan tag');
     }
 
     public function testDeleteTagByLabel()

--- a/tests/Wallabag/CoreBundle/Controller/EntryControllerTest.php
+++ b/tests/Wallabag/CoreBundle/Controller/EntryControllerTest.php
@@ -341,22 +341,23 @@ class EntryControllerTest extends WallabagCoreTestCase
         $this->logInAs('admin');
         $client = $this->getClient();
 
-        $content = $client->getContainer()
-            ->get('doctrine.orm.entity_manager')
+        $em = $client->getContainer()
+            ->get('doctrine.orm.entity_manager');
+
+        $content = $em
             ->getRepository('WallabagCoreBundle:Entry')
             ->findByUrlAndUserId($this->url, $this->getLoggedInUserId());
 
         // empty content
         $content->setContent('');
-        $client->getContainer()->get('doctrine.orm.entity_manager')->persist($content);
-        $client->getContainer()->get('doctrine.orm.entity_manager')->flush();
+        $em->persist($content);
+        $em->flush();
 
         $client->request('GET', '/reload/'.$content->getId());
 
         $this->assertEquals(302, $client->getResponse()->getStatusCode());
 
-        $content = $client->getContainer()
-            ->get('doctrine.orm.entity_manager')
+        $content = $em
             ->getRepository('WallabagCoreBundle:Entry')
             ->findByUrlAndUserId($this->url, $this->getLoggedInUserId());
 
@@ -486,9 +487,11 @@ class EntryControllerTest extends WallabagCoreTestCase
         $this->logInAs('admin');
         $client = $this->getClient();
 
+        $em = $client->getContainer()
+            ->get('doctrine.orm.entity_manager');
+
         // add a new content to be removed later
-        $user = $client->getContainer()
-            ->get('doctrine.orm.entity_manager')
+        $user = $em
             ->getRepository('WallabagUserBundle:User')
             ->findOneByUserName('admin');
 
@@ -502,12 +505,8 @@ class EntryControllerTest extends WallabagCoreTestCase
         $content->setArchived(true);
         $content->setLanguage('fr');
 
-        $client->getContainer()
-            ->get('doctrine.orm.entity_manager')
-            ->persist($content);
-        $client->getContainer()
-            ->get('doctrine.orm.entity_manager')
-            ->flush();
+        $em->persist($content);
+        $em->flush();
 
         $client->request('GET', '/view/'.$content->getId());
         $this->assertEquals(200, $client->getResponse()->getStatusCode());


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Documentation | no
| Translation   | no
| Fixed tickets | fix https://github.com/wallabag/wallabag/issues/2270
| License       | MIT

When the association between a tag and an entry is removed, if the tag doesn’t have other entries, we can remove it.

Also add more tests for that part and ensure TagControllerTest is isolated from the rest of the test suite (finally!)