### PR TITLE
Add export notice at the end of the epub

### DIFF
--- a/src/Wallabag/CoreBundle/Helper/EntriesExport.php
+++ b/src/Wallabag/CoreBundle/Helper/EntriesExport.php
@@ -148,8 +148,6 @@ class EntriesExport
             $book->setCoverImage('Cover.png', file_get_contents($this->logoPath), 'image/png');
         }
 
-        $book->addChapter('Notices', 'Cover2.html', $content_start.$this->getExportInformation('PHPePub').$bookEnd);
-
         $book->buildTOC();
 
         /*
@@ -169,6 +167,8 @@ class EntriesExport
             $chapter = $content_start.$entry->getContent().$bookEnd;
             $book->addChapter($entry->getTitle(), htmlspecialchars($filename).'.html', $chapter, true, EPub::EXTERNAL_REF_ADD);
         }
+
+        $book->addChapter('Notices', 'Cover2.html', $content_start.$this->getExportInformation('PHPePub').$bookEnd);
 
         return Response::create(
             $book->getBook(),


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | maybe
| Documentation | no
| Translation   | no
| License       | MIT

The text "Produced by wallabag with PHPePub" is the first page of any epub.

On ebooks reader, it is common (e.g. kobo) to use the first page as the cover of
unread books, which makes it more difficult to differentiate the books.

Move the Notices chapter at the end of the book.

[Example of EPUB produced with the patch](https://framadrop.org/r/weF9UJ92_0#XPyno0a1/K6ehw+h/2l9+TXzwv444MGFqwxo5MXML4M=)

PS: unsure why the TOC is at the last page...