### PR TITLE
If reload content failed, don’t update it

### DIFF
--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -50,6 +50,7 @@ wallabag_core:
     rss_limit: 50
     reading_speed: 1
     cache_lifetime: 10
+    fetching_error_message: "wallabag can't retrieve contents for this article. Please report this issue to us."
 
 wallabag_user:
     registration_enabled: "%fosuser_registration%"

--- a/src/Wallabag/CoreBundle/Controller/EntryController.php
+++ b/src/Wallabag/CoreBundle/Controller/EntryController.php
@@ -330,6 +330,15 @@ class EntryController extends Controller
 
         $this->updateEntry($entry, 'entry_reloaded');
 
+        // if refreshing entry failed, don't save it
+        if ($this->getParameter('wallabag_core.fetching_error_message') === $entry->getContent()) {
+            $bag = $this->get('session')->getFlashBag();
+            $bag->clear();
+            $bag->add('notice', 'flashes.entry.notice.entry_reloaded_failed');
+
+            return $this->redirect($this->generateUrl('view', ['id' => $entry->getId()]));
+        }
+
         $em = $this->getDoctrine()->getManager();
         $em->persist($entry);
         $em->flush();

--- a/src/Wallabag/CoreBundle/DependencyInjection/Configuration.php
+++ b/src/Wallabag/CoreBundle/DependencyInjection/Configuration.php
@@ -39,6 +39,8 @@ class Configuration implements ConfigurationInterface
                 ->integerNode('cache_lifetime')
                     ->defaultValue(10)
                 ->end()
+                ->scalarNode('fetching_error_message')
+                ->end()
             ->end()
         ;
 

--- a/src/Wallabag/CoreBundle/DependencyInjection/WallabagCoreExtension.php
+++ b/src/Wallabag/CoreBundle/DependencyInjection/WallabagCoreExtension.php
@@ -23,6 +23,7 @@ class WallabagCoreExtension extends Extension
         $container->setParameter('wallabag_core.version', $config['version']);
         $container->setParameter('wallabag_core.paypal_url', $config['paypal_url']);
         $container->setParameter('wallabag_core.cache_lifetime', $config['cache_lifetime']);
+        $container->setParameter('wallabag_core.fetching_error_message', $config['fetching_error_message']);
 
         $loader = new Loader\YamlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
         $loader->load('services.yml');

--- a/src/Wallabag/CoreBundle/Resources/config/services.yml
+++ b/src/Wallabag/CoreBundle/Resources/config/services.yml
@@ -40,7 +40,7 @@ services:
         class: Graby\Graby
         arguments:
             -
-                error_message: "wallabag can't retrieve contents for this article. Please report this issue to us."
+                error_message: '%wallabag_core.fetching_error_message%'
                 http_client:
                     user_agents:
                         'lifehacker.com': 'PHP/5.2'

--- a/tests/Wallabag/CoreBundle/Controller/EntryControllerTest.php
+++ b/tests/Wallabag/CoreBundle/Controller/EntryControllerTest.php
@@ -366,8 +366,6 @@ class EntryControllerTest extends WallabagCoreTestCase
 
     /**
      * @depends testPostNewOk
-     *
-     * This test will require an internet connection.
      */
     public function testReloadWithFetchingFailed()
     {

--- a/tests/Wallabag/CoreBundle/Controller/EntryControllerTest.php
+++ b/tests/Wallabag/CoreBundle/Controller/EntryControllerTest.php
@@ -359,9 +359,49 @@ class EntryControllerTest extends WallabagCoreTestCase
 
         $content = $em
             ->getRepository('WallabagCoreBundle:Entry')
-            ->findByUrlAndUserId($this->url, $this->getLoggedInUserId());
+            ->find($content->getId());
 
         $this->assertNotEmpty($content->getContent());
+    }
+
+    /**
+     * @depends testPostNewOk
+     *
+     * This test will require an internet connection.
+     */
+    public function testReloadWithFetchingFailed()
+    {
+        $this->logInAs('admin');
+        $client = $this->getClient();
+
+        $em = $client->getContainer()
+            ->get('doctrine.orm.entity_manager');
+
+        $content = $em
+            ->getRepository('WallabagCoreBundle:Entry')
+            ->findByUrlAndUserId($this->url, $this->getLoggedInUserId());
+
+        // put a known failed url
+        $content->setUrl('http://0.0.0.0/failed.html');
+        $em->persist($content);
+        $em->flush();
+
+        $client->request('GET', '/reload/'.$content->getId());
+
+        $this->assertEquals(302, $client->getResponse()->getStatusCode());
+
+        // force EntityManager to clear previous entity
+        // otherwise, retrieve the same entity will retrieve change from the previous request :0
+        $em->clear();
+        $newContent = $em
+            ->getRepository('WallabagCoreBundle:Entry')
+            ->find($content->getId());
+
+        $newContent->setUrl($this->url);
+        $em->persist($newContent);
+        $em->flush();
+
+        $this->assertNotEquals($client->getContainer()->getParameter('wallabag_core.fetching_error_message'), $newContent->getContent());
     }
 
     public function testEdit()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes (kind of)
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Documentation | no
| Translation   | no
| Fixed tickets | fix https://github.com/wallabag/wallabag/issues/2440
| License       | MIT

In case user wants a fresh version of the current one and the website isn’t available, don’t erase it with a boring message saying wallabag wasn’t able to refresh the content.