### PR TITLE
Fix entry reading time

### DIFF
--- a/src/Wallabag/CoreBundle/Resources/views/themes/material/Entry/_card_actions.html.twig
+++ b/src/Wallabag/CoreBundle/Resources/views/themes/material/Entry/_card_actions.html.twig
@@ -1,8 +1,6 @@
 <div class="card-action">
     <span class="reading-time grey-text">
-        <i class="material-icons" title="{{ 'entry.list.reading_time'|trans }}">timer</i>
-        {{ entry.readingTime / app.user.config.readingSpeed|round }} min&nbsp;
-
+        {% include "@WallabagCore/themes/material/Entry/_reading_time.html.twig" with {'entry': entry} only %}
         <i class="material-icons hide-on-med-and-down" title="{{ 'entry.view.created_at'|trans }}">today</i>
         <span class="hide-on-med-and-down">&nbsp;{{ entry.createdAt|date('Y-m-d') }}</span>
     </span>

--- a/src/Wallabag/CoreBundle/Resources/views/themes/material/Entry/_reading_time.html.twig
+++ b/src/Wallabag/CoreBundle/Resources/views/themes/material/Entry/_reading_time.html.twig
@@ -1,0 +1,7 @@
+{% set readingTime = entry.readingTime / app.user.config.readingSpeed %}
+<i class="material-icons">timer</i>
+{% if readingTime > 0 %}
+    {{ 'entry.list.reading_time_minutes_short'|trans({'%readingTime%': readingTime|round}) }}
+{% else %}
+    {{ 'entry.list.reading_time_less_one_minute_short'|trans|raw }}
+{% endif %}

--- a/src/Wallabag/CoreBundle/Resources/views/themes/material/Entry/entry.html.twig
+++ b/src/Wallabag/CoreBundle/Resources/views/themes/material/Entry/entry.html.twig
@@ -214,13 +214,7 @@
         <aside>
             <ul class="tools">
                 <li>
-                    {% set readingTime = entry.readingTime / app.user.config.readingSpeed %}
-                    <i class="material-icons">timer</i>
-                    {% if readingTime > 0 %}
-                        {{ 'entry.list.reading_time_minutes_short'|trans({'%readingTime%': readingTime|round}) }}
-                    {% else %}
-                        {{ 'entry.list.reading_time_less_one_minute_short'|trans|raw }}
-                    {% endif %}
+                    {% include "@WallabagCore/themes/material/Entry/_reading_time.html.twig" with {'entry': entry} only %}
                 </li>
                 <li>
                     <i class="material-icons" title="{{ 'entry.view.created_at'|trans }}">today</i>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Documentation | no

Before:
Reading time of entries on the main view was broken because of a wrong rounded value.

After:
The reading time code is now shared between both views.
