### PR TITLE
Avoid error when Redis isn't here in tests

### DIFF
--- a/tests/Wallabag/ImportBundle/Controller/ChromeControllerTest.php
+++ b/tests/Wallabag/ImportBundle/Controller/ChromeControllerTest.php
@@ -54,6 +54,7 @@ class ChromeControllerTest extends WallabagCoreTestCase
 
     public function testImportChromeWithRedisEnabled()
     {
+        $this->checkRedis();
         $this->logInAs('admin');
         $client = $this->getClient();
         $client->getContainer()->get('craue_config')->set('import_with_redis', 1);

--- a/tests/Wallabag/ImportBundle/Controller/FirefoxControllerTest.php
+++ b/tests/Wallabag/ImportBundle/Controller/FirefoxControllerTest.php
@@ -54,6 +54,7 @@ class FirefoxControllerTest extends WallabagCoreTestCase
 
     public function testImportFirefoxWithRedisEnabled()
     {
+        $this->checkRedis();
         $this->logInAs('admin');
         $client = $this->getClient();
         $client->getContainer()->get('craue_config')->set('import_with_redis', 1);


### PR DESCRIPTION
Add missing check about Redis for tests.
Running test without Redis won't fail now and @tcitworld'll be happy again :frog: 