### PR TITLE
Added migration to rename uuid to uid

### DIFF
--- a/app/DoctrineMigrations/Version20161214094402.php
+++ b/app/DoctrineMigrations/Version20161214094402.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace Application\Migrations;
+
+use Doctrine\DBAL\Migrations\AbstractMigration;
+use Doctrine\DBAL\Schema\Schema;
+use Symfony\Component\DependencyInjection\ContainerAwareInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Renamed uuid to uid in entry table
+ */
+class Version20161214094402 extends AbstractMigration implements ContainerAwareInterface
+{
+    /**
+     * @var ContainerInterface
+     */
+    private $container;
+
+    public function setContainer(ContainerInterface $container = null)
+    {
+        $this->container = $container;
+    }
+
+    private function getTable($tableName)
+    {
+        return $this->container->getParameter('database_table_prefix').$tableName;
+    }
+
+    /**
+     * @param Schema $schema
+     */
+    public function up(Schema $schema)
+    {
+        $entryTable = $schema->getTable($this->getTable('entry'));
+
+        $this->skipIf($entryTable->hasColumn('uid'), 'It seems that you already played this migration.');
+
+        switch ($this->connection->getDatabasePlatform()->getName()) {
+            case 'sqlite':
+                //
+                break;
+            case 'mysql':
+                $this->addSql('ALTER TABLE '.$this->getTable('entry').' CHANGE uuid uid VARCHAR(23)');
+                break;
+            case 'postgresql':
+                $this->addSql('ALTER TABLE '.$this->getTable('entry').' RENAME uuid TO uid');
+        }
+    }
+
+    /**
+     * @param Schema $schema
+     */
+    public function down(Schema $schema)
+    {
+        $entryTable = $schema->getTable($this->getTable('entry'));
+
+        $this->skipIf($entryTable->hasColumn('uuid'), 'It seems that you already played this migration.');
+
+        switch ($this->connection->getDatabasePlatform()->getName()) {
+            case 'sqlite':
+                //
+                break;
+            case 'mysql':
+                $this->addSql('ALTER TABLE '.$this->getTable('entry').' CHANGE uid uuid VARCHAR(23)');
+                break;
+            case 'postgresql':
+                $this->addSql('ALTER TABLE '.$this->getTable('entry').' RENAME uid TO uuid');
+        }
+    }
+}

--- a/app/DoctrineMigrations/Version20161214094402.php
+++ b/app/DoctrineMigrations/Version20161214094402.php
@@ -38,7 +38,11 @@ class Version20161214094402 extends AbstractMigration implements ContainerAwareI
 
         switch ($this->connection->getDatabasePlatform()->getName()) {
             case 'sqlite':
-                //
+                $this->addSql('CREATE TEMPORARY TABLE __temp__wallabag_entry AS SELECT id, user_id, uuid, title, url, is_archived, is_starred, content, created_at, updated_at, mimetype, language, reading_time, domain_name, preview_picture, is_public FROM '.$this->getTable('entry'));
+                $this->addSql('DROP TABLE '.$this->getTable('entry'));
+                $this->addSql('CREATE TABLE '.$this->getTable('entry').' (id INTEGER NOT NULL, user_id INTEGER DEFAULT NULL, uid CLOB DEFAULT NULL COLLATE BINARY, title CLOB DEFAULT NULL COLLATE BINARY, url CLOB DEFAULT NULL COLLATE BINARY, is_archived BOOLEAN NOT NULL, is_starred BOOLEAN NOT NULL, content CLOB DEFAULT NULL COLLATE BINARY, created_at DATETIME NOT NULL, updated_at DATETIME NOT NULL, mimetype CLOB DEFAULT NULL COLLATE BINARY, language CLOB DEFAULT NULL COLLATE BINARY, reading_time INTEGER DEFAULT NULL, domain_name CLOB DEFAULT NULL COLLATE BINARY, preview_picture CLOB DEFAULT NULL COLLATE BINARY, is_public BOOLEAN DEFAULT "0", PRIMARY KEY(id));');
+                $this->addSql('INSERT INTO '.$this->getTable('entry').' (id, user_id, uid, title, url, is_archived, is_starred, content, created_at, updated_at, mimetype, language, reading_time, domain_name, preview_picture, is_public) SELECT id, user_id, uuid, title, url, is_archived, is_starred, content, created_at, updated_at, mimetype, language, reading_time, domain_name, preview_picture, is_public FROM __temp__wallabag_entry;');
+                $this->addSql('DROP TABLE __temp__wallabag_entry');
                 break;
             case 'mysql':
                 $this->addSql('ALTER TABLE '.$this->getTable('entry').' CHANGE uuid uid VARCHAR(23)');
@@ -59,7 +63,7 @@ class Version20161214094402 extends AbstractMigration implements ContainerAwareI
 
         switch ($this->connection->getDatabasePlatform()->getName()) {
             case 'sqlite':
-                //
+                throw new SkipMigrationException('Too complex ...');
                 break;
             case 'mysql':
                 $this->addSql('ALTER TABLE '.$this->getTable('entry').' CHANGE uid uuid VARCHAR(23)');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Documentation | no
| Translation   | no
| Fixed tickets | N/A
| License       | MIT

I forgot a migration to rename `uuid` field in entry table. I was sure that this field was added in 2.2. 

Doctrine migrations removed renameColumn(). I need to write this migration in SQL. 
But SQLite 🤢 ...