### PR TITLE
unify Download/Export wording.

### DIFF
--- a/src/Wallabag/CoreBundle/Resources/translations/messages.da.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.da.yml
@@ -214,7 +214,7 @@ entry:
             # share_email_label: 'Email'
             # public_link: 'public link'
             # delete_public_link: 'delete public link'
-            download: 'Download'
+            # export: 'Export'
             # print: 'Print'
             problem:
                 label: 'Problemer?'

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.de.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.de.yml
@@ -214,7 +214,7 @@ entry:
             share_email_label: 'E-Mail'
             public_link: 'Öffentlicher Link'
             delete_public_link: 'Lösche öffentlichen Link'
-            download: 'Herunterladen'
+            download: 'Exportieren'
             print: 'Drucken'
             problem:
                 label: 'Probleme?'

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.de.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.de.yml
@@ -214,7 +214,7 @@ entry:
             share_email_label: 'E-Mail'
             public_link: 'Öffentlicher Link'
             delete_public_link: 'Lösche öffentlichen Link'
-            download: 'Exportieren'
+            export: 'Exportieren'
             print: 'Drucken'
             problem:
                 label: 'Probleme?'

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.en.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.en.yml
@@ -214,7 +214,7 @@ entry:
             share_email_label: 'Email'
             public_link: 'public link'
             delete_public_link: 'delete public link'
-            download: 'Export'
+            export: 'Export'
             print: 'Print'
             problem:
                 label: 'Problems?'

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.en.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.en.yml
@@ -214,7 +214,7 @@ entry:
             share_email_label: 'Email'
             public_link: 'public link'
             delete_public_link: 'delete public link'
-            download: 'Download'
+            download: 'Export'
             print: 'Print'
             problem:
                 label: 'Problems?'

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.es.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.es.yml
@@ -214,7 +214,7 @@ entry:
             share_email_label: 'e-mail'
             public_link: 'enlace público'
             delete_public_link: 'eliminar enlace público'
-            download: 'Exportar'
+            export: 'Exportar'
             print: 'Imprimir'
             problem:
                 label: '¿Algún problema?'

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.es.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.es.yml
@@ -214,7 +214,7 @@ entry:
             share_email_label: 'e-mail'
             public_link: 'enlace público'
             delete_public_link: 'eliminar enlace público'
-            download: 'Descargar'
+            download: 'Exportar'
             print: 'Imprimir'
             problem:
                 label: '¿Algún problema?'

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.fa.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.fa.yml
@@ -214,7 +214,7 @@ entry:
             share_email_label: 'نشانی ایمیل'
             # public_link: 'public link'
             # delete_public_link: 'delete public link'
-            download: 'بارگیری'
+            export: 'بارگیری'
             print: 'چاپ'
             problem:
                 label: 'مشکلات؟'

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.fr.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.fr.yml
@@ -214,7 +214,7 @@ entry:
             share_email_label: "Courriel"
             public_link: "Lien public"
             delete_public_link: "Supprimer le lien public"
-            download: "Télécharger"
+            download: "Exporter"
             print: "Imprimer"
             problem:
                 label: "Un problème ?"

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.fr.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.fr.yml
@@ -214,7 +214,7 @@ entry:
             share_email_label: "Courriel"
             public_link: "Lien public"
             delete_public_link: "Supprimer le lien public"
-            download: "Exporter"
+            export: "Exporter"
             print: "Imprimer"
             problem:
                 label: "Un problème ?"

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.it.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.it.yml
@@ -214,7 +214,7 @@ entry:
             share_email_label: 'E-mail'
             # public_link: 'public link'
             # delete_public_link: 'delete public link'
-            download: 'Download'
+            download: 'Esporta'
             print: 'Stampa'
             problem:
                 label: 'Problemi?'

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.it.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.it.yml
@@ -214,7 +214,7 @@ entry:
             share_email_label: 'E-mail'
             # public_link: 'public link'
             # delete_public_link: 'delete public link'
-            download: 'Esporta'
+            export: 'Esporta'
             print: 'Stampa'
             problem:
                 label: 'Problemi?'

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.oc.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.oc.yml
@@ -214,7 +214,7 @@ entry:
             share_email_label: 'Corrièl'
             public_link: 'ligam public'
             delete_public_link: 'suprimir lo ligam public'
-            download: 'Telecargar'
+            download: 'Exportar'
             print: 'Imprimir'
             problem:
                 label: 'Un problèma ?'

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.oc.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.oc.yml
@@ -214,7 +214,7 @@ entry:
             share_email_label: 'Corrièl'
             public_link: 'ligam public'
             delete_public_link: 'suprimir lo ligam public'
-            download: 'Exportar'
+            export: 'Exportar'
             print: 'Imprimir'
             problem:
                 label: 'Un problèma ?'

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.pl.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.pl.yml
@@ -214,7 +214,7 @@ entry:
             share_email_label: 'Adres email'
             public_link: 'Publiczny link'
             delete_public_link: 'Usuń publiczny link'
-            download: 'Export'
+            export: 'Export'
             print: 'Drukuj'
             problem:
                 label: 'Problemy'

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.pl.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.pl.yml
@@ -214,7 +214,7 @@ entry:
             share_email_label: 'Adres email'
             public_link: 'Publiczny link'
             delete_public_link: 'Usuń publiczny link'
-            download: 'Pobierz'
+            download: 'Export'
             print: 'Drukuj'
             problem:
                 label: 'Problemy'

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.pt.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.pt.yml
@@ -214,7 +214,7 @@ entry:
             share_email_label: 'E-mail'
             public_link: 'link público'
             delete_public_link: 'apagar link público'
-            download: 'Exportar'
+            export: 'Exportar'
             print: 'Imprimir'
             problem:
                 label: 'Problemas?'

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.pt.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.pt.yml
@@ -214,7 +214,7 @@ entry:
             share_email_label: 'E-mail'
             public_link: 'link público'
             delete_public_link: 'apagar link público'
-            download: 'Download'
+            download: 'Exportar'
             print: 'Imprimir'
             problem:
                 label: 'Problemas?'

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.ro.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.ro.yml
@@ -214,7 +214,7 @@ entry:
             share_email_label: 'E-mail'
             # public_link: 'public link'
             # delete_public_link: 'delete public link'
-            download: 'Descarcă'
+            export: 'Descarcă'
             # print: 'Print'
             problem:
                 label: 'Probleme?'

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.tr.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.tr.yml
@@ -214,7 +214,7 @@ entry:
             share_email_label: 'E-posta'
             # public_link: 'public link'
             # delete_public_link: 'delete public link'
-            download: 'Dışa Aktar'
+            export: 'Dışa Aktar'
             # print: 'Print'
             problem:
                 label: 'Bir sorun mu var?'

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.tr.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.tr.yml
@@ -214,7 +214,7 @@ entry:
             share_email_label: 'E-posta'
             # public_link: 'public link'
             # delete_public_link: 'delete public link'
-            download: 'İndir'
+            download: 'Dışa Aktar'
             # print: 'Print'
             problem:
                 label: 'Bir sorun mu var?'

--- a/src/Wallabag/CoreBundle/Resources/views/themes/material/Entry/entry.html.twig
+++ b/src/Wallabag/CoreBundle/Resources/views/themes/material/Entry/entry.html.twig
@@ -179,7 +179,7 @@
         <li class="bold">
             <a class="waves-effect collapsible-header">
                 <i class="material-icons small">file_download</i>
-                <span>{{ 'entry.view.left_menu.download'|trans }}</span>
+                <span>{{ 'entry.view.left_menu.export'|trans }}</span>
             </a>
             <div class="collapsible-body">
                 <ul>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Documentation | no
| Translation   | yes
| Fixed tickets | #2967 
| License       | MIT

Use export in article view as well.
The translation has been taken from entry.list.export_title when available.
