### PR TITLE
Added tooltips in header bar

### DIFF
--- a/src/Wallabag/CoreBundle/Resources/views/themes/material/layout.html.twig
+++ b/src/Wallabag/CoreBundle/Resources/views/themes/material/layout.html.twig
@@ -85,7 +85,7 @@
             <div class="input-field nav-panel-buttom">
                 <ul>
                     <li class="bold">
-                        <a title="{{ 'menu.top.add_new_entry'|trans }}" class="waves-effect" href="{{ path('new') }}" id="nav-btn-add">
+                        <a class="waves-effect tooltipped" data-position="bottom" data-delay="50" data-tooltip="{{ 'menu.top.add_new_entry'|trans }}" href="{{ path('new') }}" id="nav-btn-add">
                             <i class="material-icons">add</i>
                         </a>
                     </li>
@@ -95,12 +95,12 @@
                         </a>
                     </li>-->
                     <li id="button_filters">
-                        <a title="{{ 'menu.top.filter_entries'|trans }}" href="#" data-activates="filters" class="nav-panel-menu button-collapse-right">
+                        <a class="nav-panel-menu button-collapse-right tooltipped" data-position="bottom" data-delay="50" data-tooltip="{{ 'menu.top.filter_entries'|trans }}" href="#" data-activates="filters">
                             <i class="material-icons">filter_list</i>
                         </a>
                     </li>
                     <li id="button_export">
-                        <a title="{{ 'menu.top.export'|trans }}" class="nav-panel-menu button-collapse-right" href="#" data-activates="export">
+                        <a class="nav-panel-menu button-collapse-right tooltipped" data-position="bottom" data-delay="50" data-tooltip="{{ 'menu.top.export'|trans }}" href="#" data-activates="export">
                             <i class="material-icons">file_download</i>
                         </a>
                     </li>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Documentation | no
| Translation   | no
| Fixed tickets | N/A
| License       | MIT

We used `title` but it takes time to be displayed. With these tooltips, we have the information in 50ms 👍 
I use tooltips from materializecss http://materializecss.com/dialogs.html#tooltip 

Screenshot: 

![capture d ecran 2016-11-11 a 23 00 44](https://cloud.githubusercontent.com/assets/121870/20237342/5d246e50-a8cf-11e6-818d-e94aa97d436e.png)
