### PR TITLE
Use created_at as default sort

### DIFF
--- a/app/DoctrineMigrations/Version20161104073720.php
+++ b/app/DoctrineMigrations/Version20161104073720.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Application\Migrations;
+
+use Doctrine\DBAL\Migrations\AbstractMigration;
+use Doctrine\DBAL\Schema\Schema;
+use Symfony\Component\DependencyInjection\ContainerAwareInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+class Version20161104073720 extends AbstractMigration implements ContainerAwareInterface
+{
+    /**
+     * @var ContainerInterface
+     */
+    private $container;
+
+    public function setContainer(ContainerInterface $container = null)
+    {
+        $this->container = $container;
+    }
+
+    private function getTable($tableName)
+    {
+        return $this->container->getParameter('database_table_prefix') . $tableName;
+    }
+
+    /**
+     * @param Schema $schema
+     */
+    public function up(Schema $schema)
+    {
+        switch ($this->connection->getDatabasePlatform()->getName()) {
+            case 'sqlite':
+                $this->addSql('CREATE INDEX `created_at` ON `'.$this->getTable('entry').'` (`created_at` DESC)');
+                break;
+
+            case 'mysql':
+                $this->addSql('ALTER TABLE '.$this->getTable('entry').' ADD INDEX created_at (created_at);');
+                break;
+
+            case 'postgresql':
+                $this->addSql('CREATE INDEX created_at ON '.$this->getTable('entry').' (created_at DESC)');
+        }
+    }
+
+    /**
+     * @param Schema $schema
+     */
+    public function down(Schema $schema)
+    {
+
+    }
+}

--- a/src/Wallabag/CoreBundle/Entity/Entry.php
+++ b/src/Wallabag/CoreBundle/Entity/Entry.php
@@ -19,7 +19,11 @@ use Wallabag\AnnotationBundle\Entity\Annotation;
  *
  * @XmlRoot("entry")
  * @ORM\Entity(repositoryClass="Wallabag\CoreBundle\Repository\EntryRepository")
- * @ORM\Table(name="`entry`", options={"collate"="utf8mb4_unicode_ci", "charset"="utf8mb4"})
+ * @ORM\Table(
+ *     name="`entry`",
+ *     options={"collate"="utf8mb4_unicode_ci", "charset"="utf8mb4"},
+ *     indexes={@ORM\Index(name="created_at", columns={"created_at"})}
+ * )
  * @ORM\HasLifecycleCallbacks()
  * @Hateoas\Relation("self", href = "expr('/api/entries/' ~ object.getId())")
  */

--- a/src/Wallabag/CoreBundle/Repository/EntryRepository.php
+++ b/src/Wallabag/CoreBundle/Repository/EntryRepository.php
@@ -22,7 +22,7 @@ class EntryRepository extends EntityRepository
         return $this->createQueryBuilder('e')
             ->leftJoin('e.user', 'u')
             ->andWhere('u.id = :userId')->setParameter('userId', $userId)
-            ->orderBy('e.id', 'desc')
+            ->orderBy('e.createdAt', 'desc')
         ;
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Documentation | no
| Translation   | no
| Fixed tickets | #2531 
| License       | MIT

Imported content use the real creation date. If we sort by id, it'll
display contents in reverse order.

Following https://github.com/wallabag/wallabag/pull/2534 but this time I added an index to avoid database to use a `filesort` instead of the index