### PR TITLE
Remove dev FOSUserBundle

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -65,7 +65,7 @@
         "liip/theme-bundle": "~1.1",
         "lexik/form-filter-bundle": "~5.0",
         "j0k3r/graby": "~1.0",
-        "friendsofsymfony/user-bundle": "2.0.x-dev",
+        "friendsofsymfony/user-bundle": "^2.0",
         "friendsofsymfony/oauth-server-bundle": "^1.5",
         "stof/doctrine-extensions-bundle": "^1.2",
         "scheb/two-factor-bundle": "~2.0",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | ?
| Documentation | no
| Translation   | no
| Fixed tickets | https://github.com/wallabag/wallabag/issues/3043
| License       | MIT

FOSUserBundle is now stable (finally).