### PR TITLE
Fixed export by tags with a tag which contains space

### DIFF
--- a/src/Wallabag/CoreBundle/Controller/TagController.php
+++ b/src/Wallabag/CoreBundle/Controller/TagController.php
@@ -143,7 +143,7 @@ class TagController extends Controller
             'form' => null,
             'entries' => $entries,
             'currentPage' => $page,
-            'tag' => $tag->getLabel(),
+            'tag' => $tag->getSlug(),
         ]);
     }
 }

--- a/src/Wallabag/CoreBundle/DataFixtures/ORM/LoadTagData.php
+++ b/src/Wallabag/CoreBundle/DataFixtures/ORM/LoadTagData.php
@@ -15,7 +15,7 @@ class LoadTagData extends AbstractFixture implements OrderedFixtureInterface
     public function load(ObjectManager $manager)
     {
         $tag1 = new Tag();
-        $tag1->setLabel('foo');
+        $tag1->setLabel('foo bar');
 
         $manager->persist($tag1);
 

--- a/tests/Wallabag/CoreBundle/Controller/ExportControllerTest.php
+++ b/tests/Wallabag/CoreBundle/Controller/ExportControllerTest.php
@@ -119,7 +119,7 @@ class ExportControllerTest extends WallabagCoreTestCase
         $this->assertEquals('binary', $headers->get('content-transfer-encoding'));
 
         ob_start();
-        $crawler = $client->request('GET', '/export/tag_entries.pdf?tag=foo');
+        $crawler = $client->request('GET', '/export/tag_entries.pdf?tag=foo-bar');
         ob_end_clean();
 
         $this->assertEquals(200, $client->getResponse()->getStatusCode());
@@ -241,7 +241,7 @@ class ExportControllerTest extends WallabagCoreTestCase
         $this->assertEquals($contentInDB->getLanguage(), $content[0]['language']);
         $this->assertEquals($contentInDB->getReadingtime(), $content[0]['reading_time']);
         $this->assertEquals($contentInDB->getDomainname(), $content[0]['domain_name']);
-        $this->assertEquals(['foo', 'baz'], $content[0]['tags']);
+        $this->assertEquals(['foo bar', 'baz'], $content[0]['tags']);
     }
 
     public function testXmlExport()

--- a/tests/Wallabag/CoreBundle/Controller/TagControllerTest.php
+++ b/tests/Wallabag/CoreBundle/Controller/TagControllerTest.php
@@ -61,7 +61,7 @@ class TagControllerTest extends WallabagCoreTestCase
 
         // tag already exists but still not assigned to this entry
         $data = [
-            'tag[label]' => 'foo',
+            'tag[label]' => 'foo bar',
         ];
 
         $client->submit($form, $data);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Documentation | no
| Translation   | no
| Fixed tickets | N/A
| License       | MIT

When an article had a tag with space inside (eg: "Intelligence artificielle"), the export failed.

```
Uncaught Symfony\Component\Debug\Exception\FatalThrowableError: Call to a member function getId() on null in /var/www/wallabag/src/Wallabag/CoreBundle/Controller/ExportController.php:66 Stack trace: #0 [internal function]: Wallabag\CoreBundle\Controller\ExportController->downloadEntriesAction(Object(Symfony\Component\HttpFoundation\Request), 'pdf', 'tag_entries')
```