### PR TITLE
Create a new entry via API even when its content can't be retrieved

### DIFF
--- a/src/Wallabag/ApiBundle/Controller/EntryRestController.php
+++ b/src/Wallabag/ApiBundle/Controller/EntryRestController.php
@@ -199,10 +199,19 @@ class EntryRestController extends WallabagRestController
         $entry = $this->get('wallabag_core.entry_repository')->findByUrlAndUserId($url, $this->getUser()->getId());
 
         if (false === $entry) {
-            $entry = $this->get('wallabag_core.content_proxy')->updateEntry(
-                new Entry($this->getUser()),
-                $url
-            );
+            $entry = new Entry($this->getUser());
+            try {
+                $entry = $this->get('wallabag_core.content_proxy')->updateEntry(
+                    $entry,
+                    $url
+                );
+            } catch (\Exception $e) {
+                $this->get('logger')->error('Error while saving an entry', [
+                    'exception' => $e,
+                    'entry' => $entry,
+                ]);
+                $entry->setUrl($url);
+            }
         }
 
         if (!is_null($title)) {

--- a/tests/Wallabag/ApiBundle/Controller/EntryRestControllerTest.php
+++ b/tests/Wallabag/ApiBundle/Controller/EntryRestControllerTest.php
@@ -4,6 +4,7 @@ namespace Tests\Wallabag\ApiBundle\Controller;
 
 use Tests\Wallabag\ApiBundle\WallabagApiTestCase;
 use Wallabag\CoreBundle\Entity\Tag;
+use Wallabag\CoreBundle\Helper\ContentProxy;
 
 class EntryRestControllerTest extends WallabagApiTestCase
 {
@@ -357,6 +358,29 @@ class EntryRestControllerTest extends WallabagApiTestCase
         $this->assertEquals(true, $content['is_archived']);
         $this->assertEquals(false, $content['is_starred']);
         $this->assertCount(2, $content['tags']);
+    }
+
+    public function testPostEntryWhenFetchContentFails()
+    {
+        /** @var \Symfony\Component\DependencyInjection\Container $container */
+        $container = $this->client->getContainer();
+        $contentProxy = $this->getMockBuilder(ContentProxy::class)
+            ->disableOriginalConstructor()
+            ->setMethods(['updateEntry'])
+            ->getMock();
+        $contentProxy->expects($this->any())
+            ->method('updateEntry')
+            ->willThrowException(new \Exception('Test Fetch content fails'));
+        $container->set('wallabag_core.content_proxy', $contentProxy);
+
+        $this->client->request('POST', '/api/entries.json', [
+            'url' => 'http://www.example.com/',
+        ]);
+
+        $this->assertEquals(200, $this->client->getResponse()->getStatusCode());
+        $content = json_decode($this->client->getResponse()->getContent(), true);
+        $this->assertGreaterThan(0, $content['id']);
+        $this->assertEquals('http://www.example.com/', $content['url']);
     }
 
     public function testPostArchivedAndStarredEntry()


### PR DESCRIPTION


| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Documentation | no
| Translation   | no
| Fixed tickets | #2988
| License       | MIT

<!--
- Please fill in this template according to the PR you're about to submit.
- Replace this comment by a description of what your PR is solving.
-->
