### PR TITLE
Add ability to patch an entry with more fields

### DIFF
--- a/src/Wallabag/CoreBundle/Helper/ContentProxy.php
+++ b/src/Wallabag/CoreBundle/Helper/ContentProxy.php
@@ -105,7 +105,7 @@ class ContentProxy
             }
         }
 
-        if (!empty($content['authors'])) {
+        if (!empty($content['authors']) && is_array($content['authors'])) {
             $entry->setPublishedBy($content['authors']);
         }
 

--- a/tests/Wallabag/ApiBundle/Controller/EntryRestControllerTest.php
+++ b/tests/Wallabag/ApiBundle/Controller/EntryRestControllerTest.php
@@ -477,6 +477,10 @@ class EntryRestControllerTest extends WallabagApiTestCase
             'tags' => 'new tag '.uniqid(),
             'starred' => '1',
             'archive' => '0',
+            'language' => 'de_DE',
+            'preview_picture' => 'http://preview.io/picture.jpg',
+            'authors' => 'bob,sponge',
+            'content' => 'awesome',
         ]);
 
         $this->assertEquals(200, $this->client->getResponse()->getStatusCode());
@@ -488,6 +492,11 @@ class EntryRestControllerTest extends WallabagApiTestCase
         $this->assertEquals('New awesome title', $content['title']);
         $this->assertGreaterThan($nbTags, count($content['tags']));
         $this->assertEquals(1, $content['user_id']);
+        $this->assertEquals('de_DE', $content['language']);
+        $this->assertEquals('http://preview.io/picture.jpg', $content['preview_picture']);
+        $this->assertContains('sponge', $content['published_by']);
+        $this->assertContains('bob', $content['published_by']);
+        $this->assertEquals('awesome', $content['content']);
     }
 
     public function testPatchEntryWithoutQuotes()
@@ -509,6 +518,7 @@ class EntryRestControllerTest extends WallabagApiTestCase
             'tags' => 'new tag '.uniqid(),
             'starred' => 1,
             'archive' => 0,
+            'authors' => ['bob', 'sponge'],
         ]);
 
         $this->assertEquals(200, $this->client->getResponse()->getStatusCode());
@@ -519,6 +529,7 @@ class EntryRestControllerTest extends WallabagApiTestCase
         $this->assertEquals($entry->getUrl(), $content['url']);
         $this->assertEquals('New awesome title', $content['title']);
         $this->assertGreaterThan($nbTags, count($content['tags']));
+        $this->assertTrue(empty($content['published_by']), 'Authors were not saved because of an array instead of a string');
     }
 
     public function testGetTagsEntry()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Documentation | no
| Translation   | no
| Fixed tickets | https://github.com/wallabag/wallabag/issues/3169
| License       | MIT

Like when we create an entry, we can now patch an entry with new fields:
- content
- language
- preview_picture
- published_at
- authors
