### PR TITLE
Add ability to use Redis with password

### DIFF
--- a/app/config/parameters.yml.dist
+++ b/app/config/parameters.yml.dist
@@ -55,3 +55,4 @@ parameters:
     redis_host: localhost
     redis_port: 6379
     redis_path: null
+    redis_password: null

--- a/docs/de/user/parameters.rst
+++ b/docs/de/user/parameters.rst
@@ -39,6 +39,7 @@ Wenn du nicht weißt, welchen Wert du setzen sollst, belasse es bei dem Standard
         redis_host: localhost
         redis_port: 6379
         redis_path: null
+        redis_password: null
 
 Bedeutung von jedem Parameter
 -----------------------------
@@ -91,3 +92,4 @@ Bedeutung von jedem Parameter
    "redis_host", "localhost", "IP oder Hostname des Zielservers (ignoriert bei Unix Schema)"
    "redis_port", "6379", "TCP/IP Port des Zielservers (ignoriert bei Unix Schema)"
    "redis_path", "null", "Pfad zur Unix Domain Socket Datei, wenn Redis Unix Domain Sockets nutzt"
+   "redis_password", "null", "Password defined in the Redis server configuration (parameter `requirepass` in `redis.conf`)"

--- a/docs/de/user/parameters.rst
+++ b/docs/de/user/parameters.rst
@@ -92,4 +92,4 @@ Bedeutung von jedem Parameter
    "redis_host", "localhost", "IP oder Hostname des Zielservers (ignoriert bei Unix Schema)"
    "redis_port", "6379", "TCP/IP Port des Zielservers (ignoriert bei Unix Schema)"
    "redis_path", "null", "Pfad zur Unix Domain Socket Datei, wenn Redis Unix Domain Sockets nutzt"
-   "redis_password", "null", "Password defined in the Redis server configuration (parameter `requirepass` in `redis.conf`)"
+   "redis_password", "null", "Kennwort, welches in der Redis-Server-Konfiguration definiert ist (Parameter `requirepass` in `redis.conf`)"

--- a/docs/en/user/parameters.rst
+++ b/docs/en/user/parameters.rst
@@ -39,6 +39,7 @@ If you don't know which value you need to set, please leave the default one.
         redis_host: localhost
         redis_port: 6379
         redis_path: null
+        redis_password: null
 
 Meaning of each parameter
 -------------------------
@@ -92,3 +93,4 @@ Meaning of each parameter
    "redis_host", "localhost", "IP or hostname of the target server (ignored for unix scheme)"
    "redis_port", "6379", "TCP/IP port of the target server (ignored for unix scheme)"
    "redis_path", "null", "Path of the UNIX domain socket file used when connecting to Redis using UNIX domain sockets"
+   "redis_password", "null", "Password defined in the Redis server configuration (parameter `requirepass` in `redis.conf`)"

--- a/docs/fr/user/parameters.rst
+++ b/docs/fr/user/parameters.rst
@@ -39,6 +39,7 @@ Si vous ne savez pas quelle valeur vous devez mettre, laissez celle par défaut.
         redis_host: localhost
         redis_port: 6379
         redis_path: null
+        redis_password: null
 
 Meaning of each parameter
 -------------------------
@@ -91,3 +92,4 @@ Meaning of each parameter
    "redis_host", "localhost", "IP ou hôte du serveur cible (ignoré pour un schéma unix)"
    "redis_port", "6379", "Port TCP/IP du serveur cible (ignoré pour un schéma unix)"
    "redis_path", "null", "Chemin du fichier de socket du domaine UNIX utilisé quand on se connecte à Redis en utilisant les sockets du domaine UNIX"
+   "redis_password", "null", "Mot de passe défini dans la configuration serveur de Redis (paramètre `requirepass` dans `redis.conf`)"

--- a/src/Wallabag/CoreBundle/Resources/config/services.yml
+++ b/src/Wallabag/CoreBundle/Resources/config/services.yml
@@ -110,6 +110,7 @@ services:
                 host: '%redis_host%'
                 port: '%redis_port%'
                 path: '%redis_path%'
+                password: '%redis_password%'
 
     wallabag_core.exception_controller:
         class: Wallabag\CoreBundle\Controller\ExceptionController


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | kinf of
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Documentation | yes
| Translation   | yes
| Fixed tickets | fix #2579
| License       | MIT

We can now use a password for the Redis connection.
If you want to define one, [use that answer](http://stackoverflow.com/a/7548743/569101).