### PR TITLE
scripts/update.sh: 18: scripts/update.sh: composer.phar: not found

### DIFF
--- a/scripts/require.sh
+++ b/scripts/require.sh
@@ -5,5 +5,5 @@ if [ ! -f composer.phar ]; then
     echo "composer.phar not found, we'll see if composer is installed globally."
     command -v composer >/dev/null 2>&1 || { echo >&2 "wallabag requires composer but it's not installed (see http://doc.wallabag.org/en/master/user/installation.html). Aborting."; exit 1; }
 else
-    COMPOSER_COMMAND='composer.phar'
+    COMPOSER_COMMAND='./composer.phar'
 fi


### PR DESCRIPTION
when composer.phar is not globally installed, we should add "./" in front of "composer.phar" to run it from the current folder.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | n/a
| Documentation | no
| Translation   | no
| Fixed tickets | none yet
| License       | MIT

<!--
- Please fill in this template according to the PR you're about to submit.
- Replace this comment by a description of what your PR is solving.
-->
