### PR TITLE
Show number of annotations instead of nbAnnotations placeholder

### DIFF
--- a/src/Wallabag/CoreBundle/Resources/translations/messages.da.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.da.yml
@@ -195,7 +195,7 @@ entry:
                 description: 'Vises artiklen forkert?'
         edit_title: 'Rediger titel'
         original_article: 'original'
-        # annotations_on_the_entry: '{0} No annotations|{1} One annotation|]1,Inf[ %nbAnnotations% annotations'
+        # annotations_on_the_entry: '{0} No annotations|{1} One annotation|]1,Inf[ %count% annotations'
         created_at: 'Oprettelsesdato'
     new:
         page_title: 'Gem ny artikel'

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.de.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.de.yml
@@ -195,7 +195,7 @@ entry:
                 description: 'Erscheint dieser Artikel falsch?'
         edit_title: 'Titel ändern'
         original_article: 'original'
-        annotations_on_the_entry: '{0} Keine Anmerkungen|{1} Eine Anmerkung|]1,Inf[ %nbAnnotations% Anmerkungen'
+        annotations_on_the_entry: '{0} Keine Anmerkungen|{1} Eine Anmerkung|]1,Inf[ %count% Anmerkungen'
         created_at: 'Erstellungsdatum'
     new:
         page_title: 'Neuen Artikel speichern'

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.en.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.en.yml
@@ -195,7 +195,7 @@ entry:
                 description: 'Does this article appear wrong?'
         edit_title: 'Edit title'
         original_article: 'original'
-        annotations_on_the_entry: '{0} No annotations|{1} One annotation|]1,Inf[ %nbAnnotations% annotations'
+        annotations_on_the_entry: '{0} No annotations|{1} One annotation|]1,Inf[ %count% annotations'
         created_at: 'Creation date'
     new:
         page_title: 'Save new entry'

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.es.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.es.yml
@@ -195,7 +195,7 @@ entry:
                 description: '¿Este artículo no se muestra bien?'
         edit_title: 'Modificar el título'
         original_article: 'original'
-        annotations_on_the_entry: '{0} Sin anotaciones|{1} Una anotación|]1,Inf[ %nbAnnotations% anotaciones'
+        annotations_on_the_entry: '{0} Sin anotaciones|{1} Una anotación|]1,Inf[ %count% anotaciones'
         created_at: 'Fecha de creación'
     new:
         page_title: 'Guardar un nuevo artículo'

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.fr.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.fr.yml
@@ -195,7 +195,7 @@ entry:
                 description: "Est-ce que cet article s'affiche mal ?"
         edit_title: 'Modifier le titre'
         original_article: 'original'
-        annotations_on_the_entry: '{0} Aucune annotation|{1} Une annotation|]1,Inf[ %nbAnnotations% annotations'
+        annotations_on_the_entry: '{0} Aucune annotation|{1} Une annotation|]1,Inf[ %count% annotations'
         created_at: 'Date de création'
     new:
         page_title: 'Sauvegarder un nouvel article'

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.it.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.it.yml
@@ -195,7 +195,7 @@ entry:
                 description: 'Questo contenuto viene visualizzato male?'
         edit_title: 'Modifica titolo'
         original_article: 'originale'
-        annotations_on_the_entry: '{0} Nessuna annotazione|{1} Una annotazione|]1,Inf[ %nbAnnotations% annotazioni'
+        annotations_on_the_entry: '{0} Nessuna annotazione|{1} Una annotazione|]1,Inf[ %count% annotazioni'
         created_at: 'Data di creazione'
     new:
         page_title: 'Salva un nuovo contenuto'

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.oc.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.oc.yml
@@ -195,7 +195,7 @@ entry:
                 description: "Marca mal la presentacion d'aqueste article ?"
         edit_title: 'Modificar lo títol'
         original_article: 'original'
-        annotations_on_the_entry: "{0} Pas cap d'anotacion|{1} Una anotacion|]1,Inf[ %nbAnnotations% anotacions"
+        annotations_on_the_entry: "{0} Pas cap d'anotacion|{1} Una anotacion|]1,Inf[ %count% anotacions"
         created_at: 'Data de creacion'
     new:
         page_title: 'Enregistrar un novèl article'

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.pl.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.pl.yml
@@ -195,7 +195,7 @@ entry:
                 description: 'Czy ten artykuł wygląda źle?'
         edit_title: 'Edytuj tytuł'
         original_article: 'oryginalny'
-        annotations_on_the_entry: '{0} Nie ma adnotacji |{1} Jedna adnotacja |]1,Inf[ %nbAnnotations% adnotacji'
+        annotations_on_the_entry: '{0} Nie ma adnotacji |{1} Jedna adnotacja |]1,Inf[ %count% adnotacji'
         created_at: 'Czas stworzenia'
     new:
         page_title: 'Zapisz nowy wpis'

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.ro.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.ro.yml
@@ -195,7 +195,7 @@ entry:
                 description: 'Îți pare ciudat articolul?'
         edit_title: 'Editează titlul'
         original_article: 'original'
-        # annotations_on_the_entry: '{0} No annotations|{1} One annotation|]1,Inf[ %nbAnnotations% annotations'
+        # annotations_on_the_entry: '{0} No annotations|{1} One annotation|]1,Inf[ %count% annotations'
         created_at: 'Data creării'
     new:
         page_title: 'Salvează un nou articol'

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.tr.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.tr.yml
@@ -194,7 +194,7 @@ entry:
                 description: 'Bu makalede herhangi bir yanlışlık mı var?'
         edit_title: 'Başlığı düzenle'
         original_article: 'orijinal'
-        # annotations_on_the_entry: '{0} No annotations|{1} One annotation|]1,Inf[ %nbAnnotations% annotations'
+        # annotations_on_the_entry: '{0} No annotations|{1} One annotation|]1,Inf[ %count% annotations'
         created_at: 'Oluşturulma tarihi'
     new:
         page_title: 'Yeni makaleyi kaydet'

--- a/src/Wallabag/CoreBundle/Resources/views/themes/baggy/Entry/entry.html.twig
+++ b/src/Wallabag/CoreBundle/Resources/views/themes/baggy/Entry/entry.html.twig
@@ -54,7 +54,6 @@
                 {% endif %}
             </i>
 
-            {% set nbAnnotations = entry.annotations | length %}
             <span class="tool link"><i class="material-icons link">comment</i> {{ 'entry.view.annotations_on_the_entry'|transchoice(entry.annotations | length) }}</span>
             <aside class="tags">
                 <div class="card-entry-tags">


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? |no
| Tests pass?   | n/a
| Documentation | no
| Translation   | yes
| Fixed tickets | n/a
| License       | MIT

When there was more than one annotation, the `%nbAnnotations%` placeholder was displayed in both themes, instead of actual number.