### PR TITLE
Define a dev version for the master

### DIFF
--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -30,7 +30,7 @@ framework:
     assets: ~
 
 wallabag_core:
-    version: 2.1.1
+    version: 2.1.2-dev
     paypal_url: "https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=9UBA65LG3FX9Y&lc=gb"
     languages:
         en: 'English'


### PR DESCRIPTION
This is to be sure that user testing wallabag from the master will have the version defined as dev.

What do you think?