### PR TITLE
Fixed display for note in installation page

### DIFF
--- a/docs/de/user/installation.rst
+++ b/docs/de/user/installation.rst
@@ -7,7 +7,8 @@ Voraussetzungen
 wallabag ist kompatibel mit PHP >= 5.5, inkl. PHP 7.
 
 .. note::
-To install wallabag easily, we create a ``Makefile``, so you need to have the ``make`` tool.
+
+    To install wallabag easily, we create a ``Makefile``, so you need to have the ``make`` tool.
 
 wallabag nutzt eine große Anzahl an Bibliotheken, um zu funktionieren. Diese Bibliotheken müssen mit einem Tool namens Composer installiert werden. Du musst es installieren sofern du es bisher noch nicht gemacht hast.
 

--- a/docs/en/user/installation.rst
+++ b/docs/en/user/installation.rst
@@ -7,7 +7,8 @@ Requirements
 wallabag is compatible with PHP >= 5.5, including PHP 7.
 
 .. note::
-To install wallabag easily, we create a ``Makefile``, so you need to have the ``make`` tool.
+
+    To install wallabag easily, we create a ``Makefile``, so you need to have the ``make`` tool.
 
 wallabag uses a large number of PHP libraries in order to function. These libraries must be installed with a tool called Composer. You need to install it if you have not already done so and be sure to use the 1.2 version (if you already have Composer, run a ``composer selfupdate``).
 

--- a/docs/fr/user/installation.rst
+++ b/docs/fr/user/installation.rst
@@ -7,7 +7,8 @@ Pré-requis
 wallabag est compatible avec PHP >= 5.5, PHP 7 inclus.
 
 .. note::
-Pour installer wallabag facilement, nous avons créé un ``Makefile``, vous avez donc besoin d'avoir installé l'outil ``make``.
+
+    Pour installer wallabag facilement, nous avons créé un ``Makefile``, vous avez donc besoin d'avoir installé l'outil ``make``.
 
 wallabag utilise un grand nombre de bibliothèques PHP pour fonctionner. Ces bibliothèques doivent être installées à l'aide d'un outil nommé Composer. Vous devez l'installer si ce n'est déjà fait et vous assurer que vous utilisez bien la version 1.2 (si vous avez déjà Composer, faite un ``composer selfupdate``).
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Documentation | yes
| Translation   | yes
| Fixed tickets | 
| License       | MIT

I have an other problem on the english homepage. 
`user-docs` is not converted into a link, see http://doc.wallabag.org/en/master/index.html, contrary to french and german documentations. Need help for this bug. 