### PR TITLE
Add client_credentials oAuth2 auth method

### DIFF
--- a/src/Wallabag/ApiBundle/Controller/DeveloperController.php
+++ b/src/Wallabag/ApiBundle/Controller/DeveloperController.php
@@ -43,7 +43,7 @@ class DeveloperController extends Controller
         $clientForm->handleRequest($request);
 
         if ($clientForm->isSubmitted() && $clientForm->isValid()) {
-            $client->setAllowedGrantTypes(['token', 'authorization_code', 'password', 'refresh_token']);
+            $client->setAllowedGrantTypes(['client_credentials', 'token', 'authorization_code', 'password', 'refresh_token']);
             $em->persist($client);
             $em->flush();
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | yes
| Tests pass?   | yes
| Documentation | https://github.com/wallabag/doc/pull/20
| Translation   | no
| Fixed tickets | https://github.com/wallabag/wallabag/issues/2800
| License       | MIT

While https://github.com/wallabag/wallabag/pull/3068 needs more changes to be ready, we can allow apps to use the `client_credentials` auth method instead of the `password` one (which sends the user's credentials every time, and requires apps to save them).
Now apps can simply request an `access_token` with the `client ID` and `secret ID`. There's no `refresh_token`.
The `password` auth method is still available but we can depreciate it.

cc @wallabag/contributors 