### PR TITLE
Some fixes

### DIFF
--- a/app/Resources/CraueConfigBundle/translations/CraueConfigBundle.da.yml
+++ b/app/Resources/CraueConfigBundle/translations/CraueConfigBundle.da.yml
@@ -23,7 +23,7 @@ export: "eksport"
 import: "import"
 misc: "misc"
 modify_settings: "Gem ændring"
-piwik_host: Hosting af din side hos Piwik
+piwik_host: Hosting af din side hos Piwik (uden http:// eller https://)
 piwik_site_id: ID for din side hos Piwik
 piwik_enabled: Aktiver Piwik
 demo_mode_enabled: "Aktiver demo-indstilling? (anvendes kun til wallabags offentlige demo)"

--- a/app/Resources/CraueConfigBundle/translations/CraueConfigBundle.de.yml
+++ b/app/Resources/CraueConfigBundle/translations/CraueConfigBundle.de.yml
@@ -23,7 +23,7 @@ export: "Export"
 import: "Import"
 misc: "Verschiedenes"
 modify_settings: "Übernehmen"
-piwik_host: Host deiner Webseite in Piwik
+piwik_host: Host deiner Webseite in Piwik (ohne http:// oder https://)
 piwik_site_id: ID deiner Webseite in Piwik
 piwik_enabled: Piwik aktivieren
 demo_mode_enabled: "Test-Modus aktivieren? (nur für die öffentliche wallabag-Demo genutzt)"

--- a/app/Resources/CraueConfigBundle/translations/CraueConfigBundle.en.yml
+++ b/app/Resources/CraueConfigBundle/translations/CraueConfigBundle.en.yml
@@ -23,7 +23,7 @@ export: "export"
 import: "import"
 misc: "misc"
 modify_settings: "apply"
-piwik_host: Host of your website in Piwik
+piwik_host: Host of your website in Piwik (without http:// ou https://)
 piwik_site_id: ID of your website in Piwik
 piwik_enabled: Enable Piwik
 demo_mode_enabled: "Enable demo mode ? (only used for the wallabag public demo)"

--- a/app/Resources/CraueConfigBundle/translations/CraueConfigBundle.es.yml
+++ b/app/Resources/CraueConfigBundle/translations/CraueConfigBundle.es.yml
@@ -23,7 +23,7 @@ export: "exportar"
 import: "importar"
 misc: "misc"
 modify_settings: "modificar configuración"
-piwik_host: Host de tu website de Piwik
+piwik_host: Host de tu website de Piwik (sin http:// o https://)
 piwik_site_id: ID de tu website de Piwik
 piwik_enabled: Activar Piwik
 demo_mode_enabled: "Activar modo demo (sólo usado para la demo de wallabag)"

--- a/app/Resources/CraueConfigBundle/translations/CraueConfigBundle.fa.yml
+++ b/app/Resources/CraueConfigBundle/translations/CraueConfigBundle.fa.yml
@@ -23,7 +23,7 @@ export: "برون‌سپاری"
 import: "درون‌ریزی"
 misc: "غیره"
 modify_settings: "اعمال"
-# piwik_host: Host of your website in Piwik
+# piwik_host: Host of your website in Piwik (without http:// or https://)
 # piwik_site_id: ID of your website in Piwik
 # piwik_enabled: Enable Piwik
 # demo_mode_enabled: "Enable demo mode ? (only used for the wallabag public demo)"

--- a/app/Resources/CraueConfigBundle/translations/CraueConfigBundle.fr.yml
+++ b/app/Resources/CraueConfigBundle/translations/CraueConfigBundle.fr.yml
@@ -23,7 +23,7 @@ export: "export"
 import: "import"
 misc: "divers"
 modify_settings: "appliquer"
-piwik_host: URL de votre site dans Piwik
+piwik_host: URL de votre site dans Piwik (sans http:// ou https://)
 piwik_site_id: ID de votre site dans Piwik
 piwik_enabled: Activer Piwik
 demo_mode_enabled: "Activer le mode démo ? (utiliser uniquement pour la démo publique de wallabag)"

--- a/app/Resources/CraueConfigBundle/translations/CraueConfigBundle.it.yml
+++ b/app/Resources/CraueConfigBundle/translations/CraueConfigBundle.it.yml
@@ -23,7 +23,7 @@ export: "esporta"
 import: "importa"
 misc: "misc"
 modify_settings: "applica"
-piwik_host: Host del tuo sito in Piwik
+piwik_host: Host del tuo sito in Piwik (senza http:// o https://)
 piwik_site_id: ID del tuo sito in Piwik
 piwik_enabled: Abilita Piwik
 demo_mode_enabled: "Abilita modalità demo ? (usato solo per la demo pubblica di wallabag)"

--- a/app/Resources/CraueConfigBundle/translations/CraueConfigBundle.oc.yml
+++ b/app/Resources/CraueConfigBundle/translations/CraueConfigBundle.oc.yml
@@ -23,7 +23,7 @@ export: "expòrt"
 import: "impòrt"
 misc: "divèrs"
 modify_settings: "aplicar"
-piwik_host: URL de vòstre site dins Piwik
+piwik_host: URL de vòstre site dins Piwik (sense http:// o https://)
 piwik_site_id: ID de vòstre site dins Piwik
 piwik_enabled: Activar Piwik
 demo_mode_enabled: "Activar lo mode demostracion ? (utilizar solament per la demostracion publica de wallabag)"

--- a/app/Resources/CraueConfigBundle/translations/CraueConfigBundle.pl.yml
+++ b/app/Resources/CraueConfigBundle/translations/CraueConfigBundle.pl.yml
@@ -23,7 +23,7 @@ export: "eksport"
 import: "import"
 misc: "różne"
 modify_settings: "zatwierdz"
-piwik_host: Host twojej strony Piwik
+piwik_host: Host twojej strony Piwik (bez http:// lub https://)
 piwik_site_id: ID twojej strony Piwik
 piwik_enabled: Włacz Piwik
 demo_mode_enabled: "Włacz tryb demo? (używany wyłącznie dla publicznej demonstracji Wallabag)"

--- a/app/Resources/CraueConfigBundle/translations/CraueConfigBundle.ro.yml
+++ b/app/Resources/CraueConfigBundle/translations/CraueConfigBundle.ro.yml
@@ -23,7 +23,7 @@ export: "exportă"
 import: "importă"
 misc: "diverse"
 modify_settings: "aplică"
-# piwik_host: Host of your website in Piwik
+# piwik_host: Host of your website in Piwik (without http:// or https://)
 # piwik_site_id: ID of your website in Piwik
 # piwik_enabled: Enable Piwik
 # demo_mode_enabled: "Enable demo mode ? (only used for the wallabag public demo)"

--- a/app/Resources/CraueConfigBundle/translations/CraueConfigBundle.tr.yml
+++ b/app/Resources/CraueConfigBundle/translations/CraueConfigBundle.tr.yml
@@ -23,7 +23,7 @@
 # import: "import"
 # misc: "misc"
 # modify_settings: "apply"
-# piwik_host: Host of your website in Piwik
+# piwik_host: Host of your website in Piwik (without http:// or https://)
 # piwik_site_id: ID of your website in Piwik
 # piwik_enabled: Enable Piwik
 # demo_mode_enabled: "Enable demo mode ? (only used for the wallabag public demo)"

--- a/src/Wallabag/CoreBundle/Command/InstallCommand.php
+++ b/src/Wallabag/CoreBundle/Command/InstallCommand.php
@@ -364,7 +364,7 @@ class InstallCommand extends ContainerAwareCommand
             ],
             [
                 'name' => 'piwik_host',
-                'value' => 'http://v2.wallabag.org',
+                'value' => 'v2.wallabag.org',
                 'section' => 'analytics',
             ],
             [

--- a/src/Wallabag/CoreBundle/DataFixtures/ORM/LoadSettingData.php
+++ b/src/Wallabag/CoreBundle/DataFixtures/ORM/LoadSettingData.php
@@ -122,7 +122,7 @@ class LoadSettingData extends AbstractFixture implements OrderedFixtureInterface
             ],
             [
                 'name' => 'piwik_host',
-                'value' => 'http://v2.wallabag.org',
+                'value' => 'v2.wallabag.org',
                 'section' => 'analytics',
             ],
             [

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.da.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.da.yml
@@ -445,6 +445,9 @@ user:
         # delete_confirm: Are you sure?
         # back_to_list: Back to list
 
+error:
+    # page_title: An error occurred
+
 flashes:
     config:
         notice:

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.de.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.de.yml
@@ -445,6 +445,9 @@ user:
         delete_confirm: Bist du sicher?
         back_to_list: Zurück zur Liste
 
+error:
+    # page_title: An error occurred
+
 flashes:
     config:
         notice:

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.en.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.en.yml
@@ -445,6 +445,9 @@ user:
         delete_confirm: Are you sure?
         back_to_list: Back to list
 
+error:
+    page_title: An error occurred
+
 flashes:
     config:
         notice:

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.es.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.es.yml
@@ -445,6 +445,9 @@ user:
         # delete_confirm: Are you sure?
         # back_to_list: Back to list
 
+error:
+    # page_title: An error occurred
+
 flashes:
     config:
         notice:

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.fa.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.fa.yml
@@ -444,6 +444,9 @@ user:
         # delete_confirm: Are you sure?
         # back_to_list: Back to list
 
+error:
+    # page_title: An error occurred
+
 flashes:
     config:
         notice:

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.fr.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.fr.yml
@@ -365,7 +365,7 @@ import:
         how_to: "Choisissez le fichier de sauvegarde de vos marques-page et cliquez sur le bouton pour l'importer. Soyez avertis que le processus peut prendre un temps assez long car tous les articles doivent être récupérés en ligne."
     instapaper:
         page_title: 'Import > Instapaper'
-        description: 'Sur la page des paramètres (`https://www.instapaper.com/user<https://www.instapaper.com/user>`_), cliquez sur "Download .CSV file" dans la section "Export". Un fichier CSV se téléchargera ("instapaper-export.csv").'
+        description: 'Sur la page des paramètres (https://www.instapaper.com/user), cliquez sur "Download .CSV file" dans la section "Export". Un fichier CSV se téléchargera ("instapaper-export.csv").'
         how_to: "Choisissez le fichier de votre export Instapaper et cliquez sur le bouton ci-dessous pour l'importer."
 
 developer:

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.fr.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.fr.yml
@@ -445,6 +445,9 @@ user:
         delete_confirm: Êtes-vous sûr?
         back_to_list: Revenir à la liste
 
+error:
+    page_title: Une erreur est survenue
+
 flashes:
     config:
         notice:

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.it.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.it.yml
@@ -445,6 +445,9 @@ user:
         # delete_confirm: Are you sure?
         # back_to_list: Back to list
 
+error:
+    # page_title: An error occurred
+
 flashes:
     config:
         notice:

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.oc.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.oc.yml
@@ -445,6 +445,9 @@ user:
         # delete_confirm: Are you sure?
         # back_to_list: Back to list
 
+error:
+    # page_title: An error occurred
+
 flashes:
     config:
         notice:

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.pl.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.pl.yml
@@ -445,6 +445,9 @@ user:
         delete_confirm: Jesteś pewien?
         back_to_list: Powrót do listy
 
+error:
+    # page_title: An error occurred
+
 flashes:
     config:
         notice:

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.ro.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.ro.yml
@@ -445,6 +445,9 @@ user:
         # delete_confirm: Are you sure?
         # back_to_list: Back to list
 
+error:
+    # page_title: An error occurred
+
 flashes:
     config:
         notice:

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.tr.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.tr.yml
@@ -444,6 +444,9 @@ user:
         # delete_confirm: Are you sure?
         # back_to_list: Back to list
 
+error:
+    # page_title: An error occurred
+
 flashes:
     config:
         notice:

--- a/src/Wallabag/CoreBundle/Resources/views/themes/common/Entry/share.html.twig
+++ b/src/Wallabag/CoreBundle/Resources/views/themes/common/Entry/share.html.twig
@@ -39,7 +39,7 @@
         <meta name="twitter:image" content="{{ picturePath }}" />
         <meta name="twitter:site" content="@wallabagapp" />
         <meta name="twitter:title" content="{{ entry.title | raw }}" />
-        <meta name="twitter:description" content="{{ entry.title | raw }}" />
+        <meta name="twitter:description" content="{{ entry.content|striptags|slice(0, 300)|raw }}&hellip;" />
     </head>
     <body>
         <header>

--- a/src/Wallabag/CoreBundle/Twig/WallabagExtension.php
+++ b/src/Wallabag/CoreBundle/Twig/WallabagExtension.php
@@ -138,8 +138,11 @@ class WallabagExtension extends \Twig_Extension implements \Twig_Extension_Globa
         $interval = $user->getCreatedAt()->diff(new \DateTime('now'));
         $nbDays = (int) $interval->format('%a') ?: 1;
 
+        // force setlocale for date translation
+        setlocale(LC_TIME, strtolower($user->getConfig()->getLanguage()).'_'.strtoupper(strtolower($user->getConfig()->getLanguage())));
+
         return $this->translator->trans('footer.stats', [
-            '%user_creation%' => $user->getCreatedAt()->format('F jS, Y'),
+            '%user_creation%' => strftime('%e %B %Y', $user->getCreatedAt()->getTimestamp()),
             '%nb_archives%' => $nbArchives,
             '%per_day%' => round($nbArchives / $nbDays, 2),
         ]);

--- a/src/Wallabag/ImportBundle/Consumer/AbstractConsumer.php
+++ b/src/Wallabag/ImportBundle/Consumer/AbstractConsumer.php
@@ -50,9 +50,10 @@ abstract class AbstractConsumer
         $entry = $this->import->parseEntry($storedEntry);
 
         if (null === $entry) {
-            $this->logger->warning('Unable to parse entry', ['entry' => $storedEntry]);
+            $this->logger->warning('Entry already exists', ['entry' => $storedEntry]);
 
-            return false;
+            // return true to skip message
+            return true;
         }
 
         try {

--- a/src/Wallabag/ImportBundle/Import/BrowserImport.php
+++ b/src/Wallabag/ImportBundle/Import/BrowserImport.php
@@ -139,12 +139,24 @@ abstract class BrowserImport extends AbstractImport
     public function parseEntry(array $importedEntry)
     {
         if ((!array_key_exists('guid', $importedEntry) || (!array_key_exists('id', $importedEntry))) && is_array(reset($importedEntry))) {
+            if ($this->producer) {
+                $this->parseEntriesForProducer($importedEntry);
+
+                return;
+            }
+
             $this->parseEntries($importedEntry);
 
             return;
         }
 
         if (array_key_exists('children', $importedEntry)) {
+            if ($this->producer) {
+                $this->parseEntriesForProducer($importedEntry['children']);
+
+                return;
+            }
+
             $this->parseEntries($importedEntry['children']);
 
             return;

--- a/tests/Wallabag/ImportBundle/Consumer/RedisEntryConsumerTest.php
+++ b/tests/Wallabag/ImportBundle/Consumer/RedisEntryConsumerTest.php
@@ -219,7 +219,7 @@ JSON;
 
         $res = $consumer->manage($body);
 
-        $this->assertFalse($res);
+        $this->assertTrue($res);
         $this->assertFalse($consumer->isStopJob($body));
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | ?
| Documentation | no
| Translation   | yes
| Fixed tickets | fix #2476, fix #2474, fix #2469, fix #2441
| License       | MIT


### Translate footer date  … (related to #2476)

I use a kind of hacky way to convert the user locale (defined with 2 letters, like `fr`) into a local with 5 letters (like `fr_FR`). I guess it should work on most of the case..

### Avoid RabbitMQ consumer to loop  …

When the `parseEntry` returns null it means the entry already exists in the database. Sending `false` as return, will requeue the message which will then loop forever.

### Requeue depending on producer  …

Browser import can requeue message from `parseEntry` but we should take care of the way import are handled (depending on the producer)

### Fix missing translations

#2474 `error.page_title` was missing

### Update translation for piwik_host

#2469 mostly to avoid confusion about the protocol in url

### Update Twitter card description

#2441 truncate the entry description as it's done in the entries listing