### PR TITLE
Ignore ActionMarkAsRead when removing tag from entry

### DIFF
--- a/src/Wallabag/CoreBundle/Controller/TagController.php
+++ b/src/Wallabag/CoreBundle/Controller/TagController.php
@@ -70,7 +70,7 @@ class TagController extends Controller
             $em->flush();
         }
 
-        $redirectUrl = $this->get('wallabag_core.helper.redirect')->to($request->headers->get('referer'));
+        $redirectUrl = $this->get('wallabag_core.helper.redirect')->to($request->headers->get('referer'), '', true);
 
         return $this->redirect($redirectUrl);
     }

--- a/src/Wallabag/CoreBundle/Helper/Redirect.php
+++ b/src/Wallabag/CoreBundle/Helper/Redirect.php
@@ -21,12 +21,13 @@ class Redirect
     }
 
     /**
-     * @param string $url      URL to redirect
-     * @param string $fallback Fallback URL if $url is null
+     * @param string $url                    URL to redirect
+     * @param string $fallback               Fallback URL if $url is null
+     * @param bool   $ignoreActionMarkAsRead Ignore configured action when mark as read
      *
      * @return string
      */
-    public function to($url, $fallback = '')
+    public function to($url, $fallback = '', $ignoreActionMarkAsRead = false)
     {
         $user = $this->tokenStorage->getToken() ? $this->tokenStorage->getToken()->getUser() : null;
 
@@ -34,7 +35,8 @@ class Redirect
             return $url;
         }
 
-        if (Config::REDIRECT_TO_HOMEPAGE === $user->getConfig()->getActionMarkAsRead()) {
+        if (!$ignoreActionMarkAsRead &&
+              Config::REDIRECT_TO_HOMEPAGE === $user->getConfig()->getActionMarkAsRead()) {
             return $this->router->generate('homepage');
         }
 

--- a/tests/Wallabag/CoreBundle/Controller/TagControllerTest.php
+++ b/tests/Wallabag/CoreBundle/Controller/TagControllerTest.php
@@ -134,6 +134,12 @@ class TagControllerTest extends WallabagCoreTestCase
         $this->assertEquals(302, $client->getResponse()->getStatusCode());
         $this->assertEquals($entryUri, $client->getResponse()->getTargetUrl());
 
+        // re-retrieve the entry to be sure to get fresh data from database (mostly for tags)
+        $entry = $client->getContainer()
+            ->get('doctrine.orm.entity_manager')
+            ->getRepository('WallabagCoreBundle:Entry')
+            ->findByUrlAndUserId('http://0.0.0.0/entry1', $this->getLoggedInUserId());
+
         $this->assertNotContains($this->tagName, $entry->getTags());
 
         $client->request('GET', '/remove-tag/'.$entry->getId().'/'.$tag->getId());

--- a/tests/Wallabag/CoreBundle/Controller/TagControllerTest.php
+++ b/tests/Wallabag/CoreBundle/Controller/TagControllerTest.php
@@ -126,9 +126,13 @@ class TagControllerTest extends WallabagCoreTestCase
             ->getRepository('WallabagCoreBundle:Tag')
             ->findOneByEntryAndTagLabel($entry, $this->tagName);
 
+        // We make a first request to set an history and test redirection after tag deletion
+        $client->request('GET', '/view/'.$entry->getId());
+        $entryUri = $client->getRequest()->getUri();
         $client->request('GET', '/remove-tag/'.$entry->getId().'/'.$tag->getId());
 
         $this->assertEquals(302, $client->getResponse()->getStatusCode());
+        $this->assertEquals($entryUri, $client->getResponse()->getTargetUrl());
 
         $this->assertNotContains($this->tagName, $entry->getTags());
 

--- a/tests/Wallabag/CoreBundle/Helper/RedirectTest.php
+++ b/tests/Wallabag/CoreBundle/Helper/RedirectTest.php
@@ -89,4 +89,22 @@ class RedirectTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals($this->routerMock->generate('homepage'), $redirectUrl);
     }
+
+    public function testUserForRedirectWithIgnoreActionMarkAsRead()
+    {
+        $this->token->getUser()->getConfig()->setActionMarkAsRead(Config::REDIRECT_TO_HOMEPAGE);
+
+        $redirectUrl = $this->redirect->to('/unread/list', '', true);
+
+        $this->assertEquals('/unread/list', $redirectUrl);
+    }
+
+    public function testUserForRedirectNullWithFallbackWithIgnoreActionMarkAsRead()
+    {
+        $this->token->getUser()->getConfig()->setActionMarkAsRead(Config::REDIRECT_TO_HOMEPAGE);
+
+        $redirectUrl = $this->redirect->to(null, 'fallback', true);
+
+        $this->assertEquals('fallback', $redirectUrl);
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | somewhat?
| Deprecations? | no
| Tests pass?   | -
| Documentation | no
| Translation   | no
| Fixed tickets | #2835 
| License       | MIT

Ignore ActionMarkAsRead to stay on entry when removing a tag.