### PR TITLE
Fix password layout

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -76,5 +76,5 @@ script:
     - if [[ $CS_FIXER = run ]]; then php bin/php-cs-fixer fix src/ --verbose --dry-run ; fi;
     - if [[ $VALIDATE_TRANSLATION_FILE = run ]]; then php bin/console lint:yaml src/Wallabag/CoreBundle/Resources/translations -v ; fi;
     - if [[ $VALIDATE_TRANSLATION_FILE = run ]]; then php bin/console lint:yaml app/Resources/CraueConfigBundle/translations -v ; fi;
-    - if [[ $VALIDATE_TRANSLATION_FILE = run ]]; then php bin/console lint:yaml app/Resources/FOSUserBundle/translations -v ; fi;
+    - if [[ $VALIDATE_TRANSLATION_FILE = run ]]; then php bin/console lint:yaml src/Wallabag/UserBundle/Resources/translations -v ; fi;
     - if [[ $ASSETS = build ]]; then ./node_modules/grunt-cli/bin/grunt tests; fi;

--- a/app/DoctrineMigrations/Version20161122203647.php
+++ b/app/DoctrineMigrations/Version20161122203647.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace Application\Migrations;
+
+use Doctrine\DBAL\Migrations\AbstractMigration;
+use Doctrine\DBAL\Schema\Schema;
+use Symfony\Component\DependencyInjection\ContainerAwareInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Methods and properties removed from `FOS\UserBundle\Model\User`
+ *
+ * - `$expired`
+ * - `$credentialsExpired`
+ * - `setExpired()` (use `setExpiresAt(\DateTime::now()` instead)
+ * - `setCredentialsExpired()` (use `setCredentialsExpireAt(\DateTime::now()` instead)
+ *
+ * You need to drop the fields `expired` and `credentials_expired` from your database
+ * schema, because they aren't mapped anymore.
+ */
+class Version20161122203647 extends AbstractMigration implements ContainerAwareInterface
+{
+    /**
+     * @var ContainerInterface
+     */
+    private $container;
+
+    public function setContainer(ContainerInterface $container = null)
+    {
+        $this->container = $container;
+    }
+
+    private function getTable($tableName)
+    {
+        return $this->container->getParameter('database_table_prefix') . $tableName;
+    }
+
+    /**
+     * @param Schema $schema
+     */
+    public function up(Schema $schema)
+    {
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() === 'sqlite', 'This up migration can\'t be executed on SQLite databases, because SQLite don\'t support DROP COLUMN.');
+
+        $this->addSql('ALTER TABLE '.$this->getTable('user').' DROP expired');
+        $this->addSql('ALTER TABLE '.$this->getTable('user').' DROP credentials_expired');
+    }
+
+    /**
+     * @param Schema $schema
+     */
+    public function down(Schema $schema)
+    {
+        $this->addSql('ALTER TABLE '.$this->getTable('user').' ADD expired tinyint(1) NULL DEFAULT 0');
+        $this->addSql('ALTER TABLE '.$this->getTable('user').' ADD credentials_expired tinyint(1) NULL DEFAULT 0');
+    }
+}

--- a/app/Resources/FOSUserBundle/translations/FOSUserBundle.da.yml
+++ b/app/Resources/FOSUserBundle/translations/FOSUserBundle.da.yml
@@ -1,2 +1,0 @@
-Login: "Log ind"
-Enter your email address below and we'll send you password reset instructions.: "Indtast din emailadresse nedenfor, så sender vi dig instrukser til at nulstille din adgangskode."

--- a/app/Resources/FOSUserBundle/translations/FOSUserBundle.de.yml
+++ b/app/Resources/FOSUserBundle/translations/FOSUserBundle.de.yml
@@ -1,2 +1,0 @@
-Login: "Anmelden"
-Enter your email address below and we'll send you password reset instructions.: "Tippe deine E-Mail-Adresse unten ein und wir senden dir die Anweisungen, wie du dein Kennwort zurücksetzen kannst."

--- a/app/Resources/FOSUserBundle/translations/FOSUserBundle.es.yml
+++ b/app/Resources/FOSUserBundle/translations/FOSUserBundle.es.yml
@@ -1,2 +1,0 @@
-Login: "Logearse"
-Enter your email address below and we'll send you password reset instructions.: "Introduzca su dirección de email y le enviaremos las instrucciones para resetear su contraseña."

--- a/app/Resources/FOSUserBundle/translations/FOSUserBundle.fr.yml
+++ b/app/Resources/FOSUserBundle/translations/FOSUserBundle.fr.yml
@@ -1,2 +1,0 @@
-Login: "Se connecter"
-Enter your email address below and we'll send you password reset instructions.: "Renseignez votre adresse courriel, nous vous enverrons les instructions pour réinitialiser votre mot de passe."

--- a/app/Resources/FOSUserBundle/translations/FOSUserBundle.oc.yml
+++ b/app/Resources/FOSUserBundle/translations/FOSUserBundle.oc.yml
@@ -1,2 +1,0 @@
-Login: "Se connectar"
-Enter your email address below and we'll send you password reset instructions.: "Picatz vòstra adreça de corrièl çai-jos, vos mandarem las instruccions per reïnicializar vòstre senhal."

--- a/app/Resources/FOSUserBundle/translations/FOSUserBundle.pl.yml
+++ b/app/Resources/FOSUserBundle/translations/FOSUserBundle.pl.yml
@@ -1,2 +1,0 @@
-Login: "Logowanie"
-Enter your email address below and we'll send you password reset instructions.: "Wpisz poniżej swój adres email, abyśmy mogli wysłać ci instrukcję resetowania hasła."

--- a/app/Resources/FOSUserBundle/translations/FOSUserBundle.pt.yml
+++ b/app/Resources/FOSUserBundle/translations/FOSUserBundle.pt.yml
@@ -1,2 +1,0 @@
-Login: "Login"
-Enter your email address below and we'll send you password reset instructions.: "Digite seu endereço de e-mail para enviarmos as instruções de recupeção de sua senha."

--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -210,6 +210,7 @@ fos_user:
     from_email:
         address:        "%from_email%"
         sender_name:    wallabag
+
 fos_oauth_server:
     db_driver:           orm
     client_class:        Wallabag\ApiBundle\Entity\Client
@@ -217,10 +218,10 @@ fos_oauth_server:
     refresh_token_class: Wallabag\ApiBundle\Entity\RefreshToken
     auth_code_class:     Wallabag\ApiBundle\Entity\AuthCode
     service:
-        user_provider: fos_user.user_manager
+        user_provider: fos_user.user_provider.username_email
         options:
             refresh_token_lifetime: 1209600
-                
+
 scheb_two_factor:
     trusted_computer:
         enabled: true

--- a/composer.json
+++ b/composer.json
@@ -49,7 +49,7 @@
         "doctrine/doctrine-cache-bundle": "^1.2",
         "twig/extensions": "~1.0",
         "symfony/swiftmailer-bundle": "^2.3",
-        "symfony/monolog-bundle": "^2.8",
+        "symfony/monolog-bundle": "^3.0",
         "sensio/distribution-bundle": "^5.0",
         "sensio/framework-extra-bundle": "^3.0.2",
         "incenteev/composer-parameter-handler": "^2.0",

--- a/composer.json
+++ b/composer.json
@@ -65,7 +65,7 @@
         "liip/theme-bundle": "~1.1",
         "lexik/form-filter-bundle": "~5.0",
         "j0k3r/graby": "~1.0",
-        "friendsofsymfony/user-bundle": "dev-master#e168ed64629d034cb9cbbffb9d4350f62ef04fab as 2.0.x-dev",
+        "friendsofsymfony/user-bundle": "2.0.x-dev",
         "friendsofsymfony/oauth-server-bundle": "^1.5",
         "stof/doctrine-extensions-bundle": "^1.2",
         "scheb/two-factor-bundle": "~2.0",

--- a/docs/de/developer/translate.rst
+++ b/docs/de/developer/translate.rst
@@ -20,7 +20,7 @@ der ISO 639-1 Code deiner Sprache ist (`siehe Wikipedia <https://en.wikipedia.or
 Andere Dateien zum Übersetzen:
 
 - https://github.com/wallabag/wallabag/tree/master/app/Resources/CraueConfigBundle/translations.
-- https://github.com/wallabag/wallabag/tree/master/app/Resources/FOSUserBundle/translations.
+- https://github.com/wallabag/wallabag/tree/master/src/Wallabag/UserBundle/Resources/translations.
 
 Du musst die ``THE_TRANSLATION_FILE.CODE.yml`` Dateien erstellen.
 

--- a/docs/en/developer/translate.rst
+++ b/docs/en/developer/translate.rst
@@ -20,7 +20,7 @@ is the ISO 639-1 code of your language (`see wikipedia <https://en.wikipedia.org
 Other files to translate:
 
 - https://github.com/wallabag/wallabag/tree/master/app/Resources/CraueConfigBundle/translations.
-- https://github.com/wallabag/wallabag/tree/master/app/Resources/FOSUserBundle/translations.
+- https://github.com/wallabag/wallabag/tree/master/src/Wallabag/UserBundle/Resources/translations.
 
 You have to create ``THE_TRANSLATION_FILE.CODE.yml`` files.
 

--- a/docs/fr/developer/translate.rst
+++ b/docs/fr/developer/translate.rst
@@ -23,7 +23,6 @@ Autres fichiers à traduire :
 - https://github.com/wallabag/wallabag/tree/master/app/Resources/CraueConfigBundle/translations.
 - https://github.com/wallabag/wallabag/tree/master/src/Wallabag/UserBundle/Resources/translations.
 
-
 Vous devez créer les fichiers ``LE_FICHIER_DE_TRADUCTION.CODE.yml``.
 
 Fichier de configuration

--- a/docs/fr/developer/translate.rst
+++ b/docs/fr/developer/translate.rst
@@ -21,7 +21,8 @@ où CODE est le code ISO 639-1 de votre langue (`cf wikipedia <https://fr.wikipe
 Autres fichiers à traduire :
 
 - https://github.com/wallabag/wallabag/tree/master/app/Resources/CraueConfigBundle/translations.
-- https://github.com/wallabag/wallabag/tree/master/app/Resources/FOSUserBundle/translations.
+- https://github.com/wallabag/wallabag/tree/master/src/Wallabag/UserBundle/Resources/translations.
+
 
 Vous devez créer les fichiers ``LE_FICHIER_DE_TRADUCTION.CODE.yml``.
 

--- a/src/Wallabag/UserBundle/Repository/UserRepository.php
+++ b/src/Wallabag/UserBundle/Repository/UserRepository.php
@@ -48,7 +48,7 @@ class UserRepository extends EntityRepository
     {
         return $this->createQueryBuilder('u')
             ->select('count(u)')
-            ->andWhere('u.expired = false')
+            ->andWhere('u.enabled = true')
             ->getQuery()
             ->getSingleScalarResult();
     }

--- a/src/Wallabag/UserBundle/Resources/views/Resetting/check_email.html.twig
+++ b/src/Wallabag/UserBundle/Resources/views/Resetting/check_email.html.twig
@@ -5,7 +5,7 @@
 {% block fos_user_content %}
 <div class="card-content">
     <div class="row">
-        {{ 'resetting.check_email'|trans({'%email%': email}) }}
+        <p>{{ 'resetting.check_email'|trans({'%tokenLifetime%': tokenLifetime}) }}</p>
     </div>
 </div>
 {% endblock fos_user_content %}

--- a/tests/Wallabag/CoreBundle/Controller/ConfigControllerTest.php
+++ b/tests/Wallabag/CoreBundle/Controller/ConfigControllerTest.php
@@ -592,13 +592,13 @@ class ConfigControllerTest extends WallabagCoreTestCase
         $user = $em
             ->getRepository('WallabagUserBundle:User')
             ->findOneByUsername('empty');
-        $user->setExpired(1);
+        $user->setEnabled(false);
         $em->persist($user);
 
         $user = $em
             ->getRepository('WallabagUserBundle:User')
             ->findOneByUsername('bob');
-        $user->setExpired(1);
+        $user->setEnabled(false);
         $em->persist($user);
 
         $em->flush();
@@ -614,13 +614,13 @@ class ConfigControllerTest extends WallabagCoreTestCase
         $user = $em
             ->getRepository('WallabagUserBundle:User')
             ->findOneByUsername('empty');
-        $user->setExpired(0);
+        $user->setEnabled(true);
         $em->persist($user);
 
         $user = $em
             ->getRepository('WallabagUserBundle:User')
             ->findOneByUsername('bob');
-        $user->setExpired(0);
+        $user->setEnabled(true);
         $em->persist($user);
 
         $em->flush();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Documentation | yes
| Translation   | yes
| Fixed tickets | fix #2580
| License       | MIT

When resetting the password, the overridden template we used wasn’t well spelled.

And since we are using a locked version of FOSUser (on a custom commit, because they breaks change in [that next commit](https://github.com/FriendsOfSymfony/FOSUserBundle/commit/f7a1f513753517601e94a0c208fdf8d24d1b85ce)), the translation of `resetting.check_email` is wrong in any language but english.

![image](https://cloud.githubusercontent.com/assets/62333/20465436/517db932-af5d-11e6-8a95-79610f068ee1.png)

Because of that missing translations, I didn't set the milestone to 2.2. Should we wait for FOSUser to FINALLY RELEASE A FUCKING NEW VERSION and then got that translation or we don't care?

I also removed an old FOSUser overridden translation which isn't used anymore.