### PR TITLE
Skip auth when no credentials are found

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -84,7 +84,7 @@
         "javibravo/simpleue": "^1.0",
         "symfony/dom-crawler": "^3.1",
         "friendsofsymfony/jsrouting-bundle": "^1.6",
-        "bdunogier/guzzle-site-authenticator": "dev-master"
+        "bdunogier/guzzle-site-authenticator": "dev-callback_forms"
     },
     "require-dev": {
         "doctrine/doctrine-fixtures-bundle": "~2.2",

--- a/composer.json
+++ b/composer.json
@@ -84,7 +84,7 @@
         "javibravo/simpleue": "^1.0",
         "symfony/dom-crawler": "^3.1",
         "friendsofsymfony/jsrouting-bundle": "^1.6",
-        "bdunogier/guzzle-site-authenticator": "dev-callback_forms"
+        "bdunogier/guzzle-site-authenticator": "dev-master"
     },
     "require-dev": {
         "doctrine/doctrine-fixtures-bundle": "~2.2",

--- a/src/Wallabag/CoreBundle/GuzzleSiteAuthenticator/GrabySiteConfigBuilder.php
+++ b/src/Wallabag/CoreBundle/GuzzleSiteAuthenticator/GrabySiteConfigBuilder.php
@@ -54,7 +54,7 @@ class GrabySiteConfigBuilder implements SiteConfigBuilder
             $host = substr($host, 4);
         }
 
-        if (!isset($this->credentials[$host])) {
+        if (empty($this->credentials[$host])) {
             $this->logger->debug('Auth: no credentials available for host.', ['host' => $host]);
 
             return false;

--- a/src/Wallabag/CoreBundle/Helper/HttpClientFactory.php
+++ b/src/Wallabag/CoreBundle/Helper/HttpClientFactory.php
@@ -51,6 +51,7 @@ class HttpClientFactory
         $this->cookieJar->clear();
         // need to set the (shared) cookie jar
         $client = new Client(['handler' => new SafeCurlHandler(), 'defaults' => ['cookies' => $this->cookieJar]]);
+
         foreach ($this->subscribers as $subscriber) {
             $client->getEmitter()->attach($subscriber);
         }

--- a/src/Wallabag/CoreBundle/Resources/config/services.yml
+++ b/src/Wallabag/CoreBundle/Resources/config/services.yml
@@ -63,6 +63,9 @@ services:
         arguments:
             - "@wallabag_core.graby.config_builder"
             - "%sites_credentials%"
+            - '@logger'
+        tags:
+            - { name: monolog.logger, channel: graby }
 
     # service alias override
     bd_guzzle_site_authenticator.site_config_builder:


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Documentation | no
| Translation   | no
| Fixed tickets | https://github.com/wallabag/guzzle-site-authenticator/pull/15
| License       | MIT

If we can’t find a credential for the current host, even if it required login, we won’t add them and website will be fetched without any login.

Also, add logger.

Tested using NextINpact content and it worked well :call_me_hand: 