### PR TITLE
Fix API pagination is broken if perPage is custom value

### DIFF
--- a/src/Wallabag/ApiBundle/Controller/EntryRestController.php
+++ b/src/Wallabag/ApiBundle/Controller/EntryRestController.php
@@ -98,12 +98,13 @@ class EntryRestController extends WallabagRestController
         $tags = $request->query->get('tags', '');
         $since = $request->query->get('since', 0);
 
+        /** @var \Pagerfanta\Pagerfanta $pager */
         $pager = $this->getDoctrine()
             ->getRepository('WallabagCoreBundle:Entry')
             ->findEntries($this->getUser()->getId(), $isArchived, $isStarred, $sort, $order, $since, $tags);
 
-        $pager->setCurrentPage($page);
         $pager->setMaxPerPage($perPage);
+        $pager->setCurrentPage($page);
 
         $pagerfantaFactory = new PagerfantaFactory('page', 'perPage');
         $paginatedCollection = $pagerfantaFactory->createRepresentation(

--- a/tests/Wallabag/ApiBundle/Controller/EntryRestControllerTest.php
+++ b/tests/Wallabag/ApiBundle/Controller/EntryRestControllerTest.php
@@ -156,6 +156,22 @@ class EntryRestControllerTest extends WallabagApiTestCase
         $this->assertEquals('application/json', $this->client->getResponse()->headers->get('Content-Type'));
     }
 
+    public function testGetEntriesOnPageTwo()
+    {
+        $this->client->request('GET', '/api/entries', [
+            'page' => 2,
+            'perPage' => 2,
+        ]);
+
+        $this->assertEquals(200, $this->client->getResponse()->getStatusCode());
+
+        $content = json_decode($this->client->getResponse()->getContent(), true);
+
+        $this->assertGreaterThanOrEqual(0, $content['total']);
+        $this->assertEquals(2, $content['page']);
+        $this->assertEquals(2, $content['limit']);
+    }
+
     public function testGetStarredEntries()
     {
         $this->client->request('GET', '/api/entries', ['starred' => 1, 'sort' => 'updated']);


### PR DESCRIPTION
 
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Documentation | no
| Translation   | no
| Fixed tickets | #2720
| License       | MIT

<!--
- Please fill in this template according to the PR you're about to submit.
- Replace this comment by a description of what your PR is solving.
-->
