### PR TITLE
Correct create_application en string

### DIFF
--- a/src/Wallabag/CoreBundle/Resources/translations/messages.en.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.en.yml
@@ -359,7 +359,7 @@ quickstart:
     developer:
         title: 'Developers'
         description: 'We also thought to the developers: Docker, API, translations, etc.'
-        create_application: 'Create your third application'
+        create_application: 'Create your third-party application'
         use_docker: 'Use Docker to install wallabag'
     docs:
         title: 'Full documentation'


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | ?
| Documentation | no
| Translation   | yes
| Fixed tickets | no
| License       | MIT

Correct one typo in CoreBundle messages.en.yml.
I didn't manage to run tests yet.