### PR TITLE
Removed user join in query builder

### DIFF
--- a/src/Wallabag/CoreBundle/Repository/EntryRepository.php
+++ b/src/Wallabag/CoreBundle/Repository/EntryRepository.php
@@ -20,8 +20,7 @@ class EntryRepository extends EntityRepository
     private function getBuilderByUser($userId)
     {
         return $this->createQueryBuilder('e')
-            ->leftJoin('e.user', 'u')
-            ->andWhere('u.id = :userId')->setParameter('userId', $userId)
+            ->andWhere('e.user = :userId')->setParameter('userId', $userId)
             ->orderBy('e.createdAt', 'desc')
         ;
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Documentation | no
| Translation   | no
| Fixed tickets | N/A
| License       | MIT

I removed join on user table. We only need user id.
I think we can have performance gain. 
I saw very looong queries on app.wallabag.it with this QueryBuilder. 