### PR TITLE
Import: we now skip messages when user is null

### DIFF
--- a/src/Wallabag/ImportBundle/Consumer/AbstractConsumer.php
+++ b/src/Wallabag/ImportBundle/Consumer/AbstractConsumer.php
@@ -46,7 +46,8 @@ abstract class AbstractConsumer
         if (null === $user) {
             $this->logger->warning('Unable to retrieve user', ['entry' => $storedEntry]);
 
-            return false;
+            // return true to skip message
+            return true;
         }
 
         $this->import->setUser($user);

--- a/tests/Wallabag/ImportBundle/Consumer/AMQPEntryConsumerTest.php
+++ b/tests/Wallabag/ImportBundle/Consumer/AMQPEntryConsumerTest.php
@@ -183,7 +183,9 @@ JSON;
 
         $message = new AMQPMessage($body);
 
-        $consumer->execute($message);
+        $res = $consumer->execute($message);
+
+        $this->assertTrue($res);
     }
 
     public function testMessageWithEntryProcessed()

--- a/tests/Wallabag/ImportBundle/Consumer/RedisEntryConsumerTest.php
+++ b/tests/Wallabag/ImportBundle/Consumer/RedisEntryConsumerTest.php
@@ -182,7 +182,7 @@ JSON;
 
         $res = $consumer->manage($body);
 
-        $this->assertFalse($res);
+        $this->assertTrue($res);
     }
 
     public function testMessageWithEntryProcessed()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Documentation | no
| Translation   | no
| Fixed tickets | N/A
| License       | MIT

On wallabag.it, I have sometimes imports which still run because user deleted its account after launching import. 
So RabbitMQ tries perpetually to read these messages, because they stay in queue. 

Now, when a user is deleted, we read the messages.