### PR TITLE
fix #2582 - Documentation, Nginx config: disable all other PHP file from symphony

### DIFF
--- a/docs/de/user/installation.rst
+++ b/docs/de/user/installation.rst
@@ -187,6 +187,12 @@ Angenommen du willst wallabag in das Verzeichnis ``/var/www/wallabag`` installie
             internal;
         }
 
+        # return 404 for all other php files not matching the front controller
+        # this prevents access to other php files you don't want to be accessible.
+        location ~ \.php$ {
+            return 404;
+        }
+
         error_log /var/log/nginx/wallabag_error.log;
         access_log /var/log/nginx/wallabag_access.log;
     }

--- a/docs/en/user/installation.rst
+++ b/docs/en/user/installation.rst
@@ -186,6 +186,12 @@ Assuming you installed wallabag in the ``/var/www/wallabag`` folder, here's the 
             internal;
         }
 
+        # return 404 for all other php files not matching the front controller
+        # this prevents access to other php files you don't want to be accessible.
+        location ~ \.php$ {
+            return 404;
+        }
+
         error_log /var/log/nginx/wallabag_error.log;
         access_log /var/log/nginx/wallabag_access.log;
     }

--- a/docs/fr/user/installation.rst
+++ b/docs/fr/user/installation.rst
@@ -183,6 +183,12 @@ En imaginant que vous vouliez installer wallabag dans le dossier ``/var/www/wall
             internal;
         }
 
+        # return 404 for all other php files not matching the front controller
+        # this prevents access to other php files you don't want to be accessible.
+        location ~ \.php$ {
+            return 404;
+        }
+
         error_log /var/log/nginx/wallabag_error.log;
         access_log /var/log/nginx/wallabag_access.log;
     }


### PR DESCRIPTION
Documentation: Regarding
https://www.nginx.com/resources/wiki/start/topics/recipes/symfony/ we
need to limit access to config.php and make_dev.php files from Nginx.
That's why we return 404 error page for these files.