### PR TITLE
Use default locale for user config

### DIFF
--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -46,7 +46,7 @@ wallabag_core:
         it: 'Italiano'
     items_on_page: 12
     theme: material
-    language: en
+    language: '%locale%'
     rss_limit: 50
     reading_speed: 1
     cache_lifetime: 10


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Documentation | no
| Translation   | no
| Fixed tickets | https://github.com/wallabag/wallabag/issues/2379
| License       | MIT

Should fix https://github.com/wallabag/wallabag/issues/2379

When creating a user, we set the language config “en” by default. We should use the defined locale (from `parameters.yml`) instead