### PR TITLE
Add support for configurable base path

### DIFF
--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -27,7 +27,8 @@ framework:
         save_path: "%kernel.root_dir%/../var/sessions/%kernel.environment%"
     fragments: ~
     http_method_override: true
-    assets: ~
+    assets:
+        base_path: "%base_path%"
 
 wallabag_core:
     version: 2.2.1
@@ -148,12 +149,12 @@ fos_rest:
     format_listener:
         enabled: true
         rules:
-            - { path: "^/api/entries/([0-9]+)/export.(.*)", priorities: ['epub', 'mobi', 'pdf', 'txt', 'csv'], fallback_format: json, prefer_extension: false }
-            - { path: "^/api", priorities: ['json', 'xml'], fallback_format: json, prefer_extension: false }
-            - { path: "^/annotations", priorities: ['json', 'xml'], fallback_format: json, prefer_extension: false }
+            - { path: "^%base_path%/api/entries/([0-9]+)/export.(.*)", priorities: ['epub', 'mobi', 'pdf', 'txt', 'csv'], fallback_format: json, prefer_extension: false }
+            - { path: "^%base_path%/api", priorities: ['json', 'xml'], fallback_format: json, prefer_extension: false }
+            - { path: "^%base_path%/annotations", priorities: ['json', 'xml'], fallback_format: json, prefer_extension: false }
             # for an unknown reason, EACH REQUEST goes to FOS\RestBundle\EventListener\FormatListener
             # so we need to add custom rule for custom api export but also for all other routes of the application...
-            - { path: '^/', priorities: ['text/html', '*/*'], fallback_format: html, prefer_extension: false }
+            - { path: '^%base_path%/', priorities: ['text/html', '*/*'], fallback_format: html, prefer_extension: false }
 
 nelmio_api_doc:
     sandbox:
@@ -173,17 +174,17 @@ nelmio_cors:
         hosts: []
         #origin_regex: false
     paths:
-        '^/api/':
+        '^%base_path%/api/':
             allow_origin: ['*']
             allow_headers: ['X-Custom-Auth']
             allow_methods: ['POST', 'PUT', 'PATCH','GET', 'DELETE']
             max_age: 3600
-        '^/oauth/':
+        '^%base_path%/oauth/':
             allow_origin: ['*']
             allow_headers: ['X-Custom-Auth']
             allow_methods: ['POST', 'PUT', 'GET', 'DELETE']
             max_age: 3600
-        '^/':
+        '^%base_path%/':
             #origin_regex: true
             allow_origin: ['^http://localhost:[0-9]+']
             allow_headers: ['X-Custom-Auth']

--- a/app/config/parameters.yml.dist
+++ b/app/config/parameters.yml.dist
@@ -1,5 +1,10 @@
 # This file is a "template" of what your parameters.yml file should look like
 parameters:
+    # The base path you install Wallabag on. Enables support for installations
+    # under http://myhost.com/<basepath>.  Do not ever add a trailing slash.
+    # Leave empty if you install Wallabag in the web server's document root.
+    base_path: ""
+
     # Uncomment these settings or manually update your parameters.yml
     # to use docker-compose
     #

--- a/app/config/routing.yml
+++ b/app/config/routing.yml
@@ -1,37 +1,45 @@
 wallabag_annotation:
-  type : rest
-  resource: "@WallabagAnnotationBundle/Resources/config/routing_annotations.yml"
+    type: rest
+    resource: "@WallabagAnnotationBundle/Resources/config/routing_annotations.yml"
+    prefix: "%base_path%/"
 
 wallabag_import:
     resource: "@WallabagImportBundle/Controller/"
     type: annotation
-    prefix: /import
+    prefix: "%base_path%/import"
 
 wallabag_user:
     resource: "@WallabagUserBundle/Controller/"
     type: annotation
-    prefix: /users
+    prefix: "%base_path%/users"
 
 wallabag_api:
     resource: "@WallabagApiBundle/Controller/"
     type: annotation
-    prefix: /
+    prefix: "%base_path%/"
 
 app:
     resource: "@WallabagCoreBundle/Controller/"
     type: annotation
+    prefix: "%base_path%/"
 
 doc-api:
     resource: "@NelmioApiDocBundle/Resources/config/routing.yml"
-    prefix: /api/doc
+    prefix: "%base_path%/api/doc"
 
-rest :
-    type : rest
-    resource : "routing_rest.yml"
-    prefix : /api
+rest:
+    type: rest
+    resource: "routing_rest.yml"
+    prefix: "%base_path%/api"
 
 homepage:
-    path: "/{page}"
+    path: "%base_path%/"
+    defaults:
+        _controller: WallabagCoreBundle:Entry:showUnread
+        page : 1
+
+homepage_paging:
+    path: "%base_path%/{page}"
     defaults:
         _controller: WallabagCoreBundle:Entry:showUnread
         page : 1
@@ -40,14 +48,17 @@ homepage:
 
 fos_user:
     resource: "@FOSUserBundle/Resources/config/routing/all.xml"
+    prefix: "%base_path%"
 
 fos_oauth_server_token:
     resource: "@FOSOAuthServerBundle/Resources/config/routing/token.xml"
+    prefix: "%base_path%"
 
 craue_config_settings_modify:
-    path: /settings
+    path: "%base_path%/settings"
     defaults:
         _controller: CraueConfigBundle:Settings:modify
 
 fos_js_routing:
     resource: "@FOSJsRoutingBundle/Resources/config/routing/routing.xml"
+    prefix: "%base_path%"

--- a/app/config/security.yml
+++ b/app/config/security.yml
@@ -19,49 +19,52 @@ security:
     firewalls:
         # disables authentication for assets and the profiler, adapt it according to your needs
         dev:
-            pattern: ^/(_(profiler|wdt)|css|images|js)/
+            pattern: "^%base_path%/(_(profiler|wdt)|css|images|js)/"
             security: false
 
         oauth_token:
-            pattern: ^/oauth/v2/token
+            pattern: "^%base_path%/oauth/v2/token"
             security: false
 
         api:
-            pattern: /api/.*
+            pattern: "%base_path%/api/.*"
             fos_oauth: true
             stateless: true
             anonymous: true
 
         login_firewall:
-            pattern: ^/login$
+            pattern: "^%base_path%/login$"
             anonymous:  ~
 
         secured_area:
-            pattern: ^/
+            pattern: "^%base_path%/"
             form_login:
                 provider: fos_userbundle
                 csrf_token_generator: security.csrf.token_manager
+                login_path: "%base_path%/login"
+                check_path: "%base_path%/login_check"
+                default_target_path: "%base_path%/"
 
             anonymous: true
             remember_me:
                 secret: "%secret%"
                 lifetime: 31536000
-                path: /
+                path: "%base_path%/"
                 domain: ~
 
             logout:
-                path:   /logout
-                target: /
+                path:   "%base_path%/logout"
+                target: "%base_path%/"
 
     access_control:
-        - { path: ^/api/doc, roles: IS_AUTHENTICATED_ANONYMOUSLY }
-        - { path: ^/api/version, roles: IS_AUTHENTICATED_ANONYMOUSLY }
-        - { path: ^/login, roles: IS_AUTHENTICATED_ANONYMOUSLY }
-        - { path: ^/register, role: IS_AUTHENTICATED_ANONYMOUSLY }
-        - { path: ^/resetting, role: IS_AUTHENTICATED_ANONYMOUSLY }
-        - { path: /(unread|starred|archive).xml$, roles: IS_AUTHENTICATED_ANONYMOUSLY }
-        - { path: ^/share, roles: IS_AUTHENTICATED_ANONYMOUSLY }
-        - { path: ^/settings, roles: ROLE_SUPER_ADMIN }
-        - { path: ^/annotations, roles: ROLE_USER }
-        - { path: ^/users, roles: ROLE_SUPER_ADMIN }
-        - { path: ^/, roles: ROLE_USER }
+        - { path: "^%base_path%/api/doc", roles: IS_AUTHENTICATED_ANONYMOUSLY }
+        - { path: "^%base_path%/api/version", roles: IS_AUTHENTICATED_ANONYMOUSLY }
+        - { path: "^%base_path%/login", roles: IS_AUTHENTICATED_ANONYMOUSLY }
+        - { path: "^%base_path%/register", role: IS_AUTHENTICATED_ANONYMOUSLY }
+        - { path: "^%base_path%/resetting", role: IS_AUTHENTICATED_ANONYMOUSLY }
+        - { path: "^%base_path%/.*/(unread|starred|archive).xml$", roles: IS_AUTHENTICATED_ANONYMOUSLY }
+        - { path: "^%base_path%/share", roles: IS_AUTHENTICATED_ANONYMOUSLY }
+        - { path: "^%base_path%/settings", roles: ROLE_SUPER_ADMIN }
+        - { path: "^%base_path%/annotations", roles: ROLE_USER }
+        - { path: "^%base_path%/users", roles: ROLE_SUPER_ADMIN }
+        - { path: "^%base_path%/", roles: ROLE_USER }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | maybe (PHP composer dies while retrieving deps)
| Documentation | in app/config/paramaters.yml.dist
| Translation   | n/a
| Fixed tickets | #1913 (primary feature request) #1075 #2214 #2273 
| License       | MIT

* Added base_path parameter to configuration so users are able to install Wallabag in a subdirectory of the web server's document root
* Tested with the Wallabag Android client, the Wallabagger Firefox extension and by requesting https://localhost/wallabag/oauth/v2/token
* Superseeds pull request https://github.com/wallabag/wallabag/pull/2181 as proposed by @alanpearce in https://github.com/wallabag/wallabag/pull/2181#issuecomment-279999348