### PR TITLE
Remove automatic closing of the window from bookmarklet

### DIFF
--- a/src/Wallabag/CoreBundle/Resources/views/themes/common/Static/_bookmarklet.html.twig
+++ b/src/Wallabag/CoreBundle/Resources/views/themes/common/Static/_bookmarklet.html.twig
@@ -1,1 +1,1 @@
-<a id="bookmarklet" ondragend="this.click();" href="javascript:var url=location.href||url;var wllbg=window.open('{{ url('bookmarklet') }}?url=' + encodeURI(url),'_blank');wllbg.close();void(0);">bag it!</a>
+<a id="bookmarklet" ondragend="this.click();" href="javascript:(function(){var url=location.href||url;var wllbg=window.open('{{ url('bookmarklet') }}?url=' + encodeURI(url),'_blank');})();">bag it!</a>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | n/a
| Documentation | no
| Translation   | no
| Fixed tickets | #2130, #2210, #1960
| License       | MIT

Current bookmarklet is broken, because it opens new Wallabag window, and closes it immediately, before Wallabag has a chance to add the link to the database.

Ideal solution would be to have the bookmarklet act _within_ the article page (like Pocket does), but that's significant amount of work. This PR prevents new window from being automatically closed. I realize it's not ideal, but at least it makes the bookmarklet work.

Additionally, I surrounded the JavaScript code with anonymous function, to avoid polluting page's scope by bookmarklet's variables.