### PR TITLE
Fix display the form errors correctly

### DIFF
--- a/src/Wallabag/ApiBundle/Form/Type/ClientType.php
+++ b/src/Wallabag/ApiBundle/Form/Type/ClientType.php
@@ -16,7 +16,11 @@ class ClientType extends AbstractType
     {
         $builder
             ->add('name', TextType::class, ['label' => 'developer.client.form.name_label'])
-            ->add('redirect_uris', UrlType::class, ['required' => false, 'label' => 'developer.client.form.redirect_uris_label'])
+            ->add('redirect_uris', UrlType::class, [
+                'required' => false,
+                'label' => 'developer.client.form.redirect_uris_label',
+                'property_path' => 'redirectUris',
+            ])
             ->add('save', SubmitType::class, ['label' => 'developer.client.form.save_label'])
         ;
 

--- a/src/Wallabag/CoreBundle/Form/Type/ConfigType.php
+++ b/src/Wallabag/CoreBundle/Form/Type/ConfigType.php
@@ -39,9 +39,11 @@ class ConfigType extends AbstractType
             ])
             ->add('items_per_page', null, [
                 'label' => 'config.form_settings.items_per_page_label',
+                'property_path' => 'itemsPerPage',
             ])
             ->add('reading_speed', ChoiceType::class, [
                 'label' => 'config.form_settings.reading_speed.label',
+                'property_path' => 'readingSpeed',
                 'choices' => [
                     'config.form_settings.reading_speed.100_word' => '0.5',
                     'config.form_settings.reading_speed.200_word' => '1',
@@ -51,6 +53,7 @@ class ConfigType extends AbstractType
             ])
             ->add('action_mark_as_read', ChoiceType::class, [
                 'label' => 'config.form_settings.action_mark_as_read.label',
+                'property_path' => 'actionMarkAsRead',
                 'choices' => [
                     'config.form_settings.action_mark_as_read.redirect_homepage' => Config::REDIRECT_TO_HOMEPAGE,
                     'config.form_settings.action_mark_as_read.redirect_current_page' => Config::REDIRECT_TO_CURRENT_PAGE,
@@ -61,6 +64,7 @@ class ConfigType extends AbstractType
                 'label' => 'config.form_settings.language_label',
             ])
             ->add('pocket_consumer_key', null, [
+                'property_path' => 'pocketConsumerKey',
                 'label' => 'config.form_settings.pocket_consumer_key_label',
             ])
             ->add('save', SubmitType::class, [

--- a/src/Wallabag/CoreBundle/Form/Type/EditEntryType.php
+++ b/src/Wallabag/CoreBundle/Form/Type/EditEntryType.php
@@ -21,6 +21,7 @@ class EditEntryType extends AbstractType
             ->add('is_public', CheckboxType::class, [
                 'required' => false,
                 'label' => 'entry.edit.is_public_label',
+                'property_path' => 'isPublic',
             ])
             ->add('url', TextType::class, [
                 'disabled' => true,

--- a/src/Wallabag/CoreBundle/Form/Type/RssType.php
+++ b/src/Wallabag/CoreBundle/Form/Type/RssType.php
@@ -14,6 +14,7 @@ class RssType extends AbstractType
         $builder
             ->add('rss_limit', null, [
                 'label' => 'config.form_rss.rss_limit',
+                'property_path' => 'rssLimit',
             ])
             ->add('save', SubmitType::class, [
                 'label' => 'config.form.save',


### PR DESCRIPTION
Use `property_path` form option to map underscored form fields
to object properties

@see https://github.com/symfony/symfony/issues/9162#issuecomment-25431148

Fix #3067

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Documentation | no
| Translation   | no
| Fixed tickets | #3067 
| License       | MIT

<!--
- Please fill in this template according to the PR you're about to submit.
- Replace this comment by a description of what your PR is solving.
-->
