### PR TITLE
Fixed duplicate entry for share_public in craue_setting_table

### DIFF
--- a/app/DoctrineMigrations/Version20160410190541.php
+++ b/app/DoctrineMigrations/Version20160410190541.php
@@ -34,7 +34,7 @@ class Version20160410190541 extends AbstractMigration implements ContainerAwareI
     {
         $entryTable = $schema->getTable($this->getTable('entry'));
 
-        $this->skipIf($entryTable->hasColumn('uid'), 'It seems that you already played this migration.');
+        $this->skipIf($entryTable->hasColumn('uid') || $entryTable->hasColumn('uuid'), 'It seems that you already played this migration.');
 
         $entryTable->addColumn('uid', 'string', [
             'notnull' => false,

--- a/app/DoctrineMigrations/Version20160410190541.php
+++ b/app/DoctrineMigrations/Version20160410190541.php
@@ -40,7 +40,15 @@ class Version20160410190541 extends AbstractMigration implements ContainerAwareI
             'notnull' => false,
             'length' => 23,
         ]);
-        $this->addSql('INSERT INTO '.$this->getTable('craue_config_setting')." (name, value, section) VALUES ('share_public', '1', 'entry')");
+
+        $sharePublic = $this->container
+            ->get('doctrine.orm.default_entity_manager')
+            ->getConnection()
+            ->fetchArray('SELECT * FROM '.$this->getTable('craue_config_setting')." WHERE name = 'share_public'");
+
+        if (false === $sharePublic) {
+            $this->addSql('INSERT INTO '.$this->getTable('craue_config_setting')." (name, value, section) VALUES ('share_public', '1', 'entry')");
+        }
     }
 
     /**

--- a/docs/de/user/query-upgrade-21-22.rst
+++ b/docs/de/user/query-upgrade-21-22.rst
@@ -724,6 +724,111 @@ Migration down
     CREATE UNIQUE INDEX UNIQ_1D63E7E5A0D96FBF ON wallabag_user (email_canonical)
     CREATE UNIQUE INDEX UNIQ_1D63E7E5C05FB297 ON wallabag_user (confirmation_token)
 
+Migration 20161214094402
+------------------------
+
+MySQL
+^^^^^
+
+Migration up
+""""""""""""
+
+.. code-block:: sql
+
+    ALTER TABLE wallabag_entry CHANGE uuid uid VARCHAR(23)
+
+Migration down
+""""""""""""""
+
+.. code-block:: sql
+
+    ALTER TABLE wallabag_entry CHANGE uid uuid VARCHAR(23)
+
+PostgreSQL
+^^^^^^^^^^
+
+Migration up
+""""""""""""
+
+.. code-block:: sql
+
+    ALTER TABLE wallabag_entry RENAME uuid TO uid
+
+Migration down
+""""""""""""""
+
+.. code-block:: sql
+
+    ALTER TABLE wallabag_entry RENAME uid TO uuid
+
+SQLite
+^^^^^^
+
+Migration up
+""""""""""""
+
+.. code-block:: sql
+
+    CREATE TABLE __temp__wallabag_entry (
+        id    INTEGER NOT NULL,
+        user_id   INTEGER DEFAULT NULL,
+        uid  VARCHAR(23) DEFAULT NULL,
+        title CLOB DEFAULT NULL,
+        url   CLOB DEFAULT NULL,
+        is_archived   BOOLEAN NOT NULL,
+        is_starred    BOOLEAN NOT NULL,
+        content   CLOB DEFAULT NULL,
+        created_at    DATETIME NOT NULL,
+        updated_at    DATETIME NOT NULL,
+        mimetype  CLOB DEFAULT NULL,
+        language  CLOB DEFAULT NULL,
+        reading_time  INTEGER DEFAULT NULL,
+        domain_name   CLOB DEFAULT NULL,
+        preview_picture   CLOB DEFAULT NULL,
+        is_public BOOLEAN DEFAULT '0',
+        http_status   VARCHAR(3) DEFAULT NULL,
+        PRIMARY KEY(id)
+    );
+    INSERT INTO __temp__wallabag_entry SELECT id,user_id,uuid,title,url,is_archived,is_starred,content,created_at,updated_at,mimetype,language,reading_time,domain_name,preview_picture,is_public,http_status FROM wallabag_entry;
+    DROP TABLE wallabag_entry;
+    ALTER TABLE __temp__wallabag_entry RENAME TO wallabag_entry
+    CREATE INDEX uid ON wallabag_entry (uid)
+    CREATE INDEX created_at ON wallabag_entry (created_at)
+    CREATE INDEX IDX_F4D18282A76ED395 ON wallabag_entry (user_id)
+
+
+Migration down
+""""""""""""""
+
+.. code-block:: sql
+
+    CREATE TABLE __temp__wallabag_entry (
+        id    INTEGER NOT NULL,
+        user_id   INTEGER DEFAULT NULL,
+        uuid  VARCHAR(23) DEFAULT NULL,
+        title CLOB DEFAULT NULL,
+        url   CLOB DEFAULT NULL,
+        is_archived   BOOLEAN NOT NULL,
+        is_starred    BOOLEAN NOT NULL,
+        content   CLOB DEFAULT NULL,
+        created_at    DATETIME NOT NULL,
+        updated_at    DATETIME NOT NULL,
+        mimetype  CLOB DEFAULT NULL,
+        language  CLOB DEFAULT NULL,
+        reading_time  INTEGER DEFAULT NULL,
+        domain_name   CLOB DEFAULT NULL,
+        preview_picture   CLOB DEFAULT NULL,
+        is_public BOOLEAN DEFAULT '0',
+        http_status   VARCHAR(3) DEFAULT NULL,
+        PRIMARY KEY(id)
+    );
+    INSERT INTO __temp__wallabag_entry SELECT id,user_id,uid,title,url,is_archived,is_starred,content,created_at,updated_at,mimetype,language,reading_time,domain_name,preview_picture,is_public,http_status FROM wallabag_entry;
+    DROP TABLE wallabag_entry;
+    ALTER TABLE __temp__wallabag_entry RENAME TO wallabag_entry
+    CREATE INDEX uid ON wallabag_entry (uid)
+    CREATE INDEX created_at ON wallabag_entry (created_at)
+    CREATE INDEX IDX_F4D18282A76ED395 ON wallabag_entry (user_id)
+
 Migration 20161214094403
 ------------------------
 

--- a/docs/en/user/query-upgrade-21-22.rst
+++ b/docs/en/user/query-upgrade-21-22.rst
@@ -724,6 +724,111 @@ Migration down
     CREATE UNIQUE INDEX UNIQ_1D63E7E5A0D96FBF ON wallabag_user (email_canonical)
     CREATE UNIQUE INDEX UNIQ_1D63E7E5C05FB297 ON wallabag_user (confirmation_token)
 
+Migration 20161214094402
+------------------------
+
+MySQL
+^^^^^
+
+Migration up
+""""""""""""
+
+.. code-block:: sql
+
+    ALTER TABLE wallabag_entry CHANGE uuid uid VARCHAR(23)
+
+Migration down
+""""""""""""""
+
+.. code-block:: sql
+
+    ALTER TABLE wallabag_entry CHANGE uid uuid VARCHAR(23)
+
+PostgreSQL
+^^^^^^^^^^
+
+Migration up
+""""""""""""
+
+.. code-block:: sql
+
+    ALTER TABLE wallabag_entry RENAME uuid TO uid
+
+Migration down
+""""""""""""""
+
+.. code-block:: sql
+
+    ALTER TABLE wallabag_entry RENAME uid TO uuid
+
+SQLite
+^^^^^^
+
+Migration up
+""""""""""""
+
+.. code-block:: sql
+
+    CREATE TABLE __temp__wallabag_entry (
+        id    INTEGER NOT NULL,
+        user_id   INTEGER DEFAULT NULL,
+        uid  VARCHAR(23) DEFAULT NULL,
+        title CLOB DEFAULT NULL,
+        url   CLOB DEFAULT NULL,
+        is_archived   BOOLEAN NOT NULL,
+        is_starred    BOOLEAN NOT NULL,
+        content   CLOB DEFAULT NULL,
+        created_at    DATETIME NOT NULL,
+        updated_at    DATETIME NOT NULL,
+        mimetype  CLOB DEFAULT NULL,
+        language  CLOB DEFAULT NULL,
+        reading_time  INTEGER DEFAULT NULL,
+        domain_name   CLOB DEFAULT NULL,
+        preview_picture   CLOB DEFAULT NULL,
+        is_public BOOLEAN DEFAULT '0',
+        http_status   VARCHAR(3) DEFAULT NULL,
+        PRIMARY KEY(id)
+    );
+    INSERT INTO __temp__wallabag_entry SELECT id,user_id,uuid,title,url,is_archived,is_starred,content,created_at,updated_at,mimetype,language,reading_time,domain_name,preview_picture,is_public,http_status FROM wallabag_entry;
+    DROP TABLE wallabag_entry;
+    ALTER TABLE __temp__wallabag_entry RENAME TO wallabag_entry
+    CREATE INDEX uid ON wallabag_entry (uid)
+    CREATE INDEX created_at ON wallabag_entry (created_at)
+    CREATE INDEX IDX_F4D18282A76ED395 ON wallabag_entry (user_id)
+
+
+Migration down
+""""""""""""""
+
+.. code-block:: sql
+
+    CREATE TABLE __temp__wallabag_entry (
+        id    INTEGER NOT NULL,
+        user_id   INTEGER DEFAULT NULL,
+        uuid  VARCHAR(23) DEFAULT NULL,
+        title CLOB DEFAULT NULL,
+        url   CLOB DEFAULT NULL,
+        is_archived   BOOLEAN NOT NULL,
+        is_starred    BOOLEAN NOT NULL,
+        content   CLOB DEFAULT NULL,
+        created_at    DATETIME NOT NULL,
+        updated_at    DATETIME NOT NULL,
+        mimetype  CLOB DEFAULT NULL,
+        language  CLOB DEFAULT NULL,
+        reading_time  INTEGER DEFAULT NULL,
+        domain_name   CLOB DEFAULT NULL,
+        preview_picture   CLOB DEFAULT NULL,
+        is_public BOOLEAN DEFAULT '0',
+        http_status   VARCHAR(3) DEFAULT NULL,
+        PRIMARY KEY(id)
+    );
+    INSERT INTO __temp__wallabag_entry SELECT id,user_id,uid,title,url,is_archived,is_starred,content,created_at,updated_at,mimetype,language,reading_time,domain_name,preview_picture,is_public,http_status FROM wallabag_entry;
+    DROP TABLE wallabag_entry;
+    ALTER TABLE __temp__wallabag_entry RENAME TO wallabag_entry
+    CREATE INDEX uid ON wallabag_entry (uid)
+    CREATE INDEX created_at ON wallabag_entry (created_at)
+    CREATE INDEX IDX_F4D18282A76ED395 ON wallabag_entry (user_id)
+
 Migration 20161214094403
 ------------------------
 

--- a/docs/fr/user/query-upgrade-21-22.rst
+++ b/docs/fr/user/query-upgrade-21-22.rst
@@ -724,6 +724,111 @@ Migration down
     CREATE UNIQUE INDEX UNIQ_1D63E7E5A0D96FBF ON wallabag_user (email_canonical)
     CREATE UNIQUE INDEX UNIQ_1D63E7E5C05FB297 ON wallabag_user (confirmation_token)
 
+Migration 20161214094402
+------------------------
+
+MySQL
+^^^^^
+
+Migration up
+""""""""""""
+
+.. code-block:: sql
+
+    ALTER TABLE wallabag_entry CHANGE uuid uid VARCHAR(23)
+
+Migration down
+""""""""""""""
+
+.. code-block:: sql
+
+    ALTER TABLE wallabag_entry CHANGE uid uuid VARCHAR(23)
+
+PostgreSQL
+^^^^^^^^^^
+
+Migration up
+""""""""""""
+
+.. code-block:: sql
+
+    ALTER TABLE wallabag_entry RENAME uuid TO uid
+
+Migration down
+""""""""""""""
+
+.. code-block:: sql
+
+    ALTER TABLE wallabag_entry RENAME uid TO uuid
+
+SQLite
+^^^^^^
+
+Migration up
+""""""""""""
+
+.. code-block:: sql
+
+    CREATE TABLE __temp__wallabag_entry (
+        id    INTEGER NOT NULL,
+        user_id   INTEGER DEFAULT NULL,
+        uid  VARCHAR(23) DEFAULT NULL,
+        title CLOB DEFAULT NULL,
+        url   CLOB DEFAULT NULL,
+        is_archived   BOOLEAN NOT NULL,
+        is_starred    BOOLEAN NOT NULL,
+        content   CLOB DEFAULT NULL,
+        created_at    DATETIME NOT NULL,
+        updated_at    DATETIME NOT NULL,
+        mimetype  CLOB DEFAULT NULL,
+        language  CLOB DEFAULT NULL,
+        reading_time  INTEGER DEFAULT NULL,
+        domain_name   CLOB DEFAULT NULL,
+        preview_picture   CLOB DEFAULT NULL,
+        is_public BOOLEAN DEFAULT '0',
+        http_status   VARCHAR(3) DEFAULT NULL,
+        PRIMARY KEY(id)
+    );
+    INSERT INTO __temp__wallabag_entry SELECT id,user_id,uuid,title,url,is_archived,is_starred,content,created_at,updated_at,mimetype,language,reading_time,domain_name,preview_picture,is_public,http_status FROM wallabag_entry;
+    DROP TABLE wallabag_entry;
+    ALTER TABLE __temp__wallabag_entry RENAME TO wallabag_entry
+    CREATE INDEX uid ON wallabag_entry (uid)
+    CREATE INDEX created_at ON wallabag_entry (created_at)
+    CREATE INDEX IDX_F4D18282A76ED395 ON wallabag_entry (user_id)
+
+
+Migration down
+""""""""""""""
+
+.. code-block:: sql
+
+    CREATE TABLE __temp__wallabag_entry (
+        id    INTEGER NOT NULL,
+        user_id   INTEGER DEFAULT NULL,
+        uuid  VARCHAR(23) DEFAULT NULL,
+        title CLOB DEFAULT NULL,
+        url   CLOB DEFAULT NULL,
+        is_archived   BOOLEAN NOT NULL,
+        is_starred    BOOLEAN NOT NULL,
+        content   CLOB DEFAULT NULL,
+        created_at    DATETIME NOT NULL,
+        updated_at    DATETIME NOT NULL,
+        mimetype  CLOB DEFAULT NULL,
+        language  CLOB DEFAULT NULL,
+        reading_time  INTEGER DEFAULT NULL,
+        domain_name   CLOB DEFAULT NULL,
+        preview_picture   CLOB DEFAULT NULL,
+        is_public BOOLEAN DEFAULT '0',
+        http_status   VARCHAR(3) DEFAULT NULL,
+        PRIMARY KEY(id)
+    );
+    INSERT INTO __temp__wallabag_entry SELECT id,user_id,uid,title,url,is_archived,is_starred,content,created_at,updated_at,mimetype,language,reading_time,domain_name,preview_picture,is_public,http_status FROM wallabag_entry;
+    DROP TABLE wallabag_entry;
+    ALTER TABLE __temp__wallabag_entry RENAME TO wallabag_entry
+    CREATE INDEX uid ON wallabag_entry (uid)
+    CREATE INDEX created_at ON wallabag_entry (created_at)
+    CREATE INDEX IDX_F4D18282A76ED395 ON wallabag_entry (user_id)
+
 Migration 20161214094403
 ------------------------
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Documentation | yes
| Translation   | yes
| Fixed tickets | #2795
| License       | MIT

- [x] Duplicate entry for `share_public` internal setting (see https://github.com/wallabag/wallabag/issues/2795#issuecomment-275868820)
- [x] Missing documentation about renaming `uuid` to `uid` into entry table. (see https://github.com/wallabag/wallabag/issues/2795#issuecomment-275934106)
- [x] some migrations aren't well played