### PR TITLE
Fixed imports with is_starred and is_archived

### DIFF
--- a/src/Wallabag/ImportBundle/Import/ChromeImport.php
+++ b/src/Wallabag/ImportBundle/Import/ChromeImport.php
@@ -39,7 +39,8 @@ class ChromeImport extends BrowserImport
             'title' => $entry['name'],
             'html' => false,
             'url' => $entry['url'],
-            'is_archived' => $this->markAsRead,
+            'is_archived' => (int) $this->markAsRead,
+            'is_starred' => false,
             'tags' => '',
             'created_at' => substr($entry['date_added'], 0, 10),
         ];

--- a/src/Wallabag/ImportBundle/Import/FirefoxImport.php
+++ b/src/Wallabag/ImportBundle/Import/FirefoxImport.php
@@ -39,7 +39,8 @@ class FirefoxImport extends BrowserImport
             'title' => $entry['title'],
             'html' => false,
             'url' => $entry['uri'],
-            'is_archived' => $this->markAsRead,
+            'is_archived' => (int) $this->markAsRead,
+            'is_starred' => false,
             'tags' => '',
             'created_at' => substr($entry['dateAdded'], 0, 10),
         ];

--- a/src/Wallabag/ImportBundle/Import/WallabagV2Import.php
+++ b/src/Wallabag/ImportBundle/Import/WallabagV2Import.php
@@ -36,7 +36,8 @@ class WallabagV2Import extends WallabagImport
         return [
             'html' => $entry['content'],
             'content_type' => $entry['mimetype'],
-            'is_archived' => ($entry['is_archived'] || $this->markAsRead),
+            'is_archived' => (int) ($entry['is_archived'] || $this->markAsRead),
+            'is_starred' => false,
         ] + $entry;
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Documentation | no
| Translation   | no
| Fixed tickets | N/A
| License       | MIT

During imports on wallabag.it, I found errors. 
`is_archived` and `is_starred` aren't nullable. So we need to set values. 

I don't know if I can improve tests. If necessary, I'll have on them a look later.