### PR TITLE
Empty preview pictures and language return null

### DIFF
--- a/src/Wallabag/CoreBundle/Helper/ContentProxy.php
+++ b/src/Wallabag/CoreBundle/Helper/ContentProxy.php
@@ -120,12 +120,12 @@ class ContentProxy
 
         $this->validateAndSetLanguage(
             $entry,
-            isset($content['language']) ? $content['language'] : ''
+            isset($content['language']) ? $content['language'] : null
         );
 
         $this->validateAndSetPreviewPicture(
             $entry,
-            isset($content['open_graph']['og_image']) ? $content['open_graph']['og_image'] : ''
+            isset($content['open_graph']['og_image']) ? $content['open_graph']['og_image'] : null
         );
 
         // if content is an image, define it as a preview too

--- a/tests/Wallabag/CoreBundle/Helper/ContentProxyTest.php
+++ b/tests/Wallabag/CoreBundle/Helper/ContentProxyTest.php
@@ -206,7 +206,7 @@ class ContentProxyTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('http://1.1.1.1', $entry->getUrl());
         $this->assertEquals('this is my title', $entry->getTitle());
         $this->assertContains('this is my content', $entry->getContent());
-        $this->assertEmpty($entry->getPreviewPicture());
+        $this->assertNull($entry->getPreviewPicture());
         $this->assertEquals('text/html', $entry->getMimetype());
         $this->assertEquals('fr', $entry->getLanguage());
         $this->assertEquals('200', $entry->getHttpStatus());
@@ -252,7 +252,7 @@ class ContentProxyTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('this is my title', $entry->getTitle());
         $this->assertContains('this is my content', $entry->getContent());
         $this->assertEquals('text/html', $entry->getMimetype());
-        $this->assertEmpty($entry->getLanguage());
+        $this->assertNull($entry->getLanguage());
         $this->assertEquals('200', $entry->getHttpStatus());
         $this->assertEquals(4.0, $entry->getReadingTime());
         $this->assertEquals('1.1.1.1', $entry->getDomainName());
@@ -300,7 +300,7 @@ class ContentProxyTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('http://1.1.1.1', $entry->getUrl());
         $this->assertEquals('this is my title', $entry->getTitle());
         $this->assertContains('this is my content', $entry->getContent());
-        $this->assertEmpty($entry->getPreviewPicture());
+        $this->assertNull($entry->getPreviewPicture());
         $this->assertEquals('text/html', $entry->getMimetype());
         $this->assertEquals('fr', $entry->getLanguage());
         $this->assertEquals('200', $entry->getHttpStatus());


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Documentation | no
| Translation   | no
| Fixed tickets | #3192
| License       | MIT


