### PR TITLE
Retrieve tag / tags value from query or request

### DIFF
--- a/src/Wallabag/ApiBundle/Controller/TagRestController.php
+++ b/src/Wallabag/ApiBundle/Controller/TagRestController.php
@@ -44,7 +44,7 @@ class TagRestController extends WallabagRestController
     public function deleteTagLabelAction(Request $request)
     {
         $this->validateAuthentication();
-        $label = $request->request->get('tag', '');
+        $label = $request->get('tag', '');
 
         $tag = $this->getDoctrine()->getRepository('WallabagCoreBundle:Tag')->findOneByLabel($label);
 
@@ -78,7 +78,7 @@ class TagRestController extends WallabagRestController
     {
         $this->validateAuthentication();
 
-        $tagsLabels = $request->request->get('tags', '');
+        $tagsLabels = $request->get('tags', '');
 
         $tags = [];
 

--- a/tests/Wallabag/ApiBundle/Controller/TagRestControllerTest.php
+++ b/tests/Wallabag/ApiBundle/Controller/TagRestControllerTest.php
@@ -54,7 +54,18 @@ class TagRestControllerTest extends WallabagApiTestCase
         $this->assertNull($tag, $tagName.' was removed because it begun an orphan tag');
     }
 
-    public function testDeleteTagByLabel()
+    public function dataForDeletingTagByLabel()
+    {
+        return [
+            'by_query' => [true],
+            'by_body' => [false],
+        ];
+    }
+
+    /**
+     * @dataProvider dataForDeletingTagByLabel
+     */
+    public function testDeleteTagByLabel($useQueryString)
     {
         $em = $this->client->getContainer()->get('doctrine.orm.entity_manager');
         $entry = $this->client->getContainer()
@@ -73,7 +84,11 @@ class TagRestControllerTest extends WallabagApiTestCase
         $em->persist($entry);
         $em->flush();
 
-        $this->client->request('DELETE', '/api/tag/label.json', ['tag' => $tag->getLabel()]);
+        if ($useQueryString) {
+            $this->client->request('DELETE', '/api/tag/label.json?tag='.$tag->getLabel());
+        } else {
+            $this->client->request('DELETE', '/api/tag/label.json', ['tag' => $tag->getLabel()]);
+        }
 
         $this->assertEquals(200, $this->client->getResponse()->getStatusCode());
 
@@ -98,7 +113,10 @@ class TagRestControllerTest extends WallabagApiTestCase
         $this->assertEquals(404, $this->client->getResponse()->getStatusCode());
     }
 
-    public function testDeleteTagsByLabel()
+    /**
+     * @dataProvider dataForDeletingTagByLabel
+     */
+    public function testDeleteTagsByLabel($useQueryString)
     {
         $em = $this->client->getContainer()->get('doctrine.orm.entity_manager');
         $entry = $this->client->getContainer()
@@ -122,7 +140,11 @@ class TagRestControllerTest extends WallabagApiTestCase
         $em->persist($entry);
         $em->flush();
 
-        $this->client->request('DELETE', '/api/tags/label.json', ['tags' => $tag->getLabel().','.$tag2->getLabel()]);
+        if ($useQueryString) {
+            $this->client->request('DELETE', '/api/tags/label.json?tags='.$tag->getLabel().','.$tag2->getLabel());
+        } else {
+            $this->client->request('DELETE', '/api/tags/label.json', ['tags' => $tag->getLabel().','.$tag2->getLabel()]);
+        }
 
         $this->assertEquals(200, $this->client->getResponse()->getStatusCode());
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Documentation | no
| Translation   | no
| Fixed tickets | https://github.com/wallabag/wallabag/issues/2709
| License       | MIT

It allows to request to delete a tag using query string instead of body parameter (which seems to be the standard).
Instead of breaking the previous behavior, I used a generic way to retrieve parameter (which looks into request attributes, query parameters and request parameters)