### PR TITLE
Added french documentation for parameters.yml

### DIFF
--- a/docs/de/index.rst
+++ b/docs/de/index.rst
@@ -44,6 +44,7 @@ Die Dokumentation ist in anderen Sprachen verfügbar :
    user/filters
    user/tags
    user/android
+   user/parameters
 
 .. _dev-docs:
 

--- a/docs/de/user/parameters.rst
+++ b/docs/de/user/parameters.rst
@@ -1,0 +1,50 @@
+Was bedeuten die Parameter?
+===========================
+.. csv-table:: Datenbankparameter
+   :header: "Name", "Standardwert", "Beschreibung"
+
+   "database_driver", "pdo_sqlite", "Sollte pdo_sqlite oder pdo_mysql oder pdo_pgsql sein"
+   "database_host", "127.0.0.1", "Hostadresse deiner Datenbank (normalerweise localhost oder 127.0.0.1)"
+   "database_port", "~", "Port deiner Datenbank (Du kannst ``~`` stehen lassen, um den Standardport zu nutzen)"
+   "database_name", "symfony", "Benenne deine Datenbank"
+   "database_user", "root", "Benutzer, der Schreibrecht in der Datenbank hat"
+   "database_password", "~", "Passwort des Benutzers"
+   "database_path", "``""%kernel.root_dir%/../data/db/wallabag.sqlite""``", "nur für SQLite, definiere, wo die Datenbankdatei abgelegt werden soll. Lass den Parameter leer für andere Datenbanktypen."
+   "database_table_prefix", "wallabag_", "alle wallabag Tabellen erhalten diesen Präfix im Namen. Du kannst einen ``_`` dafür im Präfix nutzen, um das zu verdeutlichen."
+   "database_socket", "null", "Wenn deine Datenbank einen Socket statt TCP nutzt, schreibe hier den Pfad zum Socket hin (andere Verbindungsparameter werden dann ignoriert."
+
+.. csv-table:: Konfiguration, um mit wallabag E-Mails senden zu können
+   :header: "Name", "Standardwert", "Beschreibung"
+
+   "mailer_transport", "smtp",  "Die exakte Transportmethode, um E-Mails zuzustellen. Gültige Werte sind: smtp, gmail, mail, sendmail, null (was das Mailen deaktivert)"
+   "mailer_host", "127.0.0.1",  "Der Host, zu dem sich verbunden wird, wenn SMTP als Transport genutzt wird."
+   "mailer_user", "~",  "Der Benutzername, wenn SMTP als Transport genutzt wird."
+   "mailer_password", "~",  "Das Passwort, wenn SMTP als Transport genutzt wird."
+
+.. csv-table:: Andere wallabag Optionen
+   :header: "Name", "Standardwert", "Beschreibung"
+
+   "locale", "en", "Standardsprache deiner wallabag Instanz (wie z.B. en, fr, es, etc.)"
+   "secret", "ovmpmAWXRCabNlMgzlzFXDYmCFfzGv", "Dieser String sollte einzigartig für deine Applikation sein und er wird genutzt, um sicherheitsrelevanten Operationen mehr Entropie hinzuzufügen."
+   "twofactor_auth", "true", "true, um Zwei-Faktor-Authentifizierung zu aktivieren"
+   "twofactor_sender", "no-reply@wallabag.org", "E-Mail-Adresse des Senders der Mails mit dem Code für die Zwei-Faktor-Authentifizierung"
+   "fosuser_registration", "true", "true, um die Registrierung für jedermann zu aktivieren"
+   "fosuser_confirmation", "true", "true, um eine Bestätigungsmail für jede Registrierung zu senden"
+   "from_email", "no-reply@wallabag.org", "E-Mail-Adresse, die im Absenderfeld jeder Mail genutzt wird"
+   "rss_limit", "50", "Artikellimit für RSS Feeds"
+
+.. csv-table:: RabbitMQ Konfiguration
+   :header: "Name", "Standardwert", "Beschreibung"
+
+   "rabbitmq_host", "localhost", "Host deines RabbitMQ"
+   "rabbitmq_port", "5672", "Port deines RabbitMQ"
+   "rabbitmq_user", "guest", "Benutzer, der die Queue lesen kann"
+   "rabbitmq_password", "guest", "Passwort dieses Benutzers"
+
+.. csv-table:: Redis Konfiguration
+   :header: "Name", "Standardwert", "Beschreibung"
+
+   "redis_scheme", "tcp", "Bestimmt das Protokoll, dass genutzt wird, um mit Redis zu kommunizieren. Gültige Werte sind: tcp, unix, http"
+   "redis_host", "localhost", "IP oder Hostname des Zielservers (ignoriert bei Unix Schema)"
+   "redis_port", "6379", "TCP/IP Port des Zielservers (ignoriert bei Unix Schema)"
+   "redis_path", "null", "Pfad zur Unix Domain Socket Datei, wenn Redis Unix Domain Sockets nutzt"

--- a/docs/en/index.rst
+++ b/docs/en/index.rst
@@ -45,6 +45,7 @@ The documentation is available in other languages:
    user/filters
    user/tags
    user/android
+   user/parameters
 
 .. _dev-docs:
 

--- a/docs/en/user/parameters.rst
+++ b/docs/en/user/parameters.rst
@@ -9,9 +9,9 @@ What is the meaning of the parameters?
    "database_name", "symfony", "name of your database"
    "database_user", "root", "user that can write to this database"
    "database_password", "~", "password of that user"
-   "database_path", "``""%kernel.root_dir%/../data/db/wallabag.sqlite""``", "only for SQLite, define where to put the database file. Leave it for other database"
+   "database_path", "``""%kernel.root_dir%/../data/db/wallabag.sqlite""``", "only for SQLite, define where to put the database file. Leave it empty for other database"
    "database_table_prefix", "wallabag_", "all wallabag's tables will be prefixed with that string. You can include a ``_`` for clarity"
-   "database_socket", "null", "If your database is using a socket instead of tcp, put the path of the socket (other connection parameters will then be ignored"
+   "database_socket", "null", "If your database is using a socket instead of tcp, put the path of the socket (other connection parameters will then be ignored)"
 
 .. csv-table:: Configuration to send emails from wallabag
    :header: "name", "default", "description"
@@ -38,7 +38,7 @@ What is the meaning of the parameters?
 
    "rabbitmq_host", "localhost", "Host of your RabbitMQ"
    "rabbitmq_port", "5672", "Port of your RabbitMQ"
-   "rabbitmq_user", "guest", "Usee that can read queues"
+   "rabbitmq_user", "guest", "User that can read queues"
    "rabbitmq_password", "guest", "Password of that user"
 
 .. csv-table:: Redis configuration

--- a/docs/fr/index.rst
+++ b/docs/fr/index.rst
@@ -45,6 +45,7 @@ La documentation est disponible dans d'autres langues :
    user/share
    user/filters
    user/tags
+   user/parameters
 
 .. _dev-docs:
 

--- a/docs/fr/user/parameters.rst
+++ b/docs/fr/user/parameters.rst
@@ -1,0 +1,50 @@
+À quoi servent les paramètres ?
+===============================
+.. csv-table:: Paramètres de base de données
+   :header: "name", "default", "description"
+
+   "database_driver", "pdo_sqlite", "Doit être pdo_sqlite ou pdo_mysql ou pdo_pgsql"
+   "database_host", "127.0.0.1", "Hôte de votre base de données (généralement localhost ou 127.0.0.1)"
+   "database_port", "~", "Port de votre base de données (vous pouvez laisser ``~`` pour utiliser celui par défaut)"
+   "database_name", "symfony", "Nom de votre base de données"
+   "database_user", "root", "Utilisateur de votre base de données"
+   "database_password", "~", "Mot de passe de cet utilisateur"
+   "database_path", "``""%kernel.root_dir%/../data/db/wallabag.sqlite""``", "Uniquement pour SQLite. Chemin du fichier de base de données. Laissez vide pour les autres bases de données."
+   "database_table_prefix", "wallabag_", "Toutes les tables de wallabag seront préfixées par cette chaine. Vous pouvez ajouter un ``_`` pour plus de clarté"
+   "database_socket", "null", "Si votre base de données utilise un socket plutôt que tcp, spécifiez le chemin du socket (les autres paramètres de connexion seront alors ignorés)"
+
+.. csv-table:: Configuration pour envoyer des emails depuis wallabag
+   :header: "name", "default", "description"
+
+   "mailer_transport", "smtp",  "Méthode de transport exacte utilisée pour envoyer des emails. Les valeurs correctes sont : smtp, gmail, mail, sendmail, null (ce qui désactivera l'envoi des emails)"
+   "mailer_host", "127.0.0.1",  "Hôte sur lequel se connecter quand on utilise smtp comme transport."
+   "mailer_user", "~",  "Utilisateur smtp."
+   "mailer_password", "~",  "Mot de passe de cet utilisateur."
+
+.. csv-table:: Autres options de wallabag
+   :header: "name", "default", "description"
+
+   "locale", "en", "Langue par défaut de votre instance wallabag (comme en, fr, es, etc.)"
+   "secret", "ovmpmAWXRCabNlMgzlzFXDYmCFfzGv", "C'est une chaine qui doit être unique à votre application et qui est couramment utilisée pour ajouter plus d'entropie aux opérations relatives à la sécurité."
+   "twofactor_auth", "true", "true pour activer l'authentification à deux facteurs"
+   "twofactor_sender", "no-reply@wallabag.org", "Email de l'expéditeur du code de l'authentification à deux facteurs"
+   "fosuser_registration", "true", "true pour activer l'inscription publique"
+   "fosuser_confirmation", "true", "true pour envoyer un email de confirmation pour chaque création de compte"
+   "from_email", "no-reply@wallabag.org", "Email de l'expéditeur pour chaque email envoyé"
+   "rss_limit", "50", "Limite pour les flux RSS"
+
+.. csv-table:: Configuration RabbitMQ
+   :header: "name", "default", "description"
+
+   "rabbitmq_host", "localhost", "Hôte de votre instance RabbitMQ"
+   "rabbitmq_port", "5672", "Port de votre instance RabbitMQ"
+   "rabbitmq_user", "guest", "Utilisateur de votre instance RabbitMQ"
+   "rabbitmq_password", "guest", "Mot de passe de cet utilisateur"
+
+.. csv-table:: Configuration Redis
+   :header: "name", "default", "description"
+
+   "redis_scheme", "tcp", "Définit le protocole utilisé pour commuiquer avec l'instance Redis. Les valeurs correctes sont : tcp, unix, http"
+   "redis_host", "localhost", "IP ou hôte du serveur cible (ignoré pour un schéma unix)"
+   "redis_port", "6379", "Port TCP/IP du serveur cible (ignoré pour un schéma unix)"
+   "redis_path", "null", "Chemin du fichier de socket du domaine UNIX utilisé quand on se connecte à Redis en utilisant les sockets du domaine UNIX"


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  |  no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Documentation | yes
| Translation   | yes
| Fixed tickets | 
| License       | MIT

In #2392, we forgot french documentation and links for the menu. 

@Strubbl @jlnostr Can you help us for the german translation please? :) 