### PR TITLE
reorder contrib strings in about page

### DIFF
--- a/src/Wallabag/CoreBundle/Resources/views/themes/common/Static/about.html.twig
+++ b/src/Wallabag/CoreBundle/Resources/views/themes/common/Static/about.html.twig
@@ -46,7 +46,7 @@
                     <div id="set3" class="col s12">
                         <dl>
                             <dt>{{ 'about.helping.description'|trans }}</dt>
-                            <dd>{{ 'about.helping.by_contributing_2'|trans }} <a href="https://github.com/wallabag/wallabag/issues/1254">{{ 'about.helping.by_contributing'|trans }}</a></dd>
+                            <dd>{{ 'about.helping.by_contributing'|trans }} <a href="https://github.com/wallabag/wallabag/issues/1254">{{ 'about.helping.by_contributing_2'|trans }}</a></dd>
                             <dd><a href="{{ paypal_url }}">{{ 'about.helping.by_paypal'|trans }}</a></dd>
                         </dl>
                     </div>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Documentation | no
| Translation   | no
| Fixed tickets | #2891 
| License       | MIT


The two contribute strings were mixed up
