### PR TITLE
Show active list in the left menu during search

### DIFF
--- a/src/Wallabag/CoreBundle/Resources/views/themes/material/layout.html.twig
+++ b/src/Wallabag/CoreBundle/Resources/views/themes/material/layout.html.twig
@@ -33,17 +33,29 @@
             {% endblock %}
 
             {% set currentRoute = app.request.attributes.get('_route') %}
+            {% set currentRouteFromQueryParams = app.request.query.get('currentRoute') %}
 
-            <li class="bold {% if currentRoute == 'unread' or currentRoute == 'homepage' %}active{% endif %}">
+            {% set activeRoute = null %}
+            {% if currentRoute == 'all' or currentRouteFromQueryParams == 'all' %}
+               {% set activeRoute = 'all' %}
+            {% elseif currentRoute == 'archive' or currentRouteFromQueryParams == 'archive' %}
+               {% set activeRoute = 'archive' %}
+            {% elseif currentRoute == 'starred' or currentRouteFromQueryParams == 'starred' %}
+               {% set activeRoute = 'starred' %}
+            {% elseif currentRoute == 'unread' or currentRoute == 'homepage' or currentRouteFromQueryParams == 'unread' %}
+               {% set activeRoute = 'unread' %}
+            {% endif %}
+
+            <li class="bold {% if activeRoute == 'unread' %}active{% endif %}">
                 <a class="waves-effect" href="{{ path('unread') }}">{{ 'menu.left.unread'|trans }} <span class="numberItems grey-text">{{ count_entries('unread') }}</span></a>
             </li>
-            <li class="bold {% if currentRoute == 'starred' %}active{% endif %}">
+            <li class="bold {% if activeRoute == 'starred' %}active{% endif %}">
                 <a class="waves-effect" href="{{ path('starred') }}">{{ 'menu.left.starred'|trans }} <span class="numberItems grey-text">{{ count_entries('starred') }}</span></a>
             </li>
-            <li class="bold {% if currentRoute == 'archive' %}active{% endif %}">
+            <li class="bold {% if activeRoute == 'archive' %}active{% endif %}">
                 <a class="waves-effect" href="{{ path('archive') }}">{{ 'menu.left.archive'|trans }} <span class="numberItems grey-text">{{ count_entries('archive') }}</span></a>
             </li>
-            <li class="bold {% if currentRoute == 'all' %}active{% endif %}">
+            <li class="bold {% if activeRoute == 'all' %}active{% endif %}">
                 <a class="waves-effect" href="{{ path('all') }}">{{ 'menu.left.all_articles'|trans }} <span class="numberItems grey-text">{{ count_entries('all') }}</span></a>
             </li>
             <li class="bold border-bottom {% if currentRoute == 'tags' %}active{% endif %}">


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | -
| Deprecations? | no
| Tests pass?   | -
| Documentation |  no
| Translation   | no
| Fixed tickets | -
| License       | MIT

This PR adds `active` class to the list used for the current search. The active list is retrieved from the `currentRoute` query parameter.