### PR TITLE
Create (and return) a client after creating a new user using the API

### DIFF
--- a/src/Wallabag/ApiBundle/Controller/UserRestController.php
+++ b/src/Wallabag/ApiBundle/Controller/UserRestController.php
@@ -28,13 +28,14 @@ class UserRestController extends WallabagRestController
     }
 
     /**
-     * Register an user.
+     * Register an user and create a client.
      *
      * @ApiDoc(
      *      requirements={
      *          {"name"="username", "dataType"="string", "required"=true, "description"="The user's username"},
      *          {"name"="password", "dataType"="string", "required"=true, "description"="The user's password"},
-     *          {"name"="email", "dataType"="string", "required"=true, "description"="The user's email"}
+     *          {"name"="email", "dataType"="string", "required"=true, "description"="The user's email"},
+     *          {"name"="client_name", "dataType"="string", "required"=true, "description"="The client name (to be used by your app)"}
      *      }
      * )
      *
@@ -100,7 +101,7 @@ class UserRestController extends WallabagRestController
 
         // create a default client
         $client = new Client($user);
-        $client->setName('Default client');
+        $client->setName($request->request->get('client_name', 'Default client'));
 
         $this->getDoctrine()->getManager()->persist($client);
 

--- a/src/Wallabag/ApiBundle/Entity/Client.php
+++ b/src/Wallabag/ApiBundle/Entity/Client.php
@@ -5,6 +5,9 @@ namespace Wallabag\ApiBundle\Entity;
 use Doctrine\ORM\Mapping as ORM;
 use FOS\OAuthServerBundle\Entity\Client as BaseClient;
 use Wallabag\UserBundle\Entity\User;
+use JMS\Serializer\Annotation\Groups;
+use JMS\Serializer\Annotation\SerializedName;
+use JMS\Serializer\Annotation\VirtualProperty;
 
 /**
  * @ORM\Table("oauth2_clients")
@@ -23,6 +26,8 @@ class Client extends BaseClient
      * @var string
      *
      * @ORM\Column(name="name", type="text", nullable=false)
+     *
+     * @Groups({"user_api_with_client"})
      */
     protected $name;
 
@@ -35,6 +40,14 @@ class Client extends BaseClient
      * @ORM\OneToMany(targetEntity="AccessToken", mappedBy="client", cascade={"remove"})
      */
     protected $accessTokens;
+
+    /**
+     * @var string
+     *
+     * @SerializedName("client_secret")
+     * @Groups({"user_api_with_client"})
+     */
+    protected $secret;
 
     /**
      * @ORM\ManyToOne(targetEntity="Wallabag\UserBundle\Entity\User", inversedBy="clients")
@@ -77,5 +90,15 @@ class Client extends BaseClient
     public function getUser()
     {
         return $this->user;
+    }
+
+    /**
+     * @VirtualProperty
+     * @SerializedName("client_id")
+     * @Groups({"user_api_with_client"})
+     */
+    public function getClientId()
+    {
+        return $this->getId().'_'.$this->getRandomId();
     }
 }

--- a/src/Wallabag/CoreBundle/Resources/views/themes/common/Developer/index.html.twig
+++ b/src/Wallabag/CoreBundle/Resources/views/themes/common/Developer/index.html.twig
@@ -33,7 +33,7 @@
                                     <table class="striped">
                                         <tr>
                                             <td>{{ 'developer.existing_clients.field_id'|trans }}</td>
-                                            <td><strong><code>{{ client.id }}_{{ client.randomId }}</code></strong></td>
+                                            <td><strong><code>{{ client.clientId }}</code></strong></td>
                                         </tr>
                                         <tr>
                                             <td>{{ 'developer.existing_clients.field_secret'|trans }}</td>

--- a/src/Wallabag/UserBundle/Entity/User.php
+++ b/src/Wallabag/UserBundle/Entity/User.php
@@ -110,6 +110,8 @@ class User extends BaseUser implements TwoFactorInterface, TrustedComputerInterf
     private $trusted;
 
     /**
+     * @var ArrayCollection
+     *
      * @ORM\OneToMany(targetEntity="Wallabag\ApiBundle\Entity\Client", mappedBy="user", cascade={"remove"})
      */
     protected $clients;
@@ -306,10 +308,8 @@ class User extends BaseUser implements TwoFactorInterface, TrustedComputerInterf
      */
     public function getFirstClient()
     {
-        if (empty($this->clients)) {
-            return $this->clients;
+        if (!empty($this->clients)) {
+            return $this->clients->first();
         }
-
-        return $this->clients->first();
     }
 }

--- a/src/Wallabag/UserBundle/Entity/User.php
+++ b/src/Wallabag/UserBundle/Entity/User.php
@@ -6,6 +6,7 @@ use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\ORM\Mapping as ORM;
 use JMS\Serializer\Annotation\Groups;
 use JMS\Serializer\Annotation\XmlRoot;
+use JMS\Serializer\Annotation\Accessor;
 use Scheb\TwoFactorBundle\Model\Email\TwoFactorInterface;
 use Scheb\TwoFactorBundle\Model\TrustedComputerInterface;
 use FOS\UserBundle\Model\User as BaseUser;
@@ -36,7 +37,7 @@ class User extends BaseUser implements TwoFactorInterface, TrustedComputerInterf
      * @ORM\Id
      * @ORM\GeneratedValue(strategy="AUTO")
      *
-     * @Groups({"user_api"})
+     * @Groups({"user_api", "user_api_with_client"})
      */
     protected $id;
 
@@ -45,21 +46,21 @@ class User extends BaseUser implements TwoFactorInterface, TrustedComputerInterf
      *
      * @ORM\Column(name="name", type="text", nullable=true)
      *
-     * @Groups({"user_api"})
+     * @Groups({"user_api", "user_api_with_client"})
      */
     protected $name;
 
     /**
      * @var string
      *
-     * @Groups({"user_api"})
+     * @Groups({"user_api", "user_api_with_client"})
      */
     protected $username;
 
     /**
      * @var string
      *
-     * @Groups({"user_api"})
+     * @Groups({"user_api", "user_api_with_client"})
      */
     protected $email;
 
@@ -68,7 +69,7 @@ class User extends BaseUser implements TwoFactorInterface, TrustedComputerInterf
      *
      * @ORM\Column(name="created_at", type="datetime")
      *
-     * @Groups({"user_api"})
+     * @Groups({"user_api", "user_api_with_client"})
      */
     protected $createdAt;
 
@@ -77,7 +78,7 @@ class User extends BaseUser implements TwoFactorInterface, TrustedComputerInterf
      *
      * @ORM\Column(name="updated_at", type="datetime")
      *
-     * @Groups({"user_api"})
+     * @Groups({"user_api", "user_api_with_client"})
      */
     protected $updatedAt;
 
@@ -97,7 +98,8 @@ class User extends BaseUser implements TwoFactorInterface, TrustedComputerInterf
     private $authCode;
 
     /**
-     * @var bool Enabled yes/no
+     * @var bool
+     *
      * @ORM\Column(type="boolean")
      */
     private $twoFactorAuthentication = false;
@@ -111,6 +113,14 @@ class User extends BaseUser implements TwoFactorInterface, TrustedComputerInterf
      * @ORM\OneToMany(targetEntity="Wallabag\ApiBundle\Entity\Client", mappedBy="user", cascade={"remove"})
      */
     protected $clients;
+
+    /**
+     * @see getFirstClient() below
+     *
+     * @Groups({"user_api_with_client"})
+     * @Accessor(getter="getFirstClient")
+     */
+    protected $default_client;
 
     public function __construct()
     {
@@ -287,5 +297,19 @@ class User extends BaseUser implements TwoFactorInterface, TrustedComputerInterf
     public function getClients()
     {
         return $this->clients;
+    }
+
+    /**
+     * Only used by the API when creating a new user it'll also return the first client (which was also created at the same time).
+     *
+     * @return Client
+     */
+    public function getFirstClient()
+    {
+        if (empty($this->clients)) {
+            return $this->clients;
+        }
+
+        return $this->clients->first();
     }
 }

--- a/tests/Wallabag/AnnotationBundle/Controller/AnnotationControllerTest.php
+++ b/tests/Wallabag/AnnotationBundle/Controller/AnnotationControllerTest.php
@@ -85,7 +85,7 @@ class AnnotationControllerTest extends WallabagAnnotationTestCase
             'text' => 'my annotation',
             'quote' => 'my quote',
             'ranges' => [
-                ['start' => '', 'startOffset' => 24, 'end' => '', 'endOffset' => 31]
+                ['start' => '', 'startOffset' => 24, 'end' => '', 'endOffset' => 31],
             ],
         ]);
         $this->client->request('POST', $prefixUrl.'/'.$entry->getId().'.json', [], [], $headers, $content);
@@ -130,7 +130,7 @@ class AnnotationControllerTest extends WallabagAnnotationTestCase
             'text' => 'my annotation',
             'quote' => $longQuote,
             'ranges' => [
-                ['start' => '', 'startOffset' => 24, 'end' => '', 'endOffset' => 31]
+                ['start' => '', 'startOffset' => 24, 'end' => '', 'endOffset' => 31],
             ],
         ]);
         $this->client->request('POST', $prefixUrl.'/'.$entry->getId().'.json', [], [], $headers, $content);

--- a/tests/Wallabag/ApiBundle/Controller/UserRestControllerTest.php
+++ b/tests/Wallabag/ApiBundle/Controller/UserRestControllerTest.php
@@ -85,6 +85,7 @@ class UserRestControllerTest extends WallabagApiTestCase
             'username' => 'google',
             'password' => 'googlegoogle',
             'email' => 'wallabag@google.com',
+            'client_name' => 'My client name !!',
         ]);
 
         $this->assertEquals(201, $client->getResponse()->getStatusCode());
@@ -104,7 +105,7 @@ class UserRestControllerTest extends WallabagApiTestCase
         $this->assertArrayHasKey('client_secret', $content['default_client']);
         $this->assertArrayHasKey('client_id', $content['default_client']);
 
-        $this->assertEquals('Default client', $content['default_client']['name']);
+        $this->assertEquals('My client name !!', $content['default_client']['name']);
 
         $this->assertEquals('application/json', $client->getResponse()->headers->get('Content-Type'));
 

--- a/tests/Wallabag/ApiBundle/Controller/UserRestControllerTest.php
+++ b/tests/Wallabag/ApiBundle/Controller/UserRestControllerTest.php
@@ -61,9 +61,15 @@ class UserRestControllerTest extends WallabagApiTestCase
         $this->assertArrayHasKey('username', $content);
         $this->assertArrayHasKey('created_at', $content);
         $this->assertArrayHasKey('updated_at', $content);
+        $this->assertArrayHasKey('default_client', $content);
 
         $this->assertEquals('wallabag@google.com', $content['email']);
         $this->assertEquals('google', $content['username']);
+
+        $this->assertArrayHasKey('client_secret', $content['default_client']);
+        $this->assertArrayHasKey('client_id', $content['default_client']);
+
+        $this->assertEquals('Default client', $content['default_client']['name']);
 
         $this->assertEquals('application/json', $this->client->getResponse()->headers->get('Content-Type'));
 
@@ -90,9 +96,15 @@ class UserRestControllerTest extends WallabagApiTestCase
         $this->assertArrayHasKey('username', $content);
         $this->assertArrayHasKey('created_at', $content);
         $this->assertArrayHasKey('updated_at', $content);
+        $this->assertArrayHasKey('default_client', $content);
 
         $this->assertEquals('wallabag@google.com', $content['email']);
         $this->assertEquals('google', $content['username']);
+
+        $this->assertArrayHasKey('client_secret', $content['default_client']);
+        $this->assertArrayHasKey('client_id', $content['default_client']);
+
+        $this->assertEquals('Default client', $content['default_client']['name']);
 
         $this->assertEquals('application/json', $client->getResponse()->headers->get('Content-Type'));
 

--- a/tests/Wallabag/CoreBundle/Command/ShowUserCommandTest.php
+++ b/tests/Wallabag/CoreBundle/Command/ShowUserCommandTest.php
@@ -4,10 +4,8 @@ namespace Tests\Wallabag\CoreBundle\Command;
 
 use Symfony\Bundle\FrameworkBundle\Console\Application;
 use Symfony\Component\Console\Tester\CommandTester;
-use Wallabag\CoreBundle\Command\CleanDuplicatesCommand;
 use Tests\Wallabag\CoreBundle\WallabagCoreTestCase;
 use Wallabag\CoreBundle\Command\ShowUserCommand;
-use Wallabag\CoreBundle\Entity\Entry;
 use Wallabag\UserBundle\Entity\User;
 
 class ShowUserCommandTest extends WallabagCoreTestCase


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Documentation | yes
| Translation   | no
| Fixed tickets | https://github.com/wallabag/wallabag/issues/3056
| License       | MIT

While creating a new user using the API, we also create a new client for the current user.
So the app which just create the user can use its newly created client to configure the app.

That new client is only return after creating the user.
When calling the endpoint /api/user to get user information, the new client information won’t be return.

Here is a response when creating a user:

```json
{
  "id": 5,
  "username": "username",
  "email": "email@google.io",
  "created_at": "2017-06-07T23:23:19+0200",
  "updated_at": "2017-06-07T23:23:19+0200",
  "default_client": {
    "client_secret": "3srtm3ign4ow84oocss0c4s4gscswo44kwkowocs8ggwgowk88",
    "client_id": "2_1t041dsqpae8kg4swo8gksscwks8kw4g0wwso84ocgk8kwkk8w",
    "name": "Default client"
  }
}
```

And when you request a logged in user:

```json
{
  "id": 5,
  "username": "username",
  "email": "email@google.io",
  "created_at": "2017-06-07T23:23:19+0200",
  "updated_at": "2017-06-07T23:23:19+0200"
}
```

Poke @jlnostr @bourvill 