### PR TITLE
docs: fix link to wallabag-stats project

### DIFF
--- a/docs/de/developer/api.rst
+++ b/docs/de/developer/api.rst
@@ -268,4 +268,4 @@ Einige Applikationen oder Bibliotheken nutzen unsere API. Hier ist eine nicht ab
 - `.NET library for the wallabag v2 API <https://github.com/jlnostr/wallabag-api>`_ von Julian Oster.
 - `Python API for wallabag <https://github.com/foxmask/wallabag_api>`_ von FoxMaSk, für sein Projekt `Trigger Happy <https://blog.trigger-happy.eu/>`_.
 - `A plugin <https://github.com/joshp23/ttrss-to-wallabag-v2>`_ entworfen für `Tiny Tiny RSS <https://tt-rss.org/gitlab/fox/tt-rss/wikis/home>`_, das die wallabag v2 API nutzt. Von Josh Panter.
-- `Golang wrapper for the wallabag API <https://github.com/Strubbl/wallabago>`_ von Strubbl, für sein Projekt `wallabag-stats Graph<https://github.com/Strubbl/wallabag-stats>`_.
+- `Golang wrapper for the wallabag API <https://github.com/Strubbl/wallabago>`_ von Strubbl, für sein Projekt `wallabag-stats Graph <https://github.com/Strubbl/wallabag-stats>`_.

--- a/docs/en/developer/api.rst
+++ b/docs/en/developer/api.rst
@@ -267,4 +267,4 @@ Some applications or libraries use our API. Here is a non-exhaustive list of the
 - `.NET library for the wallabag v2 API <https://github.com/jlnostr/wallabag-api>`_ by Julian Oster.
 - `Python API for wallabag <https://github.com/foxmask/wallabag_api>`_ by FoxMaSk, for his project `Trigger Happy <https://blog.trigger-happy.eu/>`_.
 - `A plugin <https://github.com/joshp23/ttrss-to-wallabag-v2>`_ designed for `Tiny Tiny RSS <https://tt-rss.org/gitlab/fox/tt-rss/wikis/home>`_ that makes use of the wallabag v2 API. By Josh Panter.
-- `Golang wrapper for the wallabag API <https://github.com/Strubbl/wallabago>`_ by Strubbl, for his project `wallabag-stats graph<https://github.com/Strubbl/wallabag-stats>`_.
+- `Golang wrapper for the wallabag API <https://github.com/Strubbl/wallabago>`_ by Strubbl, for his project `wallabag-stats graph <https://github.com/Strubbl/wallabag-stats>`_.

--- a/docs/fr/developer/api.rst
+++ b/docs/fr/developer/api.rst
@@ -267,4 +267,4 @@ Certaines applications ou bibliothèques utilisent notre API. En voici une liste
 - `.NET library for the wallabag v2 API <https://github.com/jlnostr/wallabag-api>`_ par Julian Oster.
 - `Python API for wallabag <https://github.com/foxmask/wallabag_api>`_ par FoxMaSk, pour son projet `Trigger Happy <https://blog.trigger-happy.eu/>`_.
 - `Un plugin <https://github.com/joshp23/ttrss-to-wallabag-v2>`_ conçu pour `Tiny Tiny RSS <https://tt-rss.org/gitlab/fox/tt-rss/wikis/home>`_  qui utilise l'API wallabag v2. Par Josh Panter.
-- `Golang wrapper for the wallabag API <https://github.com/Strubbl/wallabago>`_ par Strubbl, pour son projet `wallabag-stats graphe<https://github.com/Strubbl/wallabag-stats>`_.
+- `Golang wrapper for the wallabag API <https://github.com/Strubbl/wallabago>`_ par Strubbl, pour son projet `wallabag-stats graphe <https://github.com/Strubbl/wallabag-stats>`_.


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes|
| New feature?  | |no
| BC breaks?    | |no
| Deprecations? | |no
| Tests pass?   | |no
| Documentation | yes|
| Translation   | yes|
| Fixed tickets | comma-separated list of tickets fixed by the PR, if any
| License       | MIT

sorry, i failed to link correctly. a space needs to be between link name and url. :crying_cat_face: 