### PR TITLE
Save alpha channel when downloading PNG images

### DIFF
--- a/src/Wallabag/CoreBundle/Helper/DownloadImages.php
+++ b/src/Wallabag/CoreBundle/Helper/DownloadImages.php
@@ -144,6 +144,8 @@ class DownloadImages
                 $this->logger->debug('DownloadImages: Re-creating jpg');
                 break;
             case 'png':
+                imagealphablending($im, false);
+                imagesavealpha($im, true);
                 imagepng($im, $localPath, ceil(self::REGENERATE_PICTURES_QUALITY / 100 * 9));
                 $this->logger->debug('DownloadImages: Re-creating png');
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | -
| Documentation | no
| Translation   | no
| Fixed tickets | #2805 
| License       | MIT

Save alpha channel when downloading PNG images

Fixes #2805 