### PR TITLE
Round readingtime to avoid crazy number

### DIFF
--- a/src/Wallabag/CoreBundle/Resources/views/themes/material/Entry/entries.html.twig
+++ b/src/Wallabag/CoreBundle/Resources/views/themes/material/Entry/entries.html.twig
@@ -78,7 +78,7 @@
                     <div class="card-action">
                         <span class="reading-time grey-text">
                             <i class="material-icons" title="{{ 'entry.list.reading_time'|trans }}">timer</i>
-                            {{ entry.readingTime / app.user.config.readingSpeed }} min
+                            {{ entry.readingTime / app.user.config.readingSpeed|round }} min
                         </span>
 
                         <ul class="tools right">


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Documentation | no
| Translation   | no
| Fixed tickets | fix #2544
| License       | MIT

Like `8.666666666667 min`.
This bug was already fixed in the 2.2 branch (see https://github.com/wallabag/wallabag/blob/2.2/src/Wallabag/CoreBundle/Resources/views/themes/material/Entry/entries.html.twig#L42)