### PR TITLE
Added require.sh to check if composer is installed

### DIFF
--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -1,6 +1,10 @@
 #! /usr/bin/env bash
-# You can execute this file to install wallabag dev environmnet
-# eg: `sh install.sh prod`
+# You can execute this file to install wallabag dev environment
+# eg: `sh dev.sh`
+
+DIR="${BASH_SOURCE%/*}"
+if [[ ! -d "$DIR" ]]; then DIR="$PWD"; fi
+. "$DIR/require.sh"
 
 composer install
 php bin/console wallabag:install

--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -2,10 +2,12 @@
 # You can execute this file to install wallabag dev environment
 # eg: `sh dev.sh`
 
+COMPOSER_COMMAND='composer'
+
 DIR="${BASH_SOURCE%/*}"
 if [[ ! -d "$DIR" ]]; then DIR="$PWD"; fi
 . "$DIR/require.sh"
 
-composer install
+$COMPOSER_COMMAND install
 php bin/console wallabag:install
 php bin/console server:run

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -2,6 +2,8 @@
 # You can execute this file to install wallabag
 # eg: `sh install.sh prod`
 
+COMPOSER_COMMAND='composer'
+
 DIR="${BASH_SOURCE%/*}"
 if [[ ! -d "$DIR" ]]; then DIR="$PWD"; fi
 . "$DIR/require.sh"
@@ -10,5 +12,5 @@ ENV=$1
 TAG=$(git describe --tags $(git rev-list --tags --max-count=1))
 
 git checkout $TAG
-SYMFONY_ENV=$ENV composer install --no-dev -o --prefer-dist
+SYMFONY_ENV=$ENV $COMPOSER_COMMAND install --no-dev -o --prefer-dist
 php bin/console wallabag:install --env=$ENV

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -2,7 +2,9 @@
 # You can execute this file to install wallabag
 # eg: `sh install.sh prod`
 
-command -v composer >/dev/null 2>&1 || { echo >&2 "wallabag requires composer but it's not installed (see http://doc.wallabag.org/en/master/user/installation.html). Aborting."; exit 1; }
+DIR="${BASH_SOURCE%/*}"
+if [[ ! -d "$DIR" ]]; then DIR="$PWD"; fi
+. "$DIR/require.sh"
 
 ENV=$1
 TAG=$(git describe --tags $(git rev-list --tags --max-count=1))

--- a/scripts/require.sh
+++ b/scripts/require.sh
@@ -3,6 +3,7 @@
 
 if [ ! -f composer.phar ]; then
     echo "composer.phar not found, we'll see if composer is installed globally."
+    command -v composer >/dev/null 2>&1 || { echo >&2 "wallabag requires composer but it's not installed (see http://doc.wallabag.org/en/master/user/installation.html). Aborting."; exit 1; }
+else
+    COMPOSER_COMMAND='composer.phar'
 fi
-
-command -v composer >/dev/null 2>&1 || { echo >&2 "wallabag requires composer but it's not installed (see http://doc.wallabag.org/en/master/user/installation.html). Aborting."; exit 1; }

--- a/scripts/require.sh
+++ b/scripts/require.sh
@@ -1,0 +1,8 @@
+#! /usr/bin/env bash
+# File used to check dependencies
+
+if [ ! -f composer.phar ]; then
+    echo "composer.phar not found, we'll see if composer is installed globally."
+fi
+
+command -v composer >/dev/null 2>&1 || { echo >&2 "wallabag requires composer but it's not installed (see http://doc.wallabag.org/en/master/user/installation.html). Aborting."; exit 1; }

--- a/scripts/update.sh
+++ b/scripts/update.sh
@@ -2,6 +2,8 @@
 # You can execute this file to update wallabag
 # eg: `sh update.sh prod`
 
+COMPOSER_COMMAND='composer'
+
 DIR="${BASH_SOURCE%/*}"
 if [[ ! -d "$DIR" ]]; then DIR="$PWD"; fi
 . "$DIR/require.sh"
@@ -13,5 +15,5 @@ rm -rf var/cache/*
 git fetch origin
 git fetch --tags
 git checkout $TAG --force
-SYMFONY_ENV=$ENV composer install --no-dev -o --prefer-dist
+SYMFONY_ENV=$ENV $COMPOSER_COMMAND install --no-dev -o --prefer-dist
 php bin/console cache:clear --env=$ENV

--- a/scripts/update.sh
+++ b/scripts/update.sh
@@ -2,6 +2,10 @@
 # You can execute this file to update wallabag
 # eg: `sh update.sh prod`
 
+DIR="${BASH_SOURCE%/*}"
+if [[ ! -d "$DIR" ]]; then DIR="$PWD"; fi
+. "$DIR/require.sh"
+
 ENV=$1
 TAG=$(git describe --tags $(git rev-list --tags --max-count=1))
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Documentation | no
| Translation   | no
| Fixed tickets | 
| License       | MIT

As discussed in #2500, we need to check if composer is installed locally (with a `composer.phar` file). 
I added a `require.sh` file to check it. 