### PR TITLE
Limit rule to 255

### DIFF
--- a/src/Wallabag/CoreBundle/Entity/TaggingRule.php
+++ b/src/Wallabag/CoreBundle/Entity/TaggingRule.php
@@ -28,6 +28,7 @@ class TaggingRule
      * @var string
      *
      * @Assert\NotBlank()
+     * @Assert\Length(max=255)
      * @RulerZAssert\ValidRule(
      *  allowed_variables={"title", "url", "isArchived", "isStared", "content", "language", "mimetype", "readingTime", "domainName"},
      *  allowed_operators={">", "<", ">=", "<=", "=", "is", "!=", "and", "not", "or", "matches"}

--- a/tests/Wallabag/CoreBundle/Controller/ConfigControllerTest.php
+++ b/tests/Wallabag/CoreBundle/Controller/ConfigControllerTest.php
@@ -515,6 +515,29 @@ class ConfigControllerTest extends WallabagCoreTestCase
         }
     }
 
+    public function testTaggingRuleTooLong()
+    {
+        $this->logInAs('admin');
+        $client = $this->getClient();
+
+        $crawler = $client->request('GET', '/config');
+
+        $this->assertEquals(200, $client->getResponse()->getStatusCode());
+
+        $form = $crawler->filter('button[id=tagging_rule_save]')->form();
+
+        $crawler = $client->submit($form, [
+            'tagging_rule[rule]' => str_repeat('title', 60),
+            'tagging_rule[tags]' => 'cool tag',
+        ]);
+
+        $this->assertEquals(200, $client->getResponse()->getStatusCode());
+
+        $this->assertGreaterThan(1, $body = $crawler->filter('body')->extract(['_text']));
+
+        $this->assertContains('255 characters', $body[0]);
+    }
+
     public function testDeletingTaggingRuleFromAnOtherUser()
     {
         $this->logInAs('bob');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Documentation | no
| Translation   | no
| Fixed tickets | fix #2678
| License       | MIT

Limiting tagging rule to 255 to avoid database error when saving