### PR TITLE
Added floating button on entry view for mobile

### DIFF
--- a/src/Wallabag/CoreBundle/Resources/views/themes/material/Entry/entry.html.twig
+++ b/src/Wallabag/CoreBundle/Resources/views/themes/material/Entry/entry.html.twig
@@ -257,6 +257,17 @@
         <article>
             {{ entry.content | raw }}
         </article>
+
+        <div class="fixed-action-btn horizontal click-to-toggle hide-on-large-only">
+            <a class="btn-floating btn-large">
+              <i class="material-icons">menu</i>
+            </a>
+            <ul>
+              <li><a class="btn-floating" href="{{ path('archive_entry', { 'id': entry.id }) }}"><i class="material-icons">done</i></a></li>
+              <li><a class="btn-floating" href="{{ path('star_entry', { 'id': entry.id }) }}"><i class="material-icons">star_outline</i></a></li>
+              <li><a class="btn-floating" href="{{ path('delete_entry', { 'id': entry.id }) }}"><i class="material-icons">delete</i></a></li>
+            </ul>
+        </div>
     </div>
 
 <script id="annotationroutes" type="application/json">


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Documentation | no
| Translation   | no
| Fixed tickets | #2647 
| License       | MIT

Fix #2647 

This floating button is only visible on tablet or smartphone. 

![capture d ecran 2016-11-30 a 16 07 07](https://cloud.githubusercontent.com/assets/121870/20757627/628ed42e-b717-11e6-860f-8111d64afa65.png)

![capture d ecran 2016-11-30 a 16 07 16](https://cloud.githubusercontent.com/assets/121870/20757631/65fcc314-b717-11e6-9d1f-ac49d07a6795.png)

