### PR TITLE
Mention example instance in docs

### DIFF
--- a/docs/en/developer/api.rst
+++ b/docs/en/developer/api.rst
@@ -8,7 +8,7 @@ Requirements
 
 * wallabag freshly (or not) installed on http://localhost:8000
 * ``httpie`` installed on your computer (`see project website <https://github.com/jkbrzt/httpie>`__). Note that you can also adapt the commands using curl or wget.
-* all the API methods are documented here http://localhost:8000/api/doc
+* all the API methods are documented here http://localhost:8000/api/doc (on your instance) and `on our example instance <http://v2.wallabag.org/api/doc>`_ 
 
 Creating a new API client
 -------------------------


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Documentation | yes
| Translation   | no
| Fixed tickets | #2443
| License       | MIT

Namely http://v2.wallabag.org/api/doc, so api methods can be looked up without installing wallabag first.