### PR TITLE
Avoid false preview image

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -84,7 +84,7 @@
         "javibravo/simpleue": "^1.0",
         "symfony/dom-crawler": "^3.1",
         "friendsofsymfony/jsrouting-bundle": "^1.6",
-        "bdunogier/guzzle-site-authenticator": "^1.0@beta"
+        "bdunogier/guzzle-site-authenticator": "dev-master"
     },
     "require-dev": {
         "doctrine/doctrine-fixtures-bundle": "~2.2",

--- a/src/Wallabag/CoreBundle/Helper/ContentProxy.php
+++ b/src/Wallabag/CoreBundle/Helper/ContentProxy.php
@@ -88,7 +88,7 @@ class ContentProxy
             $entry->setDomainName($domainName);
         }
 
-        if (isset($content['open_graph']['og_image'])) {
+        if (isset($content['open_graph']['og_image']) && $content['open_graph']['og_image']) {
             $entry->setPreviewPicture($content['open_graph']['og_image']);
         }
 

--- a/tests/Wallabag/CoreBundle/Controller/SecurityControllerTest.php
+++ b/tests/Wallabag/CoreBundle/Controller/SecurityControllerTest.php
@@ -82,6 +82,6 @@ class SecurityControllerTest extends WallabagCoreTestCase
 
         $client->followRedirects();
         $crawler = $client->request('GET', '/register');
-        $this->assertContains('registration.submit', $crawler->filter('body')->extract(['_text'])[0]);
+        $this->assertContains('registration.submit', $client->getResponse()->getContent());
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Documentation | no
| Translation   | no
| Fixed tickets | https://github.com/wallabag/ios-app/issues/62
| License       | MIT

If the website doesn't provide an og_image, the value will be false and so it'll be saved like that in the database.
We prefer to leave it as null instead of false.
