### PR TITLE
Use up-to-date Firefox extension and add F-Droid link for Android app.

### DIFF
--- a/docs/de/user/articles.rst
+++ b/docs/de/user/articles.rst
@@ -30,7 +30,7 @@ Klicke darauf, um ein neues Feld anzuzeigen, füge die Artikel-URL ein und drüc
 Firefox
 """""""
 
-Du kannst das `Firefox-Addon hier <https://addons.mozilla.org/firefox/addon/wallabag-v2/> herunterladen`_.
+Du kannst das `Firefox-Addon hier <https://addons.mozilla.org/firefox/addon/wallabagger/> herunterladen`_.
 
 Chrome
 """"""
@@ -43,7 +43,7 @@ Du kannst das `Chrome-Addon hier <https://chrome.google.com/webstore/detail/wall
 Android
 """""""
 
-Du kannst die `Android-App hier <https://play.google.com/store/apps/details?id=fr.gaulupeau.apps.InThePoche> herunterladen`_.
+Du kannst die `Android-App hier <https://play.google.com/store/apps/details?id=fr.gaulupeau.apps.InThePoche> herunterladen`_ oder auf `F-Droid <https://f-droid.org/repository/browse/?fdid=fr.gaulupeau.apps.InThePoche>`_.
 
 Windows 10 in general
 """""""""""""""""""""

--- a/docs/de/user/articles.rst
+++ b/docs/de/user/articles.rst
@@ -43,7 +43,7 @@ Du kannst das `Chrome-Addon hier <https://chrome.google.com/webstore/detail/wall
 Android
 """""""
 
-Du kannst die `Android-App hier <https://play.google.com/store/apps/details?id=fr.gaulupeau.apps.InThePoche> herunterladen`_ oder auf `F-Droid <https://f-droid.org/repository/browse/?fdid=fr.gaulupeau.apps.InThePoche>`_.
+Du kannst die `Android-App hier <https://play.google.com/store/apps/details?id=fr.gaulupeau.apps.InThePoche>`_ oder auf `F-Droid <https://f-droid.org/repository/browse/?fdid=fr.gaulupeau.apps.InThePoche>`_ herunterladen.
 
 Windows 10 in general
 """""""""""""""""""""

--- a/docs/en/user/articles.rst
+++ b/docs/en/user/articles.rst
@@ -34,7 +34,7 @@ By using a browser add-on
 Firefox
 """""""
 
-You can download the `Firefox addon here <https://addons.mozilla.org/fr/firefox/addon/wallabagger/>`_.
+You can download the `Firefox addon here <https://addons.mozilla.org/firefox/addon/wallabagger/>`_.
 
 Chrome
 """"""

--- a/docs/en/user/articles.rst
+++ b/docs/en/user/articles.rst
@@ -34,20 +34,20 @@ By using a browser add-on
 Firefox
 """""""
 
-You can download the `Firefox addon here <https://addons.mozilla.org/firefox/addon/wallabag-v2/>`_.
+You can download the `Firefox addon here <https://addons.mozilla.org/fr/firefox/addon/wallabagger/>`_.
 
 Chrome
 """"""
 
 You can download the `Chrome addon here <https://chrome.google.com/webstore/detail/wallabagger/gbmgphmejlcoihgedabhgjdkcahacjlj?hl=fr>`_.
 
-By using your smarphone application
+By using your smartphone application
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Android
 """""""
 
-You can download the `Android application here <https://play.google.com/store/apps/details?id=fr.gaulupeau.apps.InThePoche>`_.
+You can download the `Android application here <https://play.google.com/store/apps/details?id=fr.gaulupeau.apps.InThePoche>`_ or on `F-Droid <https://f-droid.org/repository/browse/?fdid=fr.gaulupeau.apps.InThePoche>`_.
 
 Windows Phone
 """""""""""""

--- a/docs/fr/user/articles.rst
+++ b/docs/fr/user/articles.rst
@@ -40,7 +40,7 @@ En utilisant l'extension de votre navigateur
 Firefox
 """""""
 
-Vous pouvez télécharger `l'extension Firefox ici <https://addons.mozilla.org/firefox/addon/wallabag-v2/>`_.
+Vous pouvez télécharger `l'extension Firefox ici <https://addons.mozilla.org/firefox/addon/wallabagger/>`_.
 
 Chrome
 """"""
@@ -53,7 +53,7 @@ En utilisant l'application de votre smartphone
 Android
 """""""
 
-Vous pouvez télécharger `l'application Android ici <https://play.google.com/store/apps/details?id=fr.gaulupeau.apps.InThePoche>`_.
+Vous pouvez télécharger `l'application Android ici <https://play.google.com/store/apps/details?id=fr.gaulupeau.apps.InThePoche>`_ ou sur `F-Droid <https://f-droid.org/repository/browse/?fdid=fr.gaulupeau.apps.InThePoche>`_.
 
 Windows Phone
 ~~~~~~~~~~~~~

--- a/docs/fr/user/articles.rst
+++ b/docs/fr/user/articles.rst
@@ -18,7 +18,7 @@ En utilisant le bookmarklet
 Sur la page ``Aide``, vous avez un onglet ``Bookmarklet``. Glissez/déposez le lien ``bag it!``
 dans votre barre de favoris de votre navigateur.
 
-Maintennat, à chaque fois que vous lisez un article et que vous souhaitez le sauvegarder,
+Maintenant, à chaque fois que vous lisez un article et que vous souhaitez le sauvegarder,
 cliquez sur le lien ``bag it!`` dans votre barre de favoris. L'article est enregistré.
 
 En utilisant le formulaire classique

--- a/docs/it/user/articles.rst
+++ b/docs/it/user/articles.rst
@@ -32,7 +32,7 @@ Usando un add-on del browser
 Firefox
 """""""
 
-Potete scaricare `qui l'addon per Firefox <https://addons.mozilla.org/firefox/addon/wallabag-v2/>`_.
+Potete scaricare `qui l'addon per Firefox <https://addons.mozilla.org/firefox/addon/wallabagger/>`_.
 
 Chrome
 """"""
@@ -45,7 +45,7 @@ Usando la vostra applicazione per smartphone
 Android
 """""""
 
-Potete scaricare `qui l'applicazione per Android <https://play.google.com/store/apps/details?id=fr.gaulupeau.apps.InThePoche>`_.
+Potete scaricare `qui l'applicazione per Android <https://play.google.com/store/apps/details?id=fr.gaulupeau.apps.InThePoche>`_ o via `F-Droid <https://f-droid.org/repository/browse/?fdid=fr.gaulupeau.apps.InThePoche>`_.
 
 Windows Phone
 """""""""""""

--- a/docs/it/user/articles.rst
+++ b/docs/it/user/articles.rst
@@ -45,7 +45,7 @@ Usando la vostra applicazione per smartphone
 Android
 """""""
 
-Potete scaricare `qui l'applicazione per Android <https://play.google.com/store/apps/details?id=fr.gaulupeau.apps.InThePoche>`_ o via `F-Droid <https://f-droid.org/repository/browse/?fdid=fr.gaulupeau.apps.InThePoche>`_.
+Potete scaricare `qui l'applicazione per Android <https://play.google.com/store/apps/details?id=fr.gaulupeau.apps.InThePoche>`_ o tramite `F-Droid <https://f-droid.org/repository/browse/?fdid=fr.gaulupeau.apps.InThePoche>`_.
 
 Windows Phone
 """""""""""""


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Documentation | yes
| Translation   | yes
| License       | MIT

- Update URL for Firefox extension to Wallabager instead of deprecated extension
- Add F-Droid link for Android app
- Fux a typo