### PR TITLE
Fixed internal settings form

### DIFF
--- a/app/Resources/CraueConfigBundle/views/Settings/modify.html.twig
+++ b/app/Resources/CraueConfigBundle/views/Settings/modify.html.twig
@@ -33,8 +33,7 @@
                     {{ 'modify_settings' | trans({}, 'CraueConfigBundle') }}
                 </button>
 
-                {{ form_rest(form) }}
-                {{ form_end(form) }}
+                {{ form_widget(form._token) }}
             </div>
         </div>
     </div>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Documentation | no
| Translation   | no
| Fixed tickets | #...
| License       | MIT

Removed these useless lines: 

![capture d ecran 2017-06-12 a 10 35 06](https://user-images.githubusercontent.com/121870/27025851-30d5d1b6-4f5c-11e7-9619-5740bc99bd35.png)
