### PR TITLE
Removed outputWalkers for pagination

### DIFF
--- a/src/Wallabag/CoreBundle/Controller/EntryController.php
+++ b/src/Wallabag/CoreBundle/Controller/EntryController.php
@@ -319,7 +319,7 @@ class EntryController extends Controller
             $this->get('lexik_form_filter.query_builder_updater')->addFilterConditions($form, $qb);
         }
 
-        $pagerAdapter = new DoctrineORMAdapter($qb->getQuery());
+        $pagerAdapter = new DoctrineORMAdapter($qb->getQuery(), true, false);
 
         $entries = $this->get('wallabag_core.helper.prepare_pager_for_entries')
             ->prepare($pagerAdapter, $page);

--- a/src/Wallabag/CoreBundle/Controller/RssController.php
+++ b/src/Wallabag/CoreBundle/Controller/RssController.php
@@ -85,7 +85,7 @@ class RssController extends Controller
                 throw new \InvalidArgumentException(sprintf('Type "%s" is not implemented.', $type));
         }
 
-        $pagerAdapter = new DoctrineORMAdapter($qb->getQuery());
+        $pagerAdapter = new DoctrineORMAdapter($qb->getQuery(), true, false);
         $entries = new Pagerfanta($pagerAdapter);
 
         $perPage = $user->getConfig()->getRssLimit() ?: $this->getParameter('wallabag_core.rss_limit');

--- a/src/Wallabag/CoreBundle/Repository/EntryRepository.php
+++ b/src/Wallabag/CoreBundle/Repository/EntryRepository.php
@@ -171,7 +171,7 @@ class EntryRepository extends EntityRepository
             $qb->orderBy('e.updatedAt', $order);
         }
 
-        $pagerAdapter = new DoctrineORMAdapter($qb);
+        $pagerAdapter = new DoctrineORMAdapter($qb, true, false);
 
         return new Pagerfanta($pagerAdapter);
     }

--- a/src/Wallabag/CoreBundle/Repository/EntryRepository.php
+++ b/src/Wallabag/CoreBundle/Repository/EntryRepository.php
@@ -125,9 +125,7 @@ class EntryRepository extends EntityRepository
     {
         return $this
             ->getBuilderByUser($userId)
-            ->leftJoin('e.tags', 't')
-            ->groupBy('e.id')
-            ->having('count(t.id) = 0');
+            ->andWhere('size(e.tags) = 0');
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Documentation | no
| Translation   | no
| Fixed tickets | N/A
| License       | MIT

Due to overload on app.wallabag.it, we disabled output walkers (see https://github.com/whiteoctober/Pagerfanta/issues/115)

The query to fetch all entries before:

![capture d ecran 2016-12-13 a 15 24 54](https://cloud.githubusercontent.com/assets/121870/21155032/d4767872-c170-11e6-9984-8fffde03394f.png)

The query to fetch all entries after:

![capture d ecran 2016-12-13 a 15 37 35](https://cloud.githubusercontent.com/assets/121870/21155039/d8b2947a-c170-11e6-8492-7881670c5c72.png)
