### PR TITLE
Inject parameter instead of service

### DIFF
--- a/src/Wallabag/CoreBundle/Helper/EntriesExport.php
+++ b/src/Wallabag/CoreBundle/Helper/EntriesExport.php
@@ -8,7 +8,6 @@ use JMS\Serializer\SerializerBuilder;
 use PHPePub\Core\EPub;
 use PHPePub\Core\Structure\OPF\DublinCore;
 use Symfony\Component\HttpFoundation\Response;
-use Craue\ConfigBundle\Util\Config;
 
 /**
  * This class doesn't have unit test BUT it's fully covered by a functional test with ExportControllerTest.
@@ -27,12 +26,12 @@ class EntriesExport
         </div>';
 
     /**
-     * @param Config $craueConfig CraueConfig instance to get wallabag instance url from database
+     * @param string $wallabagUrl Wallabag instance url
      * @param string $logoPath    Path to the logo FROM THE BUNDLE SCOPE
      */
-    public function __construct(Config $craueConfig, $logoPath)
+    public function __construct($wallabagUrl, $logoPath)
     {
-        $this->wallabagUrl = $craueConfig->get('wallabag_url');
+        $this->wallabagUrl = $wallabagUrl;
         $this->logoPath = $logoPath;
     }
 

--- a/src/Wallabag/CoreBundle/Resources/config/services.yml
+++ b/src/Wallabag/CoreBundle/Resources/config/services.yml
@@ -91,7 +91,7 @@ services:
     wallabag_core.helper.entries_export:
         class: Wallabag\CoreBundle\Helper\EntriesExport
         arguments:
-            - "@craue_config"
+            - '@=service(''craue_config'').get(''wallabag_url'')'
             - src/Wallabag/CoreBundle/Resources/public/themes/_global/img/appicon/apple-touch-icon-152.png
 
     wallabag.operator.array.matches:

--- a/src/Wallabag/ImportBundle/Resources/config/services.yml
+++ b/src/Wallabag/ImportBundle/Resources/config/services.yml
@@ -20,7 +20,6 @@ services:
         arguments:
             - "@doctrine.orm.entity_manager"
             - "@wallabag_core.content_proxy"
-            - "@craue_config"
         calls:
             - [ setClient, [ "@wallabag_import.pocket.client" ] ]
             - [ setLogger, [ "@logger" ]]

--- a/src/Wallabag/UserBundle/Mailer/AuthCodeMailer.php
+++ b/src/Wallabag/UserBundle/Mailer/AuthCodeMailer.php
@@ -4,7 +4,6 @@ namespace Wallabag\UserBundle\Mailer;
 
 use Scheb\TwoFactorBundle\Model\Email\TwoFactorInterface;
 use Scheb\TwoFactorBundle\Mailer\AuthCodeMailerInterface;
-use Craue\ConfigBundle\Util\Config;
 
 /**
  * Custom mailer for TwoFactorBundle email.
@@ -61,16 +60,17 @@ class AuthCodeMailer implements AuthCodeMailerInterface
      * @param \Twig_Environment $twig
      * @param string            $senderEmail
      * @param string            $senderName
-     * @param Config            $craueConfig Craue\Config instance to get wallabag support url from database
+     * @param string            $supportUrl  wallabag support url
+     * @param string            $wallabagUrl wallabag instance url
      */
-    public function __construct(\Swift_Mailer $mailer, \Twig_Environment $twig, $senderEmail, $senderName, Config $craueConfig)
+    public function __construct(\Swift_Mailer $mailer, \Twig_Environment $twig, $senderEmail, $senderName, $supportUrl, $wallabagUrl)
     {
         $this->mailer = $mailer;
         $this->twig = $twig;
         $this->senderEmail = $senderEmail;
         $this->senderName = $senderName;
-        $this->supportUrl = $craueConfig->get('wallabag_support_url');
-        $this->wallabagUrl = $craueConfig->get('wallabag_url');
+        $this->supportUrl = $supportUrl;
+        $this->wallabagUrl = $wallabagUrl;
     }
 
     /**

--- a/src/Wallabag/UserBundle/Resources/config/services.yml
+++ b/src/Wallabag/UserBundle/Resources/config/services.yml
@@ -6,7 +6,8 @@ services:
             - "@twig"
             - "%scheb_two_factor.email.sender_email%"
             - "%scheb_two_factor.email.sender_name%"
-            - "@craue_config"
+            - '@=service(''craue_config'').get(''wallabag_support_url'')'
+            - '@=service(''craue_config'').get(''wallabag_url'')'
 
     wallabag_user.password_resetting:
         class: Wallabag\UserBundle\EventListener\PasswordResettingListener

--- a/tests/Wallabag/UserBundle/Mailer/AuthCodeMailerTest.php
+++ b/tests/Wallabag/UserBundle/Mailer/AuthCodeMailerTest.php
@@ -26,7 +26,6 @@ class AuthCodeMailerTest extends \PHPUnit_Framework_TestCase
     protected $mailer;
     protected $spool;
     protected $twig;
-    protected $config;
 
     protected function setUp()
     {
@@ -44,14 +43,6 @@ class AuthCodeMailerTest extends \PHPUnit_Framework_TestCase
 TWIG;
 
         $this->twig = new \Twig_Environment(new \Twig_Loader_Array(['WallabagUserBundle:TwoFactor:email_auth_code.html.twig' => $twigTemplate]));
-
-        $this->config = $this->getMockBuilder('Craue\ConfigBundle\Util\Config')
-            ->disableOriginalConstructor()
-            ->getMock();
-
-        $this->config->expects($this->any())
-            ->method('get')
-            ->willReturn('http://0.0.0.0/support');
     }
 
     public function testSendEmail()
@@ -67,7 +58,8 @@ TWIG;
             $this->twig,
             'nobody@test.io',
             'wallabag test',
-            $this->config
+            'http://0.0.0.0/support',
+            'http://0.0.0.0/'
         );
 
         $authCodeMailer->sendAuthCode($user);


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Documentation | no |
| Translation | no |
| Fixed tickets |  |
| License | MIT |

We are injecting CraueConfig service when we only need to retrieve one or two values from it.
Instead I discovered we can directly inject a value from a service in the service definition!
