### PR TITLE
Use created_at as default sort

### DIFF
--- a/src/Wallabag/CoreBundle/Repository/EntryRepository.php
+++ b/src/Wallabag/CoreBundle/Repository/EntryRepository.php
@@ -22,7 +22,7 @@ class EntryRepository extends EntityRepository
         return $this->createQueryBuilder('e')
             ->leftJoin('e.user', 'u')
             ->andWhere('u.id = :userId')->setParameter('userId', $userId)
-            ->orderBy('e.id', 'desc')
+            ->orderBy('e.createdAt', 'desc')
         ;
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Documentation | no
| Translation   | no
| Fixed tickets | fix #2531 
| License       | MIT

Imported content use the real creation date. If we sort by id, it'll
display contents in reverse order.