### PR TITLE
Mark as mobile app capable

### DIFF
--- a/src/Wallabag/CoreBundle/Resources/views/base.html.twig
+++ b/src/Wallabag/CoreBundle/Resources/views/base.html.twig
@@ -11,6 +11,8 @@
             <!--[if IE]>
             <meta http-equiv="X-UA-Compatible" content="IE=10">
             <![endif]-->
+            
+            <meta name="mobile-web-app-capable" content="yes">
 
             <link rel="apple-touch-icon" type="image/png" href="{{ asset('bundles/wallabagcore/themes/_global/img/appicon/apple-touch-icon-152.png') }}" sizes="152x152">
             <link rel="icon" type="image/png" href="{{ asset('bundles/wallabagcore/themes/_global/img/appicon/apple-touch-icon-152.png') }}" sizes="152x152">


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Documentation | no
| Translation   | no
| Fixed tickets | 
| License       | MIT

This will allow wallabag web-app to be added to the homescreen on smartphones, without the URL bar etc.. so that is acts more like a real application.

