### PR TITLE
Moved total messages from import

### DIFF
--- a/src/Wallabag/CoreBundle/Resources/views/themes/material/layout.html.twig
+++ b/src/Wallabag/CoreBundle/Resources/views/themes/material/layout.html.twig
@@ -19,8 +19,6 @@
             Materialize.toast('{{ flashMessage|trans }}', 4000);
         </script>
     {% endfor %}
-
-    {{ render(controller("WallabagImportBundle:Import:checkQueue")) }}
 {% endblock %}
 
 {% block menu %}

--- a/src/Wallabag/ImportBundle/Resources/views/Import/index.html.twig
+++ b/src/Wallabag/ImportBundle/Resources/views/Import/index.html.twig
@@ -2,6 +2,12 @@
 
 {% block title %}{{ 'import.page_title'|trans }}{% endblock %}
 
+{% block messages %}
+    {{ render(controller("WallabagImportBundle:Import:checkQueue")) }}
+
+    {{ parent() }}
+{% endblock %}
+
 {% block content %}
 <div class="row">
     <div class="col s12">


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Documentation | no
| Translation   | no
| Fixed tickets | N/A
| License       | MIT

Because this notification is annoying for a wallabag admin, and because it takes some resources to be run, I think it's better to display it only on the Import page. 
