### PR TITLE
remove language on html tag

### DIFF
--- a/src/Wallabag/CoreBundle/Resources/views/base.html.twig
+++ b/src/Wallabag/CoreBundle/Resources/views/base.html.twig
@@ -3,7 +3,7 @@
 <!--[if lte IE 7]><html class="no-js ie7 ie67 ie678" lang="en"><![endif]-->
 <!--[if IE 8]><html class="no-js ie8 ie678" lang="en"><![endif]-->
 <!--[if gt IE 8]><html class="no-js" lang="en"><![endif]-->
-<html lang="fr">
+<html>
     <head>
         {% block head %}
             <meta name="viewport" content="initial-scale=1.0">


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | -
| Documentation | -
| Translation   | -
| Fixed tickets | -
| License       | MIT

I use Chrome on an English/German Ubuntu. The language of my user is also configured to be English. Annoyingly the translation integrated in Chrome detects that Wallabag is French (which is not the case, it's English) and translates it then from English to German. To fix it, i removed the language from the html tag. 

I'm not aware of a potential side effect. I think another way to fix it would be to take the language of the current user and set it in the tag.



