### PR TITLE
Fixed mapping entities

### DIFF
--- a/src/Wallabag/CoreBundle/Entity/SiteCredential.php
+++ b/src/Wallabag/CoreBundle/Entity/SiteCredential.php
@@ -57,7 +57,7 @@ class SiteCredential
     private $createdAt;
 
     /**
-     * @ORM\ManyToOne(targetEntity="Wallabag\UserBundle\Entity\User", inversedBy="site_credentials")
+     * @ORM\ManyToOne(targetEntity="Wallabag\UserBundle\Entity\User", inversedBy="siteCredentials")
      */
     private $user;
 

--- a/src/Wallabag/UserBundle/Entity/User.php
+++ b/src/Wallabag/UserBundle/Entity/User.php
@@ -97,7 +97,7 @@ class User extends BaseUser implements TwoFactorInterface, TrustedComputerInterf
      *
      * @ORM\OneToMany(targetEntity="Wallabag\CoreBundle\Entity\SiteCredential", mappedBy="user", cascade={"remove"})
      */
-    protected $site_credentials;
+    protected $siteCredentials;
 
     /**
      * @var ArrayCollection

--- a/src/Wallabag/UserBundle/Entity/User.php
+++ b/src/Wallabag/UserBundle/Entity/User.php
@@ -95,6 +95,13 @@ class User extends BaseUser implements TwoFactorInterface, TrustedComputerInterf
     /**
      * @var ArrayCollection
      *
+     * @ORM\OneToMany(targetEntity="Wallabag\CoreBundle\Entity\SiteCredential", mappedBy="user", cascade={"remove"})
+     */
+    protected $site_credentials;
+
+    /**
+     * @var ArrayCollection
+     *
      * @ORM\OneToMany(targetEntity="Wallabag\ApiBundle\Entity\Client", mappedBy="user", cascade={"remove"})
      */
     protected $clients;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Documentation | no
| Translation   | no
| Fixed tickets | #...
| License       | MIT

There were this error in the console:

> The association Wallabag\CoreBundle\Entity\SiteCredential#user refers to the inverse side field Wallabag\UserBundle\Entity\User#site_credentials which does not exist.
