### PR TITLE
Add ability to reload entry from API

### DIFF
--- a/src/Wallabag/ApiBundle/Controller/EntryRestController.php
+++ b/src/Wallabag/ApiBundle/Controller/EntryRestController.php
@@ -287,7 +287,7 @@ class EntryRestController extends WallabagRestController
 
     /**
      * Reload an entry.
-     * An empty response with HTTP Status 304 will be send if we weren't able to update the content (because it hasn't changed or we got an error)
+     * An empty response with HTTP Status 304 will be send if we weren't able to update the content (because it hasn't changed or we got an error).
      *
      * @ApiDoc(
      *      requirements={

--- a/tests/Wallabag/ApiBundle/Controller/EntryRestControllerTest.php
+++ b/tests/Wallabag/ApiBundle/Controller/EntryRestControllerTest.php
@@ -690,7 +690,11 @@ class EntryRestControllerTest extends WallabagApiTestCase
         }
 
         $this->client->request('PATCH', '/api/entries/'.$entry->getId().'/reload.json');
-        $this->assertEquals(304, $this->client->getResponse()->getStatusCode());
+        $this->assertEquals(400, $this->client->getResponse()->getStatusCode());
+
+        $this->assertContains('Error while trying to extract content', $this->client->getResponse()->getContent());
+
+        $this->assertEquals('application/json', $this->client->getResponse()->headers->get('Content-Type'));
     }
 
     public function testReloadEntry()

--- a/tests/Wallabag/ApiBundle/Controller/EntryRestControllerTest.php
+++ b/tests/Wallabag/ApiBundle/Controller/EntryRestControllerTest.php
@@ -681,10 +681,9 @@ class EntryRestControllerTest extends WallabagApiTestCase
 
     public function testReloadEntryErrorWhileFetching()
     {
-        $entry = $this->client->getContainer()
-            ->get('doctrine.orm.entity_manager')
+        $entry = $this->client->getContainer()->get('doctrine.orm.entity_manager')
             ->getRepository('WallabagCoreBundle:Entry')
-            ->findOneBy(['user' => 1, 'isArchived' => false]);
+            ->findByUrlAndUserId('http://0.0.0.0/entry4', 1);
 
         if (!$entry) {
             $this->markTestSkipped('No content found in db.');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Documentation | yes (api doc)
| Translation   | no
| Fixed tickets | fix #2489
| License       | MIT

Entry can be reloaded using the API.
Note that if we can't reload the entry (because we can't retrieve content OR the retrieved content failed), an empty 304 will be returned.
Otherwise, the full new entry will be return.