### PR TITLE
Fix entities definition

### DIFF
--- a/src/Wallabag/ApiBundle/Entity/AccessToken.php
+++ b/src/Wallabag/ApiBundle/Entity/AccessToken.php
@@ -19,7 +19,7 @@ class AccessToken extends BaseAccessToken
     protected $id;
 
     /**
-     * @ORM\ManyToOne(targetEntity="Client")
+     * @ORM\ManyToOne(targetEntity="Client", inversedBy="accessTokens")
      * @ORM\JoinColumn(nullable=false)
      */
     protected $client;

--- a/src/Wallabag/ApiBundle/Entity/RefreshToken.php
+++ b/src/Wallabag/ApiBundle/Entity/RefreshToken.php
@@ -19,7 +19,7 @@ class RefreshToken extends BaseRefreshToken
     protected $id;
 
     /**
-     * @ORM\ManyToOne(targetEntity="Client")
+     * @ORM\ManyToOne(targetEntity="Client", inversedBy="refreshTokens")
      * @ORM\JoinColumn(nullable=false)
      */
     protected $client;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Documentation | no
| Translation   | no
| Fixed tickets | 
| License       | MIT

As per Doctrine said in the debug tool bar:

- The field Wallabag\ApiBundle\Entity\Client#refreshTokens is on the inverse side of a bi-directional relationship, but the specified mappedBy association on the target-entity Wallabag\ApiBundle\Entity\RefreshToken#client does not contain the required 'inversedBy="refreshTokens"' attribute.

- The field Wallabag\ApiBundle\Entity\Client#accessTokens is on the inverse side of a bi-directional relationship, but the specified mappedBy association on the target-entity Wallabag\ApiBundle\Entity\AccessToken#client does not contain the required 'inversedBy="accessTokens"' attribute.