### PR TITLE
Validate language & preview picture fields

### DIFF
--- a/src/Wallabag/CoreBundle/Helper/ContentProxy.php
+++ b/src/Wallabag/CoreBundle/Helper/ContentProxy.php
@@ -19,6 +19,7 @@ class ContentProxy
 {
     protected $graby;
     protected $tagger;
+    protected $validator;
     protected $logger;
     protected $mimeGuesser;
     protected $fetchingErrorMessage;
@@ -127,7 +128,7 @@ class ContentProxy
             isset($content['open_graph']['og_image']) ? $content['open_graph']['og_image'] : ''
         );
 
-        // if content is an image define as a preview too
+        // if content is an image, define it as a preview too
         if (!empty($content['content_type']) && in_array($this->mimeGuesser->guess($content['content_type']), ['jpeg', 'jpg', 'gif', 'png'], true)) {
             $this->validateAndSetPreviewPicture(
                 $entry,

--- a/src/Wallabag/CoreBundle/Helper/ContentProxy.php
+++ b/src/Wallabag/CoreBundle/Helper/ContentProxy.php
@@ -7,7 +7,7 @@ use Psr\Log\LoggerInterface;
 use Wallabag\CoreBundle\Entity\Entry;
 use Wallabag\CoreBundle\Tools\Utils;
 use Symfony\Component\HttpFoundation\File\MimeType\MimeTypeExtensionGuesser;
-use Symfony\Component\Validator\Constraints\Language as LanguageConstraint;
+use Symfony\Component\Validator\Constraints\Locale as LocaleConstraint;
 use Symfony\Component\Validator\Constraints\Url as UrlConstraint;
 use Symfony\Component\Validator\Validator\ValidatorInterface;
 
@@ -176,7 +176,7 @@ class ContentProxy
     {
         $errors = $this->validator->validate(
             $value,
-            (new LanguageConstraint())
+            (new LocaleConstraint())
         );
 
         if (0 === count($errors)) {

--- a/src/Wallabag/CoreBundle/Helper/ContentProxy.php
+++ b/src/Wallabag/CoreBundle/Helper/ContentProxy.php
@@ -174,6 +174,10 @@ class ContentProxy
      */
     private function validateAndSetLanguage($entry, $value)
     {
+        // some lang are defined as fr-FR, es-ES.
+        // replacing - by _ might increase language support
+        $value = str_replace('-', '_', $value);
+
         $errors = $this->validator->validate(
             $value,
             (new LocaleConstraint())

--- a/src/Wallabag/CoreBundle/Resources/config/services.yml
+++ b/src/Wallabag/CoreBundle/Resources/config/services.yml
@@ -90,6 +90,7 @@ services:
         arguments:
             - "@wallabag_core.graby"
             - "@wallabag_core.rule_based_tagger"
+            - "@validator"
             - "@logger"
             - '%wallabag_core.fetching_error_message%'
 

--- a/tests/Wallabag/ApiBundle/Controller/EntryRestControllerTest.php
+++ b/tests/Wallabag/ApiBundle/Controller/EntryRestControllerTest.php
@@ -345,7 +345,7 @@ class EntryRestControllerTest extends WallabagApiTestCase
             'tags' => 'google',
             'title' => 'New title for my article',
             'content' => 'my content',
-            'language' => 'de_DE',
+            'language' => 'de',
             'published_at' => '2016-09-08T11:55:58+0200',
             'authors' => 'bob,helen',
         ]);
@@ -362,7 +362,7 @@ class EntryRestControllerTest extends WallabagApiTestCase
         $this->assertEquals(1, $content['user_id']);
         $this->assertCount(2, $content['tags']);
         $this->assertSame('my content', $content['content']);
-        $this->assertSame('de_DE', $content['language']);
+        $this->assertSame('de', $content['language']);
         $this->assertSame('2016-09-08T11:55:58+0200', $content['published_at']);
         $this->assertCount(2, $content['published_by']);
         $this->assertContains('bob', $content['published_by']);
@@ -477,7 +477,7 @@ class EntryRestControllerTest extends WallabagApiTestCase
             'tags' => 'new tag '.uniqid(),
             'starred' => '1',
             'archive' => '0',
-            'language' => 'de_DE',
+            'language' => 'de_AT',
             'preview_picture' => 'http://preview.io/picture.jpg',
             'authors' => 'bob,sponge',
             'content' => 'awesome',
@@ -492,7 +492,7 @@ class EntryRestControllerTest extends WallabagApiTestCase
         $this->assertEquals('New awesome title', $content['title']);
         $this->assertGreaterThan($nbTags, count($content['tags']));
         $this->assertEquals(1, $content['user_id']);
-        $this->assertEquals('de_DE', $content['language']);
+        $this->assertEquals('de_AT', $content['language']);
         $this->assertEquals('http://preview.io/picture.jpg', $content['preview_picture']);
         $this->assertContains('sponge', $content['published_by']);
         $this->assertContains('bob', $content['published_by']);

--- a/tests/Wallabag/CoreBundle/Controller/EntryControllerTest.php
+++ b/tests/Wallabag/CoreBundle/Controller/EntryControllerTest.php
@@ -990,7 +990,6 @@ class EntryControllerTest extends WallabagCoreTestCase
         $this->assertContains('Perpignan', $entry->getTitle());
         // instead of checking for the filename (which might change) check that the image is now local
         $this->assertContains('http://v2.wallabag.org/assets/images/', $entry->getContent());
-        $this->assertEquals('fr', $entry->getLanguage());
 
         $client->getContainer()->get('craue_config')->set('download_images_enabled', 0);
     }

--- a/tests/Wallabag/CoreBundle/Controller/EntryControllerTest.php
+++ b/tests/Wallabag/CoreBundle/Controller/EntryControllerTest.php
@@ -1252,9 +1252,9 @@ class EntryControllerTest extends WallabagCoreTestCase
                 'https://www.pravda.ru/world/09-06-2017/1337283-qatar-0/',
                 'ru',
             ],
-            'wrong fr-FR' => [
-                'http://www.zataz.com/fff-darknet/axzz4jUg2QJjH',
-                '',
+            'fr-FR' => [
+                'http://www.zataz.com/90-des-dossiers-medicaux-des-coreens-du-sud-vendus-a-des-entreprises-privees/',
+                'fr_FR',
             ],
             'de' => [
                 'http://www.bild.de/politik/ausland/theresa-may/wahlbeben-grossbritannien-analyse-52108924.bild.html',
@@ -1280,9 +1280,13 @@ class EntryControllerTest extends WallabagCoreTestCase
                 'http://precodoscombustiveis.com.br/postos/cidade/4121/pr/maringa',
                 'pt_BR',
             ],
-            'fucked list of languages' => [
+            'fucked_list_of_languages' => [
                 'http://geocatalog.webservice-energy.org/geonetwork/srv/eng/main.home',
                 '',
+            ],
+            'es-ES' => [
+                'http://www.muylinux.com/2015/04/17/odf-reino-unido-microsoft-google',
+                'es_ES',
             ],
         ];
     }

--- a/tests/Wallabag/ImportBundle/Controller/ReadabilityControllerTest.php
+++ b/tests/Wallabag/ImportBundle/Controller/ReadabilityControllerTest.php
@@ -120,7 +120,7 @@ class ReadabilityControllerTest extends WallabagCoreTestCase
 
         $this->assertNotEmpty($content->getMimetype(), 'Mimetype for http://www.zataz.com is ok');
         $this->assertNotEmpty($content->getPreviewPicture(), 'Preview picture for http://www.zataz.com is ok');
-        $this->assertEmpty($content->getLanguage(), 'Language for http://www.zataz.com is empty because not valid (fr-FR)');
+        $this->assertNotEmpty($content->getLanguage(), 'Language for http://www.zataz.com is ok');
 
         $tags = $content->getTags();
         $this->assertContains('foot', $tags, 'It includes the "foot" tag');

--- a/tests/Wallabag/ImportBundle/Controller/ReadabilityControllerTest.php
+++ b/tests/Wallabag/ImportBundle/Controller/ReadabilityControllerTest.php
@@ -120,7 +120,7 @@ class ReadabilityControllerTest extends WallabagCoreTestCase
 
         $this->assertNotEmpty($content->getMimetype(), 'Mimetype for http://www.zataz.com is ok');
         $this->assertNotEmpty($content->getPreviewPicture(), 'Preview picture for http://www.zataz.com is ok');
-        $this->assertNotEmpty($content->getLanguage(), 'Language for http://www.zataz.com is ok');
+        $this->assertEmpty($content->getLanguage(), 'Language for http://www.zataz.com is empty because not valid (fr-FR)');
 
         $tags = $content->getTags();
         $this->assertContains('foot', $tags, 'It includes the "foot" tag');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Documentation | no
| Translation   | no
| Fixed tickets | https://github.com/wallabag/wallabag/issues/3186
| License       | MIT

_This is a proposal.
Any suggestions on which fields might be a good to validate is welcome._

Instead of saving the value of each field right into the content without any validation, it seems better to validate them **before**.
This might sounds obvious now we say that but we didn't do it before that PR.
