### PR TITLE
Ensure craue_config_setting migration are ok

### DIFF
--- a/app/DoctrineMigrations/Version20160911214952.php
+++ b/app/DoctrineMigrations/Version20160911214952.php
@@ -29,8 +29,25 @@ class Version20160911214952 extends AbstractMigration implements ContainerAwareI
      */
     public function up(Schema $schema)
     {
-        $this->addSql('INSERT INTO '.$this->getTable('craue_config_setting')." (name, value, section) VALUES ('import_with_redis', 0, 'import')");
-        $this->addSql('INSERT INTO '.$this->getTable('craue_config_setting')." (name, value, section) VALUES ('import_with_rabbitmq', 0, 'import')");
+        $redis = $this->container
+            ->get('doctrine.orm.default_entity_manager')
+            ->getConnection()
+            ->fetchArray('SELECT * FROM '.$this->getTable('craue_config_setting').' WHERE name = "import_with_redis"');
+
+        if (false === $redis) {
+            $this->addSql('INSERT INTO '.$this->getTable('craue_config_setting')." (name, value, section) VALUES ('import_with_redis', 0, 'import')");
+        }
+
+        $rabbitmq = $this->container
+            ->get('doctrine.orm.default_entity_manager')
+            ->getConnection()
+            ->fetchArray('SELECT * FROM '.$this->getTable('craue_config_setting').' WHERE name = "import_with_rabbitmq"');
+
+        if (false === $rabbitmq) {
+            $this->addSql('INSERT INTO '.$this->getTable('craue_config_setting')." (name, value, section) VALUES ('import_with_rabbitmq', 0, 'import')");
+        }
+
+        $this->skipIf(false !== $rabbitmq && false !== $redis, 'It seems that you already played this migration.');
     }
 
     /**

--- a/app/DoctrineMigrations/Version20160911214952.php
+++ b/app/DoctrineMigrations/Version20160911214952.php
@@ -32,7 +32,7 @@ class Version20160911214952 extends AbstractMigration implements ContainerAwareI
         $redis = $this->container
             ->get('doctrine.orm.default_entity_manager')
             ->getConnection()
-            ->fetchArray('SELECT * FROM '.$this->getTable('craue_config_setting').' WHERE name = "import_with_redis"');
+            ->fetchArray('SELECT * FROM '.$this->getTable('craue_config_setting')." WHERE name = 'import_with_redis'");
 
         if (false === $redis) {
             $this->addSql('INSERT INTO '.$this->getTable('craue_config_setting')." (name, value, section) VALUES ('import_with_redis', 0, 'import')");
@@ -41,7 +41,7 @@ class Version20160911214952 extends AbstractMigration implements ContainerAwareI
         $rabbitmq = $this->container
             ->get('doctrine.orm.default_entity_manager')
             ->getConnection()
-            ->fetchArray('SELECT * FROM '.$this->getTable('craue_config_setting').' WHERE name = "import_with_rabbitmq"');
+            ->fetchArray('SELECT * FROM '.$this->getTable('craue_config_setting')." WHERE name = 'import_with_rabbitmq'");
 
         if (false === $rabbitmq) {
             $this->addSql('INSERT INTO '.$this->getTable('craue_config_setting')." (name, value, section) VALUES ('import_with_rabbitmq', 0, 'import')");

--- a/app/DoctrineMigrations/Version20161031132655.php
+++ b/app/DoctrineMigrations/Version20161031132655.php
@@ -29,6 +29,13 @@ class Version20161031132655 extends AbstractMigration implements ContainerAwareI
      */
     public function up(Schema $schema)
     {
+        $images = $this->container
+            ->get('doctrine.orm.default_entity_manager')
+            ->getConnection()
+            ->fetchArray('SELECT * FROM '.$this->getTable('craue_config_setting').' WHERE name = "download_images_enabled"');
+
+        $this->skipIf(false !== $images, 'It seems that you already played this migration.');
+
         $this->addSql('INSERT INTO "'.$this->getTable('craue_config_setting')."\" (name, value, section) VALUES ('download_images_enabled', 0, 'misc')");
     }
 

--- a/app/DoctrineMigrations/Version20161031132655.php
+++ b/app/DoctrineMigrations/Version20161031132655.php
@@ -32,7 +32,7 @@ class Version20161031132655 extends AbstractMigration implements ContainerAwareI
         $images = $this->container
             ->get('doctrine.orm.default_entity_manager')
             ->getConnection()
-            ->fetchArray('SELECT * FROM '.$this->getTable('craue_config_setting').' WHERE name = "download_images_enabled"');
+            ->fetchArray('SELECT * FROM '.$this->getTable('craue_config_setting')." WHERE name = 'download_images_enabled'");
 
         $this->skipIf(false !== $images, 'It seems that you already played this migration.');
 

--- a/app/DoctrineMigrations/Version20161117071626.php
+++ b/app/DoctrineMigrations/Version20161117071626.php
@@ -29,8 +29,25 @@ class Version20161117071626 extends AbstractMigration implements ContainerAwareI
      */
     public function up(Schema $schema)
     {
-        $this->addSql('INSERT INTO '.$this->getTable('craue_config_setting')." (name, value, section) VALUES ('share_unmark', 0, 'entry')");
-        $this->addSql('INSERT INTO '.$this->getTable('craue_config_setting')." (name, value, section) VALUES ('unmark_url', 'https://unmark.it', 'entry')");
+        $share = $this->container
+            ->get('doctrine.orm.default_entity_manager')
+            ->getConnection()
+            ->fetchArray('SELECT * FROM '.$this->getTable('craue_config_setting').' WHERE name = "share_unmark"');
+
+        if (false === $share) {
+            $this->addSql('INSERT INTO '.$this->getTable('craue_config_setting')." (name, value, section) VALUES ('share_unmark', 0, 'entry')");
+        }
+
+        $unmark = $this->container
+            ->get('doctrine.orm.default_entity_manager')
+            ->getConnection()
+            ->fetchArray('SELECT * FROM '.$this->getTable('craue_config_setting').' WHERE name = "unmark_url"');
+
+        if (false === $unmark) {
+            $this->addSql('INSERT INTO '.$this->getTable('craue_config_setting')." (name, value, section) VALUES ('unmark_url', 'https://unmark.it', 'entry')");
+        }
+
+        $this->skipIf(false !== $share && false !== $unmark, 'It seems that you already played this migration.');
     }
 
     /**

--- a/app/DoctrineMigrations/Version20161117071626.php
+++ b/app/DoctrineMigrations/Version20161117071626.php
@@ -32,7 +32,7 @@ class Version20161117071626 extends AbstractMigration implements ContainerAwareI
         $share = $this->container
             ->get('doctrine.orm.default_entity_manager')
             ->getConnection()
-            ->fetchArray('SELECT * FROM '.$this->getTable('craue_config_setting').' WHERE name = "share_unmark"');
+            ->fetchArray('SELECT * FROM '.$this->getTable('craue_config_setting')." WHERE name = 'share_unmark'");
 
         if (false === $share) {
             $this->addSql('INSERT INTO '.$this->getTable('craue_config_setting')." (name, value, section) VALUES ('share_unmark', 0, 'entry')");
@@ -41,7 +41,7 @@ class Version20161117071626 extends AbstractMigration implements ContainerAwareI
         $unmark = $this->container
             ->get('doctrine.orm.default_entity_manager')
             ->getConnection()
-            ->fetchArray('SELECT * FROM '.$this->getTable('craue_config_setting').' WHERE name = "unmark_url"');
+            ->fetchArray('SELECT * FROM '.$this->getTable('craue_config_setting')." WHERE name = 'unmark_url'");
 
         if (false === $unmark) {
             $this->addSql('INSERT INTO '.$this->getTable('craue_config_setting')." (name, value, section) VALUES ('unmark_url', 'https://unmark.it', 'entry')");

--- a/app/DoctrineMigrations/Version20161122144743.php
+++ b/app/DoctrineMigrations/Version20161122144743.php
@@ -32,6 +32,13 @@ class Version20161122144743 extends AbstractMigration implements ContainerAwareI
      */
     public function up(Schema $schema)
     {
+        $access = $this->container
+            ->get('doctrine.orm.default_entity_manager')
+            ->getConnection()
+            ->fetchArray('SELECT * FROM '.$this->getTable('craue_config_setting').' WHERE name = "restricted_access"');
+
+        $this->skipIf(false !== $access, 'It seems that you already played this migration.');
+
         $this->addSql('INSERT INTO '.$this->getTable('craue_config_setting')." (name, value, section) VALUES ('restricted_access', 0, 'entry')");
     }
 

--- a/app/DoctrineMigrations/Version20161122144743.php
+++ b/app/DoctrineMigrations/Version20161122144743.php
@@ -35,7 +35,7 @@ class Version20161122144743 extends AbstractMigration implements ContainerAwareI
         $access = $this->container
             ->get('doctrine.orm.default_entity_manager')
             ->getConnection()
-            ->fetchArray('SELECT * FROM '.$this->getTable('craue_config_setting').' WHERE name = "restricted_access"');
+            ->fetchArray('SELECT * FROM '.$this->getTable('craue_config_setting')." WHERE name = 'restricted_access'");
 
         $this->skipIf(false !== $access, 'It seems that you already played this migration.');
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | could be
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Documentation | no
| Translation   | no
| Fixed tickets | #...
| License       | MIT

We now can run the migration every time, new line from `craue_config_setting` are properly checked.