### PR TITLE
Added hasColumn() in migration to check column existence

### DIFF
--- a/app/DoctrineMigrations/Version20160410190541.php
+++ b/app/DoctrineMigrations/Version20160410190541.php
@@ -29,15 +29,14 @@ class Version20160410190541 extends AbstractMigration implements ContainerAwareI
      */
     public function up(Schema $schema)
     {
-        $this->skipIf($schema->getTable($this->getTable('entry'))->hasColumn('uuid'), 'It seems that you already played this migration.');
+        $entryTable = $schema->getTable($this->getTable('entry'));
 
-        if ($this->connection->getDatabasePlatform()->getName() == 'postgresql') {
-            $this->addSql('ALTER TABLE "'.$this->getTable('entry').'" ADD uuid UUID DEFAULT NULL');
-        } else {
-            $this->addSql('ALTER TABLE "'.$this->getTable('entry').'" ADD uuid LONGTEXT DEFAULT NULL');
-        }
+        $this->skipIf($entryTable->hasColumn('uuid'), 'It seems that you already played this migration.');
 
-        $this->addSql('INSERT INTO "'.$this->getTable('craue_config_setting')."\" (name, value, section) VALUES ('share_public', '1', 'entry')");
+        $entryTable->addColumn('uuid', 'guid', [
+            'notnull' => false,
+        ]);
+        $this->addSql('INSERT INTO '.$this->getTable('craue_config_setting')." (name, value, section) VALUES ('share_public', '1', 'entry')");
     }
 
     /**
@@ -45,9 +44,9 @@ class Version20160410190541 extends AbstractMigration implements ContainerAwareI
      */
     public function down(Schema $schema)
     {
-        $this->skipIf($this->connection->getDatabasePlatform()->getName() != 'sqlite', 'This down migration can\'t be executed on SQLite databases, because SQLite don\'t support DROP COLUMN.');
+        $entryTable = $schema->getTable($this->getTable('entry'));
+        $entryTable->dropColumn('uuid');
 
-        $this->addSql('ALTER TABLE "'.$this->getTable('entry').'" DROP uuid');
-        $this->addSql('DELETE FROM "'.$this->getTable('craue_config_setting')."\" WHERE name = 'share_public'");
+        $this->addSql('DELETE FROM '.$this->getTable('craue_config_setting')." WHERE name = 'share_public'");
     }
 }

--- a/app/DoctrineMigrations/Version20160410190541.php
+++ b/app/DoctrineMigrations/Version20160410190541.php
@@ -21,7 +21,41 @@ class Version20160410190541 extends AbstractMigration implements ContainerAwareI
 
     private function getTable($tableName)
     {
-        return $this->container->getParameter('database_table_prefix') . $tableName;
+        return $this->container->getParameter('database_table_prefix').$tableName;
+    }
+
+    private function hasColumn($tableName, $columnName)
+    {
+        switch ($this->connection->getDatabasePlatform()->getName()) {
+            case 'sqlite':
+                $rows = $this->connection->executeQuery('pragma table_info('.$tableName.')')->fetchAll();
+                foreach ($rows as $column) {
+                    if (strcasecmp($column['name'], $columnName) === 0) {
+                        return true;
+                    }
+                }
+
+                return false;
+            case 'mysql':
+                $rows = $this->connection->executeQuery('SHOW COLUMNS FROM '.$tableName)->fetchAll();
+                foreach ($rows as $column) {
+                    if (strcasecmp($column['Field'], $columnName) === 0) {
+                        return true;
+                    }
+                }
+
+                return false;
+            case 'postgresql':
+                $sql = sprintf("SELECT count(*)
+                    FROM information_schema.columns
+                    WHERE table_schema = 'public' AND table_name = '%s' AND column_name = '%s'",
+                    $tableName,
+                    $columnName
+                );
+                $result = $this->connection->executeQuery($sql)->fetch();
+
+                return  $result['count'] > 0;
+        }
     }
 
     /**
@@ -29,13 +63,15 @@ class Version20160410190541 extends AbstractMigration implements ContainerAwareI
      */
     public function up(Schema $schema)
     {
+        $this->skipIf($this->hasColumn($this->getTable('entry'), 'uuid'), 'It seems that you already played this migration.');
+
         if ($this->connection->getDatabasePlatform()->getName() == 'postgresql') {
             $this->addSql('ALTER TABLE "'.$this->getTable('entry').'" ADD uuid UUID DEFAULT NULL');
         } else {
             $this->addSql('ALTER TABLE "'.$this->getTable('entry').'" ADD uuid LONGTEXT DEFAULT NULL');
         }
 
-        $this->addSql("INSERT INTO \"".$this->getTable('craue_config_setting')."\" (name, value, section) VALUES ('share_public', '1', 'entry')");
+        $this->addSql('INSERT INTO "'.$this->getTable('craue_config_setting')."\" (name, value, section) VALUES ('share_public', '1', 'entry')");
     }
 
     /**
@@ -43,9 +79,9 @@ class Version20160410190541 extends AbstractMigration implements ContainerAwareI
      */
     public function down(Schema $schema)
     {
-        $this->abortIf($this->connection->getDatabasePlatform()->getName() != 'sqlite', 'This down migration can\'t be executed on SQLite databases, because SQLite don\'t support DROP COLUMN.');
+        $this->skipIf($this->connection->getDatabasePlatform()->getName() != 'sqlite', 'This down migration can\'t be executed on SQLite databases, because SQLite don\'t support DROP COLUMN.');
 
         $this->addSql('ALTER TABLE "'.$this->getTable('entry').'" DROP uuid');
-        $this->addSql("DELETE FROM \"".$this->getTable('craue_config_setting')."\" WHERE name = 'share_public'");
+        $this->addSql('DELETE FROM "'.$this->getTable('craue_config_setting')."\" WHERE name = 'share_public'");
     }
 }

--- a/app/DoctrineMigrations/Version20160812120952.php
+++ b/app/DoctrineMigrations/Version20160812120952.php
@@ -29,20 +29,10 @@ class Version20160812120952 extends AbstractMigration implements ContainerAwareI
      */
     public function up(Schema $schema)
     {
-        $this->skipIf($schema->getTable($this->getTable('oauth2_clients'))->hasColumn('name'), 'It seems that you already played this migration.');
+        $clientsTable = $schema->getTable($this->getTable('oauth2_clients'));
+        $this->skipIf($clientsTable->hasColumn('name'), 'It seems that you already played this migration.');
 
-        switch ($this->connection->getDatabasePlatform()->getName()) {
-            case 'sqlite':
-                $this->addSql('ALTER TABLE '.$this->getTable('oauth2_clients').' ADD name longtext DEFAULT NULL');
-                break;
-
-            case 'mysql':
-                $this->addSql('ALTER TABLE '.$this->getTable('oauth2_clients').' ADD name longtext COLLATE \'utf8_unicode_ci\' DEFAULT NULL');
-                break;
-
-            case 'postgresql':
-                $this->addSql('ALTER TABLE '.$this->getTable('oauth2_clients').' ADD name text DEFAULT NULL');
-        }
+        $clientsTable->addColumn('name', 'blob');
     }
 
     /**
@@ -50,8 +40,7 @@ class Version20160812120952 extends AbstractMigration implements ContainerAwareI
      */
     public function down(Schema $schema)
     {
-        $this->skipIf($this->connection->getDatabasePlatform()->getName() == 'sqlite', 'Migration can only be executed safely on \'mysql\' or \'postgresql\'.');
-
-        $this->addSql('ALTER TABLE '.$this->getTable('oauth2_clients').' DROP COLUMN name');
+        $clientsTable = $schema->getTable($this->getTable('oauth2_clients'));
+        $clientsTable->dropColumn('name');
     }
 }

--- a/app/DoctrineMigrations/Version20160812120952.php
+++ b/app/DoctrineMigrations/Version20160812120952.php
@@ -50,7 +50,7 @@ class Version20160812120952 extends AbstractMigration implements ContainerAwareI
      */
     public function down(Schema $schema)
     {
-        $this->abortIf($this->connection->getDatabasePlatform()->getName() == 'sqlite', 'Migration can only be executed safely on \'mysql\' or \'postgresql\'.');
+        $this->skipIf($this->connection->getDatabasePlatform()->getName() == 'sqlite', 'Migration can only be executed safely on \'mysql\' or \'postgresql\'.');
 
         $this->addSql('ALTER TABLE '.$this->getTable('oauth2_clients').' DROP COLUMN name');
     }

--- a/app/DoctrineMigrations/Version20160812120952.php
+++ b/app/DoctrineMigrations/Version20160812120952.php
@@ -21,7 +21,7 @@ class Version20160812120952 extends AbstractMigration implements ContainerAwareI
 
     private function getTable($tableName)
     {
-        return $this->container->getParameter('database_table_prefix') . $tableName;
+        return $this->container->getParameter('database_table_prefix').$tableName;
     }
 
     /**
@@ -29,6 +29,8 @@ class Version20160812120952 extends AbstractMigration implements ContainerAwareI
      */
     public function up(Schema $schema)
     {
+        $this->skipIf($schema->getTable($this->getTable('oauth2_clients'))->hasColumn('name'), 'It seems that you already played this migration.');
+
         switch ($this->connection->getDatabasePlatform()->getName()) {
             case 'sqlite':
                 $this->addSql('ALTER TABLE '.$this->getTable('oauth2_clients').' ADD name longtext DEFAULT NULL');

--- a/app/DoctrineMigrations/Version20160911214952.php
+++ b/app/DoctrineMigrations/Version20160911214952.php
@@ -29,8 +29,8 @@ class Version20160911214952 extends AbstractMigration implements ContainerAwareI
      */
     public function up(Schema $schema)
     {
-        $this->addSql('INSERT INTO "'.$this->getTable('craue_config_setting').'" (name, value, section) VALUES (\'import_with_redis\', \'0\', \'import\')');
-        $this->addSql('INSERT INTO "'.$this->getTable('craue_config_setting').'" (name, value, section) VALUES (\'import_with_rabbitmq\', \'0\', \'import\')');
+        $this->addSql('INSERT INTO '.$this->getTable('craue_config_setting')." (name, value, section) VALUES ('import_with_redis', 0, 'import')");
+        $this->addSql('INSERT INTO '.$this->getTable('craue_config_setting')." (name, value, section) VALUES ('import_with_rabbitmq', 0, 'import')");
     }
 
     /**
@@ -38,5 +38,7 @@ class Version20160911214952 extends AbstractMigration implements ContainerAwareI
      */
     public function down(Schema $schema)
     {
+        $this->addSql('DELETE FROM '.$this->getTable('craue_config_setting')." WHERE name = 'import_with_redis';");
+        $this->addSql('DELETE FROM '.$this->getTable('craue_config_setting')." WHERE name = 'import_with_rabbitmq';");
     }
 }

--- a/app/DoctrineMigrations/Version20160911214952.php
+++ b/app/DoctrineMigrations/Version20160911214952.php
@@ -21,7 +21,7 @@ class Version20160911214952 extends AbstractMigration implements ContainerAwareI
 
     private function getTable($tableName)
     {
-        return $this->container->getParameter('database_table_prefix') . $tableName;
+        return $this->container->getParameter('database_table_prefix').$tableName;
     }
 
     /**

--- a/app/DoctrineMigrations/Version20160916201049.php
+++ b/app/DoctrineMigrations/Version20160916201049.php
@@ -40,7 +40,7 @@ class Version20160916201049 extends AbstractMigration implements ContainerAwareI
      */
     public function down(Schema $schema)
     {
-        $this->abortIf($this->connection->getDatabasePlatform()->getName() == 'sqlite', 'Migration can only be executed safely on \'mysql\' or \'postgresql\'.');
+        $this->skipIf($this->connection->getDatabasePlatform()->getName() == 'sqlite', 'Migration can only be executed safely on \'mysql\' or \'postgresql\'.');
 
         $this->addSql('ALTER TABLE "'.$this->getTable('config').'" DROP pocket_consumer_key');
         $this->addSql('INSERT INTO "'.$this->getTable('craue_config_setting')."\" (name, value, section) VALUES ('pocket_consumer_key', NULL, 'import')");

--- a/app/DoctrineMigrations/Version20160916201049.php
+++ b/app/DoctrineMigrations/Version20160916201049.php
@@ -21,7 +21,7 @@ class Version20160916201049 extends AbstractMigration implements ContainerAwareI
 
     private function getTable($tableName)
     {
-        return $this->container->getParameter('database_table_prefix') . $tableName;
+        return $this->container->getParameter('database_table_prefix').$tableName;
     }
 
     /**
@@ -29,8 +29,10 @@ class Version20160916201049 extends AbstractMigration implements ContainerAwareI
      */
     public function up(Schema $schema)
     {
+        $this->skipIf($schema->getTable($this->getTable('config'))->hasColumn('pocket_consumer_key'), 'It seems that you already played this migration.');
+
         $this->addSql('ALTER TABLE "'.$this->getTable('config').'" ADD pocket_consumer_key VARCHAR(255) DEFAULT NULL');
-        $this->addSql("DELETE FROM \"".$this->getTable('craue_config_setting')."\" WHERE name = 'pocket_consumer_key';");
+        $this->addSql('DELETE FROM "'.$this->getTable('craue_config_setting')."\" WHERE name = 'pocket_consumer_key';");
     }
 
     /**
@@ -41,6 +43,6 @@ class Version20160916201049 extends AbstractMigration implements ContainerAwareI
         $this->abortIf($this->connection->getDatabasePlatform()->getName() == 'sqlite', 'Migration can only be executed safely on \'mysql\' or \'postgresql\'.');
 
         $this->addSql('ALTER TABLE "'.$this->getTable('config').'" DROP pocket_consumer_key');
-        $this->addSql("INSERT INTO \"".$this->getTable('craue_config_setting')."\" (name, value, section) VALUES ('pocket_consumer_key', NULL, 'import')");
+        $this->addSql('INSERT INTO "'.$this->getTable('craue_config_setting')."\" (name, value, section) VALUES ('pocket_consumer_key', NULL, 'import')");
     }
 }

--- a/app/DoctrineMigrations/Version20160916201049.php
+++ b/app/DoctrineMigrations/Version20160916201049.php
@@ -29,10 +29,12 @@ class Version20160916201049 extends AbstractMigration implements ContainerAwareI
      */
     public function up(Schema $schema)
     {
-        $this->skipIf($schema->getTable($this->getTable('config'))->hasColumn('pocket_consumer_key'), 'It seems that you already played this migration.');
+        $configTable = $schema->getTable($this->getTable('config'));
 
-        $this->addSql('ALTER TABLE "'.$this->getTable('config').'" ADD pocket_consumer_key VARCHAR(255) DEFAULT NULL');
-        $this->addSql('DELETE FROM "'.$this->getTable('craue_config_setting')."\" WHERE name = 'pocket_consumer_key';");
+        $this->skipIf($configTable->hasColumn('pocket_consumer_key'), 'It seems that you already played this migration.');
+
+        $userTable->addColumn('pocket_consumer_key', 'string');
+        $this->addSql('DELETE FROM '.$this->getTable('craue_config_setting')." WHERE name = 'pocket_consumer_key';");
     }
 
     /**
@@ -40,9 +42,8 @@ class Version20160916201049 extends AbstractMigration implements ContainerAwareI
      */
     public function down(Schema $schema)
     {
-        $this->skipIf($this->connection->getDatabasePlatform()->getName() == 'sqlite', 'Migration can only be executed safely on \'mysql\' or \'postgresql\'.');
-
-        $this->addSql('ALTER TABLE "'.$this->getTable('config').'" DROP pocket_consumer_key');
-        $this->addSql('INSERT INTO "'.$this->getTable('craue_config_setting')."\" (name, value, section) VALUES ('pocket_consumer_key', NULL, 'import')");
+        $configTable = $schema->getTable($this->getTable('config'));
+        $clientsTable->dropColumn('pocket_consumer_key');
+        $this->addSql('INSERT INTO '.$this->getTable('craue_config_setting')." (name, value, section) VALUES ('pocket_consumer_key', NULL, 'import')");
     }
 }

--- a/app/DoctrineMigrations/Version20160916201049.php
+++ b/app/DoctrineMigrations/Version20160916201049.php
@@ -33,7 +33,7 @@ class Version20160916201049 extends AbstractMigration implements ContainerAwareI
 
         $this->skipIf($configTable->hasColumn('pocket_consumer_key'), 'It seems that you already played this migration.');
 
-        $userTable->addColumn('pocket_consumer_key', 'string');
+        $configTable->addColumn('pocket_consumer_key', 'string');
         $this->addSql('DELETE FROM '.$this->getTable('craue_config_setting')." WHERE name = 'pocket_consumer_key';");
     }
 
@@ -43,7 +43,7 @@ class Version20160916201049 extends AbstractMigration implements ContainerAwareI
     public function down(Schema $schema)
     {
         $configTable = $schema->getTable($this->getTable('config'));
-        $clientsTable->dropColumn('pocket_consumer_key');
+        $configTable->dropColumn('pocket_consumer_key');
         $this->addSql('INSERT INTO '.$this->getTable('craue_config_setting')." (name, value, section) VALUES ('pocket_consumer_key', NULL, 'import')");
     }
 }

--- a/app/DoctrineMigrations/Version20161001072726.php
+++ b/app/DoctrineMigrations/Version20161001072726.php
@@ -21,7 +21,7 @@ class Version20161001072726 extends AbstractMigration implements ContainerAwareI
 
     private function getTable($tableName)
     {
-        return $this->container->getParameter('database_table_prefix') . $tableName;
+        return $this->container->getParameter('database_table_prefix').$tableName;
     }
 
     /**

--- a/app/DoctrineMigrations/Version20161022134138.php
+++ b/app/DoctrineMigrations/Version20161022134138.php
@@ -21,7 +21,7 @@ class Version20161022134138 extends AbstractMigration implements ContainerAwareI
 
     private function getTable($tableName)
     {
-        return $this->container->getParameter('database_table_prefix') . $tableName;
+        return $this->container->getParameter('database_table_prefix').$tableName;
     }
 
     /**
@@ -72,6 +72,5 @@ class Version20161022134138 extends AbstractMigration implements ContainerAwareI
         $this->addSql('ALTER TABLE '.$this->getTable('tag').' CHANGE `label` `label` longtext CHARACTER SET utf8 COLLATE utf8_unicode_ci;');
 
         $this->addSql('ALTER TABLE '.$this->getTable('user').' CHANGE `name` `name` longtext CHARACTER SET utf8 COLLATE utf8_unicode_ci;');
-
     }
 }

--- a/app/DoctrineMigrations/Version20161024212538.php
+++ b/app/DoctrineMigrations/Version20161024212538.php
@@ -21,7 +21,7 @@ class Version20161024212538 extends AbstractMigration implements ContainerAwareI
 
     private function getTable($tableName)
     {
-        return $this->container->getParameter('database_table_prefix') . $tableName;
+        return $this->container->getParameter('database_table_prefix').$tableName;
     }
 
     /**
@@ -30,6 +30,8 @@ class Version20161024212538 extends AbstractMigration implements ContainerAwareI
     public function up(Schema $schema)
     {
         $this->skipIf($this->connection->getDatabasePlatform()->getName() == 'sqlite', 'Migration can only be executed safely on \'mysql\' or \'postgresql\'.');
+
+        $this->skipIf($schema->getTable($this->getTable('oauth2_clients'))->hasColumn('user_id'), 'It seems that you already played this migration.');
 
         $this->addSql('ALTER TABLE '.$this->getTable('oauth2_clients').' ADD user_id INT(11) DEFAULT NULL');
         $this->addSql('ALTER TABLE '.$this->getTable('oauth2_clients').' ADD CONSTRAINT FK_clients_user_clients FOREIGN KEY (user_id) REFERENCES '.$this->getTable('user').' (id) ON DELETE CASCADE');
@@ -40,6 +42,5 @@ class Version20161024212538 extends AbstractMigration implements ContainerAwareI
      */
     public function down(Schema $schema)
     {
-
     }
 }

--- a/app/DoctrineMigrations/Version20161024212538.php
+++ b/app/DoctrineMigrations/Version20161024212538.php
@@ -29,12 +29,18 @@ class Version20161024212538 extends AbstractMigration implements ContainerAwareI
      */
     public function up(Schema $schema)
     {
-        $this->skipIf($this->connection->getDatabasePlatform()->getName() == 'sqlite', 'Migration can only be executed safely on \'mysql\' or \'postgresql\'.');
+        $clientsTable = $schema->getTable($this->getTable('oauth2_clients'));
 
-        $this->skipIf($schema->getTable($this->getTable('oauth2_clients'))->hasColumn('user_id'), 'It seems that you already played this migration.');
+        $this->skipIf($clientsTable->hasColumn('user_id'), 'It seems that you already played this migration.');
 
-        $this->addSql('ALTER TABLE '.$this->getTable('oauth2_clients').' ADD user_id INT(11) DEFAULT NULL');
-        $this->addSql('ALTER TABLE '.$this->getTable('oauth2_clients').' ADD CONSTRAINT FK_clients_user_clients FOREIGN KEY (user_id) REFERENCES '.$this->getTable('user').' (id) ON DELETE CASCADE');
+        $clientsTable->addColumn('user_id', 'integer');
+
+        $clientsTable->addForeignKeyConstraint(
+            $this->getTable('user'),
+            array('user_id'),
+            array('id'),
+            array('onDelete' => 'CASCADE')
+        );
     }
 
     /**

--- a/app/DoctrineMigrations/Version20161024212538.php
+++ b/app/DoctrineMigrations/Version20161024212538.php
@@ -37,9 +37,9 @@ class Version20161024212538 extends AbstractMigration implements ContainerAwareI
 
         $clientsTable->addForeignKeyConstraint(
             $this->getTable('user'),
-            array('user_id'),
-            array('id'),
-            array('onDelete' => 'CASCADE')
+            ['user_id'],
+            ['id'],
+            ['onDelete' => 'CASCADE']
         );
     }
 

--- a/app/DoctrineMigrations/Version20161031132655.php
+++ b/app/DoctrineMigrations/Version20161031132655.php
@@ -37,8 +37,6 @@ class Version20161031132655 extends AbstractMigration implements ContainerAwareI
      */
     public function down(Schema $schema)
     {
-        $this->skipIf($this->connection->getDatabasePlatform()->getName() == 'sqlite', 'Migration can only be executed safely on \'mysql\' or \'postgresql\'.');
-
         $this->addSql('DELETE FROM "'.$this->getTable('craue_config_setting')."\" WHERE name = 'download_images_enabled';");
     }
 }

--- a/app/DoctrineMigrations/Version20161031132655.php
+++ b/app/DoctrineMigrations/Version20161031132655.php
@@ -21,7 +21,7 @@ class Version20161031132655 extends AbstractMigration implements ContainerAwareI
 
     private function getTable($tableName)
     {
-        return $this->container->getParameter('database_table_prefix') . $tableName;
+        return $this->container->getParameter('database_table_prefix').$tableName;
     }
 
     /**
@@ -29,7 +29,7 @@ class Version20161031132655 extends AbstractMigration implements ContainerAwareI
      */
     public function up(Schema $schema)
     {
-        $this->addSql("INSERT INTO \"".$this->getTable('craue_config_setting')."\" (name, value, section) VALUES ('download_images_enabled', 0, 'misc')");
+        $this->addSql('INSERT INTO "'.$this->getTable('craue_config_setting')."\" (name, value, section) VALUES ('download_images_enabled', 0, 'misc')");
     }
 
     /**
@@ -37,8 +37,8 @@ class Version20161031132655 extends AbstractMigration implements ContainerAwareI
      */
     public function down(Schema $schema)
     {
-        $this->abortIf($this->connection->getDatabasePlatform()->getName() == 'sqlite', 'Migration can only be executed safely on \'mysql\' or \'postgresql\'.');
+        $this->skipIf($this->connection->getDatabasePlatform()->getName() == 'sqlite', 'Migration can only be executed safely on \'mysql\' or \'postgresql\'.');
 
-        $this->addSql("DELETE FROM \"".$this->getTable('craue_config_setting')."\" WHERE name = 'download_images_enabled';");
+        $this->addSql('DELETE FROM "'.$this->getTable('craue_config_setting')."\" WHERE name = 'download_images_enabled';");
     }
 }

--- a/app/DoctrineMigrations/Version20161104073720.php
+++ b/app/DoctrineMigrations/Version20161104073720.php
@@ -21,7 +21,7 @@ class Version20161104073720 extends AbstractMigration implements ContainerAwareI
 
     private function getTable($tableName)
     {
-        return $this->container->getParameter('database_table_prefix') . $tableName;
+        return $this->container->getParameter('database_table_prefix').$tableName;
     }
 
     /**
@@ -48,6 +48,5 @@ class Version20161104073720 extends AbstractMigration implements ContainerAwareI
      */
     public function down(Schema $schema)
     {
-
     }
 }

--- a/app/DoctrineMigrations/Version20161104073720.php
+++ b/app/DoctrineMigrations/Version20161104073720.php
@@ -29,18 +29,8 @@ class Version20161104073720 extends AbstractMigration implements ContainerAwareI
      */
     public function up(Schema $schema)
     {
-        switch ($this->connection->getDatabasePlatform()->getName()) {
-            case 'sqlite':
-                $this->addSql('CREATE INDEX `created_at` ON `'.$this->getTable('entry').'` (`created_at` DESC)');
-                break;
-
-            case 'mysql':
-                $this->addSql('ALTER TABLE '.$this->getTable('entry').' ADD INDEX created_at (created_at);');
-                break;
-
-            case 'postgresql':
-                $this->addSql('CREATE INDEX created_at ON '.$this->getTable('entry').' (created_at DESC)');
-        }
+        $entryTable = $schema->getTable($this->getTable('entry'));
+        $entryTable->addIndex(['created_at']);
     }
 
     /**

--- a/app/DoctrineMigrations/Version20161104073720.php
+++ b/app/DoctrineMigrations/Version20161104073720.php
@@ -14,6 +14,8 @@ class Version20161104073720 extends AbstractMigration implements ContainerAwareI
      */
     private $container;
 
+    private $indexName = 'IDX_entry_created_at';
+
     public function setContainer(ContainerInterface $container = null)
     {
         $this->container = $container;
@@ -30,7 +32,9 @@ class Version20161104073720 extends AbstractMigration implements ContainerAwareI
     public function up(Schema $schema)
     {
         $entryTable = $schema->getTable($this->getTable('entry'));
-        $entryTable->addIndex(['created_at']);
+        $this->skipIf($entryTable->hasIndex($this->indexName), 'It seems that you already played this migration.');
+
+        $entryTable->addIndex(['created_at'], $this->indexName);
     }
 
     /**
@@ -38,5 +42,9 @@ class Version20161104073720 extends AbstractMigration implements ContainerAwareI
      */
     public function down(Schema $schema)
     {
+        $entryTable = $schema->getTable($this->getTable('entry'));
+        $this->skipIf(false === $entryTable->hasIndex($this->indexName), 'It seems that you already played this migration.');
+
+        $entryTable->dropIndex($this->indexName);
     }
 }

--- a/app/DoctrineMigrations/Version20161106113822.php
+++ b/app/DoctrineMigrations/Version20161106113822.php
@@ -29,9 +29,13 @@ class Version20161106113822 extends AbstractMigration implements ContainerAwareI
      */
     public function up(Schema $schema)
     {
-        $this->skipIf($schema->getTable($this->getTable('config'))->hasColumn('action_mark_as_read'), 'It seems that you already played this migration.');
+        $configTable = $schema->getTable($this->getTable('config'));
 
-        $this->addSql('ALTER TABLE '.$this->getTable('config').' ADD action_mark_as_read INT DEFAULT 0');
+        $this->skipIf($configTable->hasColumn('action_mark_as_read'), 'It seems that you already played this migration.');
+
+        $configTable->addColumn('action_mark_as_read', 'integer', [
+            'default' => 0,
+        ]);
     }
 
     /**
@@ -39,8 +43,7 @@ class Version20161106113822 extends AbstractMigration implements ContainerAwareI
      */
     public function down(Schema $schema)
     {
-        $this->skipIf($this->connection->getDatabasePlatform()->getName() != 'sqlite', 'This down migration can\'t be executed on SQLite databases, because SQLite don\'t support DROP COLUMN.');
-
-        $this->addSql('ALTER TABLE '.$this->getTable('config').' DROP action_mark_as_read');
+        $configTable = $schema->getTable($this->getTable('config'));
+        $userTable->dropColumn('action_mark_as_read');
     }
 }

--- a/app/DoctrineMigrations/Version20161106113822.php
+++ b/app/DoctrineMigrations/Version20161106113822.php
@@ -21,7 +21,7 @@ class Version20161106113822 extends AbstractMigration implements ContainerAwareI
 
     private function getTable($tableName)
     {
-        return $this->container->getParameter('database_table_prefix') . $tableName;
+        return $this->container->getParameter('database_table_prefix').$tableName;
     }
 
     /**
@@ -29,6 +29,8 @@ class Version20161106113822 extends AbstractMigration implements ContainerAwareI
      */
     public function up(Schema $schema)
     {
+        $this->skipIf($schema->getTable($this->getTable('config'))->hasColumn('action_mark_as_read'), 'It seems that you already played this migration.');
+
         $this->addSql('ALTER TABLE '.$this->getTable('config').' ADD action_mark_as_read INT DEFAULT 0');
     }
 

--- a/app/DoctrineMigrations/Version20161106113822.php
+++ b/app/DoctrineMigrations/Version20161106113822.php
@@ -39,7 +39,7 @@ class Version20161106113822 extends AbstractMigration implements ContainerAwareI
      */
     public function down(Schema $schema)
     {
-        $this->abortIf($this->connection->getDatabasePlatform()->getName() != 'sqlite', 'This down migration can\'t be executed on SQLite databases, because SQLite don\'t support DROP COLUMN.');
+        $this->skipIf($this->connection->getDatabasePlatform()->getName() != 'sqlite', 'This down migration can\'t be executed on SQLite databases, because SQLite don\'t support DROP COLUMN.');
 
         $this->addSql('ALTER TABLE '.$this->getTable('config').' DROP action_mark_as_read');
     }

--- a/app/DoctrineMigrations/Version20161117071626.php
+++ b/app/DoctrineMigrations/Version20161117071626.php
@@ -21,7 +21,7 @@ class Version20161117071626 extends AbstractMigration implements ContainerAwareI
 
     private function getTable($tableName)
     {
-        return $this->container->getParameter('database_table_prefix') . $tableName;
+        return $this->container->getParameter('database_table_prefix').$tableName;
     }
 
     /**
@@ -29,8 +29,8 @@ class Version20161117071626 extends AbstractMigration implements ContainerAwareI
      */
     public function up(Schema $schema)
     {
-        $this->addSql("INSERT INTO ".$this->getTable('craue_config_setting')." (name, value, section) VALUES ('share_unmark', 0, 'entry')");
-        $this->addSql("INSERT INTO ".$this->getTable('craue_config_setting')." (name, value, section) VALUES ('unmark_url', 'https://unmark.it', 'entry')");
+        $this->addSql('INSERT INTO '.$this->getTable('craue_config_setting')." (name, value, section) VALUES ('share_unmark', 0, 'entry')");
+        $this->addSql('INSERT INTO '.$this->getTable('craue_config_setting')." (name, value, section) VALUES ('unmark_url', 'https://unmark.it', 'entry')");
     }
 
     /**
@@ -38,7 +38,7 @@ class Version20161117071626 extends AbstractMigration implements ContainerAwareI
      */
     public function down(Schema $schema)
     {
-        $this->addSql("DELETE FROM ".$this->getTable('craue_config_setting')." WHERE name = 'share_unmark';");
-        $this->addSql("DELETE FROM ".$this->getTable('craue_config_setting')." WHERE name = 'unmark_url';");
+        $this->addSql('DELETE FROM '.$this->getTable('craue_config_setting')." WHERE name = 'share_unmark';");
+        $this->addSql('DELETE FROM '.$this->getTable('craue_config_setting')." WHERE name = 'unmark_url';");
     }
 }

--- a/app/DoctrineMigrations/Version20161118134328.php
+++ b/app/DoctrineMigrations/Version20161118134328.php
@@ -42,7 +42,7 @@ class Version20161118134328 extends AbstractMigration implements ContainerAwareI
      */
     public function down(Schema $schema)
     {
-        $this->abortIf($this->connection->getDatabasePlatform()->getName() != 'sqlite', 'This down migration can\'t be executed on SQLite databases, because SQLite don\'t support DROP COLUMN.');
+        $this->skipIf($this->connection->getDatabasePlatform()->getName() != 'sqlite', 'This down migration can\'t be executed on SQLite databases, because SQLite don\'t support DROP COLUMN.');
 
         $this->addSql('ALTER TABLE '.$this->getTable('entry').' DROP http_status');
     }

--- a/app/DoctrineMigrations/Version20161118134328.php
+++ b/app/DoctrineMigrations/Version20161118134328.php
@@ -8,7 +8,7 @@ use Symfony\Component\DependencyInjection\ContainerAwareInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
- * Add http_status in `entry_table`
+ * Add http_status in `entry_table`.
  */
 class Version20161118134328 extends AbstractMigration implements ContainerAwareInterface
 {
@@ -24,7 +24,7 @@ class Version20161118134328 extends AbstractMigration implements ContainerAwareI
 
     private function getTable($tableName)
     {
-        return $this->container->getParameter('database_table_prefix') . $tableName;
+        return $this->container->getParameter('database_table_prefix').$tableName;
     }
 
     /**
@@ -32,6 +32,8 @@ class Version20161118134328 extends AbstractMigration implements ContainerAwareI
      */
     public function up(Schema $schema)
     {
+        $this->skipIf($schema->getTable($this->getTable('entry'))->hasColumn('http_status'), 'It seems that you already played this migration.');
+
         $this->addSql('ALTER TABLE '.$this->getTable('entry').' ADD http_status VARCHAR(3) DEFAULT NULL');
     }
 

--- a/app/DoctrineMigrations/Version20161118134328.php
+++ b/app/DoctrineMigrations/Version20161118134328.php
@@ -32,9 +32,14 @@ class Version20161118134328 extends AbstractMigration implements ContainerAwareI
      */
     public function up(Schema $schema)
     {
-        $this->skipIf($schema->getTable($this->getTable('entry'))->hasColumn('http_status'), 'It seems that you already played this migration.');
+        $entryTable = $schema->getTable($this->getTable('entry'));
 
-        $this->addSql('ALTER TABLE '.$this->getTable('entry').' ADD http_status VARCHAR(3) DEFAULT NULL');
+        $this->skipIf($entryTable->hasColumn('http_status'), 'It seems that you already played this migration.');
+
+        $entryTable->addColumn('http_status', 'string', [
+            'length' => 3,
+            'notnull' => false,
+        ]);
     }
 
     /**
@@ -42,8 +47,7 @@ class Version20161118134328 extends AbstractMigration implements ContainerAwareI
      */
     public function down(Schema $schema)
     {
-        $this->skipIf($this->connection->getDatabasePlatform()->getName() != 'sqlite', 'This down migration can\'t be executed on SQLite databases, because SQLite don\'t support DROP COLUMN.');
-
-        $this->addSql('ALTER TABLE '.$this->getTable('entry').' DROP http_status');
+        $userTable = $schema->getTable($this->getTable('entry'));
+        $userTable->dropColumn('http_status');
     }
 }

--- a/app/DoctrineMigrations/Version20161122144743.php
+++ b/app/DoctrineMigrations/Version20161122144743.php
@@ -8,7 +8,7 @@ use Symfony\Component\DependencyInjection\ContainerAwareInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
- * Add the restricted_access internal setting for articles with paywall
+ * Add the restricted_access internal setting for articles with paywall.
  */
 class Version20161122144743 extends AbstractMigration implements ContainerAwareInterface
 {
@@ -24,7 +24,7 @@ class Version20161122144743 extends AbstractMigration implements ContainerAwareI
 
     private function getTable($tableName)
     {
-        return $this->container->getParameter('database_table_prefix') . $tableName;
+        return $this->container->getParameter('database_table_prefix').$tableName;
     }
 
     /**
@@ -32,7 +32,7 @@ class Version20161122144743 extends AbstractMigration implements ContainerAwareI
      */
     public function up(Schema $schema)
     {
-        $this->addSql("INSERT INTO ".$this->getTable('craue_config_setting')." (name, value, section) VALUES ('restricted_access', 0, 'entry')");
+        $this->addSql('INSERT INTO '.$this->getTable('craue_config_setting')." (name, value, section) VALUES ('restricted_access', 0, 'entry')");
     }
 
     /**
@@ -40,6 +40,6 @@ class Version20161122144743 extends AbstractMigration implements ContainerAwareI
      */
     public function down(Schema $schema)
     {
-        $this->addSql("DELETE FROM ".$this->getTable('craue_config_setting')." WHERE name = 'restricted_access';");
+        $this->addSql('DELETE FROM '.$this->getTable('craue_config_setting')." WHERE name = 'restricted_access';");
     }
 }

--- a/app/DoctrineMigrations/Version20161122203647.php
+++ b/app/DoctrineMigrations/Version20161122203647.php
@@ -40,7 +40,7 @@ class Version20161122203647 extends AbstractMigration implements ContainerAwareI
      */
     public function up(Schema $schema)
     {
-        $this->abortIf($this->connection->getDatabasePlatform()->getName() === 'sqlite', 'This up migration can\'t be executed on SQLite databases, because SQLite don\'t support DROP COLUMN.');
+        $this->skipIf($this->connection->getDatabasePlatform()->getName() === 'sqlite', 'This up migration can\'t be executed on SQLite databases, because SQLite don\'t support DROP COLUMN.');
 
         $this->skipIf(false === $schema->getTable($this->getTable('user'))->hasColumn('expired'), 'It seems that you already played this migration.');
 

--- a/app/DoctrineMigrations/Version20161122203647.php
+++ b/app/DoctrineMigrations/Version20161122203647.php
@@ -40,15 +40,15 @@ class Version20161122203647 extends AbstractMigration implements ContainerAwareI
      */
     public function up(Schema $schema)
     {
-        $this->skipIf($this->connection->getDatabasePlatform()->getName() === 'sqlite', 'This up migration can\'t be executed on SQLite databases, because SQLite don\'t support DROP COLUMN.');
+        $userTable = $schema->getTable($this->getTable('user'));
 
-        $this->skipIf(false === $schema->getTable($this->getTable('user'))->hasColumn('expired'), 'It seems that you already played this migration.');
+        $this->skipIf(false === $userTable->hasColumn('expired'), 'It seems that you already played this migration.');
 
-        $this->addSql('ALTER TABLE '.$this->getTable('user').' DROP expired');
+        $userTable->dropColumn('expired');
 
-        $this->skipIf(false === $schema->getTable($this->getTable('user'))->hasColumn('credentials_expired'), 'It seems that you already played this migration.');
+        $this->skipIf(false === $userTable->hasColumn('credentials_expired'), 'It seems that you already played this migration.');
 
-        $this->addSql('ALTER TABLE '.$this->getTable('user').' DROP credentials_expired');
+        $userTable->dropColumn('credentials_expired');
     }
 
     /**
@@ -56,7 +56,8 @@ class Version20161122203647 extends AbstractMigration implements ContainerAwareI
      */
     public function down(Schema $schema)
     {
-        $this->addSql('ALTER TABLE '.$this->getTable('user').' ADD expired tinyint(1) NULL DEFAULT 0');
-        $this->addSql('ALTER TABLE '.$this->getTable('user').' ADD credentials_expired tinyint(1) NULL DEFAULT 0');
+        $userTable = $schema->getTable($this->getTable('user'));
+        $userTable->addColumn('expired', 'smallint');
+        $userTable->addColumn('credentials_expired', 'smallint');
     }
 }

--- a/app/DoctrineMigrations/Version20161122203647.php
+++ b/app/DoctrineMigrations/Version20161122203647.php
@@ -8,7 +8,7 @@ use Symfony\Component\DependencyInjection\ContainerAwareInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
- * Methods and properties removed from `FOS\UserBundle\Model\User`
+ * Methods and properties removed from `FOS\UserBundle\Model\User`.
  *
  * - `$expired`
  * - `$credentialsExpired`
@@ -32,7 +32,7 @@ class Version20161122203647 extends AbstractMigration implements ContainerAwareI
 
     private function getTable($tableName)
     {
-        return $this->container->getParameter('database_table_prefix') . $tableName;
+        return $this->container->getParameter('database_table_prefix').$tableName;
     }
 
     /**
@@ -42,7 +42,12 @@ class Version20161122203647 extends AbstractMigration implements ContainerAwareI
     {
         $this->abortIf($this->connection->getDatabasePlatform()->getName() === 'sqlite', 'This up migration can\'t be executed on SQLite databases, because SQLite don\'t support DROP COLUMN.');
 
+        $this->skipIf(false === $schema->getTable($this->getTable('user'))->hasColumn('expired'), 'It seems that you already played this migration.');
+
         $this->addSql('ALTER TABLE '.$this->getTable('user').' DROP expired');
+
+        $this->skipIf(false === $schema->getTable($this->getTable('user'))->hasColumn('credentials_expired'), 'It seems that you already played this migration.');
+
         $this->addSql('ALTER TABLE '.$this->getTable('user').' DROP credentials_expired');
     }
 

--- a/app/DoctrineMigrations/Version20161122203647.php
+++ b/app/DoctrineMigrations/Version20161122203647.php
@@ -42,12 +42,9 @@ class Version20161122203647 extends AbstractMigration implements ContainerAwareI
     {
         $userTable = $schema->getTable($this->getTable('user'));
 
-        $this->skipIf(false === $userTable->hasColumn('expired'), 'It seems that you already played this migration.');
+        $this->skipIf(false === $userTable->hasColumn('expired') || false === $userTable->hasColumn('credentials_expired'), 'It seems that you already played this migration.');
 
         $userTable->dropColumn('expired');
-
-        $this->skipIf(false === $userTable->hasColumn('credentials_expired'), 'It seems that you already played this migration.');
-
         $userTable->dropColumn('credentials_expired');
     }
 


### PR DESCRIPTION
I want to discuss with @wallabag/core team about this improvement. 

I know that we'll have problems with migrations when we'll release wallabag 2.2. 
We need to add as many checks as possible.

~~In this PR, I added `hasColumn()` (inspired by phinx from @robmorgan: [MySQL](https://github.com/robmorgan/phinx/blob/0.6.x-dev/src/Phinx/Db/Adapter/MysqlAdapter.php#L362), [SQLite](https://github.com/robmorgan/phinx/blob/0.6.x-dev/src/Phinx/Db/Adapter/SQLiteAdapter.php#L293), [Postgres](https://github.com/robmorgan/phinx/blob/0.6.x-dev/src/Phinx/Db/Adapter/PostgresAdapter.php#L346)).~~

~~I want to know if we need to have this feature in wallabag. And where we can store it.~~

I also replaced `abortIf` by `skipIf`. Like that, other migrations will be played.

abortIf: 

![capture d ecran 2016-11-25 a 13 51 36](https://cloud.githubusercontent.com/assets/121870/20625896/4f87f824-b316-11e6-9760-b6bd9136fdc2.png)

skipIf: 

![capture d ecran 2016-11-25 a 13 50 41](https://cloud.githubusercontent.com/assets/121870/20625878/3ab117e6-b316-11e6-9986-350ec13d2300.png)
