### PR TITLE
Set env to prod in documentation

### DIFF
--- a/docs/de/developer/maintenance.rst
+++ b/docs/de/developer/maintenance.rst
@@ -11,7 +11,7 @@ Um den Wartungsmodus zu aktivieren, führe folgendes Kommando aus:
 
 ::
 
-    bin/console lexik:maintenance:lock --no-interaction
+    bin/console lexik:maintenance:lock -e=prod --no-interaction
 
 Du kannst deine IP Adresse in ``app/config/config.yml`` setzen, wenn du Zugriff zu wallabag haben willst, auch wenn der Wartungsmodus aktiv ist. Zum Beispiel:
 
@@ -29,4 +29,4 @@ Um den Wartungsmodus zu deaktivieren, führe dieses Kommando aus:
 
 ::
 
-    bin/console lexik:maintenance:unlock
+    bin/console lexik:maintenance:unlock -e=prod

--- a/docs/de/developer/rabbitmq.rst
+++ b/docs/de/developer/rabbitmq.rst
@@ -55,23 +55,23 @@ Abhängig von welchem Service du importieren möchtest, solltest du einen Cron J
 .. code:: bash
 
   # for Pocket import
-  bin/console rabbitmq:consumer import_pocket -w
+  bin/console rabbitmq:consumer -e=prod import_pocket -w
 
   # for Readability import
-  bin/console rabbitmq:consumer import_readability -w
+  bin/console rabbitmq:consumer -e=prod import_readability -w
 
   # for Instapaper import
-  bin/console rabbitmq:consumer import_instapaper -w
+  bin/console rabbitmq:consumer -e=prod import_instapaper -w
 
   # for wallabag v1 import
-  bin/console rabbitmq:consumer import_wallabag_v1 -w
+  bin/console rabbitmq:consumer -e=prod import_wallabag_v1 -w
 
   # for wallabag v2 import
-  bin/console rabbitmq:consumer import_wallabag_v2 -w
+  bin/console rabbitmq:consumer -e=prod import_wallabag_v2 -w
 
   # for Firefox import
-  bin/console rabbitmq:consumer import_firefox -w
+  bin/console rabbitmq:consumer -e=prod import_firefox -w
 
   # for Chrome import
-  bin/console rabbitmq:consumer import_chrome -w
+  bin/console rabbitmq:consumer -e=prod import_chrome -w
 

--- a/docs/de/developer/redis.rst
+++ b/docs/de/developer/redis.rst
@@ -44,28 +44,28 @@ Abhängig von welchem Service du importieren möchtest, solltest du einen Cron J
 .. code:: bash
 
   # for Pocket import
-  bin/console wallabag:import:redis-worker pocket -vv >> /path/to/wallabag/var/logs/redis-pocket.log
+  bin/console wallabag:import:redis-worker -e=prod pocket -vv >> /path/to/wallabag/var/logs/redis-pocket.log
 
   # for Readability import
-  bin/console wallabag:import:redis-worker readability -vv >> /path/to/wallabag/var/logs/redis-readability.log
+  bin/console wallabag:import:redis-worker -e=prod readability -vv >> /path/to/wallabag/var/logs/redis-readability.log
 
   # for Instapaper import
-  bin/console wallabag:import:redis-worker instapaper -vv >> /path/to/wallabag/var/logs/redis-instapaper.log
+  bin/console wallabag:import:redis-worker -e=prod instapaper -vv >> /path/to/wallabag/var/logs/redis-instapaper.log
 
   # for wallabag v1 import
-  bin/console wallabag:import:redis-worker wallabag_v1 -vv >> /path/to/wallabag/var/logs/redis-wallabag_v1.log
+  bin/console wallabag:import:redis-worker -e=prod wallabag_v1 -vv >> /path/to/wallabag/var/logs/redis-wallabag_v1.log
 
   # for wallabag v2 import
-  bin/console wallabag:import:redis-worker wallabag_v2 -vv >> /path/to/wallabag/var/logs/redis-wallabag_v2.log
+  bin/console wallabag:import:redis-worker -e=prod wallabag_v2 -vv >> /path/to/wallabag/var/logs/redis-wallabag_v2.log
 
   # for Firefox import
-  bin/console wallabag:import:redis-worker firefox -vv >> /path/to/wallabag/var/logs/redis-firefox.log
+  bin/console wallabag:import:redis-worker -e=prod firefox -vv >> /path/to/wallabag/var/logs/redis-firefox.log
 
   # for Chrome import
-  bin/console wallabag:import:redis-worker instapaper -vv >> /path/to/wallabag/var/logs/redis-chrome.log
+  bin/console wallabag:import:redis-worker -e=prod instapaper -vv >> /path/to/wallabag/var/logs/redis-chrome.log
 
 Wenn du den Import nur für ein paar Nachrichten und nicht für alle starten willst, kannst du die Nummer (im folgenden Beispiel 12) angeben. Der Redis Worker wird dann nach der 12. Nachricht stoppen:
 
 .. code:: bash
 
-  bin/console wallabag:import:redis-worker pocket -vv --maxIterations=12
+  bin/console wallabag:import:redis-worker -e=prod pocket -vv --maxIterations=12

--- a/docs/en/developer/maintenance.rst
+++ b/docs/en/developer/maintenance.rst
@@ -11,7 +11,7 @@ To enable maintenance mode, execute this command:
 
 ::
 
-    bin/console lexik:maintenance:lock --no-interaction
+    bin/console lexik:maintenance:lock --no-interaction -e=prod
 
 You can set your IP address in ``app/config/config.yml`` if you want to access to wallabag even if maintenance mode is enabled. For example:
 
@@ -29,4 +29,4 @@ To disable maintenance mode, execute this command:
 
 ::
 
-    bin/console lexik:maintenance:unlock
+    bin/console lexik:maintenance:unlock -e=prod

--- a/docs/en/developer/rabbitmq.rst
+++ b/docs/en/developer/rabbitmq.rst
@@ -55,22 +55,22 @@ Depending on which service you want to import from you need to enable one (or ma
 .. code:: bash
 
   # for Pocket import
-  bin/console rabbitmq:consumer import_pocket -w
+  bin/console rabbitmq:consumer -e=prod import_pocket -w
 
   # for Readability import
-  bin/console rabbitmq:consumer import_readability -w
+  bin/console rabbitmq:consumer -e=prod import_readability -w
 
   # for Instapaper import
-  bin/console rabbitmq:consumer import_instapaper -w
+  bin/console rabbitmq:consumer -e=prod import_instapaper -w
 
   # for wallabag v1 import
-  bin/console rabbitmq:consumer import_wallabag_v1 -w
+  bin/console rabbitmq:consumer -e=prod import_wallabag_v1 -w
 
   # for wallabag v2 import
-  bin/console rabbitmq:consumer import_wallabag_v2 -w
+  bin/console rabbitmq:consumer -e=prod import_wallabag_v2 -w
 
   # for Firefox import
-  bin/console rabbitmq:consumer import_firefox -w
+  bin/console rabbitmq:consumer -e=prod import_firefox -w
 
   # for Chrome import
-  bin/console rabbitmq:consumer import_chrome -w
+  bin/console rabbitmq:consumer -e=prod import_chrome -w

--- a/docs/en/developer/redis.rst
+++ b/docs/en/developer/redis.rst
@@ -44,28 +44,28 @@ Depending on which service you want to import from you need to enable one (or ma
 .. code:: bash
 
   # for Pocket import
-  bin/console wallabag:import:redis-worker pocket -vv >> /path/to/wallabag/var/logs/redis-pocket.log
+  bin/console wallabag:import:redis-worker -e=prod pocket -vv >> /path/to/wallabag/var/logs/redis-pocket.log
 
   # for Readability import
-  bin/console wallabag:import:redis-worker readability -vv >> /path/to/wallabag/var/logs/redis-readability.log
+  bin/console wallabag:import:redis-worker -e=prod readability -vv >> /path/to/wallabag/var/logs/redis-readability.log
 
   # for Instapaper import
-  bin/console wallabag:import:redis-worker instapaper -vv >> /path/to/wallabag/var/logs/redis-instapaper.log
+  bin/console wallabag:import:redis-worker -e=prod instapaper -vv >> /path/to/wallabag/var/logs/redis-instapaper.log
 
   # for wallabag v1 import
-  bin/console wallabag:import:redis-worker wallabag_v1 -vv >> /path/to/wallabag/var/logs/redis-wallabag_v1.log
+  bin/console wallabag:import:redis-worker -e=prod wallabag_v1 -vv >> /path/to/wallabag/var/logs/redis-wallabag_v1.log
 
   # for wallabag v2 import
-  bin/console wallabag:import:redis-worker wallabag_v2 -vv >> /path/to/wallabag/var/logs/redis-wallabag_v2.log
+  bin/console wallabag:import:redis-worker -e=prod wallabag_v2 -vv >> /path/to/wallabag/var/logs/redis-wallabag_v2.log
 
   # for Firefox import
-  bin/console wallabag:import:redis-worker firefox -vv >> /path/to/wallabag/var/logs/redis-firefox.log
+  bin/console wallabag:import:redis-worker -e=prod firefox -vv >> /path/to/wallabag/var/logs/redis-firefox.log
 
   # for Chrome import
-  bin/console wallabag:import:redis-worker instapaper -vv >> /path/to/wallabag/var/logs/redis-chrome.log
+  bin/console wallabag:import:redis-worker -e=prod instapaper -vv >> /path/to/wallabag/var/logs/redis-chrome.log
 
 If you want to launch the import only for some messages and not all, you can specify this number (here 12) and the worker will stop right after the 12th message :
 
 .. code:: bash
 
-  bin/console wallabag:import:redis-worker pocket -vv --maxIterations=12
+  bin/console wallabag:import:redis-worker -e=prod pocket -vv --maxIterations=12

--- a/docs/fr/developer/maintenance.rst
+++ b/docs/fr/developer/maintenance.rst
@@ -11,7 +11,7 @@ Pour activer le mode maintenance, exécutez cette commande :
 
 ::
 
-    bin/console lexik:maintenance:lock --no-interaction
+    bin/console lexik:maintenance:lock --no-interaction -e=prod
 
 Vous pouvez spécifier votre adresse IP dans ``app/config/config.yml`` si vous souhaitez accéder à wallabag même si
  le mode maintenance est activé. Par exemple :
@@ -30,4 +30,4 @@ Pour désactiver le mode maintenance, exécutez cette commande :
 
 ::
 
-    bin/console lexik:maintenance:unlock
+    bin/console lexik:maintenance:unlock -e=prod

--- a/docs/fr/developer/rabbitmq.rst
+++ b/docs/fr/developer/rabbitmq.rst
@@ -55,22 +55,22 @@ En fonction du service dont vous souhaitez importer vos données, vous devez act
 .. code:: bash
 
   # for Pocket import
-  bin/console rabbitmq:consumer import_pocket -w
+  bin/console rabbitmq:consumer -e=prod import_pocket -w
 
   # for Readability import
-  bin/console rabbitmq:consumer import_readability -w
+  bin/console rabbitmq:consumer -e=prod import_readability -w
 
   # for Instapaper import
-  bin/console rabbitmq:consumer import_instapaper -w
+  bin/console rabbitmq:consumer -e=prod import_instapaper -w
 
   # for wallabag v1 import
-  bin/console rabbitmq:consumer import_wallabag_v1 -w
+  bin/console rabbitmq:consumer -e=prod import_wallabag_v1 -w
 
   # for wallabag v2 import
-  bin/console rabbitmq:consumer import_wallabag_v2 -w
+  bin/console rabbitmq:consumer -e=prod import_wallabag_v2 -w
 
   # for Firefox import
-  bin/console rabbitmq:consumer import_firefox -w
+  bin/console rabbitmq:consumer -e=prod import_firefox -w
 
   # for Chrome import
-  bin/console rabbitmq:consumer import_chrome -w
+  bin/console rabbitmq:consumer -e=prod import_chrome -w

--- a/docs/fr/developer/redis.rst
+++ b/docs/fr/developer/redis.rst
@@ -44,28 +44,28 @@ En fonction du service dont vous souhaitez importer vos données, vous devez act
 .. code:: bash
 
   # for Pocket import
-  bin/console wallabag:import:redis-worker pocket -vv >> /path/to/wallabag/var/logs/redis-pocket.log
+  bin/console wallabag:import:redis-worker -e=prod pocket -vv >> /path/to/wallabag/var/logs/redis-pocket.log
 
   # for Readability import
-  bin/console wallabag:import:redis-worker readability -vv >> /path/to/wallabag/var/logs/redis-readability.log
+  bin/console wallabag:import:redis-worker -e=prod readability -vv >> /path/to/wallabag/var/logs/redis-readability.log
 
   # for Instapaper import
-  bin/console wallabag:import:redis-worker instapaper -vv >> /path/to/wallabag/var/logs/redis-instapaper.log
+  bin/console wallabag:import:redis-worker -e=prod instapaper -vv >> /path/to/wallabag/var/logs/redis-instapaper.log
 
   # for wallabag v1 import
-  bin/console wallabag:import:redis-worker wallabag_v1 -vv >> /path/to/wallabag/var/logs/redis-wallabag_v1.log
+  bin/console wallabag:import:redis-worker -e=prod wallabag_v1 -vv >> /path/to/wallabag/var/logs/redis-wallabag_v1.log
 
   # for wallabag v2 import
-  bin/console wallabag:import:redis-worker wallabag_v2 -vv >> /path/to/wallabag/var/logs/redis-wallabag_v2.log
+  bin/console wallabag:import:redis-worker -e=prod wallabag_v2 -vv >> /path/to/wallabag/var/logs/redis-wallabag_v2.log
 
   # for Firefox import
-  bin/console wallabag:import:redis-worker firefox -vv >> /path/to/wallabag/var/logs/redis-firefox.log
+  bin/console wallabag:import:redis-worker -e=prod firefox -vv >> /path/to/wallabag/var/logs/redis-firefox.log
 
   # for Chrome import
-  bin/console wallabag:import:redis-worker instapaper -vv >> /path/to/wallabag/var/logs/redis-chrome.log
+  bin/console wallabag:import:redis-worker -e=prod instapaper -vv >> /path/to/wallabag/var/logs/redis-chrome.log
 
 Si vous souhaitez démarrer l'import pour quelques messages uniquement, vous pouvez spécifier cette valeur en paramètre (ici 12) et le client va s'arrêter après le 12ème message :
 
 .. code:: bash
 
-  bin/console wallabag:import:redis-worker pocket -vv --maxIterations=12
+  bin/console wallabag:import:redis-worker -e=prod pocket -vv --maxIterations=12


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | *kind of*
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Documentation | yes
| Translation   | no
| Fixed tickets | https://github.com/wallabag/wallabag/issues/2398
| License       | MIT

Should fix https://github.com/wallabag/wallabag/issues/2398

All `bin/console` command in the documentation should define the environment to prod to avoid error on the end user.