### PR TITLE
Sort list of available tags

### DIFF
--- a/src/Wallabag/CoreBundle/Repository/TagRepository.php
+++ b/src/Wallabag/CoreBundle/Repository/TagRepository.php
@@ -49,6 +49,7 @@ class TagRepository extends EntityRepository
             ->leftJoin('t.entries', 'e')
             ->where('e.user = :userId')->setParameter('userId', $userId)
             ->groupBy('t.id')
+            ->orderBy('t.slug')
             ->getQuery()
             ->getArrayResult();
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes/no
| Documentation | no
| Translation   | no
| Fixed tickets | #...
| License       | MIT

This adds an orderBy clause to the listing of tags for a user. This makes the list at `/tag/list` more useable as the order of the tags seems not to be that random.
