### PR TITLE
Improved Guzzle subscribers extensibility

### DIFF
--- a/src/Wallabag/CoreBundle/GuzzleSiteAuthenticator/GrabySiteConfigBuilder.php
+++ b/src/Wallabag/CoreBundle/GuzzleSiteAuthenticator/GrabySiteConfigBuilder.php
@@ -54,7 +54,7 @@ class GrabySiteConfigBuilder implements SiteConfigBuilder
             'loginUri' => $config->login_uri ?: null,
             'usernameField' => $config->login_username_field ?: null,
             'passwordField' => $config->login_password_field ?: null,
-            'extraFields' => is_array($config->login_extra_fields) ? $config->login_extra_fields : [],
+            'extraFields' => $this->processExtraFields($config->login_extra_fields),
             'notLoggedInXpath' => $config->not_logged_in_xpath ?: null,
         ];
 
@@ -64,5 +64,31 @@ class GrabySiteConfigBuilder implements SiteConfigBuilder
         }
 
         return new SiteConfig($parameters);
+    }
+
+    /**
+     * Processes login_extra_fields config, transforming an '=' separated array of strings
+     * into a key/value array.
+     *
+     * @param array|mixed $extraFieldsStrings
+     *
+     * @return array
+     */
+    protected function processExtraFields($extraFieldsStrings)
+    {
+        if (!is_array($extraFieldsStrings)) {
+            return [];
+        }
+
+        $extraFields = [];
+        foreach ($extraFieldsStrings as $extraField) {
+            if (strpos($extraField, '=') === false) {
+                continue;
+            }
+            list($fieldName, $fieldValue) = explode('=', $extraField, 2);
+            $extraFields[$fieldName] = $fieldValue;
+        }
+
+        return $extraFields;
     }
 }

--- a/src/Wallabag/CoreBundle/Helper/HttpClientFactory.php
+++ b/src/Wallabag/CoreBundle/Helper/HttpClientFactory.php
@@ -27,7 +27,7 @@ class HttpClientFactory
      *
      * @param \GuzzleHttp\Cookie\CookieJar $cookieJar
      * @param string                       $restrictedAccess This param is a kind of boolean. Values: 0 or 1
-     * @param LoggerInterface                       $logger
+     * @param LoggerInterface              $logger
      */
     public function __construct(CookieJar $cookieJar, $restrictedAccess, LoggerInterface $logger)
     {

--- a/src/Wallabag/CoreBundle/Helper/HttpClientFactory.php
+++ b/src/Wallabag/CoreBundle/Helper/HttpClientFactory.php
@@ -13,8 +13,8 @@ use Psr\Log\LoggerInterface;
  */
 class HttpClientFactory
 {
-    /** @var \GuzzleHttp\Event\SubscriberInterface */
-    private $authenticatorSubscriber;
+    /** @var [\GuzzleHttp\Event\SubscriberInterface] */
+    private $subscribers = [];
 
     /** @var \GuzzleHttp\Cookie\CookieJar */
     private $cookieJar;
@@ -25,14 +25,12 @@ class HttpClientFactory
     /**
      * HttpClientFactory constructor.
      *
-     * @param \GuzzleHttp\Event\SubscriberInterface $authenticatorSubscriber
-     * @param \GuzzleHttp\Cookie\CookieJar          $cookieJar
-     * @param string                                $restrictedAccess        this param is a kind of boolean. Values: 0 or 1
+     * @param \GuzzleHttp\Cookie\CookieJar $cookieJar
+     * @param string                       $restrictedAccess This param is a kind of boolean. Values: 0 or 1
      * @param LoggerInterface                       $logger
      */
-    public function __construct(SubscriberInterface $authenticatorSubscriber, CookieJar $cookieJar, $restrictedAccess, LoggerInterface $logger)
+    public function __construct(CookieJar $cookieJar, $restrictedAccess, LoggerInterface $logger)
     {
-        $this->authenticatorSubscriber = $authenticatorSubscriber;
         $this->cookieJar = $cookieJar;
         $this->restrictedAccess = $restrictedAccess;
         $this->logger = $logger;
@@ -53,8 +51,20 @@ class HttpClientFactory
         $this->cookieJar->clear();
         // need to set the (shared) cookie jar
         $client = new Client(['handler' => new SafeCurlHandler(), 'defaults' => ['cookies' => $this->cookieJar]]);
-        $client->getEmitter()->attach($this->authenticatorSubscriber);
+        foreach ($this->subscribers as $subscriber) {
+            $client->getEmitter()->attach($subscriber);
+        }
 
         return $client;
+    }
+
+    /**
+     * Adds a subscriber to the HTTP client.
+     *
+     * @param SubscriberInterface $subscriber
+     */
+    public function addSubscriber(SubscriberInterface $subscriber)
+    {
+        $this->subscribers[] = $subscriber;
     }
 }

--- a/src/Wallabag/CoreBundle/Resources/config/services.yml
+++ b/src/Wallabag/CoreBundle/Resources/config/services.yml
@@ -71,10 +71,11 @@ services:
     wallabag_core.guzzle.http_client_factory:
         class: Wallabag\CoreBundle\Helper\HttpClientFactory
         arguments:
-            - "@bd_guzzle_site_authenticator.authenticator_subscriber"
             - "@wallabag_core.guzzle.cookie_jar"
             - '@=service(''craue_config'').get(''restricted_access'')'
             - '@logger'
+        calls:
+            - ["addSubscriber", ["@bd_guzzle_site_authenticator.authenticator_subscriber"]]
 
     wallabag_core.guzzle.cookie_jar:
         class: GuzzleHttp\Cookie\FileCookieJar

--- a/tests/Wallabag/CoreBundle/GuzzleSiteAuthenticator/GrabySiteConfigBuilderTest.php
+++ b/tests/Wallabag/CoreBundle/GuzzleSiteAuthenticator/GrabySiteConfigBuilderTest.php
@@ -24,7 +24,7 @@ class GrabySiteConfigBuilderTest extends PHPUnit_Framework_TestCase
         $grabySiteConfig->login_uri = 'http://example.com/login';
         $grabySiteConfig->login_username_field = 'login';
         $grabySiteConfig->login_password_field = 'password';
-        $grabySiteConfig->login_extra_fields = ['field' => 'value'];
+        $grabySiteConfig->login_extra_fields = ['field=value'];
         $grabySiteConfig->not_logged_in_xpath = '//div[@class="need-login"]';
 
         $grabyConfigBuilderMock


### PR DESCRIPTION
Allows 3rd parties to register new guzzle subscribers by adding extra calls to the http_client_factory service. Used in https://github.com/bdunogier/guzzle-site-authenticator/pull/14 to fix a wrong URI during a login process.

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | yes
| Deprecations? | yes
| Tests pass?   | yes
| Documentation | yes
| Translation   | no
| Fixed tickets | n/a
| License       | MIT

Allows 3rd parties to register new guzzle subscribers by adding extra calls to `addSubscribers` on the `http_client_factory` service.

Needed to fix a bug with a particular site's response. I think it improves wallabag's extensibility, and better decouples features such as paywalls.