### PR TITLE
Move Tags assigner to a separate file

### DIFF
--- a/src/Wallabag/ApiBundle/Controller/EntryRestController.php
+++ b/src/Wallabag/ApiBundle/Controller/EntryRestController.php
@@ -318,7 +318,7 @@ class EntryRestController extends WallabagRestController
 
         $tags = $request->request->get('tags', '');
         if (!empty($tags)) {
-            $this->get('wallabag_core.content_proxy')->assignTagsToEntry($entry, $tags);
+            $this->get('wallabag_core.tags_assigner')->assignTagsToEntry($entry, $tags);
         }
 
         if (!is_null($isStarred)) {
@@ -379,7 +379,7 @@ class EntryRestController extends WallabagRestController
 
         $tags = $request->request->get('tags', '');
         if (!empty($tags)) {
-            $this->get('wallabag_core.content_proxy')->assignTagsToEntry($entry, $tags);
+            $this->get('wallabag_core.tags_assigner')->assignTagsToEntry($entry, $tags);
         }
 
         $em = $this->getDoctrine()->getManager();
@@ -497,7 +497,7 @@ class EntryRestController extends WallabagRestController
 
         $tags = $request->request->get('tags', '');
         if (!empty($tags)) {
-            $this->get('wallabag_core.content_proxy')->assignTagsToEntry($entry, $tags);
+            $this->get('wallabag_core.tags_assigner')->assignTagsToEntry($entry, $tags);
         }
 
         $em = $this->getDoctrine()->getManager();
@@ -626,7 +626,7 @@ class EntryRestController extends WallabagRestController
             $tags = $element->tags;
 
             if (false !== $entry && !(empty($tags))) {
-                $this->get('wallabag_core.content_proxy')->assignTagsToEntry($entry, $tags);
+                $this->get('wallabag_core.tags_assigner')->assignTagsToEntry($entry, $tags);
 
                 $em = $this->getDoctrine()->getManager();
                 $em->persist($entry);

--- a/src/Wallabag/CoreBundle/Controller/TagController.php
+++ b/src/Wallabag/CoreBundle/Controller/TagController.php
@@ -28,7 +28,7 @@ class TagController extends Controller
         $form->handleRequest($request);
 
         if ($form->isSubmitted() && $form->isValid()) {
-            $this->get('wallabag_core.content_proxy')->assignTagsToEntry(
+            $this->get('wallabag_core.tags_assigner')->assignTagsToEntry(
                 $entry,
                 $form->get('label')->getData()
             );

--- a/src/Wallabag/CoreBundle/Helper/ContentProxy.php
+++ b/src/Wallabag/CoreBundle/Helper/ContentProxy.php
@@ -4,10 +4,9 @@ namespace Wallabag\CoreBundle\Helper;
 
 use Graby\Graby;
 use Psr\Log\LoggerInterface;
+use Symfony\Component\EventDispatcher\EventDispatcher;
 use Wallabag\CoreBundle\Entity\Entry;
-use Wallabag\CoreBundle\Entity\Tag;
 use Wallabag\CoreBundle\Tools\Utils;
-use Wallabag\CoreBundle\Repository\TagRepository;
 use Symfony\Component\HttpFoundation\File\MimeType\MimeTypeExtensionGuesser;
 
 /**
@@ -19,16 +18,15 @@ class ContentProxy
     protected $graby;
     protected $tagger;
     protected $logger;
-    protected $tagRepository;
     protected $mimeGuesser;
     protected $fetchingErrorMessage;
+    protected $eventDispatcher;
 
-    public function __construct(Graby $graby, RuleBasedTagger $tagger, TagRepository $tagRepository, LoggerInterface $logger, $fetchingErrorMessage)
+    public function __construct(Graby $graby, RuleBasedTagger $tagger, LoggerInterface $logger, $fetchingErrorMessage)
     {
         $this->graby = $graby;
         $this->tagger = $tagger;
         $this->logger = $logger;
-        $this->tagRepository = $tagRepository;
         $this->mimeGuesser = new MimeTypeExtensionGuesser();
         $this->fetchingErrorMessage = $fetchingErrorMessage;
     }
@@ -119,54 +117,6 @@ class ContentProxy
         }
 
         return $entry;
-    }
-
-    /**
-     * Assign some tags to an entry.
-     *
-     * @param Entry        $entry
-     * @param array|string $tags          An array of tag or a string coma separated of tag
-     * @param array        $entitiesReady Entities from the EntityManager which are persisted but not yet flushed
-     *                                    It is mostly to fix duplicate tag on import @see http://stackoverflow.com/a/7879164/569101
-     */
-    public function assignTagsToEntry(Entry $entry, $tags, array $entitiesReady = [])
-    {
-        if (!is_array($tags)) {
-            $tags = explode(',', $tags);
-        }
-
-        // keeps only Tag entity from the "not yet flushed entities"
-        $tagsNotYetFlushed = [];
-        foreach ($entitiesReady as $entity) {
-            if ($entity instanceof Tag) {
-                $tagsNotYetFlushed[$entity->getLabel()] = $entity;
-            }
-        }
-
-        foreach ($tags as $label) {
-            $label = trim($label);
-
-            // avoid empty tag
-            if (0 === strlen($label)) {
-                continue;
-            }
-
-            if (isset($tagsNotYetFlushed[$label])) {
-                $tagEntity = $tagsNotYetFlushed[$label];
-            } else {
-                $tagEntity = $this->tagRepository->findOneByLabel($label);
-
-                if (is_null($tagEntity)) {
-                    $tagEntity = new Tag();
-                    $tagEntity->setLabel($label);
-                }
-            }
-
-            // only add the tag on the entry if the relation doesn't exist
-            if (false === $entry->getTags()->contains($tagEntity)) {
-                $entry->addTag($tagEntity);
-            }
-        }
     }
 
     /**

--- a/src/Wallabag/CoreBundle/Helper/ContentProxy.php
+++ b/src/Wallabag/CoreBundle/Helper/ContentProxy.php
@@ -4,7 +4,6 @@ namespace Wallabag\CoreBundle\Helper;
 
 use Graby\Graby;
 use Psr\Log\LoggerInterface;
-use Symfony\Component\EventDispatcher\EventDispatcher;
 use Wallabag\CoreBundle\Entity\Entry;
 use Wallabag\CoreBundle\Tools\Utils;
 use Symfony\Component\HttpFoundation\File\MimeType\MimeTypeExtensionGuesser;

--- a/src/Wallabag/CoreBundle/Helper/TagsAssigner.php
+++ b/src/Wallabag/CoreBundle/Helper/TagsAssigner.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace Wallabag\CoreBundle\Helper;
+
+use Wallabag\CoreBundle\Entity\Entry;
+use Wallabag\CoreBundle\Entity\Tag;
+use Wallabag\CoreBundle\Repository\TagRepository;
+
+class TagsAssigner
+{
+
+    /**
+     * @var TagRepository $tagRepository
+     */
+    protected $tagRepository;
+
+    public function __construct(TagRepository $tagRepository)
+    {
+        $this->tagRepository = $tagRepository;
+    }
+
+    /**
+     * Assign some tags to an entry.
+     *
+     * @param Entry        $entry
+     * @param array|string $tags          An array of tag or a string coma separated of tag
+     * @param array        $entitiesReady Entities from the EntityManager which are persisted but not yet flushed
+     *                                    It is mostly to fix duplicate tag on import @see http://stackoverflow.com/a/7879164/569101
+     *
+     * @return Tag[]
+     */
+    public function assignTagsToEntry(Entry $entry, $tags, array $entitiesReady = [])
+    {
+        $tagsEntities = [];
+
+        if (!is_array($tags)) {
+            $tags = explode(',', $tags);
+        }
+
+        // keeps only Tag entity from the "not yet flushed entities"
+        $tagsNotYetFlushed = [];
+        foreach ($entitiesReady as $entity) {
+            if ($entity instanceof Tag) {
+                $tagsNotYetFlushed[$entity->getLabel()] = $entity;
+            }
+        }
+
+        foreach ($tags as $label) {
+            $label = trim($label);
+
+            // avoid empty tag
+            if (0 === strlen($label)) {
+                continue;
+            }
+
+            if (isset($tagsNotYetFlushed[$label])) {
+                $tagEntity = $tagsNotYetFlushed[$label];
+            } else {
+                $tagEntity = $this->tagRepository->findOneByLabel($label);
+
+                if (null === $tagEntity) {
+                    $tagEntity = new Tag();
+                    $tagEntity->setLabel($label);
+                }
+            }
+
+            // only add the tag on the entry if the relation doesn't exist
+            if (false === $entry->getTags()->contains($tagEntity)) {
+                $entry->addTag($tagEntity);
+                $tagsEntities[] = $tagEntity;
+            }
+        }
+
+        return $tagsEntities;
+    }
+}

--- a/src/Wallabag/CoreBundle/Helper/TagsAssigner.php
+++ b/src/Wallabag/CoreBundle/Helper/TagsAssigner.php
@@ -8,9 +8,8 @@ use Wallabag\CoreBundle\Repository\TagRepository;
 
 class TagsAssigner
 {
-
     /**
-     * @var TagRepository $tagRepository
+     * @var TagRepository
      */
     protected $tagRepository;
 

--- a/src/Wallabag/CoreBundle/Resources/config/services.yml
+++ b/src/Wallabag/CoreBundle/Resources/config/services.yml
@@ -89,9 +89,13 @@ services:
         arguments:
             - "@wallabag_core.graby"
             - "@wallabag_core.rule_based_tagger"
-            - "@wallabag_core.tag_repository"
             - "@logger"
             - '%wallabag_core.fetching_error_message%'
+
+    wallabag_core.tags_assigner:
+        class: Wallabag\CoreBundle\Helper\TagsAssigner
+        arguments:
+            - "@wallabag_core.tag_repository"
 
     wallabag_core.rule_based_tagger:
         class: Wallabag\CoreBundle\Helper\RuleBasedTagger

--- a/src/Wallabag/ImportBundle/Import/AbstractImport.php
+++ b/src/Wallabag/ImportBundle/Import/AbstractImport.php
@@ -8,6 +8,7 @@ use Doctrine\ORM\EntityManager;
 use Wallabag\CoreBundle\Helper\ContentProxy;
 use Wallabag\CoreBundle\Entity\Entry;
 use Wallabag\CoreBundle\Entity\Tag;
+use Wallabag\CoreBundle\Helper\TagsAssigner;
 use Wallabag\UserBundle\Entity\User;
 use OldSound\RabbitMqBundle\RabbitMq\ProducerInterface;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
@@ -18,6 +19,7 @@ abstract class AbstractImport implements ImportInterface
     protected $em;
     protected $logger;
     protected $contentProxy;
+    protected $tagsAssigner;
     protected $eventDispatcher;
     protected $producer;
     protected $user;
@@ -26,11 +28,12 @@ abstract class AbstractImport implements ImportInterface
     protected $importedEntries = 0;
     protected $queuedEntries = 0;
 
-    public function __construct(EntityManager $em, ContentProxy $contentProxy, EventDispatcherInterface $eventDispatcher)
+    public function __construct(EntityManager $em, ContentProxy $contentProxy, TagsAssigner $tagsAssigner, EventDispatcherInterface $eventDispatcher)
     {
         $this->em = $em;
         $this->logger = new NullLogger();
         $this->contentProxy = $contentProxy;
+        $this->tagsAssigner = $tagsAssigner;
         $this->eventDispatcher = $eventDispatcher;
     }
 

--- a/src/Wallabag/ImportBundle/Import/BrowserImport.php
+++ b/src/Wallabag/ImportBundle/Import/BrowserImport.php
@@ -4,7 +4,6 @@ namespace Wallabag\ImportBundle\Import;
 
 use Wallabag\CoreBundle\Entity\Entry;
 use Wallabag\UserBundle\Entity\User;
-use Wallabag\CoreBundle\Helper\ContentProxy;
 use Wallabag\CoreBundle\Event\EntrySavedEvent;
 
 abstract class BrowserImport extends AbstractImport

--- a/src/Wallabag/ImportBundle/Import/BrowserImport.php
+++ b/src/Wallabag/ImportBundle/Import/BrowserImport.php
@@ -205,7 +205,7 @@ abstract class BrowserImport extends AbstractImport
         $entry = $this->fetchContent($entry, $data['url'], $data);
 
         if (array_key_exists('tags', $data)) {
-            $this->contentProxy->assignTagsToEntry(
+            $this->tagsAssigner->assignTagsToEntry(
                 $entry,
                 $data['tags']
             );

--- a/src/Wallabag/ImportBundle/Import/PinboardImport.php
+++ b/src/Wallabag/ImportBundle/Import/PinboardImport.php
@@ -112,7 +112,7 @@ class PinboardImport extends AbstractImport
         $entry = $this->fetchContent($entry, $data['url'], $data);
 
         if (!empty($data['tags'])) {
-            $this->contentProxy->assignTagsToEntry(
+            $this->tagsAssigner->assignTagsToEntry(
                 $entry,
                 $data['tags'],
                 $this->em->getUnitOfWork()->getScheduledEntityInsertions()

--- a/src/Wallabag/ImportBundle/Import/PocketImport.php
+++ b/src/Wallabag/ImportBundle/Import/PocketImport.php
@@ -216,7 +216,7 @@ class PocketImport extends AbstractImport
         }
 
         if (isset($importedEntry['tags']) && !empty($importedEntry['tags'])) {
-            $this->contentProxy->assignTagsToEntry(
+            $this->tagsAssigner->assignTagsToEntry(
                 $entry,
                 array_keys($importedEntry['tags']),
                 $this->em->getUnitOfWork()->getScheduledEntityInsertions()

--- a/src/Wallabag/ImportBundle/Import/PocketImport.php
+++ b/src/Wallabag/ImportBundle/Import/PocketImport.php
@@ -5,7 +5,6 @@ namespace Wallabag\ImportBundle\Import;
 use GuzzleHttp\Client;
 use GuzzleHttp\Exception\RequestException;
 use Wallabag\CoreBundle\Entity\Entry;
-use Wallabag\CoreBundle\Helper\ContentProxy;
 
 class PocketImport extends AbstractImport
 {

--- a/src/Wallabag/ImportBundle/Import/WallabagImport.php
+++ b/src/Wallabag/ImportBundle/Import/WallabagImport.php
@@ -111,7 +111,7 @@ abstract class WallabagImport extends AbstractImport
         $entry = $this->fetchContent($entry, $data['url'], $data);
 
         if (array_key_exists('tags', $data)) {
-            $this->contentProxy->assignTagsToEntry(
+            $this->tagsAssigner->assignTagsToEntry(
                 $entry,
                 $data['tags'],
                 $this->em->getUnitOfWork()->getScheduledEntityInsertions()

--- a/src/Wallabag/ImportBundle/Resources/config/services.yml
+++ b/src/Wallabag/ImportBundle/Resources/config/services.yml
@@ -20,6 +20,7 @@ services:
         arguments:
             - "@doctrine.orm.entity_manager"
             - "@wallabag_core.content_proxy"
+            - "@wallabag_core.tags_assigner"
             - "@event_dispatcher"
         calls:
             - [ setClient, [ "@wallabag_import.pocket.client" ] ]
@@ -32,6 +33,7 @@ services:
         arguments:
             - "@doctrine.orm.entity_manager"
             - "@wallabag_core.content_proxy"
+            - "@wallabag_core.tags_assigner"
             - "@event_dispatcher"
         calls:
             - [ setLogger, [ "@logger" ]]
@@ -43,6 +45,7 @@ services:
         arguments:
             - "@doctrine.orm.entity_manager"
             - "@wallabag_core.content_proxy"
+            - "@wallabag_core.tags_assigner"
             - "@event_dispatcher"
         calls:
             - [ setLogger, [ "@logger" ]]
@@ -54,6 +57,7 @@ services:
         arguments:
             - "@doctrine.orm.entity_manager"
             - "@wallabag_core.content_proxy"
+            - "@wallabag_core.tags_assigner"
             - "@event_dispatcher"
         calls:
             - [ setLogger, [ "@logger" ]]
@@ -65,6 +69,7 @@ services:
         arguments:
             - "@doctrine.orm.entity_manager"
             - "@wallabag_core.content_proxy"
+            - "@wallabag_core.tags_assigner"
             - "@event_dispatcher"
         calls:
             - [ setLogger, [ "@logger" ]]
@@ -76,6 +81,7 @@ services:
         arguments:
             - "@doctrine.orm.entity_manager"
             - "@wallabag_core.content_proxy"
+            - "@wallabag_core.tags_assigner"
             - "@event_dispatcher"
         calls:
             - [ setLogger, [ "@logger" ]]
@@ -87,6 +93,7 @@ services:
         arguments:
             - "@doctrine.orm.entity_manager"
             - "@wallabag_core.content_proxy"
+            - "@wallabag_core.tags_assigner"
             - "@event_dispatcher"
         calls:
             - [ setLogger, [ "@logger" ]]
@@ -97,6 +104,7 @@ services:
         arguments:
             - "@doctrine.orm.entity_manager"
             - "@wallabag_core.content_proxy"
+            - "@wallabag_core.tags_assigner"
             - "@event_dispatcher"
         calls:
             - [ setLogger, [ "@logger" ]]

--- a/tests/Wallabag/CoreBundle/Helper/TagsAssignerTest.php
+++ b/tests/Wallabag/CoreBundle/Helper/TagsAssignerTest.php
@@ -1,0 +1,114 @@
+<?php
+
+namespace Tests\Wallabag\CoreBundle\Helper;
+
+use Psr\Log\NullLogger;
+use Wallabag\CoreBundle\Helper\ContentProxy;
+use Wallabag\CoreBundle\Entity\Entry;
+use Wallabag\CoreBundle\Entity\Tag;
+use Wallabag\CoreBundle\Helper\TagsAssigner;
+use Wallabag\UserBundle\Entity\User;
+use Wallabag\CoreBundle\Repository\TagRepository;
+use Wallabag\CoreBundle\Helper\RuleBasedTagger;
+
+class TagsAssignerTest extends \PHPUnit_Framework_TestCase
+{
+
+    public function testAssignTagsWithArrayAndExtraSpaces()
+    {
+
+        $tagRepo = $this->getTagRepositoryMock();
+        $tagsAssigner = new TagsAssigner($tagRepo);
+
+        $entry = new Entry(new User());
+
+        $tagsAssigner->assignTagsToEntry($entry, ['   tag1', 'tag2   ']);
+
+        $this->assertCount(2, $entry->getTags());
+        $this->assertEquals('tag1', $entry->getTags()[0]->getLabel());
+        $this->assertEquals('tag2', $entry->getTags()[1]->getLabel());
+    }
+
+    public function testAssignTagsWithString()
+    {
+        $tagRepo = $this->getTagRepositoryMock();
+        $tagsAssigner = new TagsAssigner($tagRepo);
+
+        $entry = new Entry(new User());
+
+        $tagsAssigner->assignTagsToEntry($entry, 'tag1, tag2');
+
+        $this->assertCount(2, $entry->getTags());
+        $this->assertEquals('tag1', $entry->getTags()[0]->getLabel());
+        $this->assertEquals('tag2', $entry->getTags()[1]->getLabel());
+    }
+
+    public function testAssignTagsWithEmptyArray()
+    {
+        $tagRepo = $this->getTagRepositoryMock();
+        $tagsAssigner = new TagsAssigner($tagRepo);
+
+        $entry = new Entry(new User());
+
+        $tagsAssigner->assignTagsToEntry($entry, []);
+
+        $this->assertCount(0, $entry->getTags());
+    }
+
+    public function testAssignTagsWithEmptyString()
+    {
+        $tagRepo = $this->getTagRepositoryMock();
+        $tagsAssigner = new TagsAssigner($tagRepo);
+
+        $entry = new Entry(new User());
+
+        $tagsAssigner->assignTagsToEntry($entry, '');
+
+        $this->assertCount(0, $entry->getTags());
+    }
+
+    public function testAssignTagsAlreadyAssigned()
+    {
+        $tagRepo = $this->getTagRepositoryMock();
+        $tagsAssigner = new TagsAssigner($tagRepo);
+
+        $tagEntity = new Tag();
+        $tagEntity->setLabel('tag1');
+
+        $entry = new Entry(new User());
+        $entry->addTag($tagEntity);
+
+        $tagsAssigner->assignTagsToEntry($entry, 'tag1, tag2');
+
+        $this->assertCount(2, $entry->getTags());
+        $this->assertEquals('tag1', $entry->getTags()[0]->getLabel());
+        $this->assertEquals('tag2', $entry->getTags()[1]->getLabel());
+    }
+
+    public function testAssignTagsNotFlushed()
+    {
+
+        $tagRepo = $this->getTagRepositoryMock();
+        $tagRepo->expects($this->never())
+            ->method('__call');
+
+        $tagsAssigner = new TagsAssigner($tagRepo);
+
+        $tagEntity = new Tag();
+        $tagEntity->setLabel('tag1');
+
+        $entry = new Entry(new User());
+
+        $tagsAssigner->assignTagsToEntry($entry, 'tag1', [$tagEntity]);
+
+        $this->assertCount(1, $entry->getTags());
+        $this->assertEquals('tag1', $entry->getTags()[0]->getLabel());
+    }
+
+    private function getTagRepositoryMock()
+    {
+        return $this->getMockBuilder(TagRepository::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+    }
+}

--- a/tests/Wallabag/CoreBundle/Helper/TagsAssignerTest.php
+++ b/tests/Wallabag/CoreBundle/Helper/TagsAssignerTest.php
@@ -2,21 +2,16 @@
 
 namespace Tests\Wallabag\CoreBundle\Helper;
 
-use Psr\Log\NullLogger;
-use Wallabag\CoreBundle\Helper\ContentProxy;
 use Wallabag\CoreBundle\Entity\Entry;
 use Wallabag\CoreBundle\Entity\Tag;
 use Wallabag\CoreBundle\Helper\TagsAssigner;
 use Wallabag\UserBundle\Entity\User;
 use Wallabag\CoreBundle\Repository\TagRepository;
-use Wallabag\CoreBundle\Helper\RuleBasedTagger;
 
 class TagsAssignerTest extends \PHPUnit_Framework_TestCase
 {
-
     public function testAssignTagsWithArrayAndExtraSpaces()
     {
-
         $tagRepo = $this->getTagRepositoryMock();
         $tagsAssigner = new TagsAssigner($tagRepo);
 
@@ -87,7 +82,6 @@ class TagsAssignerTest extends \PHPUnit_Framework_TestCase
 
     public function testAssignTagsNotFlushed()
     {
-
         $tagRepo = $this->getTagRepositoryMock();
         $tagRepo->expects($this->never())
             ->method('__call');

--- a/tests/Wallabag/ImportBundle/Import/ChromeImportTest.php
+++ b/tests/Wallabag/ImportBundle/Import/ChromeImportTest.php
@@ -17,6 +17,7 @@ class ChromeImportTest extends \PHPUnit_Framework_TestCase
     protected $em;
     protected $logHandler;
     protected $contentProxy;
+    protected $tagsAssigner;
 
     private function getChromeImport($unsetUser = false, $dispatched = 0)
     {
@@ -30,6 +31,10 @@ class ChromeImportTest extends \PHPUnit_Framework_TestCase
             ->disableOriginalConstructor()
             ->getMock();
 
+        $this->tagsAssigner = $this->getMockBuilder('Wallabag\CoreBundle\Helper\TagsAssigner')
+            ->disableOriginalConstructor()
+            ->getMock();
+
         $dispatcher = $this->getMockBuilder('Symfony\Component\EventDispatcher\EventDispatcher')
             ->disableOriginalConstructor()
             ->getMock();
@@ -38,7 +43,7 @@ class ChromeImportTest extends \PHPUnit_Framework_TestCase
             ->expects($this->exactly($dispatched))
             ->method('dispatch');
 
-        $wallabag = new ChromeImport($this->em, $this->contentProxy, $dispatcher);
+        $wallabag = new ChromeImport($this->em, $this->contentProxy, $this->tagsAssigner, $dispatcher);
 
         $this->logHandler = new TestHandler();
         $logger = new Logger('test', [$this->logHandler]);

--- a/tests/Wallabag/ImportBundle/Import/FirefoxImportTest.php
+++ b/tests/Wallabag/ImportBundle/Import/FirefoxImportTest.php
@@ -17,6 +17,7 @@ class FirefoxImportTest extends \PHPUnit_Framework_TestCase
     protected $em;
     protected $logHandler;
     protected $contentProxy;
+    protected $tagsAssigner;
 
     private function getFirefoxImport($unsetUser = false, $dispatched = 0)
     {
@@ -30,6 +31,10 @@ class FirefoxImportTest extends \PHPUnit_Framework_TestCase
             ->disableOriginalConstructor()
             ->getMock();
 
+        $this->tagsAssigner = $this->getMockBuilder('Wallabag\CoreBundle\Helper\TagsAssigner')
+            ->disableOriginalConstructor()
+            ->getMock();
+
         $dispatcher = $this->getMockBuilder('Symfony\Component\EventDispatcher\EventDispatcher')
             ->disableOriginalConstructor()
             ->getMock();
@@ -38,7 +43,7 @@ class FirefoxImportTest extends \PHPUnit_Framework_TestCase
             ->expects($this->exactly($dispatched))
             ->method('dispatch');
 
-        $wallabag = new FirefoxImport($this->em, $this->contentProxy, $dispatcher);
+        $wallabag = new FirefoxImport($this->em, $this->contentProxy, $this->tagsAssigner, $dispatcher);
 
         $this->logHandler = new TestHandler();
         $logger = new Logger('test', [$this->logHandler]);

--- a/tests/Wallabag/ImportBundle/Import/InstapaperImportTest.php
+++ b/tests/Wallabag/ImportBundle/Import/InstapaperImportTest.php
@@ -17,6 +17,7 @@ class InstapaperImportTest extends \PHPUnit_Framework_TestCase
     protected $em;
     protected $logHandler;
     protected $contentProxy;
+    protected $tagsAssigner;
 
     private function getInstapaperImport($unsetUser = false, $dispatched = 0)
     {
@@ -30,6 +31,10 @@ class InstapaperImportTest extends \PHPUnit_Framework_TestCase
             ->disableOriginalConstructor()
             ->getMock();
 
+        $this->tagsAssigner = $this->getMockBuilder('Wallabag\CoreBundle\Helper\TagsAssigner')
+            ->disableOriginalConstructor()
+            ->getMock();
+
         $dispatcher = $this->getMockBuilder('Symfony\Component\EventDispatcher\EventDispatcher')
             ->disableOriginalConstructor()
             ->getMock();
@@ -38,7 +43,7 @@ class InstapaperImportTest extends \PHPUnit_Framework_TestCase
             ->expects($this->exactly($dispatched))
             ->method('dispatch');
 
-        $import = new InstapaperImport($this->em, $this->contentProxy, $dispatcher);
+        $import = new InstapaperImport($this->em, $this->contentProxy, $this->tagsAssigner, $dispatcher);
 
         $this->logHandler = new TestHandler();
         $logger = new Logger('test', [$this->logHandler]);

--- a/tests/Wallabag/ImportBundle/Import/PocketImportTest.php
+++ b/tests/Wallabag/ImportBundle/Import/PocketImportTest.php
@@ -23,6 +23,8 @@ class PocketImportTest extends \PHPUnit_Framework_TestCase
     protected $em;
     protected $contentProxy;
     protected $logHandler;
+    protected $tagsAssigner;
+    protected $uow;
 
     private function getPocketImport($consumerKey = 'ConsumerKey', $dispatched = 0)
     {
@@ -34,6 +36,10 @@ class PocketImportTest extends \PHPUnit_Framework_TestCase
         $this->user->setConfig($config);
 
         $this->contentProxy = $this->getMockBuilder('Wallabag\CoreBundle\Helper\ContentProxy')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $this->tagsAssigner = $this->getMockBuilder('Wallabag\CoreBundle\Helper\TagsAssigner')
             ->disableOriginalConstructor()
             ->getMock();
 
@@ -63,7 +69,7 @@ class PocketImportTest extends \PHPUnit_Framework_TestCase
             ->expects($this->exactly($dispatched))
             ->method('dispatch');
 
-        $pocket = new PocketImport($this->em, $this->contentProxy, $dispatcher);
+        $pocket = new PocketImport($this->em, $this->contentProxy, $this->tagsAssigner, $dispatcher);
         $pocket->setUser($this->user);
 
         $this->logHandler = new TestHandler();

--- a/tests/Wallabag/ImportBundle/Import/ReadabilityImportTest.php
+++ b/tests/Wallabag/ImportBundle/Import/ReadabilityImportTest.php
@@ -17,6 +17,7 @@ class ReadabilityImportTest extends \PHPUnit_Framework_TestCase
     protected $em;
     protected $logHandler;
     protected $contentProxy;
+    protected $tagsAssigner;
 
     private function getReadabilityImport($unsetUser = false, $dispatched = 0)
     {
@@ -30,6 +31,10 @@ class ReadabilityImportTest extends \PHPUnit_Framework_TestCase
             ->disableOriginalConstructor()
             ->getMock();
 
+        $this->tagsAssigner = $this->getMockBuilder('Wallabag\CoreBundle\Helper\TagsAssigner')
+            ->disableOriginalConstructor()
+            ->getMock();
+
         $dispatcher = $this->getMockBuilder('Symfony\Component\EventDispatcher\EventDispatcher')
             ->disableOriginalConstructor()
             ->getMock();
@@ -38,7 +43,7 @@ class ReadabilityImportTest extends \PHPUnit_Framework_TestCase
             ->expects($this->exactly($dispatched))
             ->method('dispatch');
 
-        $wallabag = new ReadabilityImport($this->em, $this->contentProxy, $dispatcher);
+        $wallabag = new ReadabilityImport($this->em, $this->contentProxy, $this->tagsAssigner, $dispatcher);
 
         $this->logHandler = new TestHandler();
         $logger = new Logger('test', [$this->logHandler]);

--- a/tests/Wallabag/ImportBundle/Import/WallabagV1ImportTest.php
+++ b/tests/Wallabag/ImportBundle/Import/WallabagV1ImportTest.php
@@ -17,6 +17,8 @@ class WallabagV1ImportTest extends \PHPUnit_Framework_TestCase
     protected $em;
     protected $logHandler;
     protected $contentProxy;
+    protected $tagsAssigner;
+    protected $uow;
 
     private function getWallabagV1Import($unsetUser = false, $dispatched = 0)
     {
@@ -44,6 +46,10 @@ class WallabagV1ImportTest extends \PHPUnit_Framework_TestCase
             ->disableOriginalConstructor()
             ->getMock();
 
+        $this->tagsAssigner = $this->getMockBuilder('Wallabag\CoreBundle\Helper\TagsAssigner')
+            ->disableOriginalConstructor()
+            ->getMock();
+
         $dispatcher = $this->getMockBuilder('Symfony\Component\EventDispatcher\EventDispatcher')
             ->disableOriginalConstructor()
             ->getMock();
@@ -52,7 +58,7 @@ class WallabagV1ImportTest extends \PHPUnit_Framework_TestCase
             ->expects($this->exactly($dispatched))
             ->method('dispatch');
 
-        $wallabag = new WallabagV1Import($this->em, $this->contentProxy, $dispatcher);
+        $wallabag = new WallabagV1Import($this->em, $this->contentProxy, $this->tagsAssigner, $dispatcher);
 
         $this->logHandler = new TestHandler();
         $logger = new Logger('test', [$this->logHandler]);

--- a/tests/Wallabag/ImportBundle/Import/WallabagV2ImportTest.php
+++ b/tests/Wallabag/ImportBundle/Import/WallabagV2ImportTest.php
@@ -17,6 +17,8 @@ class WallabagV2ImportTest extends \PHPUnit_Framework_TestCase
     protected $em;
     protected $logHandler;
     protected $contentProxy;
+    protected $tagsAssigner;
+    protected $uow;
 
     private function getWallabagV2Import($unsetUser = false, $dispatched = 0)
     {
@@ -44,6 +46,10 @@ class WallabagV2ImportTest extends \PHPUnit_Framework_TestCase
             ->disableOriginalConstructor()
             ->getMock();
 
+        $this->tagsAssigner = $this->getMockBuilder('Wallabag\CoreBundle\Helper\TagsAssigner')
+            ->disableOriginalConstructor()
+            ->getMock();
+
         $dispatcher = $this->getMockBuilder('Symfony\Component\EventDispatcher\EventDispatcher')
             ->disableOriginalConstructor()
             ->getMock();
@@ -52,7 +58,7 @@ class WallabagV2ImportTest extends \PHPUnit_Framework_TestCase
             ->expects($this->exactly($dispatched))
             ->method('dispatch');
 
-        $wallabag = new WallabagV2Import($this->em, $this->contentProxy, $dispatcher);
+        $wallabag = new WallabagV2Import($this->em, $this->contentProxy, $this->tagsAssigner, $dispatcher);
 
         $this->logHandler = new TestHandler();
         $logger = new Logger('test', [$this->logHandler]);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | not really, but related https://github.com/wallabag/wallabag/issues/2864
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Documentation | no
| Translation   | no
| Fixed tickets | 
| License       | MIT

Move Tags assigner to a dedicated file. This will for instance allow sending the « Create tag » event from this file, and maybe refactoring it