### PR TITLE
Casted maxIterations for Redis import

### DIFF
--- a/src/Wallabag/ImportBundle/Command/RedisWorkerCommand.php
+++ b/src/Wallabag/ImportBundle/Command/RedisWorkerCommand.php
@@ -36,7 +36,7 @@ class RedisWorkerCommand extends ContainerAwareCommand
         $worker = new QueueWorker(
             $this->getContainer()->get('wallabag_import.queue.redis.'.$serviceName),
             $this->getContainer()->get('wallabag_import.consumer.redis.'.$serviceName),
-            $input->getOption('maxIterations')
+            (int) $input->getOption('maxIterations')
         );
 
         $worker->start();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Documentation | no
| Translation   | no
| Fixed tickets | N/A
| License       | MIT

Because Simpleue wants an integer (see https://github.com/javibravo/simpleue/blob/master/src/Simpleue/Worker/QueueWorker.php#L88), we need to cast the parameter. 

The problem is in the library I think, but it's faster to fix on our side. 