### PR TITLE
Return 304 when content isn't reloaded using the API

### DIFF
--- a/src/Wallabag/ApiBundle/Controller/EntryRestController.php
+++ b/src/Wallabag/ApiBundle/Controller/EntryRestController.php
@@ -287,7 +287,7 @@ class EntryRestController extends WallabagRestController
 
     /**
      * Reload an entry.
-     * A response with HTTP Status 400 will be return if we weren't able to update the content (because it hasn't changed or we got an error).
+     * An empty response with HTTP Status 304 will be send if we weren't able to update the content (because it hasn't changed or we got an error).
      *
      * @ApiDoc(
      *      requirements={
@@ -310,12 +310,12 @@ class EntryRestController extends WallabagRestController
                 'entry' => $entry,
             ]);
 
-            return new JsonResponse(['error' => 'Error while trying to fetch content'], 400);
+            return new JsonResponse([], 304);
         }
 
         // if refreshing entry failed, don't save it
         if ($this->getParameter('wallabag_core.fetching_error_message') === $entry->getContent()) {
-            return new JsonResponse(['error' => 'Error while trying to extract content'], 400);
+            return new JsonResponse([], 304);
         }
 
         $em = $this->getDoctrine()->getManager();

--- a/tests/Wallabag/ApiBundle/Controller/EntryRestControllerTest.php
+++ b/tests/Wallabag/ApiBundle/Controller/EntryRestControllerTest.php
@@ -690,11 +690,7 @@ class EntryRestControllerTest extends WallabagApiTestCase
         }
 
         $this->client->request('PATCH', '/api/entries/'.$entry->getId().'/reload.json');
-        $this->assertEquals(400, $this->client->getResponse()->getStatusCode());
-
-        $this->assertContains('Error while trying to extract content', $this->client->getResponse()->getContent());
-
-        $this->assertEquals('application/json', $this->client->getResponse()->headers->get('Content-Type'));
+        $this->assertEquals(304, $this->client->getResponse()->getStatusCode());
     }
 
     public function testReloadEntry()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Documentation | no
| Translation   | no
| Fixed tickets | Related #2614
| License       | MIT

Previously it was a 400 but this is more related to a real error.
Using the API user should only know the content got reloaded or not.
If reloaded: 200 otherwise: 304.