### PR TITLE
Make symfony-assets-install use `relative` symlinks

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -115,7 +115,7 @@
         "symfony-var-dir": "var",
         "symfony-web-dir": "web",
         "symfony-tests-dir": "tests",
-        "symfony-assets-install": "symlink",
+        "symfony-assets-install": "relative",
         "incenteev-parameters": {
             "file": "app/config/parameters.yml"
         }


### PR DESCRIPTION
This facilitates packaging, when installing in a different work PREFIX
than the final install location.

Signed-off-by: Olivier Mehani <shtrom@ssji.net>

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | ?
| Deprecations? | ?
| Tests pass?   | yes/no
| Documentation | no
| Translation   | no
| Fixed tickets | #...
| License       | MIT

A small change to `composer.json` so the symlinks it creates when installing assets are relative. 

Maybe linked to #2950
