### PR TITLE
Ignore tag's case

### DIFF
--- a/app/DoctrineMigrations/Version20170719231144.php
+++ b/app/DoctrineMigrations/Version20170719231144.php
@@ -1,0 +1,103 @@
+<?php
+
+namespace Application\Migrations;
+
+use Doctrine\DBAL\Migrations\AbstractMigration;
+use Doctrine\DBAL\Schema\Schema;
+use Symfony\Component\DependencyInjection\ContainerAwareInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Changed tags to lowercase
+ */
+class Version20170719231144 extends AbstractMigration implements ContainerAwareInterface
+{
+    /**
+     * @var ContainerInterface
+     */
+    private $container;
+
+    public function setContainer(ContainerInterface $container = null)
+    {
+        $this->container = $container;
+    }
+
+    private function getTable($tableName)
+    {
+        return $this->container->getParameter('database_table_prefix').$tableName;
+    }
+
+    /**
+     * @param Schema $schema
+     */
+    public function up(Schema $schema)
+    {
+        $this->skipIf($this->connection->getDatabasePlatform()->getName() == 'sqlite', 'Migration can only be executed safely on \'mysql\' or \'postgresql\'.');
+        
+        // Find tags which need to be merged
+        $dupTags = $this->connection->query("
+            SELECT LOWER(label)
+            FROM   ".$this->getTable('tag')."
+            GROUP BY LOWER(label)
+            HAVING COUNT(*) > 1"
+        );
+        $dupTags->execute();
+
+        foreach ($dupTags->fetchAll() as $duplicates) {
+            $label = $duplicates['LOWER(label)'];
+
+            // Retrieve all duplicate tags for a given tag
+            $tags = $this->connection->query("
+                SELECT id
+                FROM   ".$this->getTable('tag')."
+                WHERE  LOWER(label) = '".$label."'
+                ORDER BY id ASC"
+            );
+            $tags->execute();
+
+            $first = true;
+            $newId = null;
+            $ids = [];
+
+            foreach ($tags->fetchAll() as $tag) {
+                // Ignore the first tag as we use it as the new reference tag
+                if ($first) {
+                    $first = false;
+                    $newId = $tag['id'];
+                } else {
+                    $ids[] = $tag['id'];
+                }
+            }
+
+            // Just in case...
+            if (count($ids) > 0) {
+                // Merge tags
+                $this->addSql("
+                    UPDATE ".$this->getTable('entry_tag')."
+                    SET    tag_id = ".$newId."
+                    WHERE  tag_id IN (".implode(',', $ids).")"
+                );
+
+                // Delete unused tags
+                $this->addSql("
+                    DELETE FROM ".$this->getTable('tag')."
+                    WHERE id IN (".implode(',', $ids).")"
+                );
+            }
+        }
+
+        // Iterate over all tags to lowercase them
+        $this->addSql("
+            UPDATE ".$this->getTable('tag')."
+            SET label = LOWER(label)"
+        );
+    }
+
+    /**
+     * @param Schema $schema
+     */
+    public function down(Schema $schema)
+    {
+        throw new SkipMigrationException('Too complex ...');
+    }
+}

--- a/app/DoctrineMigrations/Version20170719231144.php
+++ b/app/DoctrineMigrations/Version20170719231144.php
@@ -8,7 +8,7 @@ use Symfony\Component\DependencyInjection\ContainerAwareInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
- * Changed tags to lowercase
+ * Changed tags to lowercase.
  */
 class Version20170719231144 extends AbstractMigration implements ContainerAwareInterface
 {
@@ -22,24 +22,19 @@ class Version20170719231144 extends AbstractMigration implements ContainerAwareI
         $this->container = $container;
     }
 
-    private function getTable($tableName)
-    {
-        return $this->container->getParameter('database_table_prefix').$tableName;
-    }
-
     /**
      * @param Schema $schema
      */
     public function up(Schema $schema)
     {
-        $this->skipIf($this->connection->getDatabasePlatform()->getName() == 'sqlite', 'Migration can only be executed safely on \'mysql\' or \'postgresql\'.');
-        
+        $this->skipIf($this->connection->getDatabasePlatform()->getName() === 'sqlite', 'Migration can only be executed safely on \'mysql\' or \'postgresql\'.');
+
         // Find tags which need to be merged
-        $dupTags = $this->connection->query("
+        $dupTags = $this->connection->query('
             SELECT LOWER(label)
-            FROM   ".$this->getTable('tag')."
+            FROM   ' . $this->getTable('tag') . '
             GROUP BY LOWER(label)
-            HAVING COUNT(*) > 1"
+            HAVING COUNT(*) > 1'
         );
         $dupTags->execute();
 
@@ -47,10 +42,10 @@ class Version20170719231144 extends AbstractMigration implements ContainerAwareI
             $label = $duplicates['LOWER(label)'];
 
             // Retrieve all duplicate tags for a given tag
-            $tags = $this->connection->query("
+            $tags = $this->connection->query('
                 SELECT id
-                FROM   ".$this->getTable('tag')."
-                WHERE  LOWER(label) = '".$label."'
+                FROM   ' . $this->getTable('tag') . "
+                WHERE  LOWER(label) = '" . $label . "'
                 ORDER BY id ASC"
             );
             $tags->execute();
@@ -72,24 +67,24 @@ class Version20170719231144 extends AbstractMigration implements ContainerAwareI
             // Just in case...
             if (count($ids) > 0) {
                 // Merge tags
-                $this->addSql("
-                    UPDATE ".$this->getTable('entry_tag')."
-                    SET    tag_id = ".$newId."
-                    WHERE  tag_id IN (".implode(',', $ids).")"
+                $this->addSql('
+                    UPDATE ' . $this->getTable('entry_tag') . '
+                    SET    tag_id = ' . $newId . '
+                    WHERE  tag_id IN (' . implode(',', $ids) . ')'
                 );
 
                 // Delete unused tags
-                $this->addSql("
-                    DELETE FROM ".$this->getTable('tag')."
-                    WHERE id IN (".implode(',', $ids).")"
+                $this->addSql('
+                    DELETE FROM ' . $this->getTable('tag') . '
+                    WHERE id IN (' . implode(',', $ids) . ')'
                 );
             }
         }
 
         // Iterate over all tags to lowercase them
-        $this->addSql("
-            UPDATE ".$this->getTable('tag')."
-            SET label = LOWER(label)"
+        $this->addSql('
+            UPDATE ' . $this->getTable('tag') . '
+            SET label = LOWER(label)'
         );
     }
 
@@ -99,5 +94,10 @@ class Version20170719231144 extends AbstractMigration implements ContainerAwareI
     public function down(Schema $schema)
     {
         throw new SkipMigrationException('Too complex ...');
+    }
+
+    private function getTable($tableName)
+    {
+        return $this->container->getParameter('database_table_prefix') . $tableName;
     }
 }

--- a/src/Wallabag/CoreBundle/Entity/Tag.php
+++ b/src/Wallabag/CoreBundle/Entity/Tag.php
@@ -78,7 +78,7 @@ class Tag
      */
     public function setLabel($label)
     {
-        $this->label = $label;
+        $this->label = mb_convert_case($label, MB_CASE_LOWER);
 
         return $this;
     }

--- a/src/Wallabag/CoreBundle/Helper/TagsAssigner.php
+++ b/src/Wallabag/CoreBundle/Helper/TagsAssigner.php
@@ -45,7 +45,7 @@ class TagsAssigner
         }
 
         foreach ($tags as $label) {
-            $label = trim($label);
+            $label = trim(mb_convert_case($label, MB_CASE_LOWER));
 
             // avoid empty tag
             if (0 === strlen($label)) {

--- a/tests/Wallabag/CoreBundle/Controller/TagControllerTest.php
+++ b/tests/Wallabag/CoreBundle/Controller/TagControllerTest.php
@@ -9,6 +9,7 @@ use Wallabag\CoreBundle\Entity\Tag;
 class TagControllerTest extends WallabagCoreTestCase
 {
     public $tagName = 'opensource';
+    public $caseTagName = 'OpenSource';
 
     public function testList()
     {
@@ -36,7 +37,7 @@ class TagControllerTest extends WallabagCoreTestCase
         $form = $crawler->filter('form[name=tag]')->form();
 
         $data = [
-            'tag[label]' => $this->tagName,
+            'tag[label]' => $this->caseTagName,
         ];
 
         $client->submit($form, $data);
@@ -45,6 +46,7 @@ class TagControllerTest extends WallabagCoreTestCase
         // be sure to reload the entry
         $entry = $this->getEntityManager()->getRepository(Entry::class)->find($entry->getId());
         $this->assertCount(1, $entry->getTags());
+        $this->assertContains($this->tagName, $entry->getTags());
 
         // tag already exists and already assigned
         $client->submit($form, $data);
@@ -80,7 +82,7 @@ class TagControllerTest extends WallabagCoreTestCase
         $form = $crawler->filter('form[name=tag]')->form();
 
         $data = [
-            'tag[label]' => 'foo2, bar2',
+            'tag[label]' => 'foo2, Bar2',
         ];
 
         $client->submit($form, $data);

--- a/tests/Wallabag/ImportBundle/Controller/PinboardControllerTest.php
+++ b/tests/Wallabag/ImportBundle/Controller/PinboardControllerTest.php
@@ -125,7 +125,7 @@ class PinboardControllerTest extends WallabagCoreTestCase
         $tags = $content->getTags();
         $this->assertContains('foot', $tags, 'It includes the "foot" tag');
         $this->assertContains('varnish', $tags, 'It includes the "varnish" tag');
-        $this->assertContains('PHP', $tags, 'It includes the "PHP" tag');
+        $this->assertContains('php', $tags, 'It includes the "php" tag');
         $this->assertSame(3, count($tags));
 
         $this->assertInstanceOf(\DateTime::class, $content->getCreatedAt());

--- a/tests/Wallabag/ImportBundle/Controller/WallabagV1ControllerTest.php
+++ b/tests/Wallabag/ImportBundle/Controller/WallabagV1ControllerTest.php
@@ -125,7 +125,7 @@ class WallabagV1ControllerTest extends WallabagCoreTestCase
 
         $tags = $content->getTags();
         $this->assertContains('foot', $tags, 'It includes the "foot" tag');
-        $this->assertContains('Framabag', $tags, 'It includes the "Framabag" tag');
+        $this->assertContains('framabag', $tags, 'It includes the "framabag" tag');
         $this->assertSame(2, count($tags));
 
         $this->assertInstanceOf(\DateTime::class, $content->getCreatedAt());


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | somewhat?
| Deprecations? | no
| Tests pass?   | -
| Documentation | no
| Translation   | no
| Fixed tickets | #2502 
| License       | MIT

Store tag labels in lowercase in order to prevent case-sensitive duplicates.

Non-lowercase tags already existing before this PR should still work as usual but any new tag will be saved in lowercase.