### PR TITLE
Lock guzzle-site-authenticator to avoid errors

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -84,7 +84,7 @@
         "javibravo/simpleue": "^1.0",
         "symfony/dom-crawler": "^3.1",
         "friendsofsymfony/jsrouting-bundle": "^1.6",
-        "bdunogier/guzzle-site-authenticator": "dev-master"
+        "bdunogier/guzzle-site-authenticator": "1.0.0-beta1"
     },
     "require-dev": {
         "doctrine/doctrine-fixtures-bundle": "~2.2",

--- a/var/SymfonyRequirements.php
+++ b/var/SymfonyRequirements.php
@@ -634,12 +634,6 @@ class SymfonyRequirements extends RequirementCollection
         );
 
         $this->addRecommendation(
-            function_exists('iconv'),
-            'iconv() should be available',
-            'Install and enable the <strong>iconv</strong> extension.'
-        );
-
-        $this->addRecommendation(
             function_exists('utf8_decode'),
             'utf8_decode() should be available',
             'Install and enable the <strong>XML</strong> extension.'


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Documentation | no
| Translation   | no
| Fixed tickets | #...
| License       | MIT

Lock guzzle-site-authenticator to avoid error when new version (which is in 2.3 branch)