### PR TITLE
Force composer to run as PHP 5.5.9

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -125,7 +125,10 @@
         "psr-4": { "Tests\\": "tests/" }
     },
     "config": {
-        "bin-dir": "bin"
+        "bin-dir": "bin",
+        "platform": {
+            "php": "5.5.9"
+        }
     },
     "minimum-stability": "dev",
     "prefer-stable": true

--- a/composer.json
+++ b/composer.json
@@ -88,7 +88,7 @@
         "doctrine/doctrine-fixtures-bundle": "~2.2",
         "doctrine/data-fixtures": "~1.1.1",
         "sensio/generator-bundle": "^3.0",
-        "phpunit/phpunit": "~5.0",
+        "phpunit/phpunit": "~4.0",
         "symfony/phpunit-bridge": "^3.0",
         "friendsofphp/php-cs-fixer": "~1.9",
         "m6web/redis-mock": "^2.0"


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Documentation | no
| Translation   | no
| Fixed tickets | fix #2617
| License       | MIT

This should be removed for the 2.3.0 since we'll drop PHP 5.5.
Should we create a 2.1.5 for that?