### PR TITLE
Api exists returns

### DIFF
--- a/src/Wallabag/ApiBundle/Controller/EntryRestController.php
+++ b/src/Wallabag/ApiBundle/Controller/EntryRestController.php
@@ -41,7 +41,7 @@ class EntryRestController extends WallabagRestController
                     ->getRepository('WallabagCoreBundle:Entry')
                     ->findByUrlAndUserId($url, $this->getUser()->getId());
 
-                $results[$url] = false === $res ? false : true;
+                $results[$url] = $res instanceof Entry ? $res->getId() : false;
             }
 
             $json = $this->get('serializer')->serialize($results, 'json');
@@ -60,7 +60,7 @@ class EntryRestController extends WallabagRestController
             ->getRepository('WallabagCoreBundle:Entry')
             ->findByUrlAndUserId($url, $this->getUser()->getId());
 
-        $exists = false === $res ? false : true;
+        $exists = $res instanceof Entry ? $res->getId() : false;
 
         $json = $this->get('serializer')->serialize(['exists' => $exists], 'json');
 

--- a/tests/Wallabag/ApiBundle/Controller/EntryRestControllerTest.php
+++ b/tests/Wallabag/ApiBundle/Controller/EntryRestControllerTest.php
@@ -642,7 +642,7 @@ class EntryRestControllerTest extends WallabagApiTestCase
 
         $content = json_decode($this->client->getResponse()->getContent(), true);
 
-        $this->assertEquals(true, $content['exists']);
+        $this->assertEquals(2, $content['exists']);
     }
 
     public function testGetEntriesExistsWithManyUrls()
@@ -657,7 +657,7 @@ class EntryRestControllerTest extends WallabagApiTestCase
 
         $this->assertArrayHasKey($url1, $content);
         $this->assertArrayHasKey($url2, $content);
-        $this->assertEquals(true, $content[$url1]);
+        $this->assertEquals(2, $content[$url1]);
         $this->assertEquals(false, $content[$url2]);
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | yes
| BC breaks?    | yes
| Deprecations? | no
| Tests pass?   | yes
| Documentation | no
| Translation   | no
| Fixed tickets | #2896
| License       | MIT

If the entry exists, `/api/exists` will now return it's id, otherwise still `false`.