### PR TITLE
Added http_status in Entry entity

### DIFF
--- a/app/DoctrineMigrations/Version20161118134328.php
+++ b/app/DoctrineMigrations/Version20161118134328.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Application\Migrations;
+
+use Doctrine\DBAL\Migrations\AbstractMigration;
+use Doctrine\DBAL\Schema\Schema;
+use Symfony\Component\DependencyInjection\ContainerAwareInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Add http_status in `entry_table`
+ */
+class Version20161118134328 extends AbstractMigration implements ContainerAwareInterface
+{
+    /**
+     * @var ContainerInterface
+     */
+    private $container;
+
+    public function setContainer(ContainerInterface $container = null)
+    {
+        $this->container = $container;
+    }
+
+    private function getTable($tableName)
+    {
+        return $this->container->getParameter('database_table_prefix') . $tableName;
+    }
+
+    /**
+     * @param Schema $schema
+     */
+    public function up(Schema $schema)
+    {
+        $this->addSql('ALTER TABLE '.$this->getTable('entry').' ADD http_status INT DEFAULT 0');
+    }
+
+    /**
+     * @param Schema $schema
+     */
+    public function down(Schema $schema)
+    {
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() != 'sqlite', 'This down migration can\'t be executed on SQLite databases, because SQLite don\'t support DROP COLUMN.');
+
+        $this->addSql('ALTER TABLE '.$this->getTable('entry').' DROP http_status');
+    }
+}

--- a/app/DoctrineMigrations/Version20161118134328.php
+++ b/app/DoctrineMigrations/Version20161118134328.php
@@ -32,7 +32,7 @@ class Version20161118134328 extends AbstractMigration implements ContainerAwareI
      */
     public function up(Schema $schema)
     {
-        $this->addSql('ALTER TABLE '.$this->getTable('entry').' ADD http_status INT DEFAULT 0');
+        $this->addSql('ALTER TABLE '.$this->getTable('entry').' ADD http_status VARCHAR(3) DEFAULT NULL');
     }
 
     /**

--- a/docs/de/user/filters.rst
+++ b/docs/de/user/filters.rst
@@ -30,6 +30,11 @@ Sprache
 wallabag (via graby) kann die Artikelsprache erkennen. Es ist einfach für dich, Artikel
 in einer bestimmten Sprache zu filtern.
 
+HTTP status
+-----------
+
+You can retrieve the articles by filtering by their HTTP status code: 200, 404, 500, etc.
+
 Lesezeit
 --------
 

--- a/docs/en/user/filters.rst
+++ b/docs/en/user/filters.rst
@@ -30,6 +30,11 @@ Language
 wallabag (via graby) can detect article language. It's easy to you to retrieve articles
 written in a specific language.
 
+HTTP status
+-----------
+
+You can retrieve the articles by filtering by their HTTP status code: 200, 404, 500, etc.
+
 Reading time
 ------------
 

--- a/docs/fr/user/filters.rst
+++ b/docs/fr/user/filters.rst
@@ -30,6 +30,11 @@ Langage
 wallabag (via graby) peut détecter la langue dans laquelle l'article est écrit.
 C'est ainsi facile pour vous de retrouver des articles écrits dans une langue spécifique.
 
+Statut HTTP
+-----------
+
+Vous pouvez retrouver des articles en filtrant par leur code HTTP : 200, 404, 500, etc.
+
 Temps de lecture
 ----------------
 

--- a/src/Wallabag/CoreBundle/Entity/Entry.php
+++ b/src/Wallabag/CoreBundle/Entity/Entry.php
@@ -181,9 +181,9 @@ class Entry
     private $isPublic;
 
     /**
-     * @var int
+     * @var string
      *
-     * @ORM\Column(name="http_status", type="integer", nullable=true)
+     * @ORM\Column(name="http_status", type="text", nullable=true)
      *
      * @Groups({"entries_for_user", "export_all"})
      */

--- a/src/Wallabag/CoreBundle/Entity/Entry.php
+++ b/src/Wallabag/CoreBundle/Entity/Entry.php
@@ -181,6 +181,15 @@ class Entry
     private $isPublic;
 
     /**
+     * @var int
+     *
+     * @ORM\Column(name="http_status", type="integer", nullable=true)
+     *
+     * @Groups({"entries_for_user", "export_all"})
+     */
+    private $httpStatus;
+
+    /**
      * @Exclude
      *
      * @ORM\ManyToOne(targetEntity="Wallabag\UserBundle\Entity\User", inversedBy="entries")
@@ -668,5 +677,25 @@ class Entry
     public function cleanUuid()
     {
         $this->uuid = null;
+    }
+
+    /**
+     * @return int
+     */
+    public function getHttpStatus()
+    {
+        return $this->httpStatus;
+    }
+
+    /**
+     * @param int $httpStatus
+     *
+     * @return Entry
+     */
+    public function setHttpStatus($httpStatus)
+    {
+        $this->httpStatus = $httpStatus;
+
+        return $this;
     }
 }

--- a/src/Wallabag/CoreBundle/Form/Type/EntryFilterType.php
+++ b/src/Wallabag/CoreBundle/Form/Type/EntryFilterType.php
@@ -11,6 +11,7 @@ use Lexik\Bundle\FormFilterBundle\Filter\Form\Type\CheckboxFilterType;
 use Lexik\Bundle\FormFilterBundle\Filter\Form\Type\ChoiceFilterType;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorage;
 
@@ -91,6 +92,18 @@ class EntryFilterType extends AbstractType
                 'label' => 'entry.filters.domain_label',
             ])
             ->add('httpStatus', TextFilterType::class, [
+                'apply_filter' => function (QueryInterface $filterQuery, $field, $values) {
+                    $value = $values['value'];
+                    if (false === array_key_exists($value, Response::$statusTexts)) {
+                        return;
+                    }
+
+                    $paramName = sprintf('%s', str_replace('.', '_', $field));
+                    $expression = $filterQuery->getExpr()->eq($field, ':'.$paramName);
+                    $parameters = array($paramName => $value);
+
+                    return $filterQuery->createCondition($expression, $parameters);
+                },
                 'label' => 'entry.filters.http_status_label',
             ])
             ->add('isArchived', CheckboxFilterType::class, [

--- a/src/Wallabag/CoreBundle/Form/Type/EntryFilterType.php
+++ b/src/Wallabag/CoreBundle/Form/Type/EntryFilterType.php
@@ -90,6 +90,9 @@ class EntryFilterType extends AbstractType
                 },
                 'label' => 'entry.filters.domain_label',
             ])
+            ->add('httpStatus', TextFilterType::class, [
+                'label' => 'entry.filters.http_status_label',
+            ])
             ->add('isArchived', CheckboxFilterType::class, [
                 'label' => 'entry.filters.archived_label',
             ])

--- a/src/Wallabag/CoreBundle/Helper/ContentProxy.php
+++ b/src/Wallabag/CoreBundle/Helper/ContentProxy.php
@@ -66,6 +66,7 @@ class ContentProxy
         $entry->setUrl($content['url'] ?: $url);
         $entry->setTitle($title);
         $entry->setContent($html);
+        $entry->setHttpStatus(isset($content['status']) ? $content['status'] : '');
 
         $entry->setLanguage($content['language']);
         $entry->setMimetype($content['content_type']);

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.da.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.da.yml
@@ -178,6 +178,7 @@ entry:
         preview_picture_label: 'Har et vist billede'
         preview_picture_help: 'Forhåndsvis billede'
         language_label: 'Sprog'
+        # http_status_label: 'HTTP status'
         reading_time:
             label: 'Læsetid i minutter'
             from: 'fra'

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.de.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.de.yml
@@ -178,6 +178,7 @@ entry:
         preview_picture_label: 'Vorschaubild vorhanden'
         preview_picture_help: 'Vorschaubild'
         language_label: 'Sprache'
+        # http_status_label: 'HTTP status'
         reading_time:
             label: 'Lesezeit in Minuten'
             from: 'von'

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.en.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.en.yml
@@ -178,6 +178,7 @@ entry:
         preview_picture_label: 'Has a preview picture'
         preview_picture_help: 'Preview picture'
         language_label: 'Language'
+        http_status_label: 'HTTP status'
         reading_time:
             label: 'Reading time in minutes'
             from: 'from'

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.es.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.es.yml
@@ -178,6 +178,7 @@ entry:
         preview_picture_label: 'Hay una foto'
         preview_picture_help: 'Foto de preview'
         language_label: 'Idioma'
+        # http_status_label: 'HTTP status'
         reading_time:
             label: 'Duración de lectura en minutos'
             from: 'de'

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.fa.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.fa.yml
@@ -178,6 +178,7 @@ entry:
         preview_picture_label: 'دارای عکس پیش‌نمایش'
         preview_picture_help: 'پیش‌نمایش عکس'
         language_label: 'زبان'
+        # http_status_label: 'HTTP status'
         reading_time:
             label: 'زمان خواندن به دقیقه'
             from: 'از'

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.fr.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.fr.yml
@@ -178,6 +178,7 @@ entry:
         preview_picture_label: "A une photo"
         preview_picture_help: "Photo"
         language_label: "Langue"
+        http_status_label: 'Statut HTTP'
         reading_time:
             label: "Durée de lecture en minutes"
             from: "de"

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.it.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.it.yml
@@ -178,6 +178,7 @@ entry:
         preview_picture_label: "Ha un'immagine di anteprima"
         preview_picture_help: 'Immagine di anteprima'
         language_label: 'Lingua'
+        # http_status_label: 'HTTP status'
         reading_time:
             label: 'Tempo di lettura in minuti'
             from: 'da'

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.oc.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.oc.yml
@@ -178,6 +178,7 @@ entry:
         preview_picture_label: 'A una fotò'
         preview_picture_help: 'Fotò'
         language_label: 'Lenga'
+        # http_status_label: 'HTTP status'
         reading_time:
             label: 'Durada de lectura en minutas'
             from: 'de'

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.pl.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.pl.yml
@@ -178,6 +178,7 @@ entry:
         preview_picture_label: 'Posiada podgląd obrazu'
         preview_picture_help: 'Podgląd obrazu'
         language_label: 'Język'
+        # http_status_label: 'HTTP status'
         reading_time:
             label: 'Czas czytania w minutach'
             from: 'od'

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.pt.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.pt.yml
@@ -178,6 +178,7 @@ entry:
         preview_picture_label: 'Possui uma imagem de preview'
         preview_picture_help: 'Imagem de preview'
         language_label: 'Idioma'
+        # http_status_label: 'HTTP status'
         reading_time:
             label: 'Tempo de leitura em minutos'
             from: 'de'

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.ro.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.ro.yml
@@ -178,6 +178,7 @@ entry:
         preview_picture_label: 'Are o imagine de previzualizare'
         preview_picture_help: 'Previzualizare imagine'
         language_label: 'Limbă'
+        # http_status_label: 'HTTP status'
         reading_time:
             label: 'Timp de citire în minute'
             from: 'de la'

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.tr.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.tr.yml
@@ -178,6 +178,7 @@ entry:
         preview_picture_label: 'Resim önizlemesi varsa'
         preview_picture_help: 'Resim önizlemesi'
         language_label: 'Dil'
+        # http_status_label: 'HTTP status'
         reading_time:
             label: 'Dakika cinsinden okuma süresi'
             from: 'başlangıç'

--- a/src/Wallabag/CoreBundle/Resources/views/themes/baggy/Entry/entries.html.twig
+++ b/src/Wallabag/CoreBundle/Resources/views/themes/baggy/Entry/entries.html.twig
@@ -112,6 +112,13 @@
                 </div>
             </div>
 
+            <div id="filter-http-status" class="filter-group">
+                {{ form_label(form.httpStatus) }}
+                <div class="input-field ">
+                    {{ form_widget(form.httpStatus) }}
+                </div>
+            </div>
+
             <div id="filter-reading-time" class="filter-group">
                 <div class="">
                     {{ form_label(form.readingTime) }}

--- a/src/Wallabag/CoreBundle/Resources/views/themes/material/Entry/entries.html.twig
+++ b/src/Wallabag/CoreBundle/Resources/views/themes/material/Entry/entries.html.twig
@@ -163,6 +163,14 @@
                 </div>
 
                 <div class="col s12">
+                    {{ form_label(form.httpStatus) }}
+                </div>
+
+                <div class="input-field col s12">
+                    {{ form_widget(form.httpStatus) }}
+                </div>
+
+                <div class="col s12">
                     {{ form_label(form.readingTime) }}
                 </div>
                 <div class="input-field col s6">

--- a/tests/Wallabag/CoreBundle/Controller/EntryControllerTest.php
+++ b/tests/Wallabag/CoreBundle/Controller/EntryControllerTest.php
@@ -961,4 +961,50 @@ class EntryControllerTest extends WallabagCoreTestCase
         $this->assertEquals(302, $client->getResponse()->getStatusCode());
         $this->assertContains('/view/'.$content->getId(), $client->getResponse()->headers->get('location'));
     }
+
+    public function testFilterOnHttpStatus()
+    {
+        $this->logInAs('admin');
+        $client = $this->getClient();
+
+        $crawler = $client->request('GET', '/new');
+        $form = $crawler->filter('form[name=entry]')->form();
+
+        $data = [
+            'entry[url]' => 'http://www.lemonde.fr/incorrect-url/',
+        ];
+
+        $client->submit($form, $data);
+
+        $crawler = $client->request('GET', '/all/list');
+        $form = $crawler->filter('button[id=submit-filter]')->form();
+
+        $data = [
+            'entry_filter[httpStatus]' => 404,
+        ];
+
+        $crawler = $client->submit($form, $data);
+
+        $this->assertCount(1, $crawler->filter('div[class=entry]'));
+
+        $crawler = $client->request('GET', '/new');
+        $form = $crawler->filter('form[name=entry]')->form();
+
+        $data = [
+            'entry[url]' => 'http://www.nextinpact.com/news/101235-wallabag-alternative-libre-a-pocket-creuse-petit-a-petit-son-nid.htm',
+        ];
+
+        $client->submit($form, $data);
+
+        $crawler = $client->request('GET', '/all/list');
+        $form = $crawler->filter('button[id=submit-filter]')->form();
+
+        $data = [
+            'entry_filter[httpStatus]' => 200,
+        ];
+
+        $crawler = $client->submit($form, $data);
+
+        $this->assertCount(1, $crawler->filter('div[class=entry]'));
+    }
 }

--- a/tests/Wallabag/CoreBundle/Controller/EntryControllerTest.php
+++ b/tests/Wallabag/CoreBundle/Controller/EntryControllerTest.php
@@ -1006,5 +1006,16 @@ class EntryControllerTest extends WallabagCoreTestCase
         $crawler = $client->submit($form, $data);
 
         $this->assertCount(1, $crawler->filter('div[class=entry]'));
+
+        $crawler = $client->request('GET', '/all/list');
+        $form = $crawler->filter('button[id=submit-filter]')->form();
+
+        $data = [
+            'entry_filter[httpStatus]' => 1024,
+        ];
+
+        $crawler = $client->submit($form, $data);
+
+        $this->assertCount(7, $crawler->filter('div[class=entry]'));
     }
 }

--- a/tests/Wallabag/CoreBundle/Helper/ContentProxyTest.php
+++ b/tests/Wallabag/CoreBundle/Helper/ContentProxyTest.php
@@ -97,6 +97,7 @@ class ContentProxyTest extends \PHPUnit_Framework_TestCase
                 'url' => '',
                 'content_type' => '',
                 'language' => '',
+                'status' => '',
                 'open_graph' => [
                     'og_title' => 'my title',
                     'og_description' => 'desc',
@@ -111,6 +112,7 @@ class ContentProxyTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('<p>Unable to retrieve readable content.</p><p><i>But we found a short description: </i></p>desc', $entry->getContent());
         $this->assertEmpty($entry->getPreviewPicture());
         $this->assertEmpty($entry->getLanguage());
+        $this->assertEmpty($entry->getHttpStatus());
         $this->assertEmpty($entry->getMimetype());
         $this->assertEquals(0.0, $entry->getReadingTime());
         $this->assertEquals('domain.io', $entry->getDomainName());
@@ -135,6 +137,7 @@ class ContentProxyTest extends \PHPUnit_Framework_TestCase
                 'url' => 'http://1.1.1.1',
                 'content_type' => 'text/html',
                 'language' => 'fr',
+                'status' => '200',
                 'open_graph' => [
                     'og_title' => 'my OG title',
                     'og_description' => 'OG desc',
@@ -151,6 +154,7 @@ class ContentProxyTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('http://3.3.3.3/cover.jpg', $entry->getPreviewPicture());
         $this->assertEquals('text/html', $entry->getMimetype());
         $this->assertEquals('fr', $entry->getLanguage());
+        $this->assertEquals('200', $entry->getHttpStatus());
         $this->assertEquals(4.0, $entry->getReadingTime());
         $this->assertEquals('1.1.1.1', $entry->getDomainName());
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Documentation | yes
| Translation   | yes
| Fixed tickets | #2589
| License       | MIT

Fix #2589

We now store the HTTP status code. 
We can filter entries thanks to the new filter, see screenshot (I added the filter in baggy theme too).
In an other PR, it's possible to improve the field (by replacing the text field with a list for example). 

![capture d ecran 2016-11-18 a 15 08 13](https://cloud.githubusercontent.com/assets/121870/20432816/3140d018-ada1-11e6-842e-bca2b91f322e.png)
