### PR TITLE
Fixed Twitter Cards by adding a description tag

### DIFF
--- a/src/Wallabag/CoreBundle/Resources/views/themes/common/Entry/share.html.twig
+++ b/src/Wallabag/CoreBundle/Resources/views/themes/common/Entry/share.html.twig
@@ -39,6 +39,7 @@
         <meta name="twitter:image" content="{{ picturePath }}" />
         <meta name="twitter:site" content="@wallabagapp" />
         <meta name="twitter:title" content="{{ entry.title | raw }}" />
+        <meta name="twitter:description" content="{{ entry.title | raw }}" />
     </head>
     <body>
         <header>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Documentation | no
| Translation   | no
| Fixed tickets | 
| License       | MIT

I put the article title in the description field, to avoid wrong content (I tried locally with an article from lemonde and it starts with a video). 