### PR TITLE
Add Instapaper to CLI import

### DIFF
--- a/src/Wallabag/ImportBundle/Command/ImportCommand.php
+++ b/src/Wallabag/ImportBundle/Command/ImportCommand.php
@@ -50,6 +50,9 @@ class ImportCommand extends ContainerAwareCommand
             case 'chrome':
                 $wallabag = $this->getContainer()->get('wallabag_import.chrome.import');
                 break;
+            case 'instapaper':
+                $wallabag = $this->getContainer()->get('wallabag_import.instapaper.import');
+                break;
             case 'v1':
             default:
                 $wallabag = $this->getContainer()->get('wallabag_import.wallabag_v1.import');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Documentation | no
| Translation   | no
| Fixed tickets | none
| License       | MIT

Hi!
I've waited way too long and finally, my Instapaper subscription ended last week. 
As I had a lot of articles, my web server was dying of timeout. 

So I've added Instapaper to the command line. Hope it's ok with you :) I can find some time to try to explain that somewhere in the doc if needed.


Magic:
```
php bin/console wallabag:import 1 instapaper-export.csv --importer=instapaper
Start : 01-11-2016 10:04:01 ---
1206 imported
0 already saved
End : 01-11-2016 10:28:20 ---
```