### PR TITLE
Force user-agent for .slashdot.org

### DIFF
--- a/src/Wallabag/CoreBundle/Resources/config/services.yml
+++ b/src/Wallabag/CoreBundle/Resources/config/services.yml
@@ -55,6 +55,7 @@ services:
                         '.fok.nl': 'Googlebot/2.1'
                         'getpocket.com': 'PHP/5.2'
                         'iansommerville.com': 'PHP/5.2'
+                        '.slashdot.org': 'PHP/5.2'
         calls:
             - [ setLogger, [ "@logger" ] ]
         tags:


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | -
| Documentation | -
| Translation   | -
| Fixed tickets | -
| License       | MIT

Slashdot replaces actual content with a form regarding cookies when
requests originate from France. By forcing the user-agent, the warning
seems to go away.