### PR TITLE
Removed support website on about page

### DIFF
--- a/src/Wallabag/CoreBundle/Resources/translations/messages.da.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.da.yml
@@ -229,7 +229,7 @@ about:
     getting_help:
         documentation: 'Dokumentation'
         bug_reports: 'Bugs'
-        support: '<a href="https://support.wallabag.org">På vor support-side</a> eller <a href="https://github.com/wallabag/wallabag/issues">på GitHub</a>'
+        support: '<a href="https://github.com/wallabag/wallabag/issues">på GitHub</a>'
     helping:
         description: 'wallabag er gratis og Open source. Du kan hjælpe os:'
         by_contributing: 'ved at bidrage til projektet:'

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.de.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.de.yml
@@ -229,7 +229,7 @@ about:
     getting_help:
         documentation: 'Dokumentation'
         bug_reports: 'Fehlerberichte'
-        support: '<a href="https://support.wallabag.org">Auf unserer Support-Webseite</a> oder <a href="https://github.com/wallabag/wallabag/issues">auf GitHub</a>'
+        support: '<a href="https://github.com/wallabag/wallabag/issues">auf GitHub</a>'
     helping:
         description: 'wallabag ist frei und Open Source. Du kannst uns helfen:'
         by_contributing: 'indem du zu dem Projekt beiträgst:'

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.en.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.en.yml
@@ -229,7 +229,7 @@ about:
     getting_help:
         documentation: 'Documentation'
         bug_reports: 'Bug reports'
-        support: '<a href="https://support.wallabag.org">On our support website</a> or <a href="https://github.com/wallabag/wallabag/issues">on GitHub</a>'
+        support: '<a href="https://github.com/wallabag/wallabag/issues">on GitHub</a>'
     helping:
         description: 'wallabag is free and open source. You can help us:'
         by_contributing: 'by contributing to the project:'

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.es.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.es.yml
@@ -229,7 +229,7 @@ about:
     getting_help:
         documentation: 'Documentación'
         bug_reports: 'Reporte de errores'
-        support: '<a href="https://support.wallabag.org">En nuestra web de apoyo website</a> o <a href="https://github.com/wallabag/wallabag/issues">en GitHub</a>'
+        support: '<a href="https://github.com/wallabag/wallabag/issues">en GitHub</a>'
     helping:
         description: 'wallabag es libre y gratuito. Usted puede ayudarnos :'
         by_contributing: 'contribuyendo al proyecto :'

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.fa.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.fa.yml
@@ -229,7 +229,7 @@ about:
     getting_help:
         documentation: 'راهنما'
         bug_reports: 'گزارش اشکال‌ها'
-        support: '<a href="https://support.wallabag.org">در وب‌گاه پشتیبانی</a> یا <a href="https://github.com/wallabag/wallabag/issues">روی GitHub</a>'
+        support: '<a href="https://github.com/wallabag/wallabag/issues">روی GitHub</a>'
     helping:
         description: 'wallabag رایگان، آزاد، و متن‌باز است. شما می‌توانید به ما کمک کنید:'
         by_contributing: 'با مشارکت در پروژه:'

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.fr.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.fr.yml
@@ -229,7 +229,7 @@ about:
     getting_help:
         documentation: "Documentation"
         bug_reports: "Rapport de bogue"
-        support: "<a href=\"https://support.wallabag.org\">Sur notre site de support</a> ou <a href=\"https://github.com/wallabag/wallabag/issues\">sur GitHub</a>"
+        support: "<a href=\"https://github.com/wallabag/wallabag/issues\">sur GitHub</a>"
     helping:
         description: "wallabag est gratuit et opensource. Vous pouvez nous aider :"
         by_contributing: "en contribuant au projet :"

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.it.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.it.yml
@@ -229,7 +229,7 @@ about:
     getting_help:
         documentation: 'Documentazione'
         bug_reports: 'Bug reports'
-        support: '<a href="https://support.wallabag.org">Sul nostro sito di supporto</a> o <a href="https://github.com/wallabag/wallabag/issues">su GitHub</a>'
+        support: '<a href="https://github.com/wallabag/wallabag/issues">su GitHub</a>'
     helping:
         description: 'wallabag è gratuito opensource. Puoi aiutarci:'
         by_contributing: 'per contribuire al progetto:'

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.oc.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.oc.yml
@@ -229,7 +229,7 @@ about:
     getting_help:
         documentation: 'Documentacion'
         bug_reports: 'Rapòrt de bugs'
-        support: "<a href=\"https://support.wallabag.org\">Sus nòstre site d'assisténcia</a> ou <a href=\"https://github.com/wallabag/wallabag/issues\">sur GitHub</a>"
+        support: "<a href=\"https://github.com/wallabag/wallabag/issues\">sur GitHub</a>"
     helping:
         description: 'wallabag es a gratuit e opensource. Nos podètz ajudar :'
         by_contributing: 'en ajudant lo projècte :'

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.pl.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.pl.yml
@@ -229,7 +229,7 @@ about:
     getting_help:
         documentation: 'Dokumentacja'
         bug_reports: 'Raportuj błędy'
-        support: '<a href="https://support.wallabag.org">Na naszej stronie wsparcia technicznego</a> lub <a href="https://github.com/wallabag/wallabag/issues">na GitHubie</a>'
+        support: '<a href="https://github.com/wallabag/wallabag/issues">na GitHubie</a>'
     helping:
         description: 'wallabag jest darmowy i otwartoźródłowy. Możesz nam pomóc:'
         by_contributing: 'przez przyłączenie się do projektu:'

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.pt.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.pt.yml
@@ -229,7 +229,7 @@ about:
     getting_help:
         documentation: 'Documentação'
         bug_reports: 'Informar bugs'
-        support: '<a href="https://support.wallabag.org">Em nosso site de suporte</a> ou <a href="https://github.com/wallabag/wallabag/issues">no GitHub</a>'
+        support: '<a href="https://github.com/wallabag/wallabag/issues">no GitHub</a>'
     helping:
         description: 'wallabag é livre e software livre. Você pode nos ajudar:'
         by_contributing: 'contribuindo com o projeto:'

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.ro.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.ro.yml
@@ -229,7 +229,7 @@ about:
     getting_help:
         documentation: 'Documentație'
         bug_reports: 'Bug-uri'
-        support: '<a href="https://support.wallabag.org">Pe site-ul nostru de suport</a> sau <a href="https://github.com/wallabag/wallabag/issues">pe GitHub</a>'
+        support: '<a href="https://github.com/wallabag/wallabag/issues">pe GitHub</a>'
     helping:
         description: 'wallabag este gratis și Open-Source. Cum ne poți ajuta:'
         by_contributing: 'contribuind la proiect:'

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.tr.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.tr.yml
@@ -228,7 +228,7 @@ about:
     getting_help:
         documentation: 'Dokümantasyon'
         bug_reports: 'Sorun bildir'
-        support: '<a href="https://support.wallabag.org">Destek internet sitesinde</a> ya da <a href="https://github.com/wallabag/wallabag/issues">GitHub üzerinde</a>'
+        support: '<a href="https://github.com/wallabag/wallabag/issues">GitHub üzerinde</a>'
     helping:
         description: 'wallabag açık kaynak kodlu ve ücretsizdir. Bize destek ol :'
         by_contributing: 'projemize katkıda bulunun :'


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Documentation | no
| Translation   | yes
| Fixed tickets | ...
| License       | MIT


support.wallabag.org website is now closed. 
