### PR TITLE
Add white-text class to card-title too

### DIFF
--- a/src/Wallabag/CoreBundle/Resources/views/themes/common/Static/quickstart.html.twig
+++ b/src/Wallabag/CoreBundle/Resources/views/themes/common/Static/quickstart.html.twig
@@ -15,7 +15,7 @@
                         <li class="col l4 m6 s12">
                             <div class="card teal darken-1">
                                 <div class="card-content white-text">
-                                    <span class="card-title">{{ 'quickstart.configure.title'|trans }}</span>
+                                    <span class="card-title white-text">{{ 'quickstart.configure.title'|trans }}</span>
                                     <p>{{ 'quickstart.configure.description'|trans }}</p>
                                 </div>
                                 <div class="card-action">
@@ -31,7 +31,7 @@
                         <li class="col l4 m6 s12">
                             <div class="card green darken-1">
                                 <div class="card-content white-text">
-                                    <span class="card-title">{{ 'quickstart.first_steps.title'|trans }}</span>
+                                    <span class="card-title white-text">{{ 'quickstart.first_steps.title'|trans }}</span>
                                     <p>{{ 'quickstart.first_steps.description'|trans }}</p>
                                 </div>
                                 <div class="card-action">
@@ -46,7 +46,7 @@
                         <li class="col l4 m6 s12">
                             <div class="card light-green darken-1">
                                 <div class="card-content white-text">
-                                    <span class="card-title">{{ 'quickstart.migrate.title'|trans }}</span>
+                                    <span class="card-title white-text">{{ 'quickstart.migrate.title'|trans }}</span>
                                     <p>{{ 'quickstart.migrate.description'|trans }}</p>
                                 </div>
                                 <div class="card-action">
@@ -63,7 +63,7 @@
                         <li class="col l4 m6 s12">
                             <div class="card blue darken-1">
                                 <div class="card-content white-text">
-                                    <span class="card-title">{{ 'quickstart.developer.title'|trans }}</span>
+                                    <span class="card-title white-text">{{ 'quickstart.developer.title'|trans }}</span>
                                     <p>{{ 'quickstart.developer.description'|trans }}</p>
                                 </div>
                                 <div class="card-action">
@@ -79,7 +79,7 @@
                         <li class="col l4 m6 s12">
                             <div class="card light-blue darken-1">
                                 <div class="card-content white-text">
-                                    <span class="card-title">{{ 'quickstart.docs.title'|trans }}</span>
+                                    <span class="card-title white-text">{{ 'quickstart.docs.title'|trans }}</span>
                                     <p>{{ 'quickstart.docs.description'|trans }}</p>
                                 </div>
                                 <div class="card-action">
@@ -95,7 +95,7 @@
                         <li class="col l4 m6 s12">
                             <div class="card cyan darken-1">
                                 <div class="card-content white-text">
-                                    <span class="card-title">{{ 'quickstart.support.title'|trans }}</span>
+                                    <span class="card-title white-text">{{ 'quickstart.support.title'|trans }}</span>
                                     <p>{{ 'quickstart.support.description'|trans }}</p>
                                 </div>
                                 <div class="card-action">


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Documentation | no
| Translation   | no
| Fixed tickets | N/A
| License       | MIT

In the QuickStart page, the cards' titles were black. With the colored background it seems weird…

### Before

![With black headings](https://framapic.org/xdjHOkEN9KVN/CkKHwbQxgC1D.png) 

### After

![With white headings](https://framapic.org/pGU56nVUdPlh/ozEzzCDzMR82.png) 
