### PR TITLE
fix path for  the install scripts

### DIFF
--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -1,11 +1,11 @@
-#! /usr/bin/env bash
+#!/usr/bin/env bash
 # You can execute this file to install wallabag dev environment
 # eg: `sh dev.sh`
 
 COMPOSER_COMMAND='composer'
 
-DIR="${BASH_SOURCE%/*}"
-if [[ ! -d "$DIR" ]]; then DIR="$PWD"; fi
+DIR="${BASH_SOURCE}"
+if [[ ! -d "$DIR" ]]; then DIR="$PWD/scripts"; fi
 . "$DIR/require.sh"
 
 $COMPOSER_COMMAND install

--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -5,7 +5,7 @@
 COMPOSER_COMMAND='composer'
 
 DIR="${BASH_SOURCE}"
-if [[ ! -d "$DIR" ]]; then DIR="$PWD/scripts"; fi
+if [ ! -d "$DIR" ]; then DIR="$PWD/scripts"; fi
 . "$DIR/require.sh"
 
 $COMPOSER_COMMAND install

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,11 +1,11 @@
-#! /usr/bin/env bash
+#!/usr/bin/env bash
 # You can execute this file to install wallabag
 # eg: `sh install.sh prod`
 
 COMPOSER_COMMAND='composer'
 
-DIR="${BASH_SOURCE%/*}"
-if [[ ! -d "$DIR" ]]; then DIR="$PWD"; fi
+DIR="${BASH_SOURCE}"
+if [[ ! -d "$DIR" ]]; then DIR="$PWD/scripts"; fi
 . "$DIR/require.sh"
 
 ENV=$1

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -5,7 +5,7 @@
 COMPOSER_COMMAND='composer'
 
 DIR="${BASH_SOURCE}"
-if [[ ! -d "$DIR" ]]; then DIR="$PWD/scripts"; fi
+if [ ! -d "$DIR" ]; then DIR="$PWD/scripts"; fi
 . "$DIR/require.sh"
 
 ENV=$1

--- a/scripts/update.sh
+++ b/scripts/update.sh
@@ -1,11 +1,11 @@
-#! /usr/bin/env bash
+#!/usr/bin/env bash
 # You can execute this file to update wallabag
 # eg: `sh update.sh prod`
 
 COMPOSER_COMMAND='composer'
 
-DIR="${BASH_SOURCE%/*}"
-if [[ ! -d "$DIR" ]]; then DIR="$PWD"; fi
+DIR="${BASH_SOURCE}"
+if [[ ! -d "$DIR" ]]; then DIR="$PWD/scripts"; fi
 . "$DIR/require.sh"
 
 ENV=$1

--- a/scripts/update.sh
+++ b/scripts/update.sh
@@ -5,7 +5,7 @@
 COMPOSER_COMMAND='composer'
 
 DIR="${BASH_SOURCE}"
-if [[ ! -d "$DIR" ]]; then DIR="$PWD/scripts"; fi
+if [ ! -d "$DIR" ]; then DIR="$PWD/scripts"; fi
 . "$DIR/require.sh"
 
 ENV=$1


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | i dont know |
| Deprecations? | no |
| Tests pass? | no |
| Documentation | no |
| Translation | no |
| Fixed tickets | #2517 |
| License | MIT |

this fix issue when installing , like : 

```
scripts/install.sh: 8: scripts/install.sh: [[: not found
scripts/install.sh: 9: .: Can't open /require.sh
Makefile:15: recipe for target 'install' failed
make: *** [install] Error 2
```
