### PR TITLE
label truncated 'Marquer comme non lu'

### DIFF
--- a/src/Wallabag/CoreBundle/Resources/translations/messages.fr.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.fr.yml
@@ -185,7 +185,7 @@ entry:
             back_to_top: "Revenir en haut"
             back_to_homepage: "Retour"
             set_as_read: "Marquer comme lu"
-            set_as_unread: "Marquer comme non lu"
+            set_as_unread: "Marq. comme non lu"
             set_as_starred: "Mettre en favori"
             view_original_article: "Article original"
             re_fetch_content: "Recharger le contenu"


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | dunno
| Documentation | no
| Translation   | yes
| Fixed tickets | #...
| License       | MIT


### Issue details

when we are on an article that has already been read, the label action to set it as unread is truncated in french "Marquer comme non" may be "Marq. comme non lu" do the trick :)

### Environment

* wallabag version (or git revision) that exhibits the issue: 2.1.5
* How did you install wallabag? Via `git clone` or by downloading the package? git
* Last wallabag version that did not exhibit the issue (if applicable): 
* php version: 7 
* OS: debian 5.8
* type of hosting (shared or dedicated): dedicated
* which storage system you choose at install (SQLite, MySQL/MariaDB or PostgreSQL): postgresql 9.6

