### PR TITLE
Add support for tag in Instapaper import

### DIFF
--- a/src/Wallabag/ImportBundle/Import/InstapaperImport.php
+++ b/src/Wallabag/ImportBundle/Import/InstapaperImport.php
@@ -68,6 +68,14 @@ class InstapaperImport extends AbstractImport
                 continue;
             }
 
+            // last element in the csv is the folder where the content belong
+            // BUT it can also be the status (since status = folder in Instapaper)
+            // and we don't want archive, unread & starred to become a tag
+            $tags = null;
+            if (false === in_array($data[3], ['Archive', 'Unread', 'Starred'])) {
+                $tags = [$data[3]];
+            }
+
             $entries[] = [
                 'url' => $data[0],
                 'title' => $data[1],
@@ -75,6 +83,7 @@ class InstapaperImport extends AbstractImport
                 'is_archived' => $data[3] === 'Archive' || $data[3] === 'Starred',
                 'is_starred' => $data[3] === 'Starred',
                 'html' => false,
+                'tags' => $tags,
             ];
         }
         fclose($handle);
@@ -117,6 +126,14 @@ class InstapaperImport extends AbstractImport
 
         // update entry with content (in case fetching failed, the given entry will be return)
         $entry = $this->fetchContent($entry, $importedEntry['url'], $importedEntry);
+
+        if (!empty($importedEntry['tags'])) {
+            $this->tagsAssigner->assignTagsToEntry(
+                $entry,
+                $importedEntry['tags'],
+                $this->em->getUnitOfWork()->getScheduledEntityInsertions()
+            );
+        }
 
         $entry->setArchived($importedEntry['is_archived']);
         $entry->setStarred($importedEntry['is_starred']);

--- a/tests/Wallabag/CoreBundle/Command/ExportCommandTest.php
+++ b/tests/Wallabag/CoreBundle/Command/ExportCommandTest.php
@@ -10,7 +10,7 @@ use Tests\Wallabag\CoreBundle\WallabagCoreTestCase;
 class ExportCommandTest extends WallabagCoreTestCase
 {
     /**
-     * @expectedException Symfony\Component\Console\Exception\RuntimeException
+     * @expectedException \Symfony\Component\Console\Exception\RuntimeException
      * @expectedExceptionMessage Not enough arguments (missing: "username")
      */
     public function testExportCommandWithoutUsername()

--- a/tests/Wallabag/CoreBundle/Command/TagAllCommandTest.php
+++ b/tests/Wallabag/CoreBundle/Command/TagAllCommandTest.php
@@ -10,7 +10,7 @@ use Tests\Wallabag\CoreBundle\WallabagCoreTestCase;
 class TagAllCommandTest extends WallabagCoreTestCase
 {
     /**
-     * @expectedException Symfony\Component\Console\Exception\RuntimeException
+     * @expectedException \Symfony\Component\Console\Exception\RuntimeException
      * @expectedExceptionMessage Not enough arguments (missing: "username")
      */
     public function testRunTagAllCommandWithoutUsername()

--- a/tests/Wallabag/CoreBundle/Helper/ContentProxyTest.php
+++ b/tests/Wallabag/CoreBundle/Helper/ContentProxyTest.php
@@ -7,7 +7,6 @@ use Wallabag\CoreBundle\Helper\ContentProxy;
 use Wallabag\CoreBundle\Entity\Entry;
 use Wallabag\CoreBundle\Entity\Tag;
 use Wallabag\UserBundle\Entity\User;
-use Wallabag\CoreBundle\Repository\TagRepository;
 use Wallabag\CoreBundle\Helper\RuleBasedTagger;
 
 class ContentProxyTest extends \PHPUnit_Framework_TestCase

--- a/tests/Wallabag/CoreBundle/ParamConverter/UsernameRssTokenConverterTest.php
+++ b/tests/Wallabag/CoreBundle/ParamConverter/UsernameRssTokenConverterTest.php
@@ -136,7 +136,7 @@ class UsernameRssTokenConverterTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException Symfony\Component\HttpKernel\Exception\NotFoundHttpException
+     * @expectedException \Symfony\Component\HttpKernel\Exception\NotFoundHttpException
      * @expectedExceptionMessage User not found
      */
     public function testApplyUserNotFound()

--- a/tests/Wallabag/ImportBundle/Command/RedisWorkerCommandTest.php
+++ b/tests/Wallabag/ImportBundle/Command/RedisWorkerCommandTest.php
@@ -11,7 +11,7 @@ use M6Web\Component\RedisMock\RedisMockFactory;
 class RedisWorkerCommandTest extends WallabagCoreTestCase
 {
     /**
-     * @expectedException Symfony\Component\Console\Exception\RuntimeException
+     * @expectedException \Symfony\Component\Console\Exception\RuntimeException
      * @expectedExceptionMessage Not enough arguments (missing: "serviceName")
      */
     public function testRunRedisWorkerCommandWithoutArguments()
@@ -28,7 +28,7 @@ class RedisWorkerCommandTest extends WallabagCoreTestCase
     }
 
     /**
-     * @expectedException Symfony\Component\Config\Definition\Exception\Exception
+     * @expectedException \Symfony\Component\Config\Definition\Exception\Exception
      * @expectedExceptionMessage No queue or consumer found for service name
      */
     public function testRunRedisWorkerCommandWithBadService()

--- a/tests/Wallabag/ImportBundle/Controller/PinboardControllerTest.php
+++ b/tests/Wallabag/ImportBundle/Controller/PinboardControllerTest.php
@@ -121,7 +121,13 @@ class PinboardControllerTest extends WallabagCoreTestCase
         $this->assertNotEmpty($content->getMimetype(), 'Mimetype for https://ma.ttias.be is ok');
         $this->assertNotEmpty($content->getPreviewPicture(), 'Preview picture for https://ma.ttias.be is ok');
         $this->assertNotEmpty($content->getLanguage(), 'Language for https://ma.ttias.be is ok');
-        $this->assertEquals(3, count($content->getTags()));
+
+        $tags = $content->getTags();
+        $this->assertContains('foot', $tags, 'It includes the "foot" tag');
+        $this->assertContains('varnish', $tags, 'It includes the "varnish" tag');
+        $this->assertContains('PHP', $tags, 'It includes the "PHP" tag');
+        $this->assertEquals(3, count($tags));
+
         $this->assertInstanceOf(\DateTime::class, $content->getCreatedAt());
         $this->assertEquals('2016-10-26', $content->getCreatedAt()->format('Y-m-d'));
     }

--- a/tests/Wallabag/ImportBundle/Controller/ReadabilityControllerTest.php
+++ b/tests/Wallabag/ImportBundle/Controller/ReadabilityControllerTest.php
@@ -121,7 +121,11 @@ class ReadabilityControllerTest extends WallabagCoreTestCase
         $this->assertNotEmpty($content->getMimetype(), 'Mimetype for http://www.zataz.com is ok');
         $this->assertNotEmpty($content->getPreviewPicture(), 'Preview picture for http://www.zataz.com is ok');
         $this->assertNotEmpty($content->getLanguage(), 'Language for http://www.zataz.com is ok');
-        $this->assertEquals(1, count($content->getTags()));
+
+        $tags = $content->getTags();
+        $this->assertContains('foot', $tags, 'It includes the "foot" tag');
+        $this->assertEquals(1, count($tags));
+
         $this->assertInstanceOf(\DateTime::class, $content->getCreatedAt());
         $this->assertEquals('2016-09-08', $content->getCreatedAt()->format('Y-m-d'));
     }

--- a/tests/Wallabag/ImportBundle/Controller/WallabagV1ControllerTest.php
+++ b/tests/Wallabag/ImportBundle/Controller/WallabagV1ControllerTest.php
@@ -116,20 +116,18 @@ class WallabagV1ControllerTest extends WallabagCoreTestCase
                 $this->getLoggedInUserId()
             );
 
-        $tag = $client->getContainer()
-            ->get('doctrine.orm.entity_manager')
-            ->getRepository('WallabagCoreBundle:Tag')
-            ->findOneByLabel('Framabag');
-
-        $this->assertTrue($content->getTags()->contains($tag));
-
         $this->assertGreaterThan(1, $body = $crawler->filter('body')->extract(['_text']));
         $this->assertContains('flashes.import.notice.summary', $body[0]);
 
         $this->assertNotEmpty($content->getMimetype(), 'Mimetype for http://www.framablog.org is ok');
         $this->assertNotEmpty($content->getPreviewPicture(), 'Preview picture for http://www.framablog.org is ok');
         $this->assertNotEmpty($content->getLanguage(), 'Language for http://www.framablog.org is ok');
-        $this->assertEquals(2, count($content->getTags()));
+
+        $tags = $content->getTags();
+        $this->assertContains('foot', $tags, 'It includes the "foot" tag');
+        $this->assertContains('Framabag', $tags, 'It includes the "Framabag" tag');
+        $this->assertEquals(2, count($tags));
+
         $this->assertInstanceOf(\DateTime::class, $content->getCreatedAt());
     }
 

--- a/tests/Wallabag/ImportBundle/Controller/WallabagV2ControllerTest.php
+++ b/tests/Wallabag/ImportBundle/Controller/WallabagV2ControllerTest.php
@@ -122,7 +122,10 @@ class WallabagV2ControllerTest extends WallabagCoreTestCase
         $this->assertNotEmpty($content->getMimetype(), 'Mimetype for http://www.liberation.fr is ok');
         $this->assertNotEmpty($content->getPreviewPicture(), 'Preview picture for http://www.liberation.fr is ok');
         $this->assertNotEmpty($content->getLanguage(), 'Language for http://www.liberation.fr is ok');
-        $this->assertEquals(1, count($content->getTags()));
+
+        $tags = $content->getTags();
+        $this->assertContains('foot', $tags, 'It includes the "foot" tag');
+        $this->assertEquals(1, count($tags));
 
         $content = $client->getContainer()
             ->get('doctrine.orm.entity_manager')
@@ -135,7 +138,13 @@ class WallabagV2ControllerTest extends WallabagCoreTestCase
         $this->assertNotEmpty($content->getMimetype(), 'Mimetype for https://www.mediapart.fr is ok');
         $this->assertNotEmpty($content->getPreviewPicture(), 'Preview picture for https://www.mediapart.fr is ok');
         $this->assertNotEmpty($content->getLanguage(), 'Language for https://www.mediapart.fr is ok');
-        $this->assertEquals(3, count($content->getTags()));
+
+        $tags = $content->getTags();
+        $this->assertContains('foot', $tags, 'It includes the "foot" tag');
+        $this->assertContains('mediapart', $tags, 'It includes the "mediapart" tag');
+        $this->assertContains('blog', $tags, 'It includes the "blog" tag');
+        $this->assertEquals(3, count($tags));
+
         $this->assertInstanceOf(\DateTime::class, $content->getCreatedAt());
         $this->assertEquals('2016-09-08', $content->getCreatedAt()->format('Y-m-d'));
         $this->assertTrue($content->isStarred(), 'Entry is starred');

--- a/tests/Wallabag/ImportBundle/fixtures/instapaper-export.csv
+++ b/tests/Wallabag/ImportBundle/fixtures/instapaper-export.csv
@@ -2,3 +2,4 @@ URL,Title,Selection,Folder
 http://www.liberation.fr/societe/2012/12/06/baumettes-un-tour-en-cellule_865551,Baumettes : un tour en cellule,,Unread
 https://redditblog.com/2016/09/20/amp-and-reactredux/,AMP and React+Redux: Why Not?,,Archive
 https://medium.com/@the_minh/why-foursquare-swarm-is-still-my-favourite-social-network-e38228493e6c,Why Foursquare / Swarm is still my favourite social network,,Starred
+http://www.20minutes.fr/high-tech/2077615-20170531-dis-donc-donald-trump-quoi-exactement-covfefe,"Dis donc Donald Trump, c'est quoi exactement «covfefe»?",,test_tag


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Documentation | no
| Translation   | no
| Fixed tickets | https://github.com/wallabag/wallabag/pull/2897
| License       | MIT

Add support for tag in Instapaper import.
Instapaper doesn't support _tags_ but folder. Folders are also used for archive, unread & starred. One article can only be in one folder. So if the folder is not Archive, Unread & Starred, it means it's a tag (for us).

Also, I've improved tags assertions in import tests.
So instead of just checking the number of tags, we also check which tag is assigned to an entry.
