### PR TITLE
Change documentation links to HTTPS

### DIFF
--- a/docs/de/user/installation.rst
+++ b/docs/de/user/installation.rst
@@ -16,7 +16,7 @@ Composer installieren:
 
 ::
 
-    curl -s http://getcomposer.org/installer | php
+    curl -s https://getcomposer.org/installer | php
 
 Du kannst eine spezifische Anleitung `hier <https://getcomposer.org/doc/00-intro.md>`__ finden.
 
@@ -86,7 +86,7 @@ Führe dieses Kommando aus, um das neueste Paket herunterzuladen und zu entpacke
 
 .. code-block:: bash
 
-    wget http://wllbg.org/latest-v2-package && tar xvf latest-v2-package
+    wget https://wllbg.org/latest-v2-package && tar xvf latest-v2-package
 
 Du findest die `md5 Hashsumme des neuesten Pakets auf unserer Website <https://www.wallabag.org/pages/download-wallabag.html>`_.
 

--- a/docs/de/user/upgrade.rst
+++ b/docs/de/user/upgrade.rst
@@ -36,7 +36,7 @@ Lade das 2.1.1-Release von wallabag herunter:
 
 .. code-block:: bash
 
-    wget http://framabag.org/wallabag-release-2.1.1.tar.gz && tar xvf wallabag-release-2.1.1.tar.gz
+    wget https://framabag.org/wallabag-release-2.1.1.tar.gz && tar xvf wallabag-release-2.1.1.tar.gz
 
 (md5 hash of the 2.1.1 package: ``9584a3b60a2b2a4de87f536548caac93``)
 
@@ -81,7 +81,7 @@ Lade das letzte Release von wallabag herunter:
 
 .. code-block:: bash
 
-    wget http://wllbg.org/latest-v2-package && tar xvf latest-v2-package
+    wget https://wllbg.org/latest-v2-package && tar xvf latest-v2-package
 
 Du findest den `aktuellen MD5-Hash auf unserer Webseite <https://www.wallabag.org/pages/download-wallabag.html>`_.
 

--- a/docs/en/user/installation.rst
+++ b/docs/en/user/installation.rst
@@ -16,7 +16,7 @@ Install Composer:
 
 ::
 
-    curl -s http://getcomposer.org/installer | php
+    curl -s https://getcomposer.org/installer | php
 
 You can find specific instructions `here <https://getcomposer.org/doc/00-intro.md>`__.
 
@@ -85,7 +85,7 @@ Execute this command to download and extract the latest package:
 
 .. code-block:: bash
 
-    wget http://wllbg.org/latest-v2-package && tar xvf latest-v2-package
+    wget https://wllbg.org/latest-v2-package && tar xvf latest-v2-package
 
 You will find the `md5 hash of the latest package on our website <https://www.wallabag.org/pages/download-wallabag.html>`_.
 

--- a/docs/en/user/upgrade.rst
+++ b/docs/en/user/upgrade.rst
@@ -36,7 +36,7 @@ Download the 2.1.1 release of wallabag:
 
 .. code-block:: bash
 
-    wget http://framabag.org/wallabag-release-2.1.1.tar.gz && tar xvf wallabag-release-2.1.1.tar.gz
+    wget https://framabag.org/wallabag-release-2.1.1.tar.gz && tar xvf wallabag-release-2.1.1.tar.gz
 
 (md5 hash of the 2.1.1 package: ``9584a3b60a2b2a4de87f536548caac93``)
 
@@ -81,7 +81,7 @@ Download the last release of wallabag:
 
 .. code-block:: bash
 
-    wget http://wllbg.org/latest-v2-package && tar xvf latest-v2-package
+    wget https://wllbg.org/latest-v2-package && tar xvf latest-v2-package
 
 You will find the `md5 hash of the latest package on our website <https://www.wallabag.org/pages/download-wallabag.html>`_.
 

--- a/docs/fr/user/installation.rst
+++ b/docs/fr/user/installation.rst
@@ -16,7 +16,7 @@ Installation de Composer :
 
 ::
 
-    curl -s http://getcomposer.org/installer | php
+    curl -s https://getcomposer.org/installer | php
 
 Vous pouvez trouver des instructions spécifiques `ici (en anglais) <https://getcomposer.org/doc/00-intro.md>`__.
 
@@ -82,7 +82,7 @@ Exécutez cette commande pour télécharger et décompresser l'archive :
 
 .. code-block:: bash
 
-    wget http://wllbg.org/latest-v2-package && tar xvf latest-v2-package
+    wget https://wllbg.org/latest-v2-package && tar xvf latest-v2-package
 
 Vous trouverez `le hash md5 du dernier package sur notre site <https://www.wallabag.org/pages/download-wallabag.html>`_.
 

--- a/docs/fr/user/upgrade.rst
+++ b/docs/fr/user/upgrade.rst
@@ -35,7 +35,7 @@ Téléchargez la version 2.1.1 de wallabag :
 
 .. code-block:: bash
 
-    wget http://framabag.org/wallabag-release-2.1.1.tar.gz && tar xvf wallabag-release-2.1.1.tar.gz
+    wget https://framabag.org/wallabag-release-2.1.1.tar.gz && tar xvf wallabag-release-2.1.1.tar.gz
 
 (hash md5 de l'archive 2.1.1 : ``9584a3b60a2b2a4de87f536548caac93``)
 
@@ -80,7 +80,7 @@ Téléchargez la dernière version de wallabag :
 
 .. code-block:: bash
 
-    wget http://wllbg.org/latest-v2-package && tar xvf latest-v2-package
+    wget https://wllbg.org/latest-v2-package && tar xvf latest-v2-package
 
 Vous trouverez `le hash md5 du dernier package sur notre site <https://www.wallabag.org/pages/download-wallabag.html>`_.
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Documentation | yes (install/upgrade doc)
| Translation   | no
| Fixed tickets | none
| License       | MIT

Even though all the websites used in the commands redirect http to
https, a man in the middle can happen with the initial request,
leading to arbitrary code execution.