### PR TITLE
Add a real configuration for CS-Fixer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@
 /bin/*
 !/bin/console
 !/bin/symfony_requirements
+.php_cs.cache
 
 # Parameters
 /app/config/parameters.yml

--- a/.php_cs
+++ b/.php_cs
@@ -1,0 +1,47 @@
+<?php
+
+return PhpCsFixer\Config::create()
+    ->setRiskyAllowed(true)
+    ->setRules([
+        '@Symfony' => true,
+        '@Symfony:risky' => true,
+        'array_syntax' => [
+            'syntax' => 'short'
+        ],
+        'combine_consecutive_unsets' => true,
+        'heredoc_to_nowdoc' => true,
+        'no_extra_consecutive_blank_lines' => [
+        'break',
+            'continue',
+            'extra',
+            'return',
+            'throw',
+            'use',
+            'parenthesis_brace_block',
+            'square_brace_block',
+            'curly_brace_block'
+        ],
+        'no_unreachable_default_argument_value' => true,
+        'no_useless_else' => true,
+        'no_useless_return' => true,
+        'ordered_class_elements' => true,
+        'ordered_imports' => true,
+        'php_unit_strict' => true,
+        'phpdoc_order' => true,
+        // 'psr4' => true,
+        'strict_comparison' => true,
+        'strict_param' => true,
+        'concat_space' => [
+            'spacing' => 'one'
+        ],
+    ])
+    ->setFinder(
+        PhpCsFixer\Finder::create()
+            ->exclude([
+                'vendor',
+                'var',
+                'web'
+            ])
+            ->in(__DIR__)
+    )
+;

--- a/.travis.yml
+++ b/.travis.yml
@@ -79,7 +79,7 @@ script:
     - echo "travis_fold:end:fixtures"
 
     - if [[ $VALIDATE_TRANSLATION_FILE = '' ]]; then ./bin/simple-phpunit -v ; fi;
-    - if [[ $CS_FIXER = run ]]; then php bin/php-cs-fixer fix src/ --verbose --dry-run ; fi;
+    - if [[ $CS_FIXER = run ]]; then php bin/php-cs-fixer fix --verbose --dry-run ; fi;
     - if [[ $VALIDATE_TRANSLATION_FILE = run ]]; then php bin/console lint:yaml src/Wallabag/CoreBundle/Resources/translations -v ; fi;
     - if [[ $VALIDATE_TRANSLATION_FILE = run ]]; then php bin/console lint:yaml app/Resources/CraueConfigBundle/translations -v ; fi;
     - if [[ $VALIDATE_TRANSLATION_FILE = run ]]; then php bin/console lint:yaml src/Wallabag/UserBundle/Resources/translations -v ; fi;

--- a/app/AppKernel.php
+++ b/app/AppKernel.php
@@ -1,7 +1,7 @@
 <?php
 
-use Symfony\Component\HttpKernel\Kernel;
 use Symfony\Component\Config\Loader\LoaderInterface;
+use Symfony\Component\HttpKernel\Kernel;
 
 class AppKernel extends Kernel
 {
@@ -64,25 +64,25 @@ class AppKernel extends Kernel
 
     public function getCacheDir()
     {
-        return dirname(__DIR__).'/var/cache/'.$this->getEnvironment();
+        return dirname(__DIR__) . '/var/cache/' . $this->getEnvironment();
     }
 
     public function getLogDir()
     {
-        return dirname(__DIR__).'/var/logs';
+        return dirname(__DIR__) . '/var/logs';
     }
 
     public function registerContainerConfiguration(LoaderInterface $loader)
     {
-        $loader->load($this->getRootDir().'/config/config_'.$this->getEnvironment().'.yml');
+        $loader->load($this->getRootDir() . '/config/config_' . $this->getEnvironment() . '.yml');
         $loader->load(function ($container) {
-           if ($container->getParameter('use_webpack_dev_server')) {
-               $container->loadFromExtension('framework', [
+            if ($container->getParameter('use_webpack_dev_server')) {
+                $container->loadFromExtension('framework', [
                    'assets' => [
                        'base_url' => 'http://localhost:8080/',
                    ],
                ]);
-           }
+            }
         });
     }
 }

--- a/app/DoctrineMigrations/Version20160410190541.php
+++ b/app/DoctrineMigrations/Version20160410190541.php
@@ -22,11 +22,6 @@ class Version20160410190541 extends AbstractMigration implements ContainerAwareI
         $this->container = $container;
     }
 
-    private function getTable($tableName)
-    {
-        return $this->container->getParameter('database_table_prefix').$tableName;
-    }
-
     /**
      * @param Schema $schema
      */
@@ -44,10 +39,10 @@ class Version20160410190541 extends AbstractMigration implements ContainerAwareI
         $sharePublic = $this->container
             ->get('doctrine.orm.default_entity_manager')
             ->getConnection()
-            ->fetchArray('SELECT * FROM '.$this->getTable('craue_config_setting')." WHERE name = 'share_public'");
+            ->fetchArray('SELECT * FROM ' . $this->getTable('craue_config_setting') . " WHERE name = 'share_public'");
 
         if (false === $sharePublic) {
-            $this->addSql('INSERT INTO '.$this->getTable('craue_config_setting')." (name, value, section) VALUES ('share_public', '1', 'entry')");
+            $this->addSql('INSERT INTO ' . $this->getTable('craue_config_setting') . " (name, value, section) VALUES ('share_public', '1', 'entry')");
         }
     }
 
@@ -59,6 +54,11 @@ class Version20160410190541 extends AbstractMigration implements ContainerAwareI
         $entryTable = $schema->getTable($this->getTable('entry'));
         $entryTable->dropColumn('uid');
 
-        $this->addSql('DELETE FROM '.$this->getTable('craue_config_setting')." WHERE name = 'share_public'");
+        $this->addSql('DELETE FROM ' . $this->getTable('craue_config_setting') . " WHERE name = 'share_public'");
+    }
+
+    private function getTable($tableName)
+    {
+        return $this->container->getParameter('database_table_prefix') . $tableName;
     }
 }

--- a/app/DoctrineMigrations/Version20160812120952.php
+++ b/app/DoctrineMigrations/Version20160812120952.php
@@ -22,11 +22,6 @@ class Version20160812120952 extends AbstractMigration implements ContainerAwareI
         $this->container = $container;
     }
 
-    private function getTable($tableName)
-    {
-        return $this->container->getParameter('database_table_prefix').$tableName;
-    }
-
     /**
      * @param Schema $schema
      */
@@ -45,5 +40,10 @@ class Version20160812120952 extends AbstractMigration implements ContainerAwareI
     {
         $clientsTable = $schema->getTable($this->getTable('oauth2_clients'));
         $clientsTable->dropColumn('name');
+    }
+
+    private function getTable($tableName)
+    {
+        return $this->container->getParameter('database_table_prefix') . $tableName;
     }
 }

--- a/app/DoctrineMigrations/Version20160911214952.php
+++ b/app/DoctrineMigrations/Version20160911214952.php
@@ -22,11 +22,6 @@ class Version20160911214952 extends AbstractMigration implements ContainerAwareI
         $this->container = $container;
     }
 
-    private function getTable($tableName)
-    {
-        return $this->container->getParameter('database_table_prefix').$tableName;
-    }
-
     /**
      * @param Schema $schema
      */
@@ -35,19 +30,19 @@ class Version20160911214952 extends AbstractMigration implements ContainerAwareI
         $redis = $this->container
             ->get('doctrine.orm.default_entity_manager')
             ->getConnection()
-            ->fetchArray('SELECT * FROM '.$this->getTable('craue_config_setting')." WHERE name = 'import_with_redis'");
+            ->fetchArray('SELECT * FROM ' . $this->getTable('craue_config_setting') . " WHERE name = 'import_with_redis'");
 
         if (false === $redis) {
-            $this->addSql('INSERT INTO '.$this->getTable('craue_config_setting')." (name, value, section) VALUES ('import_with_redis', 0, 'import')");
+            $this->addSql('INSERT INTO ' . $this->getTable('craue_config_setting') . " (name, value, section) VALUES ('import_with_redis', 0, 'import')");
         }
 
         $rabbitmq = $this->container
             ->get('doctrine.orm.default_entity_manager')
             ->getConnection()
-            ->fetchArray('SELECT * FROM '.$this->getTable('craue_config_setting')." WHERE name = 'import_with_rabbitmq'");
+            ->fetchArray('SELECT * FROM ' . $this->getTable('craue_config_setting') . " WHERE name = 'import_with_rabbitmq'");
 
         if (false === $rabbitmq) {
-            $this->addSql('INSERT INTO '.$this->getTable('craue_config_setting')." (name, value, section) VALUES ('import_with_rabbitmq', 0, 'import')");
+            $this->addSql('INSERT INTO ' . $this->getTable('craue_config_setting') . " (name, value, section) VALUES ('import_with_rabbitmq', 0, 'import')");
         }
 
         $this->skipIf(false !== $rabbitmq && false !== $redis, 'It seems that you already played this migration.');
@@ -58,7 +53,12 @@ class Version20160911214952 extends AbstractMigration implements ContainerAwareI
      */
     public function down(Schema $schema)
     {
-        $this->addSql('DELETE FROM '.$this->getTable('craue_config_setting')." WHERE name = 'import_with_redis';");
-        $this->addSql('DELETE FROM '.$this->getTable('craue_config_setting')." WHERE name = 'import_with_rabbitmq';");
+        $this->addSql('DELETE FROM ' . $this->getTable('craue_config_setting') . " WHERE name = 'import_with_redis';");
+        $this->addSql('DELETE FROM ' . $this->getTable('craue_config_setting') . " WHERE name = 'import_with_rabbitmq';");
+    }
+
+    private function getTable($tableName)
+    {
+        return $this->container->getParameter('database_table_prefix') . $tableName;
     }
 }

--- a/app/DoctrineMigrations/Version20160916201049.php
+++ b/app/DoctrineMigrations/Version20160916201049.php
@@ -22,11 +22,6 @@ class Version20160916201049 extends AbstractMigration implements ContainerAwareI
         $this->container = $container;
     }
 
-    private function getTable($tableName)
-    {
-        return $this->container->getParameter('database_table_prefix').$tableName;
-    }
-
     /**
      * @param Schema $schema
      */
@@ -37,7 +32,7 @@ class Version20160916201049 extends AbstractMigration implements ContainerAwareI
         $this->skipIf($configTable->hasColumn('pocket_consumer_key'), 'It seems that you already played this migration.');
 
         $configTable->addColumn('pocket_consumer_key', 'string', ['notnull' => false]);
-        $this->addSql('DELETE FROM '.$this->getTable('craue_config_setting')." WHERE name = 'pocket_consumer_key';");
+        $this->addSql('DELETE FROM ' . $this->getTable('craue_config_setting') . " WHERE name = 'pocket_consumer_key';");
     }
 
     /**
@@ -47,6 +42,11 @@ class Version20160916201049 extends AbstractMigration implements ContainerAwareI
     {
         $configTable = $schema->getTable($this->getTable('config'));
         $configTable->dropColumn('pocket_consumer_key');
-        $this->addSql('INSERT INTO '.$this->getTable('craue_config_setting')." (name, value, section) VALUES ('pocket_consumer_key', NULL, 'import')");
+        $this->addSql('INSERT INTO ' . $this->getTable('craue_config_setting') . " (name, value, section) VALUES ('pocket_consumer_key', NULL, 'import')");
+    }
+
+    private function getTable($tableName)
+    {
+        return $this->container->getParameter('database_table_prefix') . $tableName;
     }
 }

--- a/app/DoctrineMigrations/Version20161001072726.php
+++ b/app/DoctrineMigrations/Version20161001072726.php
@@ -3,10 +3,10 @@
 namespace Application\Migrations;
 
 use Doctrine\DBAL\Migrations\AbstractMigration;
+use Doctrine\DBAL\Migrations\SkipMigrationException;
 use Doctrine\DBAL\Schema\Schema;
 use Symfony\Component\DependencyInjection\ContainerAwareInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
-use Doctrine\DBAL\Migrations\SkipMigrationException;
 
 /**
  * Added pocket_consumer_key field on wallabag_config.
@@ -23,17 +23,12 @@ class Version20161001072726 extends AbstractMigration implements ContainerAwareI
         $this->container = $container;
     }
 
-    private function getTable($tableName)
-    {
-        return $this->container->getParameter('database_table_prefix').$tableName;
-    }
-
     /**
      * @param Schema $schema
      */
     public function up(Schema $schema)
     {
-        $this->skipIf($this->connection->getDatabasePlatform()->getName() == 'sqlite', 'Migration can only be executed safely on \'mysql\' or \'postgresql\'.');
+        $this->skipIf($this->connection->getDatabasePlatform()->getName() === 'sqlite', 'Migration can only be executed safely on \'mysql\' or \'postgresql\'.');
 
         // remove all FK from entry_tag
         switch ($this->connection->getDatabasePlatform()->getName()) {
@@ -41,16 +36,15 @@ class Version20161001072726 extends AbstractMigration implements ContainerAwareI
                 $query = $this->connection->query("
                     SELECT CONSTRAINT_NAME
                     FROM information_schema.key_column_usage
-                    WHERE TABLE_NAME = '".$this->getTable('entry_tag')."' AND CONSTRAINT_NAME LIKE 'FK_%'
-                    AND TABLE_SCHEMA = '".$this->connection->getDatabase()."'"
+                    WHERE TABLE_NAME = '" . $this->getTable('entry_tag') . "' AND CONSTRAINT_NAME LIKE 'FK_%'
+                    AND TABLE_SCHEMA = '" . $this->connection->getDatabase() . "'"
                 );
                 $query->execute();
 
                 foreach ($query->fetchAll() as $fk) {
-                    $this->addSql('ALTER TABLE '.$this->getTable('entry_tag').' DROP FOREIGN KEY '.$fk['CONSTRAINT_NAME']);
+                    $this->addSql('ALTER TABLE ' . $this->getTable('entry_tag') . ' DROP FOREIGN KEY ' . $fk['CONSTRAINT_NAME']);
                 }
                 break;
-
             case 'postgresql':
                 // http://dba.stackexchange.com/questions/36979/retrieving-all-pk-and-fk
                 $query = $this->connection->query("
@@ -60,19 +54,19 @@ class Version20161001072726 extends AbstractMigration implements ContainerAwareI
                     FROM   pg_constraint c
                     JOIN   pg_namespace n ON n.oid = c.connamespace
                     WHERE  contype = 'f'
-                    AND    conrelid::regclass::text = '".$this->getTable('entry_tag')."'
+                    AND    conrelid::regclass::text = '" . $this->getTable('entry_tag') . "'
                     AND    n.nspname = 'public';"
                 );
                 $query->execute();
 
                 foreach ($query->fetchAll() as $fk) {
-                    $this->addSql('ALTER TABLE '.$this->getTable('entry_tag').' DROP CONSTRAINT '.$fk['conname']);
+                    $this->addSql('ALTER TABLE ' . $this->getTable('entry_tag') . ' DROP CONSTRAINT ' . $fk['conname']);
                 }
                 break;
         }
 
-        $this->addSql('ALTER TABLE '.$this->getTable('entry_tag').' ADD CONSTRAINT FK_entry_tag_entry FOREIGN KEY (entry_id) REFERENCES '.$this->getTable('entry').' (id) ON DELETE CASCADE');
-        $this->addSql('ALTER TABLE '.$this->getTable('entry_tag').' ADD CONSTRAINT FK_entry_tag_tag FOREIGN KEY (tag_id) REFERENCES '.$this->getTable('tag').' (id) ON DELETE CASCADE');
+        $this->addSql('ALTER TABLE ' . $this->getTable('entry_tag') . ' ADD CONSTRAINT FK_entry_tag_entry FOREIGN KEY (entry_id) REFERENCES ' . $this->getTable('entry') . ' (id) ON DELETE CASCADE');
+        $this->addSql('ALTER TABLE ' . $this->getTable('entry_tag') . ' ADD CONSTRAINT FK_entry_tag_tag FOREIGN KEY (tag_id) REFERENCES ' . $this->getTable('tag') . ' (id) ON DELETE CASCADE');
 
         // remove entry FK from annotation
 
@@ -81,18 +75,17 @@ class Version20161001072726 extends AbstractMigration implements ContainerAwareI
                 $query = $this->connection->query("
                     SELECT CONSTRAINT_NAME
                     FROM information_schema.key_column_usage
-                    WHERE TABLE_NAME = '".$this->getTable('annotation')."'
+                    WHERE TABLE_NAME = '" . $this->getTable('annotation') . "'
                     AND CONSTRAINT_NAME LIKE 'FK_%'
                     AND COLUMN_NAME = 'entry_id'
-                    AND TABLE_SCHEMA = '".$this->connection->getDatabase()."'"
+                    AND TABLE_SCHEMA = '" . $this->connection->getDatabase() . "'"
                 );
                 $query->execute();
 
                 foreach ($query->fetchAll() as $fk) {
-                    $this->addSql('ALTER TABLE '.$this->getTable('annotation').' DROP FOREIGN KEY '.$fk['CONSTRAINT_NAME']);
+                    $this->addSql('ALTER TABLE ' . $this->getTable('annotation') . ' DROP FOREIGN KEY ' . $fk['CONSTRAINT_NAME']);
                 }
                 break;
-
             case 'postgresql':
                 // http://dba.stackexchange.com/questions/36979/retrieving-all-pk-and-fk
                 $query = $this->connection->query("
@@ -102,19 +95,19 @@ class Version20161001072726 extends AbstractMigration implements ContainerAwareI
                     FROM   pg_constraint c
                     JOIN   pg_namespace n ON n.oid = c.connamespace
                     WHERE  contype = 'f'
-                    AND    conrelid::regclass::text = '".$this->getTable('annotation')."'
+                    AND    conrelid::regclass::text = '" . $this->getTable('annotation') . "'
                     AND    n.nspname = 'public'
                     AND    pg_get_constraintdef(c.oid) LIKE '%entry_id%';"
                 );
                 $query->execute();
 
                 foreach ($query->fetchAll() as $fk) {
-                    $this->addSql('ALTER TABLE '.$this->getTable('annotation').' DROP CONSTRAINT '.$fk['conname']);
+                    $this->addSql('ALTER TABLE ' . $this->getTable('annotation') . ' DROP CONSTRAINT ' . $fk['conname']);
                 }
                 break;
         }
 
-        $this->addSql('ALTER TABLE '.$this->getTable('annotation').' ADD CONSTRAINT FK_annotation_entry FOREIGN KEY (entry_id) REFERENCES '.$this->getTable('entry').' (id) ON DELETE CASCADE');
+        $this->addSql('ALTER TABLE ' . $this->getTable('annotation') . ' ADD CONSTRAINT FK_annotation_entry FOREIGN KEY (entry_id) REFERENCES ' . $this->getTable('entry') . ' (id) ON DELETE CASCADE');
     }
 
     /**
@@ -123,5 +116,10 @@ class Version20161001072726 extends AbstractMigration implements ContainerAwareI
     public function down(Schema $schema)
     {
         throw new SkipMigrationException('Too complex ...');
+    }
+
+    private function getTable($tableName)
+    {
+        return $this->container->getParameter('database_table_prefix') . $tableName;
     }
 }

--- a/app/DoctrineMigrations/Version20161022134138.php
+++ b/app/DoctrineMigrations/Version20161022134138.php
@@ -22,11 +22,6 @@ class Version20161022134138 extends AbstractMigration implements ContainerAwareI
         $this->container = $container;
     }
 
-    private function getTable($tableName)
-    {
-        return $this->container->getParameter('database_table_prefix').$tableName;
-    }
-
     /**
      * @param Schema $schema
      */
@@ -34,28 +29,28 @@ class Version20161022134138 extends AbstractMigration implements ContainerAwareI
     {
         $this->skipIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'This migration only apply to MySQL');
 
-        $this->addSql('ALTER DATABASE '.$this->connection->getParams()['dbname'].' CHARACTER SET = utf8mb4 COLLATE = utf8mb4_unicode_ci;');
+        $this->addSql('ALTER DATABASE ' . $this->connection->getParams()['dbname'] . ' CHARACTER SET = utf8mb4 COLLATE = utf8mb4_unicode_ci;');
 
         // convert field length for utf8mb4
         // http://stackoverflow.com/a/31474509/569101
-        $this->addSql('ALTER TABLE '.$this->getTable('user').' CHANGE confirmation_token confirmation_token VARCHAR(180) DEFAULT NULL;');
-        $this->addSql('ALTER TABLE '.$this->getTable('user').' CHANGE salt salt VARCHAR(180) NOT NULL;');
-        $this->addSql('ALTER TABLE '.$this->getTable('user').' CHANGE password password VARCHAR(180) NOT NULL;');
+        $this->addSql('ALTER TABLE ' . $this->getTable('user') . ' CHANGE confirmation_token confirmation_token VARCHAR(180) DEFAULT NULL;');
+        $this->addSql('ALTER TABLE ' . $this->getTable('user') . ' CHANGE salt salt VARCHAR(180) NOT NULL;');
+        $this->addSql('ALTER TABLE ' . $this->getTable('user') . ' CHANGE password password VARCHAR(180) NOT NULL;');
 
-        $this->addSql('ALTER TABLE '.$this->getTable('annotation').' CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;');
-        $this->addSql('ALTER TABLE '.$this->getTable('entry').' CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;');
-        $this->addSql('ALTER TABLE '.$this->getTable('tag').' CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;');
-        $this->addSql('ALTER TABLE '.$this->getTable('user').' CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;');
+        $this->addSql('ALTER TABLE ' . $this->getTable('annotation') . ' CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;');
+        $this->addSql('ALTER TABLE ' . $this->getTable('entry') . ' CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;');
+        $this->addSql('ALTER TABLE ' . $this->getTable('tag') . ' CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;');
+        $this->addSql('ALTER TABLE ' . $this->getTable('user') . ' CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;');
 
-        $this->addSql('ALTER TABLE '.$this->getTable('annotation').' CHANGE `text` `text` longtext CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;');
-        $this->addSql('ALTER TABLE '.$this->getTable('annotation').' CHANGE `quote` `quote` VARCHAR(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;');
+        $this->addSql('ALTER TABLE ' . $this->getTable('annotation') . ' CHANGE `text` `text` longtext CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;');
+        $this->addSql('ALTER TABLE ' . $this->getTable('annotation') . ' CHANGE `quote` `quote` VARCHAR(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;');
 
-        $this->addSql('ALTER TABLE '.$this->getTable('entry').' CHANGE `title` `title` longtext CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;');
-        $this->addSql('ALTER TABLE '.$this->getTable('entry').' CHANGE `content` `content` longtext CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;');
+        $this->addSql('ALTER TABLE ' . $this->getTable('entry') . ' CHANGE `title` `title` longtext CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;');
+        $this->addSql('ALTER TABLE ' . $this->getTable('entry') . ' CHANGE `content` `content` longtext CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;');
 
-        $this->addSql('ALTER TABLE '.$this->getTable('tag').' CHANGE `label` `label` longtext CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;');
+        $this->addSql('ALTER TABLE ' . $this->getTable('tag') . ' CHANGE `label` `label` longtext CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;');
 
-        $this->addSql('ALTER TABLE '.$this->getTable('user').' CHANGE `name` `name` longtext CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;');
+        $this->addSql('ALTER TABLE ' . $this->getTable('user') . ' CHANGE `name` `name` longtext CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;');
     }
 
     /**
@@ -65,21 +60,26 @@ class Version20161022134138 extends AbstractMigration implements ContainerAwareI
     {
         $this->skipIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'This migration only apply to MySQL');
 
-        $this->addSql('ALTER DATABASE '.$this->connection->getParams()['dbname'].' CHARACTER SET = utf8 COLLATE = utf8_unicode_ci;');
+        $this->addSql('ALTER DATABASE ' . $this->connection->getParams()['dbname'] . ' CHARACTER SET = utf8 COLLATE = utf8_unicode_ci;');
 
-        $this->addSql('ALTER TABLE '.$this->getTable('annotation').' CONVERT TO CHARACTER SET utf8 COLLATE utf8_unicode_ci;');
-        $this->addSql('ALTER TABLE '.$this->getTable('entry').' CONVERT TO CHARACTER SET utf8 COLLATE utf8_unicode_ci;');
-        $this->addSql('ALTER TABLE '.$this->getTable('tag').' CONVERT TO CHARACTER SET utf8 COLLATE utf8_unicode_ci;');
-        $this->addSql('ALTER TABLE '.$this->getTable('user').' CONVERT TO CHARACTER SET utf8 COLLATE utf8_unicode_ci;');
+        $this->addSql('ALTER TABLE ' . $this->getTable('annotation') . ' CONVERT TO CHARACTER SET utf8 COLLATE utf8_unicode_ci;');
+        $this->addSql('ALTER TABLE ' . $this->getTable('entry') . ' CONVERT TO CHARACTER SET utf8 COLLATE utf8_unicode_ci;');
+        $this->addSql('ALTER TABLE ' . $this->getTable('tag') . ' CONVERT TO CHARACTER SET utf8 COLLATE utf8_unicode_ci;');
+        $this->addSql('ALTER TABLE ' . $this->getTable('user') . ' CONVERT TO CHARACTER SET utf8 COLLATE utf8_unicode_ci;');
 
-        $this->addSql('ALTER TABLE '.$this->getTable('annotation').' CHANGE `text` `text` longtext CHARACTER SET utf8 COLLATE utf8_unicode_ci;');
-        $this->addSql('ALTER TABLE '.$this->getTable('annotation').' CHANGE `quote` `quote` VARCHAR(255) CHARACTER SET utf8 COLLATE utf8_unicode_ci;');
+        $this->addSql('ALTER TABLE ' . $this->getTable('annotation') . ' CHANGE `text` `text` longtext CHARACTER SET utf8 COLLATE utf8_unicode_ci;');
+        $this->addSql('ALTER TABLE ' . $this->getTable('annotation') . ' CHANGE `quote` `quote` VARCHAR(255) CHARACTER SET utf8 COLLATE utf8_unicode_ci;');
 
-        $this->addSql('ALTER TABLE '.$this->getTable('entry').' CHANGE `title` `title` longtext CHARACTER SET utf8 COLLATE utf8_unicode_ci;');
-        $this->addSql('ALTER TABLE '.$this->getTable('entry').' CHANGE `content` `content` longtext CHARACTER SET utf8 COLLATE utf8_unicode_ci;');
+        $this->addSql('ALTER TABLE ' . $this->getTable('entry') . ' CHANGE `title` `title` longtext CHARACTER SET utf8 COLLATE utf8_unicode_ci;');
+        $this->addSql('ALTER TABLE ' . $this->getTable('entry') . ' CHANGE `content` `content` longtext CHARACTER SET utf8 COLLATE utf8_unicode_ci;');
 
-        $this->addSql('ALTER TABLE '.$this->getTable('tag').' CHANGE `label` `label` longtext CHARACTER SET utf8 COLLATE utf8_unicode_ci;');
+        $this->addSql('ALTER TABLE ' . $this->getTable('tag') . ' CHANGE `label` `label` longtext CHARACTER SET utf8 COLLATE utf8_unicode_ci;');
 
-        $this->addSql('ALTER TABLE '.$this->getTable('user').' CHANGE `name` `name` longtext CHARACTER SET utf8 COLLATE utf8_unicode_ci;');
+        $this->addSql('ALTER TABLE ' . $this->getTable('user') . ' CHANGE `name` `name` longtext CHARACTER SET utf8 COLLATE utf8_unicode_ci;');
+    }
+
+    private function getTable($tableName)
+    {
+        return $this->container->getParameter('database_table_prefix') . $tableName;
     }
 }

--- a/app/DoctrineMigrations/Version20161024212538.php
+++ b/app/DoctrineMigrations/Version20161024212538.php
@@ -24,11 +24,6 @@ class Version20161024212538 extends AbstractMigration implements ContainerAwareI
         $this->container = $container;
     }
 
-    private function getTable($tableName)
-    {
-        return $this->container->getParameter('database_table_prefix').$tableName;
-    }
-
     /**
      * @param Schema $schema
      */
@@ -60,8 +55,13 @@ class Version20161024212538 extends AbstractMigration implements ContainerAwareI
 
         $clientsTable->dropColumn('user_id', 'integer');
 
-        if ($this->connection->getDatabasePlatform()->getName() != 'sqlite') {
+        if ($this->connection->getDatabasePlatform()->getName() !== 'sqlite') {
             $clientsTable->removeForeignKey($this->constraintName);
         }
+    }
+
+    private function getTable($tableName)
+    {
+        return $this->container->getParameter('database_table_prefix') . $tableName;
     }
 }

--- a/app/DoctrineMigrations/Version20161031132655.php
+++ b/app/DoctrineMigrations/Version20161031132655.php
@@ -22,11 +22,6 @@ class Version20161031132655 extends AbstractMigration implements ContainerAwareI
         $this->container = $container;
     }
 
-    private function getTable($tableName)
-    {
-        return $this->container->getParameter('database_table_prefix').$tableName;
-    }
-
     /**
      * @param Schema $schema
      */
@@ -35,11 +30,11 @@ class Version20161031132655 extends AbstractMigration implements ContainerAwareI
         $images = $this->container
             ->get('doctrine.orm.default_entity_manager')
             ->getConnection()
-            ->fetchArray('SELECT * FROM '.$this->getTable('craue_config_setting')." WHERE name = 'download_images_enabled'");
+            ->fetchArray('SELECT * FROM ' . $this->getTable('craue_config_setting') . " WHERE name = 'download_images_enabled'");
 
         $this->skipIf(false !== $images, 'It seems that you already played this migration.');
 
-        $this->addSql('INSERT INTO '.$this->getTable('craue_config_setting')." (name, value, section) VALUES ('download_images_enabled', 0, 'misc')");
+        $this->addSql('INSERT INTO ' . $this->getTable('craue_config_setting') . " (name, value, section) VALUES ('download_images_enabled', 0, 'misc')");
     }
 
     /**
@@ -47,6 +42,11 @@ class Version20161031132655 extends AbstractMigration implements ContainerAwareI
      */
     public function down(Schema $schema)
     {
-        $this->addSql('DELETE FROM '.$this->getTable('craue_config_setting')." WHERE name = 'download_images_enabled';");
+        $this->addSql('DELETE FROM ' . $this->getTable('craue_config_setting') . " WHERE name = 'download_images_enabled';");
+    }
+
+    private function getTable($tableName)
+    {
+        return $this->container->getParameter('database_table_prefix') . $tableName;
     }
 }

--- a/app/DoctrineMigrations/Version20161104073720.php
+++ b/app/DoctrineMigrations/Version20161104073720.php
@@ -24,11 +24,6 @@ class Version20161104073720 extends AbstractMigration implements ContainerAwareI
         $this->container = $container;
     }
 
-    private function getTable($tableName)
-    {
-        return $this->container->getParameter('database_table_prefix').$tableName;
-    }
-
     /**
      * @param Schema $schema
      */
@@ -49,5 +44,10 @@ class Version20161104073720 extends AbstractMigration implements ContainerAwareI
         $this->skipIf(false === $entryTable->hasIndex($this->indexName), 'It seems that you already played this migration.');
 
         $entryTable->dropIndex($this->indexName);
+    }
+
+    private function getTable($tableName)
+    {
+        return $this->container->getParameter('database_table_prefix') . $tableName;
     }
 }

--- a/app/DoctrineMigrations/Version20161106113822.php
+++ b/app/DoctrineMigrations/Version20161106113822.php
@@ -22,11 +22,6 @@ class Version20161106113822 extends AbstractMigration implements ContainerAwareI
         $this->container = $container;
     }
 
-    private function getTable($tableName)
-    {
-        return $this->container->getParameter('database_table_prefix').$tableName;
-    }
-
     /**
      * @param Schema $schema
      */
@@ -52,5 +47,10 @@ class Version20161106113822 extends AbstractMigration implements ContainerAwareI
         $this->skipIf(!$configTable->hasColumn('action_mark_as_read'), 'It seems that you already played this migration.');
 
         $configTable->dropColumn('action_mark_as_read');
+    }
+
+    private function getTable($tableName)
+    {
+        return $this->container->getParameter('database_table_prefix') . $tableName;
     }
 }

--- a/app/DoctrineMigrations/Version20161117071626.php
+++ b/app/DoctrineMigrations/Version20161117071626.php
@@ -22,11 +22,6 @@ class Version20161117071626 extends AbstractMigration implements ContainerAwareI
         $this->container = $container;
     }
 
-    private function getTable($tableName)
-    {
-        return $this->container->getParameter('database_table_prefix').$tableName;
-    }
-
     /**
      * @param Schema $schema
      */
@@ -35,19 +30,19 @@ class Version20161117071626 extends AbstractMigration implements ContainerAwareI
         $share = $this->container
             ->get('doctrine.orm.default_entity_manager')
             ->getConnection()
-            ->fetchArray('SELECT * FROM '.$this->getTable('craue_config_setting')." WHERE name = 'share_unmark'");
+            ->fetchArray('SELECT * FROM ' . $this->getTable('craue_config_setting') . " WHERE name = 'share_unmark'");
 
         if (false === $share) {
-            $this->addSql('INSERT INTO '.$this->getTable('craue_config_setting')." (name, value, section) VALUES ('share_unmark', 0, 'entry')");
+            $this->addSql('INSERT INTO ' . $this->getTable('craue_config_setting') . " (name, value, section) VALUES ('share_unmark', 0, 'entry')");
         }
 
         $unmark = $this->container
             ->get('doctrine.orm.default_entity_manager')
             ->getConnection()
-            ->fetchArray('SELECT * FROM '.$this->getTable('craue_config_setting')." WHERE name = 'unmark_url'");
+            ->fetchArray('SELECT * FROM ' . $this->getTable('craue_config_setting') . " WHERE name = 'unmark_url'");
 
         if (false === $unmark) {
-            $this->addSql('INSERT INTO '.$this->getTable('craue_config_setting')." (name, value, section) VALUES ('unmark_url', 'https://unmark.it', 'entry')");
+            $this->addSql('INSERT INTO ' . $this->getTable('craue_config_setting') . " (name, value, section) VALUES ('unmark_url', 'https://unmark.it', 'entry')");
         }
 
         $this->skipIf(false !== $share && false !== $unmark, 'It seems that you already played this migration.');
@@ -58,7 +53,12 @@ class Version20161117071626 extends AbstractMigration implements ContainerAwareI
      */
     public function down(Schema $schema)
     {
-        $this->addSql('DELETE FROM '.$this->getTable('craue_config_setting')." WHERE name = 'share_unmark';");
-        $this->addSql('DELETE FROM '.$this->getTable('craue_config_setting')." WHERE name = 'unmark_url';");
+        $this->addSql('DELETE FROM ' . $this->getTable('craue_config_setting') . " WHERE name = 'share_unmark';");
+        $this->addSql('DELETE FROM ' . $this->getTable('craue_config_setting') . " WHERE name = 'unmark_url';");
+    }
+
+    private function getTable($tableName)
+    {
+        return $this->container->getParameter('database_table_prefix') . $tableName;
     }
 }

--- a/app/DoctrineMigrations/Version20161118134328.php
+++ b/app/DoctrineMigrations/Version20161118134328.php
@@ -22,11 +22,6 @@ class Version20161118134328 extends AbstractMigration implements ContainerAwareI
         $this->container = $container;
     }
 
-    private function getTable($tableName)
-    {
-        return $this->container->getParameter('database_table_prefix').$tableName;
-    }
-
     /**
      * @param Schema $schema
      */
@@ -52,5 +47,10 @@ class Version20161118134328 extends AbstractMigration implements ContainerAwareI
         $this->skipIf(!$entryTable->hasColumn('http_status'), 'It seems that you already played this migration.');
 
         $entryTable->dropColumn('http_status');
+    }
+
+    private function getTable($tableName)
+    {
+        return $this->container->getParameter('database_table_prefix') . $tableName;
     }
 }

--- a/app/DoctrineMigrations/Version20161122144743.php
+++ b/app/DoctrineMigrations/Version20161122144743.php
@@ -22,11 +22,6 @@ class Version20161122144743 extends AbstractMigration implements ContainerAwareI
         $this->container = $container;
     }
 
-    private function getTable($tableName)
-    {
-        return $this->container->getParameter('database_table_prefix').$tableName;
-    }
-
     /**
      * @param Schema $schema
      */
@@ -35,11 +30,11 @@ class Version20161122144743 extends AbstractMigration implements ContainerAwareI
         $access = $this->container
             ->get('doctrine.orm.default_entity_manager')
             ->getConnection()
-            ->fetchArray('SELECT * FROM '.$this->getTable('craue_config_setting')." WHERE name = 'restricted_access'");
+            ->fetchArray('SELECT * FROM ' . $this->getTable('craue_config_setting') . " WHERE name = 'restricted_access'");
 
         $this->skipIf(false !== $access, 'It seems that you already played this migration.');
 
-        $this->addSql('INSERT INTO '.$this->getTable('craue_config_setting')." (name, value, section) VALUES ('restricted_access', 0, 'entry')");
+        $this->addSql('INSERT INTO ' . $this->getTable('craue_config_setting') . " (name, value, section) VALUES ('restricted_access', 0, 'entry')");
     }
 
     /**
@@ -47,6 +42,11 @@ class Version20161122144743 extends AbstractMigration implements ContainerAwareI
      */
     public function down(Schema $schema)
     {
-        $this->addSql('DELETE FROM '.$this->getTable('craue_config_setting')." WHERE name = 'restricted_access';");
+        $this->addSql('DELETE FROM ' . $this->getTable('craue_config_setting') . " WHERE name = 'restricted_access';");
+    }
+
+    private function getTable($tableName)
+    {
+        return $this->container->getParameter('database_table_prefix') . $tableName;
     }
 }

--- a/app/DoctrineMigrations/Version20161122203647.php
+++ b/app/DoctrineMigrations/Version20161122203647.php
@@ -30,11 +30,6 @@ class Version20161122203647 extends AbstractMigration implements ContainerAwareI
         $this->container = $container;
     }
 
-    private function getTable($tableName)
-    {
-        return $this->container->getParameter('database_table_prefix').$tableName;
-    }
-
     /**
      * @param Schema $schema
      */
@@ -59,5 +54,10 @@ class Version20161122203647 extends AbstractMigration implements ContainerAwareI
 
         $userTable->addColumn('expired', 'smallint', ['notnull' => false]);
         $userTable->addColumn('credentials_expired', 'smallint', ['notnull' => false]);
+    }
+
+    private function getTable($tableName)
+    {
+        return $this->container->getParameter('database_table_prefix') . $tableName;
     }
 }

--- a/app/DoctrineMigrations/Version20161128084725.php
+++ b/app/DoctrineMigrations/Version20161128084725.php
@@ -22,11 +22,6 @@ class Version20161128084725 extends AbstractMigration implements ContainerAwareI
         $this->container = $container;
     }
 
-    private function getTable($tableName)
-    {
-        return $this->container->getParameter('database_table_prefix').$tableName;
-    }
-
     /**
      * @param Schema $schema
      */
@@ -45,5 +40,10 @@ class Version20161128084725 extends AbstractMigration implements ContainerAwareI
     {
         $configTable = $schema->getTable($this->getTable('config'));
         $configTable->dropColumn('list_mode');
+    }
+
+    private function getTable($tableName)
+    {
+        return $this->container->getParameter('database_table_prefix') . $tableName;
     }
 }

--- a/app/DoctrineMigrations/Version20161128131503.php
+++ b/app/DoctrineMigrations/Version20161128131503.php
@@ -28,11 +28,6 @@ class Version20161128131503 extends AbstractMigration implements ContainerAwareI
         $this->container = $container;
     }
 
-    private function getTable($tableName)
-    {
-        return $this->container->getParameter('database_table_prefix').$tableName;
-    }
-
     /**
      * @param Schema $schema
      */
@@ -57,5 +52,10 @@ class Version20161128131503 extends AbstractMigration implements ContainerAwareI
             $this->skipIf($userTable->hasColumn($field), 'It seems that you already played this migration.');
             $userTable->addColumn($field, $type, ['notnull' => false]);
         }
+    }
+
+    private function getTable($tableName)
+    {
+        return $this->container->getParameter('database_table_prefix') . $tableName;
     }
 }

--- a/app/DoctrineMigrations/Version20161214094402.php
+++ b/app/DoctrineMigrations/Version20161214094402.php
@@ -22,11 +22,6 @@ class Version20161214094402 extends AbstractMigration implements ContainerAwareI
         $this->container = $container;
     }
 
-    private function getTable($tableName)
-    {
-        return $this->container->getParameter('database_table_prefix').$tableName;
-    }
-
     /**
      * @param Schema $schema
      */
@@ -38,17 +33,17 @@ class Version20161214094402 extends AbstractMigration implements ContainerAwareI
 
         switch ($this->connection->getDatabasePlatform()->getName()) {
             case 'sqlite':
-                $this->addSql('CREATE TEMPORARY TABLE __temp__wallabag_entry AS SELECT id, user_id, uuid, title, url, is_archived, is_starred, content, created_at, updated_at, mimetype, language, reading_time, domain_name, preview_picture, is_public FROM '.$this->getTable('entry'));
-                $this->addSql('DROP TABLE '.$this->getTable('entry'));
-                $this->addSql('CREATE TABLE '.$this->getTable('entry').' (id INTEGER NOT NULL, user_id INTEGER DEFAULT NULL, uid CLOB DEFAULT NULL COLLATE BINARY, title CLOB DEFAULT NULL COLLATE BINARY, url CLOB DEFAULT NULL COLLATE BINARY, is_archived BOOLEAN NOT NULL, is_starred BOOLEAN NOT NULL, content CLOB DEFAULT NULL COLLATE BINARY, created_at DATETIME NOT NULL, updated_at DATETIME NOT NULL, mimetype CLOB DEFAULT NULL COLLATE BINARY, language CLOB DEFAULT NULL COLLATE BINARY, reading_time INTEGER DEFAULT NULL, domain_name CLOB DEFAULT NULL COLLATE BINARY, preview_picture CLOB DEFAULT NULL COLLATE BINARY, is_public BOOLEAN DEFAULT "0", PRIMARY KEY(id));');
-                $this->addSql('INSERT INTO '.$this->getTable('entry').' (id, user_id, uid, title, url, is_archived, is_starred, content, created_at, updated_at, mimetype, language, reading_time, domain_name, preview_picture, is_public) SELECT id, user_id, uuid, title, url, is_archived, is_starred, content, created_at, updated_at, mimetype, language, reading_time, domain_name, preview_picture, is_public FROM __temp__wallabag_entry;');
+                $this->addSql('CREATE TEMPORARY TABLE __temp__wallabag_entry AS SELECT id, user_id, uuid, title, url, is_archived, is_starred, content, created_at, updated_at, mimetype, language, reading_time, domain_name, preview_picture, is_public FROM ' . $this->getTable('entry'));
+                $this->addSql('DROP TABLE ' . $this->getTable('entry'));
+                $this->addSql('CREATE TABLE ' . $this->getTable('entry') . ' (id INTEGER NOT NULL, user_id INTEGER DEFAULT NULL, uid CLOB DEFAULT NULL COLLATE BINARY, title CLOB DEFAULT NULL COLLATE BINARY, url CLOB DEFAULT NULL COLLATE BINARY, is_archived BOOLEAN NOT NULL, is_starred BOOLEAN NOT NULL, content CLOB DEFAULT NULL COLLATE BINARY, created_at DATETIME NOT NULL, updated_at DATETIME NOT NULL, mimetype CLOB DEFAULT NULL COLLATE BINARY, language CLOB DEFAULT NULL COLLATE BINARY, reading_time INTEGER DEFAULT NULL, domain_name CLOB DEFAULT NULL COLLATE BINARY, preview_picture CLOB DEFAULT NULL COLLATE BINARY, is_public BOOLEAN DEFAULT "0", PRIMARY KEY(id));');
+                $this->addSql('INSERT INTO ' . $this->getTable('entry') . ' (id, user_id, uid, title, url, is_archived, is_starred, content, created_at, updated_at, mimetype, language, reading_time, domain_name, preview_picture, is_public) SELECT id, user_id, uuid, title, url, is_archived, is_starred, content, created_at, updated_at, mimetype, language, reading_time, domain_name, preview_picture, is_public FROM __temp__wallabag_entry;');
                 $this->addSql('DROP TABLE __temp__wallabag_entry');
                 break;
             case 'mysql':
-                $this->addSql('ALTER TABLE '.$this->getTable('entry').' CHANGE uuid uid VARCHAR(23)');
+                $this->addSql('ALTER TABLE ' . $this->getTable('entry') . ' CHANGE uuid uid VARCHAR(23)');
                 break;
             case 'postgresql':
-                $this->addSql('ALTER TABLE '.$this->getTable('entry').' RENAME uuid TO uid');
+                $this->addSql('ALTER TABLE ' . $this->getTable('entry') . ' RENAME uuid TO uid');
         }
     }
 
@@ -66,10 +61,15 @@ class Version20161214094402 extends AbstractMigration implements ContainerAwareI
                 throw new SkipMigrationException('Too complex ...');
                 break;
             case 'mysql':
-                $this->addSql('ALTER TABLE '.$this->getTable('entry').' CHANGE uid uuid VARCHAR(23)');
+                $this->addSql('ALTER TABLE ' . $this->getTable('entry') . ' CHANGE uid uuid VARCHAR(23)');
                 break;
             case 'postgresql':
-                $this->addSql('ALTER TABLE '.$this->getTable('entry').' RENAME uid TO uuid');
+                $this->addSql('ALTER TABLE ' . $this->getTable('entry') . ' RENAME uid TO uuid');
         }
+    }
+
+    private function getTable($tableName)
+    {
+        return $this->container->getParameter('database_table_prefix') . $tableName;
     }
 }

--- a/app/DoctrineMigrations/Version20161214094403.php
+++ b/app/DoctrineMigrations/Version20161214094403.php
@@ -24,11 +24,6 @@ class Version20161214094403 extends AbstractMigration implements ContainerAwareI
         $this->container = $container;
     }
 
-    private function getTable($tableName)
-    {
-        return $this->container->getParameter('database_table_prefix').$tableName;
-    }
-
     /**
      * @param Schema $schema
      */
@@ -49,5 +44,10 @@ class Version20161214094403 extends AbstractMigration implements ContainerAwareI
         $this->skipIf(false === $entryTable->hasIndex($this->indexName), 'It seems that you already played this migration.');
 
         $entryTable->dropIndex($this->indexName);
+    }
+
+    private function getTable($tableName)
+    {
+        return $this->container->getParameter('database_table_prefix') . $tableName;
     }
 }

--- a/app/DoctrineMigrations/Version20170127093841.php
+++ b/app/DoctrineMigrations/Version20170127093841.php
@@ -25,11 +25,6 @@ class Version20170127093841 extends AbstractMigration implements ContainerAwareI
         $this->container = $container;
     }
 
-    private function getTable($tableName)
-    {
-        return $this->container->getParameter('database_table_prefix').$tableName;
-    }
-
     /**
      * @param Schema $schema
      */
@@ -52,5 +47,10 @@ class Version20170127093841 extends AbstractMigration implements ContainerAwareI
 
         $entryTable->dropIndex($this->indexStarredName);
         $entryTable->dropIndex($this->indexArchivedName);
+    }
+
+    private function getTable($tableName)
+    {
+        return $this->container->getParameter('database_table_prefix') . $tableName;
     }
 }

--- a/app/DoctrineMigrations/Version20170327194233.php
+++ b/app/DoctrineMigrations/Version20170327194233.php
@@ -22,11 +22,6 @@ class Version20170327194233 extends AbstractMigration implements ContainerAwareI
         $this->container = $container;
     }
 
-    private function getTable($tableName)
-    {
-        return $this->container->getParameter('database_table_prefix').$tableName;
-    }
-
     /**
      * @param Schema $schema
      */
@@ -35,12 +30,12 @@ class Version20170327194233 extends AbstractMigration implements ContainerAwareI
         $scuttle = $this->container
             ->get('doctrine.orm.default_entity_manager')
             ->getConnection()
-            ->fetchArray('SELECT * FROM '.$this->getTable('craue_config_setting')." WHERE name = 'share_scuttle'");
+            ->fetchArray('SELECT * FROM ' . $this->getTable('craue_config_setting') . " WHERE name = 'share_scuttle'");
 
         $this->skipIf(false !== $scuttle, 'It seems that you already played this migration.');
 
-        $this->addSql('INSERT INTO '.$this->getTable('craue_config_setting')." (name, value, section) VALUES ('share_scuttle', '1', 'entry')");
-        $this->addSql('INSERT INTO '.$this->getTable('craue_config_setting')." (name, value, section) VALUES ('scuttle_url', 'http://scuttle.org', 'entry')");
+        $this->addSql('INSERT INTO ' . $this->getTable('craue_config_setting') . " (name, value, section) VALUES ('share_scuttle', '1', 'entry')");
+        $this->addSql('INSERT INTO ' . $this->getTable('craue_config_setting') . " (name, value, section) VALUES ('scuttle_url', 'http://scuttle.org', 'entry')");
     }
 
     /**
@@ -48,7 +43,12 @@ class Version20170327194233 extends AbstractMigration implements ContainerAwareI
      */
     public function down(Schema $schema)
     {
-        $this->addSql('DELETE FROM '.$this->getTable('craue_config_setting')." WHERE name = 'share_scuttle';");
-        $this->addSql('DELETE FROM '.$this->getTable('craue_config_setting')." WHERE name = 'scuttle_url';");
+        $this->addSql('DELETE FROM ' . $this->getTable('craue_config_setting') . " WHERE name = 'share_scuttle';");
+        $this->addSql('DELETE FROM ' . $this->getTable('craue_config_setting') . " WHERE name = 'scuttle_url';");
+    }
+
+    private function getTable($tableName)
+    {
+        return $this->container->getParameter('database_table_prefix') . $tableName;
     }
 }

--- a/app/DoctrineMigrations/Version20170405182620.php
+++ b/app/DoctrineMigrations/Version20170405182620.php
@@ -22,11 +22,6 @@ class Version20170405182620 extends AbstractMigration implements ContainerAwareI
         $this->container = $container;
     }
 
-    private function getTable($tableName)
-    {
-        return $this->container->getParameter('database_table_prefix').$tableName;
-    }
-
     /**
      * @param Schema $schema
      */
@@ -61,5 +56,10 @@ class Version20170405182620 extends AbstractMigration implements ContainerAwareI
         $this->skipIf(!$entryTable->hasColumn('published_by'), 'It seems that you already played this migration.');
 
         $entryTable->dropColumn('published_by');
+    }
+
+    private function getTable($tableName)
+    {
+        return $this->container->getParameter('database_table_prefix') . $tableName;
     }
 }

--- a/app/DoctrineMigrations/Version20170407200919.php
+++ b/app/DoctrineMigrations/Version20170407200919.php
@@ -22,11 +22,6 @@ class Version20170407200919 extends AbstractMigration implements ContainerAwareI
         $this->container = $container;
     }
 
-    private function getTable($tableName)
-    {
-        return $this->container->getParameter('database_table_prefix').$tableName;
-    }
-
     /**
      * @param Schema $schema
      */
@@ -47,5 +42,10 @@ class Version20170407200919 extends AbstractMigration implements ContainerAwareI
         $this->skipIf($entryTable->hasColumn('is_public'), 'It seems that you already played this migration.');
 
         $entryTable->addColumn('is_public', 'boolean', ['notnull' => false, 'default' => 0]);
+    }
+
+    private function getTable($tableName)
+    {
+        return $this->container->getParameter('database_table_prefix') . $tableName;
     }
 }

--- a/app/DoctrineMigrations/Version20170420134133.php
+++ b/app/DoctrineMigrations/Version20170420134133.php
@@ -22,17 +22,12 @@ class Version20170420134133 extends AbstractMigration implements ContainerAwareI
         $this->container = $container;
     }
 
-    private function getTable($tableName)
-    {
-        return $this->container->getParameter('database_table_prefix').$tableName;
-    }
-
     /**
      * @param Schema $schema
      */
     public function up(Schema $schema)
     {
-        $this->addSql('DELETE FROM '.$this->getTable('craue_config_setting')." WHERE name = 'download_pictures';");
+        $this->addSql('DELETE FROM ' . $this->getTable('craue_config_setting') . " WHERE name = 'download_pictures';");
     }
 
     /**
@@ -43,10 +38,15 @@ class Version20170420134133 extends AbstractMigration implements ContainerAwareI
         $downloadPictures = $this->container
             ->get('doctrine.orm.default_entity_manager')
             ->getConnection()
-            ->fetchArray('SELECT * FROM '.$this->getTable('craue_config_setting')." WHERE name = 'download_pictures'");
+            ->fetchArray('SELECT * FROM ' . $this->getTable('craue_config_setting') . " WHERE name = 'download_pictures'");
 
         $this->skipIf(false !== $downloadPictures, 'It seems that you already played this migration.');
 
-        $this->addSql('INSERT INTO '.$this->getTable('craue_config_setting')." (name, value, section) VALUES ('download_pictures', '1', 'entry')");
+        $this->addSql('INSERT INTO ' . $this->getTable('craue_config_setting') . " (name, value, section) VALUES ('download_pictures', '1', 'entry')");
+    }
+
+    private function getTable($tableName)
+    {
+        return $this->container->getParameter('database_table_prefix') . $tableName;
     }
 }

--- a/app/DoctrineMigrations/Version20170501115751.php
+++ b/app/DoctrineMigrations/Version20170501115751.php
@@ -8,7 +8,7 @@ use Symfony\Component\DependencyInjection\ContainerAwareInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
- * Add site credential table to store username & password for some website (behind authentication or paywall)
+ * Add site credential table to store username & password for some website (behind authentication or paywall).
  */
 class Version20170501115751 extends AbstractMigration implements ContainerAwareInterface
 {
@@ -20,11 +20,6 @@ class Version20170501115751 extends AbstractMigration implements ContainerAwareI
     public function setContainer(ContainerInterface $container = null)
     {
         $this->container = $container;
-    }
-
-    private function getTable($tableName)
-    {
-        return $this->container->getParameter('database_table_prefix').$tableName;
     }
 
     /**
@@ -57,5 +52,10 @@ class Version20170501115751 extends AbstractMigration implements ContainerAwareI
     public function down(Schema $schema)
     {
         $schema->dropTable($this->getTable('site_credential'));
+    }
+
+    private function getTable($tableName)
+    {
+        return $this->container->getParameter('database_table_prefix') . $tableName;
     }
 }

--- a/app/DoctrineMigrations/Version20170510082609.php
+++ b/app/DoctrineMigrations/Version20170510082609.php
@@ -29,11 +29,6 @@ class Version20170510082609 extends AbstractMigration implements ContainerAwareI
         $this->container = $container;
     }
 
-    private function getTable($tableName)
-    {
-        return $this->container->getParameter('database_table_prefix').$tableName;
-    }
-
     /**
      * @param Schema $schema
      */
@@ -42,7 +37,7 @@ class Version20170510082609 extends AbstractMigration implements ContainerAwareI
         $this->skipIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'This migration only apply to MySQL');
 
         foreach ($this->fields as $field) {
-            $this->addSql('ALTER TABLE '.$this->getTable('user').' CHANGE '.$field.' '.$field.' VARCHAR(180) NOT NULL;');
+            $this->addSql('ALTER TABLE ' . $this->getTable('user') . ' CHANGE ' . $field . ' ' . $field . ' VARCHAR(180) NOT NULL;');
         }
     }
 
@@ -54,7 +49,12 @@ class Version20170510082609 extends AbstractMigration implements ContainerAwareI
         $this->skipIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'This migration only apply to MySQL');
 
         foreach ($this->fields as $field) {
-            $this->addSql('ALTER TABLE '.$this->getTable('user').' CHANGE '.$field.' '.$field.' VARCHAR(255) NOT NULL;');
+            $this->addSql('ALTER TABLE ' . $this->getTable('user') . ' CHANGE ' . $field . ' ' . $field . ' VARCHAR(255) NOT NULL;');
         }
+    }
+
+    private function getTable($tableName)
+    {
+        return $this->container->getParameter('database_table_prefix') . $tableName;
     }
 }

--- a/app/DoctrineMigrations/Version20170511115400.php
+++ b/app/DoctrineMigrations/Version20170511115400.php
@@ -22,11 +22,6 @@ class Version20170511115400 extends AbstractMigration implements ContainerAwareI
         $this->container = $container;
     }
 
-    private function getTable($tableName)
-    {
-        return $this->container->getParameter('database_table_prefix').$tableName;
-    }
-
     /**
      * @param Schema $schema
      */
@@ -51,5 +46,10 @@ class Version20170511115400 extends AbstractMigration implements ContainerAwareI
         $this->skipIf(!$entryTable->hasColumn('headers'), 'It seems that you already played this migration.');
 
         $entryTable->dropColumn('headers');
+    }
+
+    private function getTable($tableName)
+    {
+        return $this->container->getParameter('database_table_prefix') . $tableName;
     }
 }

--- a/app/DoctrineMigrations/Version20170511211659.php
+++ b/app/DoctrineMigrations/Version20170511211659.php
@@ -9,7 +9,7 @@ use Symfony\Component\DependencyInjection\ContainerAwareInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
- * Increase the length of the "quote" column of "annotation" table
+ * Increase the length of the "quote" column of "annotation" table.
  */
 class Version20170511211659 extends AbstractMigration implements ContainerAwareInterface
 {
@@ -21,11 +21,6 @@ class Version20170511211659 extends AbstractMigration implements ContainerAwareI
     public function setContainer(ContainerInterface $container = null)
     {
         $this->container = $container;
-    }
-
-    private function getTable($tableName)
-    {
-        return $this->container->getParameter('database_table_prefix') . $tableName;
     }
 
     public function up(Schema $schema)
@@ -68,13 +63,11 @@ EOD
                 );
                 $this->addSql('DROP TABLE __temp__wallabag_annotation');
                 break;
-
             case 'mysql':
-                $this->addSql('ALTER TABLE '.$tableName.' MODIFY quote TEXT NOT NULL');
+                $this->addSql('ALTER TABLE ' . $tableName . ' MODIFY quote TEXT NOT NULL');
                 break;
-
             case 'postgresql':
-                $this->addSql('ALTER TABLE '.$tableName.' ALTER COLUMN quote TYPE TEXT');
+                $this->addSql('ALTER TABLE ' . $tableName . ' ALTER COLUMN quote TYPE TEXT');
                 break;
         }
     }
@@ -87,14 +80,17 @@ EOD
             case 'sqlite':
                 throw new SkipMigrationException('Too complex ...');
                 break;
-
             case 'mysql':
-                $this->addSql('ALTER TABLE '.$tableName.' MODIFY quote VARCHAR(255) NOT NULL');
+                $this->addSql('ALTER TABLE ' . $tableName . ' MODIFY quote VARCHAR(255) NOT NULL');
                 break;
-
             case 'postgresql':
-                $this->addSql('ALTER TABLE '.$tableName.' ALTER COLUMN quote TYPE VARCHAR(255)');
+                $this->addSql('ALTER TABLE ' . $tableName . ' ALTER COLUMN quote TYPE VARCHAR(255)');
                 break;
         }
+    }
+
+    private function getTable($tableName)
+    {
+        return $this->container->getParameter('database_table_prefix') . $tableName;
     }
 }

--- a/app/DoctrineMigrations/Version20170602075214.php
+++ b/app/DoctrineMigrations/Version20170602075214.php
@@ -22,11 +22,6 @@ class Version20170602075214 extends AbstractMigration implements ContainerAwareI
         $this->container = $container;
     }
 
-    private function getTable($tableName)
-    {
-        return $this->container->getParameter('database_table_prefix').$tableName;
-    }
-
     /**
      * @param Schema $schema
      */
@@ -35,11 +30,11 @@ class Version20170602075214 extends AbstractMigration implements ContainerAwareI
         $apiUserRegistration = $this->container
             ->get('doctrine.orm.default_entity_manager')
             ->getConnection()
-            ->fetchArray('SELECT * FROM '.$this->getTable('craue_config_setting')." WHERE name = 'api_user_registration'");
+            ->fetchArray('SELECT * FROM ' . $this->getTable('craue_config_setting') . " WHERE name = 'api_user_registration'");
 
         $this->skipIf(false !== $apiUserRegistration, 'It seems that you already played this migration.');
 
-        $this->addSql('INSERT INTO '.$this->getTable('craue_config_setting')." (name, value, section) VALUES ('api_user_registration', '0', 'api')");
+        $this->addSql('INSERT INTO ' . $this->getTable('craue_config_setting') . " (name, value, section) VALUES ('api_user_registration', '0', 'api')");
     }
 
     /**
@@ -47,6 +42,11 @@ class Version20170602075214 extends AbstractMigration implements ContainerAwareI
      */
     public function down(Schema $schema)
     {
-        $this->addSql('DELETE FROM '.$this->getTable('craue_config_setting')." WHERE name = 'api_user_registration';");
+        $this->addSql('DELETE FROM ' . $this->getTable('craue_config_setting') . " WHERE name = 'api_user_registration';");
+    }
+
+    private function getTable($tableName)
+    {
+        return $this->container->getParameter('database_table_prefix') . $tableName;
     }
 }

--- a/app/DoctrineMigrations/Version20170606155640.php
+++ b/app/DoctrineMigrations/Version20170606155640.php
@@ -9,7 +9,7 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
  * Remove wallabag_url from craue_config_setting.
- * It has been moved into the parameters.yml
+ * It has been moved into the parameters.yml.
  */
 class Version20170606155640 extends AbstractMigration implements ContainerAwareInterface
 {
@@ -23,11 +23,6 @@ class Version20170606155640 extends AbstractMigration implements ContainerAwareI
         $this->container = $container;
     }
 
-    private function getTable($tableName)
-    {
-        return $this->container->getParameter('database_table_prefix').$tableName;
-    }
-
     /**
      * @param Schema $schema
      */
@@ -36,11 +31,11 @@ class Version20170606155640 extends AbstractMigration implements ContainerAwareI
         $apiUserRegistration = $this->container
             ->get('doctrine.orm.default_entity_manager')
             ->getConnection()
-            ->fetchArray('SELECT * FROM '.$this->getTable('craue_config_setting')." WHERE name = 'wallabag_url'");
+            ->fetchArray('SELECT * FROM ' . $this->getTable('craue_config_setting') . " WHERE name = 'wallabag_url'");
 
         $this->skipIf(false === $apiUserRegistration, 'It seems that you already played this migration.');
 
-        $this->addSql('DELETE FROM '.$this->getTable('craue_config_setting')." WHERE name = 'wallabag_url'");
+        $this->addSql('DELETE FROM ' . $this->getTable('craue_config_setting') . " WHERE name = 'wallabag_url'");
     }
 
     /**
@@ -48,6 +43,11 @@ class Version20170606155640 extends AbstractMigration implements ContainerAwareI
      */
     public function down(Schema $schema)
     {
-        $this->addSql('INSERT INTO '.$this->getTable('craue_config_setting')." (name, value, section) VALUES ('wallabag_url', 'wallabag.me', 'misc')");
+        $this->addSql('INSERT INTO ' . $this->getTable('craue_config_setting') . " (name, value, section) VALUES ('wallabag_url', 'wallabag.me', 'misc')");
+    }
+
+    private function getTable($tableName)
+    {
+        return $this->container->getParameter('database_table_prefix') . $tableName;
     }
 }

--- a/app/autoload.php
+++ b/app/autoload.php
@@ -1,12 +1,12 @@
 <?php
 
-use Doctrine\Common\Annotations\AnnotationRegistry;
 use Composer\Autoload\ClassLoader;
+use Doctrine\Common\Annotations\AnnotationRegistry;
 
 /**
- * @var ClassLoader $loader
+ * @var ClassLoader
  */
-$loader = require __DIR__.'/../vendor/autoload.php';
+$loader = require __DIR__ . '/../vendor/autoload.php';
 
 AnnotationRegistry::registerLoader([$loader, 'loadClass']);
 

--- a/composer.json
+++ b/composer.json
@@ -91,7 +91,7 @@
         "doctrine/data-fixtures": "~1.1.1",
         "sensio/generator-bundle": "^3.0",
         "symfony/phpunit-bridge": "^3.3",
-        "friendsofphp/php-cs-fixer": "~1.9",
+        "friendsofphp/php-cs-fixer": "~2.0",
         "m6web/redis-mock": "^2.0",
         "dama/doctrine-test-bundle": "^1.0"
     },

--- a/src/Wallabag/AnnotationBundle/Controller/WallabagAnnotationController.php
+++ b/src/Wallabag/AnnotationBundle/Controller/WallabagAnnotationController.php
@@ -3,9 +3,9 @@
 namespace Wallabag\AnnotationBundle\Controller;
 
 use FOS\RestBundle\Controller\FOSRestController;
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\ParamConverter;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\ParamConverter;
 use Wallabag\AnnotationBundle\Entity\Annotation;
 use Wallabag\AnnotationBundle\Form\EditAnnotationType;
 use Wallabag\AnnotationBundle\Form\NewAnnotationType;

--- a/src/Wallabag/AnnotationBundle/Entity/Annotation.php
+++ b/src/Wallabag/AnnotationBundle/Entity/Annotation.php
@@ -3,14 +3,14 @@
 namespace Wallabag\AnnotationBundle\Entity;
 
 use Doctrine\ORM\Mapping as ORM;
-use JMS\Serializer\Annotation\ExclusionPolicy;
 use JMS\Serializer\Annotation\Exclude;
-use JMS\Serializer\Annotation\VirtualProperty;
-use JMS\Serializer\Annotation\SerializedName;
+use JMS\Serializer\Annotation\ExclusionPolicy;
 use JMS\Serializer\Annotation\Groups;
+use JMS\Serializer\Annotation\SerializedName;
+use JMS\Serializer\Annotation\VirtualProperty;
 use Symfony\Component\Validator\Constraints as Assert;
-use Wallabag\UserBundle\Entity\User;
 use Wallabag\CoreBundle\Entity\Entry;
+use Wallabag\UserBundle\Entity\User;
 
 /**
  * Annotation.
@@ -139,7 +139,7 @@ class Annotation
      */
     public function timestamps()
     {
-        if (is_null($this->createdAt)) {
+        if (null === $this->createdAt) {
             $this->createdAt = new \DateTime();
         }
         $this->updatedAt = new \DateTime();

--- a/src/Wallabag/AnnotationBundle/Repository/AnnotationRepository.php
+++ b/src/Wallabag/AnnotationBundle/Repository/AnnotationRepository.php
@@ -10,22 +10,6 @@ use Doctrine\ORM\EntityRepository;
 class AnnotationRepository extends EntityRepository
 {
     /**
-     * Return a query builder to used by other getBuilderFor* method.
-     *
-     * @param int $userId
-     *
-     * @return QueryBuilder
-     */
-    private function getBuilderByUser($userId)
-    {
-        return $this->createQueryBuilder('a')
-            ->leftJoin('a.user', 'u')
-            ->andWhere('u.id = :userId')->setParameter('userId', $userId)
-            ->orderBy('a.id', 'desc')
-        ;
-    }
-
-    /**
      * Retrieves all annotations for a user.
      *
      * @param int $userId
@@ -138,5 +122,21 @@ class AnnotationRepository extends EntityRepository
             ->andWhere('e.isArchived = true')
             ->getQuery()
             ->getResult();
+    }
+
+    /**
+     * Return a query builder to used by other getBuilderFor* method.
+     *
+     * @param int $userId
+     *
+     * @return QueryBuilder
+     */
+    private function getBuilderByUser($userId)
+    {
+        return $this->createQueryBuilder('a')
+            ->leftJoin('a.user', 'u')
+            ->andWhere('u.id = :userId')->setParameter('userId', $userId)
+            ->orderBy('a.id', 'desc')
+        ;
     }
 }

--- a/src/Wallabag/ApiBundle/Controller/AnnotationRestController.php
+++ b/src/Wallabag/ApiBundle/Controller/AnnotationRestController.php
@@ -4,10 +4,10 @@ namespace Wallabag\ApiBundle\Controller;
 
 use Nelmio\ApiDocBundle\Annotation\ApiDoc;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\ParamConverter;
-use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\JsonResponse;
-use Wallabag\CoreBundle\Entity\Entry;
+use Symfony\Component\HttpFoundation\Request;
 use Wallabag\AnnotationBundle\Entity\Annotation;
+use Wallabag\CoreBundle\Entity\Entry;
 
 class AnnotationRestController extends WallabagRestController
 {

--- a/src/Wallabag/ApiBundle/Controller/DeveloperController.php
+++ b/src/Wallabag/ApiBundle/Controller/DeveloperController.php
@@ -3,8 +3,8 @@
 namespace Wallabag\ApiBundle\Controller;
 
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
-use Symfony\Component\HttpFoundation\Request;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
+use Symfony\Component\HttpFoundation\Request;
 use Wallabag\ApiBundle\Entity\Client;
 use Wallabag\ApiBundle\Form\Type\ClientType;
 
@@ -75,7 +75,7 @@ class DeveloperController extends Controller
      */
     public function deleteClientAction(Client $client)
     {
-        if (null === $this->getUser() || $client->getUser()->getId() != $this->getUser()->getId()) {
+        if (null === $this->getUser() || $client->getUser()->getId() !== $this->getUser()->getId()) {
             throw $this->createAccessDeniedException('You can not access this client.');
         }
 

--- a/src/Wallabag/ApiBundle/Controller/EntryRestController.php
+++ b/src/Wallabag/ApiBundle/Controller/EntryRestController.php
@@ -6,14 +6,14 @@ use Hateoas\Configuration\Route;
 use Hateoas\Representation\Factory\PagerfantaFactory;
 use JMS\Serializer\SerializationContext;
 use Nelmio\ApiDocBundle\Annotation\ApiDoc;
-use Symfony\Component\HttpKernel\Exception\HttpException;
-use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Exception\HttpException;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Wallabag\CoreBundle\Entity\Entry;
 use Wallabag\CoreBundle\Entity\Tag;
-use Wallabag\CoreBundle\Event\EntrySavedEvent;
 use Wallabag\CoreBundle\Event\EntryDeletedEvent;
+use Wallabag\CoreBundle\Event\EntrySavedEvent;
 
 class EntryRestController extends WallabagRestController
 {
@@ -59,7 +59,7 @@ class EntryRestController extends WallabagRestController
         $url = $request->query->get('url', '');
 
         if (empty($url)) {
-            throw $this->createAccessDeniedException('URL is empty?, logged user id: '.$this->getUser()->getId());
+            throw $this->createAccessDeniedException('URL is empty?, logged user id: ' . $this->getUser()->getId());
         }
 
         $res = $this->getDoctrine()
@@ -239,9 +239,9 @@ class EntryRestController extends WallabagRestController
      *       }
      * )
      *
-     * @return JsonResponse
-     *
      * @throws HttpException When limit is reached
+     *
+     * @return JsonResponse
      */
     public function postEntriesListAction(Request $request)
     {
@@ -678,11 +678,11 @@ class EntryRestController extends WallabagRestController
             ]);
         }
 
-        if (!is_null($isArchived)) {
+        if (null !== $isArchived) {
             $entry->setArchived((bool) $isArchived);
         }
 
-        if (!is_null($isStarred)) {
+        if (null !== $isStarred) {
             $entry->setStarred((bool) $isStarred);
         }
 
@@ -690,7 +690,7 @@ class EntryRestController extends WallabagRestController
             $this->get('wallabag_core.tags_assigner')->assignTagsToEntry($entry, $tags);
         }
 
-        if (!is_null($isPublic)) {
+        if (null !== $isPublic) {
             if (true === (bool) $isPublic && null === $entry->getUid()) {
                 $entry->generateUid();
             } elseif (false === (bool) $isPublic) {

--- a/src/Wallabag/ApiBundle/Controller/TagRestController.php
+++ b/src/Wallabag/ApiBundle/Controller/TagRestController.php
@@ -3,8 +3,8 @@
 namespace Wallabag\ApiBundle\Controller;
 
 use Nelmio\ApiDocBundle\Annotation\ApiDoc;
-use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
 use Wallabag\CoreBundle\Entity\Entry;
 use Wallabag\CoreBundle\Entity\Tag;
 

--- a/src/Wallabag/ApiBundle/Controller/UserRestController.php
+++ b/src/Wallabag/ApiBundle/Controller/UserRestController.php
@@ -6,10 +6,10 @@ use FOS\UserBundle\Event\UserEvent;
 use FOS\UserBundle\FOSUserEvents;
 use JMS\Serializer\SerializationContext;
 use Nelmio\ApiDocBundle\Annotation\ApiDoc;
-use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\JsonResponse;
-use Wallabag\UserBundle\Entity\User;
+use Symfony\Component\HttpFoundation\Request;
 use Wallabag\ApiBundle\Entity\Client;
+use Wallabag\UserBundle\Entity\User;
 
 class UserRestController extends WallabagRestController
 {

--- a/src/Wallabag/ApiBundle/Controller/WallabagRestController.php
+++ b/src/Wallabag/ApiBundle/Controller/WallabagRestController.php
@@ -40,8 +40,8 @@ class WallabagRestController extends FOSRestController
     protected function validateUserAccess($requestUserId)
     {
         $user = $this->get('security.token_storage')->getToken()->getUser();
-        if ($requestUserId != $user->getId()) {
-            throw $this->createAccessDeniedException('Access forbidden. Entry user id: '.$requestUserId.', logged user id: '.$user->getId());
+        if ($requestUserId !== $user->getId()) {
+            throw $this->createAccessDeniedException('Access forbidden. Entry user id: ' . $requestUserId . ', logged user id: ' . $user->getId());
         }
     }
 }

--- a/src/Wallabag/ApiBundle/Entity/Client.php
+++ b/src/Wallabag/ApiBundle/Entity/Client.php
@@ -4,10 +4,10 @@ namespace Wallabag\ApiBundle\Entity;
 
 use Doctrine\ORM\Mapping as ORM;
 use FOS\OAuthServerBundle\Entity\Client as BaseClient;
-use Wallabag\UserBundle\Entity\User;
 use JMS\Serializer\Annotation\Groups;
 use JMS\Serializer\Annotation\SerializedName;
 use JMS\Serializer\Annotation\VirtualProperty;
+use Wallabag\UserBundle\Entity\User;
 
 /**
  * @ORM\Table("oauth2_clients")
@@ -99,6 +99,6 @@ class Client extends BaseClient
      */
     public function getClientId()
     {
-        return $this->getId().'_'.$this->getRandomId();
+        return $this->getId() . '_' . $this->getRandomId();
     }
 }

--- a/src/Wallabag/ApiBundle/Form/Type/ClientType.php
+++ b/src/Wallabag/ApiBundle/Form/Type/ClientType.php
@@ -5,8 +5,8 @@ namespace Wallabag\ApiBundle\Form\Type;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\CallbackTransformer;
 use Symfony\Component\Form\Extension\Core\Type\SubmitType;
-use Symfony\Component\Form\Extension\Core\Type\UrlType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\Form\Extension\Core\Type\UrlType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 

--- a/src/Wallabag/CoreBundle/Command/CleanDuplicatesCommand.php
+++ b/src/Wallabag/CoreBundle/Command/CleanDuplicatesCommand.php
@@ -76,7 +76,7 @@ class CleanDuplicatesCommand extends ContainerAwareCommand
             $url = $this->similarUrl($entry['url']);
 
             /* @var $entry Entry */
-            if (in_array($url, $urls)) {
+            if (in_array($url, $urls, true)) {
                 ++$duplicatesCount;
 
                 $em->remove($repo->find($entry['id']));
@@ -93,7 +93,7 @@ class CleanDuplicatesCommand extends ContainerAwareCommand
 
     private function similarUrl($url)
     {
-        if (in_array(substr($url, -1), ['/', '#'])) { // get rid of "/" and "#" and the end of urls
+        if (in_array(substr($url, -1), ['/', '#'], true)) { // get rid of "/" and "#" and the end of urls
             return substr($url, 0, strlen($url));
         }
 

--- a/src/Wallabag/CoreBundle/Command/ExportCommand.php
+++ b/src/Wallabag/CoreBundle/Command/ExportCommand.php
@@ -49,7 +49,7 @@ class ExportCommand extends ContainerAwareCommand
         $filePath = $input->getArgument('filepath');
 
         if (!$filePath) {
-            $filePath = $this->getContainer()->getParameter('kernel.root_dir').'/../'.sprintf('%s-export.json', $user->getUsername());
+            $filePath = $this->getContainer()->getParameter('kernel.root_dir') . '/../' . sprintf('%s-export.json', $user->getUsername());
         }
 
         try {

--- a/src/Wallabag/CoreBundle/Command/InstallCommand.php
+++ b/src/Wallabag/CoreBundle/Command/InstallCommand.php
@@ -2,6 +2,7 @@
 
 namespace Wallabag\CoreBundle\Command;
 
+use Craue\ConfigBundle\Entity\Setting;
 use FOS\UserBundle\Event\UserEvent;
 use FOS\UserBundle\FOSUserEvents;
 use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
@@ -14,7 +15,6 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Question\ConfirmationQuestion;
 use Symfony\Component\Console\Question\Question;
 use Wallabag\CoreBundle\Entity\Config;
-use Craue\ConfigBundle\Entity\Setting;
 
 class InstallCommand extends ContainerAwareCommand
 {
@@ -86,7 +86,7 @@ class InstallCommand extends ContainerAwareCommand
         if (!extension_loaded($this->getContainer()->getParameter('database_driver'))) {
             $fulfilled = false;
             $status = '<error>ERROR!</error>';
-            $help = 'Database driver "'.$this->getContainer()->getParameter('database_driver').'" is not installed.';
+            $help = 'Database driver "' . $this->getContainer()->getParameter('database_driver') . '" is not installed.';
         }
 
         $rows[] = [sprintf($label, $this->getContainer()->getParameter('database_driver')), $status, $help];
@@ -101,10 +101,10 @@ class InstallCommand extends ContainerAwareCommand
             $conn->connect();
         } catch (\Exception $e) {
             if (false === strpos($e->getMessage(), 'Unknown database')
-                && false === strpos($e->getMessage(), 'database "'.$this->getContainer()->getParameter('database_name').'" does not exist')) {
+                && false === strpos($e->getMessage(), 'database "' . $this->getContainer()->getParameter('database_name') . '" does not exist')) {
                 $fulfilled = false;
                 $status = '<error>ERROR!</error>';
-                $help = 'Can\'t connect to the database: '.$e->getMessage();
+                $help = 'Can\'t connect to the database: ' . $e->getMessage();
             }
         }
 
@@ -123,7 +123,7 @@ class InstallCommand extends ContainerAwareCommand
             if (false === version_compare($version, $minimalVersion, '>')) {
                 $fulfilled = false;
                 $status = '<error>ERROR!</error>';
-                $help = 'Your MySQL version ('.$version.') is too old, consider upgrading ('.$minimalVersion.'+).';
+                $help = 'Your MySQL version (' . $version . ') is too old, consider upgrading (' . $minimalVersion . '+).';
             }
         }
 
@@ -137,21 +137,21 @@ class InstallCommand extends ContainerAwareCommand
             if (isset($matches[1]) & version_compare($matches[1], '9.2.0', '<')) {
                 $fulfilled = false;
                 $status = '<error>ERROR!</error>';
-                $help = 'PostgreSQL should be greater than 9.1 (actual version: '.$matches[1].')';
+                $help = 'PostgreSQL should be greater than 9.1 (actual version: ' . $matches[1] . ')';
             }
         }
 
         $rows[] = [$label, $status, $help];
 
         foreach ($this->functionExists as $functionRequired) {
-            $label = '<comment>'.$functionRequired.'</comment>';
+            $label = '<comment>' . $functionRequired . '</comment>';
             $status = '<info>OK!</info>';
             $help = '';
 
             if (!function_exists($functionRequired)) {
                 $fulfilled = false;
                 $status = '<error>ERROR!</error>';
-                $help = 'You need the '.$functionRequired.' function activated';
+                $help = 'You need the ' . $functionRequired . ' function activated';
             }
 
             $rows[] = [$label, $status, $help];
@@ -351,8 +351,8 @@ class InstallCommand extends ContainerAwareCommand
             $this->getApplication()->setAutoExit(true);
 
             throw new \RuntimeException(
-                'The command "'.$command."\" generates some errors: \n\n"
-                .$output->fetch());
+                'The command "' . $command . "\" generates some errors: \n\n"
+                . $output->fetch());
         }
 
         return $this;
@@ -396,7 +396,7 @@ class InstallCommand extends ContainerAwareCommand
         }
 
         try {
-            return in_array($databaseName, $schemaManager->listDatabases());
+            return in_array($databaseName, $schemaManager->listDatabases(), true);
         } catch (\Doctrine\DBAL\Exception\DriverException $e) {
             // it means we weren't able to get database list, assume the database doesn't exist
 

--- a/src/Wallabag/CoreBundle/Controller/EntryController.php
+++ b/src/Wallabag/CoreBundle/Controller/EntryController.php
@@ -4,17 +4,17 @@ namespace Wallabag\CoreBundle\Controller;
 
 use Pagerfanta\Adapter\DoctrineORMAdapter;
 use Pagerfanta\Exception\OutOfRangeCurrentPageException;
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\Cache;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Wallabag\CoreBundle\Entity\Entry;
-use Wallabag\CoreBundle\Form\Type\EntryFilterType;
-use Wallabag\CoreBundle\Form\Type\EditEntryType;
-use Wallabag\CoreBundle\Form\Type\NewEntryType;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Cache;
-use Wallabag\CoreBundle\Event\EntrySavedEvent;
 use Wallabag\CoreBundle\Event\EntryDeletedEvent;
+use Wallabag\CoreBundle\Event\EntrySavedEvent;
+use Wallabag\CoreBundle\Form\Type\EditEntryType;
+use Wallabag\CoreBundle\Form\Type\EntryFilterType;
+use Wallabag\CoreBundle\Form\Type\NewEntryType;
 use Wallabag\CoreBundle\Form\Type\SearchEntryType;
 
 class EntryController extends Controller
@@ -49,31 +49,6 @@ class EntryController extends Controller
             'form' => $form->createView(),
             'currentRoute' => $currentRoute,
         ]);
-    }
-
-    /**
-     * Fetch content and update entry.
-     * In case it fails, $entry->getContent will return an error message.
-     *
-     * @param Entry  $entry
-     * @param string $prefixMessage Should be the translation key: entry_saved or entry_reloaded
-     */
-    private function updateEntry(Entry $entry, $prefixMessage = 'entry_saved')
-    {
-        $message = 'flashes.entry.notice.'.$prefixMessage;
-
-        try {
-            $this->get('wallabag_core.content_proxy')->updateEntry($entry, $entry->getUrl());
-        } catch (\Exception $e) {
-            $this->get('logger')->error('Error while saving an entry', [
-                'exception' => $e,
-                'entry' => $entry,
-            ]);
-
-            $message = 'flashes.entry.notice.'.$prefixMessage.'_failed';
-        }
-
-        $this->get('session')->getFlashBag()->add('notice', $message);
     }
 
     /**
@@ -220,7 +195,7 @@ class EntryController extends Controller
     public function showUnreadAction(Request $request, $page)
     {
         // load the quickstart if no entry in database
-        if ($page == 1 && $this->get('wallabag_core.entry_repository')->countAllEntriesByUser($this->getUser()->getId()) == 0) {
+        if ($page === 1 && $this->get('wallabag_core.entry_repository')->countAllEntriesByUser($this->getUser()->getId()) === 0) {
             return $this->redirect($this->generateUrl('quickstart'));
         }
 
@@ -255,83 +230,6 @@ class EntryController extends Controller
     public function showStarredAction(Request $request, $page)
     {
         return $this->showEntries('starred', $request, $page);
-    }
-
-    /**
-     * Global method to retrieve entries depending on the given type
-     * It returns the response to be send.
-     *
-     * @param string  $type    Entries type: unread, starred or archive
-     * @param Request $request
-     * @param int     $page
-     *
-     * @return \Symfony\Component\HttpFoundation\Response
-     */
-    private function showEntries($type, Request $request, $page)
-    {
-        $repository = $this->get('wallabag_core.entry_repository');
-        $searchTerm = (isset($request->get('search_entry')['term']) ? $request->get('search_entry')['term'] : '');
-        $currentRoute = (!is_null($request->query->get('currentRoute')) ? $request->query->get('currentRoute') : '');
-
-        switch ($type) {
-            case 'search':
-                $qb = $repository->getBuilderForSearchByUser($this->getUser()->getId(), $searchTerm, $currentRoute);
-
-                break;
-            case 'untagged':
-                $qb = $repository->getBuilderForUntaggedByUser($this->getUser()->getId());
-
-                break;
-            case 'starred':
-                $qb = $repository->getBuilderForStarredByUser($this->getUser()->getId());
-                break;
-
-            case 'archive':
-                $qb = $repository->getBuilderForArchiveByUser($this->getUser()->getId());
-                break;
-
-            case 'unread':
-                $qb = $repository->getBuilderForUnreadByUser($this->getUser()->getId());
-                break;
-
-            case 'all':
-                $qb = $repository->getBuilderForAllByUser($this->getUser()->getId());
-                break;
-
-            default:
-                throw new \InvalidArgumentException(sprintf('Type "%s" is not implemented.', $type));
-        }
-
-        $form = $this->createForm(EntryFilterType::class);
-
-        if ($request->query->has($form->getName())) {
-            // manually bind values from the request
-            $form->submit($request->query->get($form->getName()));
-
-            // build the query from the given form object
-            $this->get('lexik_form_filter.query_builder_updater')->addFilterConditions($form, $qb);
-        }
-
-        $pagerAdapter = new DoctrineORMAdapter($qb->getQuery(), true, false);
-
-        $entries = $this->get('wallabag_core.helper.prepare_pager_for_entries')->prepare($pagerAdapter);
-
-        try {
-            $entries->setCurrentPage($page);
-        } catch (OutOfRangeCurrentPageException $e) {
-            if ($page > 1) {
-                return $this->redirect($this->generateUrl($type, ['page' => $entries->getNbPages()]), 302);
-            }
-        }
-
-        return $this->render(
-            'WallabagCoreBundle:Entry:entries.html.twig', [
-                'form' => $form->createView(),
-                'entries' => $entries,
-                'currentPage' => $page,
-                'searchTerm' => $searchTerm,
-            ]
-        );
     }
 
     /**
@@ -487,35 +385,11 @@ class EntryController extends Controller
 
         // don't redirect user to the deleted entry (check that the referer doesn't end with the same url)
         $referer = $request->headers->get('referer');
-        $to = (1 !== preg_match('#'.$url.'$#i', $referer) ? $referer : null);
+        $to = (1 !== preg_match('#' . $url . '$#i', $referer) ? $referer : null);
 
         $redirectUrl = $this->get('wallabag_core.helper.redirect')->to($to);
 
         return $this->redirect($redirectUrl);
-    }
-
-    /**
-     * Check if the logged user can manage the given entry.
-     *
-     * @param Entry $entry
-     */
-    private function checkUserAction(Entry $entry)
-    {
-        if (null === $this->getUser() || $this->getUser()->getId() != $entry->getUser()->getId()) {
-            throw $this->createAccessDeniedException('You can not access this entry.');
-        }
-    }
-
-    /**
-     * Check for existing entry, if it exists, redirect to it with a message.
-     *
-     * @param Entry $entry
-     *
-     * @return Entry|bool
-     */
-    private function checkIfEntryAlreadyExists(Entry $entry)
-    {
-        return $this->get('wallabag_core.entry_repository')->findByUrlAndUserId($entry->getUrl(), $this->getUser()->getId());
     }
 
     /**
@@ -603,5 +477,127 @@ class EntryController extends Controller
     public function showUntaggedEntriesAction(Request $request, $page)
     {
         return $this->showEntries('untagged', $request, $page);
+    }
+
+    /**
+     * Fetch content and update entry.
+     * In case it fails, $entry->getContent will return an error message.
+     *
+     * @param Entry  $entry
+     * @param string $prefixMessage Should be the translation key: entry_saved or entry_reloaded
+     */
+    private function updateEntry(Entry $entry, $prefixMessage = 'entry_saved')
+    {
+        $message = 'flashes.entry.notice.' . $prefixMessage;
+
+        try {
+            $this->get('wallabag_core.content_proxy')->updateEntry($entry, $entry->getUrl());
+        } catch (\Exception $e) {
+            $this->get('logger')->error('Error while saving an entry', [
+                'exception' => $e,
+                'entry' => $entry,
+            ]);
+
+            $message = 'flashes.entry.notice.' . $prefixMessage . '_failed';
+        }
+
+        $this->get('session')->getFlashBag()->add('notice', $message);
+    }
+
+    /**
+     * Global method to retrieve entries depending on the given type
+     * It returns the response to be send.
+     *
+     * @param string  $type    Entries type: unread, starred or archive
+     * @param Request $request
+     * @param int     $page
+     *
+     * @return \Symfony\Component\HttpFoundation\Response
+     */
+    private function showEntries($type, Request $request, $page)
+    {
+        $repository = $this->get('wallabag_core.entry_repository');
+        $searchTerm = (isset($request->get('search_entry')['term']) ? $request->get('search_entry')['term'] : '');
+        $currentRoute = (null !== $request->query->get('currentRoute') ? $request->query->get('currentRoute') : '');
+
+        switch ($type) {
+            case 'search':
+                $qb = $repository->getBuilderForSearchByUser($this->getUser()->getId(), $searchTerm, $currentRoute);
+
+                break;
+            case 'untagged':
+                $qb = $repository->getBuilderForUntaggedByUser($this->getUser()->getId());
+
+                break;
+            case 'starred':
+                $qb = $repository->getBuilderForStarredByUser($this->getUser()->getId());
+                break;
+            case 'archive':
+                $qb = $repository->getBuilderForArchiveByUser($this->getUser()->getId());
+                break;
+            case 'unread':
+                $qb = $repository->getBuilderForUnreadByUser($this->getUser()->getId());
+                break;
+            case 'all':
+                $qb = $repository->getBuilderForAllByUser($this->getUser()->getId());
+                break;
+            default:
+                throw new \InvalidArgumentException(sprintf('Type "%s" is not implemented.', $type));
+        }
+
+        $form = $this->createForm(EntryFilterType::class);
+
+        if ($request->query->has($form->getName())) {
+            // manually bind values from the request
+            $form->submit($request->query->get($form->getName()));
+
+            // build the query from the given form object
+            $this->get('lexik_form_filter.query_builder_updater')->addFilterConditions($form, $qb);
+        }
+
+        $pagerAdapter = new DoctrineORMAdapter($qb->getQuery(), true, false);
+
+        $entries = $this->get('wallabag_core.helper.prepare_pager_for_entries')->prepare($pagerAdapter);
+
+        try {
+            $entries->setCurrentPage($page);
+        } catch (OutOfRangeCurrentPageException $e) {
+            if ($page > 1) {
+                return $this->redirect($this->generateUrl($type, ['page' => $entries->getNbPages()]), 302);
+            }
+        }
+
+        return $this->render(
+            'WallabagCoreBundle:Entry:entries.html.twig', [
+                'form' => $form->createView(),
+                'entries' => $entries,
+                'currentPage' => $page,
+                'searchTerm' => $searchTerm,
+            ]
+        );
+    }
+
+    /**
+     * Check if the logged user can manage the given entry.
+     *
+     * @param Entry $entry
+     */
+    private function checkUserAction(Entry $entry)
+    {
+        if (null === $this->getUser() || $this->getUser()->getId() !== $entry->getUser()->getId()) {
+            throw $this->createAccessDeniedException('You can not access this entry.');
+        }
+    }
+
+    /**
+     * Check for existing entry, if it exists, redirect to it with a message.
+     *
+     * @param Entry $entry
+     *
+     * @return Entry|bool
+     */
+    private function checkIfEntryAlreadyExists(Entry $entry)
+    {
+        return $this->get('wallabag_core.entry_repository')->findByUrlAndUserId($entry->getUrl(), $this->getUser()->getId());
     }
 }

--- a/src/Wallabag/CoreBundle/Controller/EntryController.php
+++ b/src/Wallabag/CoreBundle/Controller/EntryController.php
@@ -195,7 +195,7 @@ class EntryController extends Controller
     public function showUnreadAction(Request $request, $page)
     {
         // load the quickstart if no entry in database
-        if ($page === 1 && $this->get('wallabag_core.entry_repository')->countAllEntriesByUser($this->getUser()->getId()) === 0) {
+        if ((int) $page === 1 && $this->get('wallabag_core.entry_repository')->countAllEntriesByUser($this->getUser()->getId()) === 0) {
             return $this->redirect($this->generateUrl('quickstart'));
         }
 

--- a/src/Wallabag/CoreBundle/Controller/ExceptionController.php
+++ b/src/Wallabag/CoreBundle/Controller/ExceptionController.php
@@ -14,7 +14,7 @@ class ExceptionController extends BaseExceptionController
     protected function findTemplate(Request $request, $format, $code, $showException)
     {
         $name = $showException ? 'exception' : 'error';
-        if ($showException && 'html' == $format) {
+        if ($showException && 'html' === $format) {
             $name = 'exception_full';
         }
 

--- a/src/Wallabag/CoreBundle/Controller/ExportController.php
+++ b/src/Wallabag/CoreBundle/Controller/ExportController.php
@@ -55,10 +55,10 @@ class ExportController extends Controller
     public function downloadEntriesAction(Request $request, $format, $category)
     {
         $method = ucfirst($category);
-        $methodBuilder = 'getBuilderFor'.$method.'ByUser';
+        $methodBuilder = 'getBuilderFor' . $method . 'ByUser';
         $repository = $this->get('wallabag_core.entry_repository');
 
-        if ($category == 'tag_entries') {
+        if ($category === 'tag_entries') {
             $tag = $this->get('wallabag_core.tag_repository')->findOneBySlug($request->query->get('tag'));
 
             $entries = $repository->findAllByTagId(

--- a/src/Wallabag/CoreBundle/Controller/RssController.php
+++ b/src/Wallabag/CoreBundle/Controller/RssController.php
@@ -2,19 +2,19 @@
 
 namespace Wallabag\CoreBundle\Controller;
 
-use Pagerfanta\Adapter\DoctrineORMAdapter;
 use Pagerfanta\Adapter\ArrayAdapter;
+use Pagerfanta\Adapter\DoctrineORMAdapter;
 use Pagerfanta\Exception\OutOfRangeCurrentPageException;
 use Pagerfanta\Pagerfanta;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\ParamConverter;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
+use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Bundle\FrameworkBundle\Controller\Controller;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Wallabag\CoreBundle\Entity\Entry;
 use Wallabag\CoreBundle\Entity\Tag;
 use Wallabag\UserBundle\Entity\User;
-use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
 class RssController extends Controller
 {
@@ -113,7 +113,7 @@ class RssController extends Controller
             $entries->setCurrentPage($page);
         } catch (OutOfRangeCurrentPageException $e) {
             if ($page > 1) {
-                return $this->redirect($url.'?page='.$entries->getNbPages(), 302);
+                return $this->redirect($url . '?page=' . $entries->getNbPages(), 302);
             }
         }
 
@@ -121,7 +121,7 @@ class RssController extends Controller
             '@WallabagCore/themes/common/Entry/entries.xml.twig',
             [
                 'url_html' => $this->generateUrl('tag_entries', ['slug' => $tag->getSlug()], UrlGeneratorInterface::ABSOLUTE_URL),
-                'type' => 'tag ('.$tag->getLabel().')',
+                'type' => 'tag (' . $tag->getLabel() . ')',
                 'url' => $url,
                 'entries' => $entries,
             ],
@@ -147,19 +147,15 @@ class RssController extends Controller
             case 'starred':
                 $qb = $repository->getBuilderForStarredByUser($user->getId());
                 break;
-
             case 'archive':
                 $qb = $repository->getBuilderForArchiveByUser($user->getId());
                 break;
-
             case 'unread':
                 $qb = $repository->getBuilderForUnreadByUser($user->getId());
                 break;
-
             case 'all':
                 $qb = $repository->getBuilderForAllByUser($user->getId());
                 break;
-
             default:
                 throw new \InvalidArgumentException(sprintf('Type "%s" is not implemented.', $type));
         }
@@ -171,7 +167,7 @@ class RssController extends Controller
         $entries->setMaxPerPage($perPage);
 
         $url = $this->generateUrl(
-            $type.'_rss',
+            $type . '_rss',
             [
                 'username' => $user->getUsername(),
                 'token' => $user->getConfig()->getRssToken(),
@@ -183,7 +179,7 @@ class RssController extends Controller
             $entries->setCurrentPage((int) $page);
         } catch (OutOfRangeCurrentPageException $e) {
             if ($page > 1) {
-                return $this->redirect($url.'?page='.$entries->getNbPages(), 302);
+                return $this->redirect($url . '?page=' . $entries->getNbPages(), 302);
             }
         }
 

--- a/src/Wallabag/CoreBundle/Controller/SiteCredentialController.php
+++ b/src/Wallabag/CoreBundle/Controller/SiteCredentialController.php
@@ -2,12 +2,12 @@
 
 namespace Wallabag\CoreBundle\Controller;
 
-use Symfony\Component\HttpFoundation\Request;
-use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Method;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
-use Wallabag\UserBundle\Entity\User;
+use Symfony\Bundle\FrameworkBundle\Controller\Controller;
+use Symfony\Component\HttpFoundation\Request;
 use Wallabag\CoreBundle\Entity\SiteCredential;
+use Wallabag\UserBundle\Entity\User;
 
 /**
  * SiteCredential controller.
@@ -167,7 +167,7 @@ class SiteCredentialController extends Controller
      */
     private function checkUserAction(SiteCredential $siteCredential)
     {
-        if (null === $this->getUser() || $this->getUser()->getId() != $siteCredential->getUser()->getId()) {
+        if (null === $this->getUser() || $this->getUser()->getId() !== $siteCredential->getUser()->getId()) {
             throw $this->createAccessDeniedException('You can not access this site credential.');
         }
     }

--- a/src/Wallabag/CoreBundle/Controller/StaticController.php
+++ b/src/Wallabag/CoreBundle/Controller/StaticController.php
@@ -16,7 +16,9 @@ class StaticController extends Controller
 
         return $this->render(
             '@WallabagCore/themes/common/Static/howto.html.twig',
-            ['addonsUrl' => $addonsUrl]
+            [
+                'addonsUrl' => $addonsUrl,
+            ]
         );
     }
 
@@ -40,8 +42,7 @@ class StaticController extends Controller
     public function quickstartAction()
     {
         return $this->render(
-            '@WallabagCore/themes/common/Static/quickstart.html.twig',
-            []
+            '@WallabagCore/themes/common/Static/quickstart.html.twig'
         );
     }
 }

--- a/src/Wallabag/CoreBundle/Controller/TagController.php
+++ b/src/Wallabag/CoreBundle/Controller/TagController.php
@@ -4,13 +4,13 @@ namespace Wallabag\CoreBundle\Controller;
 
 use Pagerfanta\Adapter\ArrayAdapter;
 use Pagerfanta\Exception\OutOfRangeCurrentPageException;
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\ParamConverter;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Component\HttpFoundation\Request;
 use Wallabag\CoreBundle\Entity\Entry;
 use Wallabag\CoreBundle\Entity\Tag;
 use Wallabag\CoreBundle\Form\Type\NewTagType;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\ParamConverter;
 
 class TagController extends Controller
 {

--- a/src/Wallabag/CoreBundle/DataFixtures/ORM/LoadSettingData.php
+++ b/src/Wallabag/CoreBundle/DataFixtures/ORM/LoadSettingData.php
@@ -2,10 +2,10 @@
 
 namespace Wallabag\CoreBundle\DataFixtures\ORM;
 
+use Craue\ConfigBundle\Entity\Setting;
 use Doctrine\Common\DataFixtures\AbstractFixture;
 use Doctrine\Common\DataFixtures\OrderedFixtureInterface;
 use Doctrine\Common\Persistence\ObjectManager;
-use Craue\ConfigBundle\Entity\Setting;
 use Symfony\Component\DependencyInjection\ContainerAwareInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 

--- a/src/Wallabag/CoreBundle/DependencyInjection/WallabagCoreExtension.php
+++ b/src/Wallabag/CoreBundle/DependencyInjection/WallabagCoreExtension.php
@@ -31,7 +31,7 @@ class WallabagCoreExtension extends Extension
         $container->setParameter('wallabag_core.default_internal_settings', $config['default_internal_settings']);
         $container->setParameter('wallabag_core.site_credentials.encryption_key_path', $config['encryption_key_path']);
 
-        $loader = new Loader\YamlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
+        $loader = new Loader\YamlFileLoader($container, new FileLocator(__DIR__ . '/../Resources/config'));
         $loader->load('services.yml');
         $loader->load('parameters.yml');
     }

--- a/src/Wallabag/CoreBundle/Entity/Entry.php
+++ b/src/Wallabag/CoreBundle/Entity/Entry.php
@@ -5,14 +5,14 @@ namespace Wallabag\CoreBundle\Entity;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\ORM\Mapping as ORM;
 use Hateoas\Configuration\Annotation as Hateoas;
-use JMS\Serializer\Annotation\Groups;
-use JMS\Serializer\Annotation\XmlRoot;
 use JMS\Serializer\Annotation\Exclude;
-use JMS\Serializer\Annotation\VirtualProperty;
+use JMS\Serializer\Annotation\Groups;
 use JMS\Serializer\Annotation\SerializedName;
+use JMS\Serializer\Annotation\VirtualProperty;
+use JMS\Serializer\Annotation\XmlRoot;
 use Symfony\Component\Validator\Constraints as Assert;
-use Wallabag\UserBundle\Entity\User;
 use Wallabag\AnnotationBundle\Entity\Annotation;
+use Wallabag\UserBundle\Entity\User;
 
 /**
  * Entry.
@@ -478,7 +478,7 @@ class Entry
      */
     public function timestamps()
     {
-        if (is_null($this->createdAt)) {
+        if (null === $this->createdAt) {
             $this->createdAt = new \DateTime();
         }
 

--- a/src/Wallabag/CoreBundle/Entity/SiteCredential.php
+++ b/src/Wallabag/CoreBundle/Entity/SiteCredential.php
@@ -188,7 +188,7 @@ class SiteCredential
      */
     public function timestamps()
     {
-        if (is_null($this->createdAt)) {
+        if (null === $this->createdAt) {
             $this->createdAt = new \DateTime();
         }
     }

--- a/src/Wallabag/CoreBundle/Entity/Tag.php
+++ b/src/Wallabag/CoreBundle/Entity/Tag.php
@@ -4,9 +4,9 @@ namespace Wallabag\CoreBundle\Entity;
 
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\ORM\Mapping as ORM;
+use Gedmo\Mapping\Annotation as Gedmo;
 use JMS\Serializer\Annotation\ExclusionPolicy;
 use JMS\Serializer\Annotation\Expose;
-use Gedmo\Mapping\Annotation as Gedmo;
 use JMS\Serializer\Annotation\XmlRoot;
 
 /**

--- a/src/Wallabag/CoreBundle/Event/Subscriber/DownloadImagesSubscriber.php
+++ b/src/Wallabag/CoreBundle/Event/Subscriber/DownloadImagesSubscriber.php
@@ -2,13 +2,13 @@
 
 namespace Wallabag\CoreBundle\Event\Subscriber;
 
-use Symfony\Component\EventDispatcher\EventSubscriberInterface;
-use Psr\Log\LoggerInterface;
-use Wallabag\CoreBundle\Helper\DownloadImages;
-use Wallabag\CoreBundle\Entity\Entry;
-use Wallabag\CoreBundle\Event\EntrySavedEvent;
-use Wallabag\CoreBundle\Event\EntryDeletedEvent;
 use Doctrine\ORM\EntityManager;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Wallabag\CoreBundle\Entity\Entry;
+use Wallabag\CoreBundle\Event\EntryDeletedEvent;
+use Wallabag\CoreBundle\Event\EntrySavedEvent;
+use Wallabag\CoreBundle\Helper\DownloadImages;
 
 class DownloadImagesSubscriber implements EventSubscriberInterface
 {

--- a/src/Wallabag/CoreBundle/Event/Subscriber/SQLiteCascadeDeleteSubscriber.php
+++ b/src/Wallabag/CoreBundle/Event/Subscriber/SQLiteCascadeDeleteSubscriber.php
@@ -2,10 +2,10 @@
 
 namespace Wallabag\CoreBundle\Event\Subscriber;
 
+use Doctrine\Bundle\DoctrineBundle\Registry;
 use Doctrine\Common\EventSubscriber;
 use Doctrine\ORM\Event\LifecycleEventArgs;
 use Wallabag\CoreBundle\Entity\Entry;
-use Doctrine\Bundle\DoctrineBundle\Registry;
 
 /**
  * SQLite doesn't care about cascading remove, so we need to manually remove associated stuf for an Entry.

--- a/src/Wallabag/CoreBundle/Event/Subscriber/TablePrefixSubscriber.php
+++ b/src/Wallabag/CoreBundle/Event/Subscriber/TablePrefixSubscriber.php
@@ -39,12 +39,12 @@ class TablePrefixSubscriber implements EventSubscriber
             return;
         }
 
-        $classMetadata->setPrimaryTable(['name' => $this->prefix.$classMetadata->getTableName()]);
+        $classMetadata->setPrimaryTable(['name' => $this->prefix . $classMetadata->getTableName()]);
 
         foreach ($classMetadata->getAssociationMappings() as $fieldName => $mapping) {
             if ($mapping['type'] === ClassMetadataInfo::MANY_TO_MANY && isset($classMetadata->associationMappings[$fieldName]['joinTable']['name'])) {
                 $mappedTableName = $classMetadata->associationMappings[$fieldName]['joinTable']['name'];
-                $classMetadata->associationMappings[$fieldName]['joinTable']['name'] = $this->prefix.$mappedTableName;
+                $classMetadata->associationMappings[$fieldName]['joinTable']['name'] = $this->prefix . $mappedTableName;
             }
         }
     }

--- a/src/Wallabag/CoreBundle/Form/Type/EntryFilterType.php
+++ b/src/Wallabag/CoreBundle/Form/Type/EntryFilterType.php
@@ -4,12 +4,12 @@ namespace Wallabag\CoreBundle\Form\Type;
 
 use Doctrine\ORM\EntityRepository;
 use Lexik\Bundle\FormFilterBundle\Filter\FilterOperands;
-use Lexik\Bundle\FormFilterBundle\Filter\Query\QueryInterface;
-use Lexik\Bundle\FormFilterBundle\Filter\Form\Type\NumberRangeFilterType;
-use Lexik\Bundle\FormFilterBundle\Filter\Form\Type\DateRangeFilterType;
-use Lexik\Bundle\FormFilterBundle\Filter\Form\Type\TextFilterType;
 use Lexik\Bundle\FormFilterBundle\Filter\Form\Type\CheckboxFilterType;
 use Lexik\Bundle\FormFilterBundle\Filter\Form\Type\ChoiceFilterType;
+use Lexik\Bundle\FormFilterBundle\Filter\Form\Type\DateRangeFilterType;
+use Lexik\Bundle\FormFilterBundle\Filter\Form\Type\NumberRangeFilterType;
+use Lexik\Bundle\FormFilterBundle\Filter\Form\Type\TextFilterType;
+use Lexik\Bundle\FormFilterBundle\Filter\Query\QueryInterface;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\HttpFoundation\Response;
@@ -99,7 +99,7 @@ class EntryFilterType extends AbstractType
                     if (strlen($value) <= 2 || empty($value)) {
                         return;
                     }
-                    $expression = $filterQuery->getExpr()->like($field, $filterQuery->getExpr()->lower($filterQuery->getExpr()->literal('%'.$value.'%')));
+                    $expression = $filterQuery->getExpr()->like($field, $filterQuery->getExpr()->lower($filterQuery->getExpr()->literal('%' . $value . '%')));
 
                     return $filterQuery->createCondition($expression);
                 },
@@ -113,8 +113,8 @@ class EntryFilterType extends AbstractType
                     }
 
                     $paramName = sprintf('%s', str_replace('.', '_', $field));
-                    $expression = $filterQuery->getExpr()->eq($field, ':'.$paramName);
-                    $parameters = array($paramName => $value);
+                    $expression = $filterQuery->getExpr()->eq($field, ':' . $paramName);
+                    $parameters = [$paramName => $value];
 
                     return $filterQuery->createCondition($expression, $parameters);
                 },
@@ -158,7 +158,7 @@ class EntryFilterType extends AbstractType
 
                     // is_public isn't a real field
                     // we should use the "uid" field to determine if the entry has been made public
-                    $expression = $filterQuery->getExpr()->isNotNull($values['alias'].'.uid');
+                    $expression = $filterQuery->getExpr()->isNotNull($values['alias'] . '.uid');
 
                     return $filterQuery->createCondition($expression);
                 },

--- a/src/Wallabag/CoreBundle/GuzzleSiteAuthenticator/GrabySiteConfigBuilder.php
+++ b/src/Wallabag/CoreBundle/GuzzleSiteAuthenticator/GrabySiteConfigBuilder.php
@@ -6,8 +6,8 @@ use BD\GuzzleSiteAuthenticator\SiteConfig\SiteConfig;
 use BD\GuzzleSiteAuthenticator\SiteConfig\SiteConfigBuilder;
 use Graby\SiteConfig\ConfigBuilder;
 use Psr\Log\LoggerInterface;
-use Wallabag\CoreBundle\Repository\SiteCredentialRepository;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorage;
+use Wallabag\CoreBundle\Repository\SiteCredentialRepository;
 
 class GrabySiteConfigBuilder implements SiteConfigBuilder
 {
@@ -57,7 +57,7 @@ class GrabySiteConfigBuilder implements SiteConfigBuilder
     {
         // required by credentials below
         $host = strtolower($host);
-        if (substr($host, 0, 4) == 'www.') {
+        if (substr($host, 0, 4) === 'www.') {
             $host = substr($host, 4);
         }
 

--- a/src/Wallabag/CoreBundle/Helper/ContentProxy.php
+++ b/src/Wallabag/CoreBundle/Helper/ContentProxy.php
@@ -4,12 +4,12 @@ namespace Wallabag\CoreBundle\Helper;
 
 use Graby\Graby;
 use Psr\Log\LoggerInterface;
-use Wallabag\CoreBundle\Entity\Entry;
-use Wallabag\CoreBundle\Tools\Utils;
 use Symfony\Component\HttpFoundation\File\MimeType\MimeTypeExtensionGuesser;
 use Symfony\Component\Validator\Constraints\Locale as LocaleConstraint;
 use Symfony\Component\Validator\Constraints\Url as UrlConstraint;
 use Symfony\Component\Validator\Validator\ValidatorInterface;
+use Wallabag\CoreBundle\Entity\Entry;
+use Wallabag\CoreBundle\Tools\Utils;
 
 /**
  * This kind of proxy class take care of getting the content from an url
@@ -100,7 +100,7 @@ class ContentProxy
 
             // is it a timestamp?
             if (filter_var($date, FILTER_VALIDATE_INT) !== false) {
-                $date = '@'.$content['date'];
+                $date = '@' . $content['date'];
             }
 
             try {
@@ -189,7 +189,7 @@ class ContentProxy
             return;
         }
 
-        $this->logger->warning('Language validation failed. '.(string) $errors);
+        $this->logger->warning('Language validation failed. ' . (string) $errors);
     }
 
     /**
@@ -211,6 +211,6 @@ class ContentProxy
             return;
         }
 
-        $this->logger->warning('PreviewPicture validation failed. '.(string) $errors);
+        $this->logger->warning('PreviewPicture validation failed. ' . (string) $errors);
     }
 }

--- a/src/Wallabag/CoreBundle/Helper/CryptoProxy.php
+++ b/src/Wallabag/CoreBundle/Helper/CryptoProxy.php
@@ -2,10 +2,10 @@
 
 namespace Wallabag\CoreBundle\Helper;
 
-use Psr\Log\LoggerInterface;
-use Defuse\Crypto\Key;
 use Defuse\Crypto\Crypto;
 use Defuse\Crypto\Exception\WrongKeyOrModifiedCiphertextException;
+use Defuse\Crypto\Key;
+use Psr\Log\LoggerInterface;
 
 /**
  * This is a proxy to crypt and decrypt password used by SiteCredential entity.
@@ -39,7 +39,7 @@ class CryptoProxy
      */
     public function crypt($secretValue)
     {
-        $this->logger->debug('Crypto: crypting value: '.$this->mask($secretValue));
+        $this->logger->debug('Crypto: crypting value: ' . $this->mask($secretValue));
 
         return Crypto::encrypt($secretValue, $this->loadKey());
     }
@@ -53,12 +53,12 @@ class CryptoProxy
      */
     public function decrypt($cryptedValue)
     {
-        $this->logger->debug('Crypto: decrypting value: '.$this->mask($cryptedValue));
+        $this->logger->debug('Crypto: decrypting value: ' . $this->mask($cryptedValue));
 
         try {
             return Crypto::decrypt($cryptedValue, $this->loadKey());
         } catch (WrongKeyOrModifiedCiphertextException $e) {
-            throw new \RuntimeException('Decrypt fail: '.$e->getMessage());
+            throw new \RuntimeException('Decrypt fail: ' . $e->getMessage());
         }
     }
 
@@ -81,6 +81,6 @@ class CryptoProxy
      */
     private function mask($value)
     {
-        return strlen($value) > 0 ? $value[0].'*****'.$value[strlen($value) - 1] : 'Empty value';
+        return strlen($value) > 0 ? $value[0] . '*****' . $value[strlen($value) - 1] : 'Empty value';
     }
 }

--- a/src/Wallabag/CoreBundle/Helper/DetectActiveTheme.php
+++ b/src/Wallabag/CoreBundle/Helper/DetectActiveTheme.php
@@ -44,7 +44,7 @@ class DetectActiveTheme implements DeviceDetectionInterface
     {
         $token = $this->tokenStorage->getToken();
 
-        if (is_null($token)) {
+        if (null === $token) {
             return $this->defaultTheme;
         }
 

--- a/src/Wallabag/CoreBundle/Helper/DownloadImages.php
+++ b/src/Wallabag/CoreBundle/Helper/DownloadImages.php
@@ -2,12 +2,12 @@
 
 namespace Wallabag\CoreBundle\Helper;
 
-use Psr\Log\LoggerInterface;
-use Symfony\Component\DomCrawler\Crawler;
 use GuzzleHttp\Client;
 use GuzzleHttp\Message\Response;
-use Symfony\Component\HttpFoundation\File\MimeType\MimeTypeExtensionGuesser;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\DomCrawler\Crawler;
 use Symfony\Component\Finder\Finder;
+use Symfony\Component\HttpFoundation\File\MimeType\MimeTypeExtensionGuesser;
 
 class DownloadImages
 {
@@ -28,17 +28,6 @@ class DownloadImages
         $this->mimeGuesser = new MimeTypeExtensionGuesser();
 
         $this->setFolder();
-    }
-
-    /**
-     * Setup base folder where all images are going to be saved.
-     */
-    private function setFolder()
-    {
-        // if folder doesn't exist, attempt to create one and store the folder name in property $folder
-        if (!file_exists($this->baseFolder)) {
-            mkdir($this->baseFolder, 0755, true);
-        }
     }
 
     /**
@@ -97,9 +86,9 @@ class DownloadImages
             $relativePath = $this->getRelativePath($entryId);
         }
 
-        $this->logger->debug('DownloadImages: working on image: '.$imagePath);
+        $this->logger->debug('DownloadImages: working on image: ' . $imagePath);
 
-        $folderPath = $this->baseFolder.'/'.$relativePath;
+        $folderPath = $this->baseFolder . '/' . $relativePath;
 
         // build image path
         $absolutePath = $this->getAbsoluteLink($url, $imagePath);
@@ -123,7 +112,7 @@ class DownloadImages
         }
 
         $hashImage = hash('crc32', $absolutePath);
-        $localPath = $folderPath.'/'.$hashImage.'.'.$ext;
+        $localPath = $folderPath . '/' . $hashImage . '.' . $ext;
 
         try {
             $im = imagecreatefromstring($res->getBody());
@@ -156,7 +145,7 @@ class DownloadImages
 
         imagedestroy($im);
 
-        return $this->wallabagUrl.'/assets/images/'.$relativePath.'/'.$hashImage.'.'.$ext;
+        return $this->wallabagUrl . '/assets/images/' . $relativePath . '/' . $hashImage . '.' . $ext;
     }
 
     /**
@@ -167,7 +156,7 @@ class DownloadImages
     public function removeImages($entryId)
     {
         $relativePath = $this->getRelativePath($entryId);
-        $folderPath = $this->baseFolder.'/'.$relativePath;
+        $folderPath = $this->baseFolder . '/' . $relativePath;
 
         $finder = new Finder();
         $finder
@@ -183,6 +172,17 @@ class DownloadImages
     }
 
     /**
+     * Setup base folder where all images are going to be saved.
+     */
+    private function setFolder()
+    {
+        // if folder doesn't exist, attempt to create one and store the folder name in property $folder
+        if (!file_exists($this->baseFolder)) {
+            mkdir($this->baseFolder, 0755, true);
+        }
+    }
+
+    /**
      * Generate the folder where we are going to save images based on the entry url.
      *
      * @param int $entryId ID of the entry
@@ -192,8 +192,8 @@ class DownloadImages
     private function getRelativePath($entryId)
     {
         $hashId = hash('crc32', $entryId);
-        $relativePath = $hashId[0].'/'.$hashId[1].'/'.$hashId;
-        $folderPath = $this->baseFolder.'/'.$relativePath;
+        $relativePath = $hashId[0] . '/' . $hashId[1] . '/' . $hashId;
+        $folderPath = $this->baseFolder . '/' . $relativePath;
 
         if (!file_exists($folderPath)) {
             mkdir($folderPath, 0777, true);
@@ -270,7 +270,7 @@ class DownloadImages
         }
 
         if (!in_array($ext, ['jpeg', 'jpg', 'gif', 'png'], true)) {
-            $this->logger->error('DownloadImages: Processed image with not allowed extension. Skipping: '.$imagePath);
+            $this->logger->error('DownloadImages: Processed image with not allowed extension. Skipping: ' . $imagePath);
 
             return false;
         }

--- a/src/Wallabag/CoreBundle/Helper/EntriesExport.php
+++ b/src/Wallabag/CoreBundle/Helper/EntriesExport.php
@@ -63,7 +63,7 @@ class EntriesExport
      */
     public function updateTitle($method)
     {
-        $this->title = $method.' articles';
+        $this->title = $method . ' articles';
 
         if ('entry' === $method) {
             $this->title = $this->entries[0]->getTitle();
@@ -81,7 +81,7 @@ class EntriesExport
      */
     public function exportAs($format)
     {
-        $functionName = 'produce'.ucfirst($format);
+        $functionName = 'produce' . ucfirst($format);
         if (method_exists($this, $functionName)) {
             return $this->$functionName();
         }
@@ -106,12 +106,12 @@ class EntriesExport
          */
         $content_start =
             "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
-            ."<html xmlns=\"http://www.w3.org/1999/xhtml\" xmlns:epub=\"http://www.idpf.org/2007/ops\">\n"
-            .'<head>'
-            ."<meta http-equiv=\"Default-Style\" content=\"text/html; charset=utf-8\" />\n"
-            ."<title>wallabag articles book</title>\n"
-            ."</head>\n"
-            ."<body>\n";
+            . "<html xmlns=\"http://www.w3.org/1999/xhtml\" xmlns:epub=\"http://www.idpf.org/2007/ops\">\n"
+            . '<head>'
+            . "<meta http-equiv=\"Default-Style\" content=\"text/html; charset=utf-8\" />\n"
+            . "<title>wallabag articles book</title>\n"
+            . "</head>\n"
+            . "<body>\n";
 
         $bookEnd = "</body>\n</html>\n";
 
@@ -164,11 +164,11 @@ class EntriesExport
             // in filenames, we limit to A-z/0-9
             $filename = preg_replace('/[^A-Za-z0-9\-]/', '', $entry->getTitle());
 
-            $chapter = $content_start.$entry->getContent().$bookEnd;
-            $book->addChapter($entry->getTitle(), htmlspecialchars($filename).'.html', $chapter, true, EPub::EXTERNAL_REF_ADD);
+            $chapter = $content_start . $entry->getContent() . $bookEnd;
+            $book->addChapter($entry->getTitle(), htmlspecialchars($filename) . '.html', $chapter, true, EPub::EXTERNAL_REF_ADD);
         }
 
-        $book->addChapter('Notices', 'Cover2.html', $content_start.$this->getExportInformation('PHPePub').$bookEnd);
+        $book->addChapter('Notices', 'Cover2.html', $content_start . $this->getExportInformation('PHPePub') . $bookEnd);
 
         return Response::create(
             $book->getBook(),
@@ -176,7 +176,7 @@ class EntriesExport
             [
                 'Content-Description' => 'File Transfer',
                 'Content-type' => 'application/epub+zip',
-                'Content-Disposition' => 'attachment; filename="'.$this->title.'.epub"',
+                'Content-Disposition' => 'attachment; filename="' . $this->title . '.epub"',
                 'Content-Transfer-Encoding' => 'binary',
             ]
         );
@@ -228,7 +228,7 @@ class EntriesExport
                 'Accept-Ranges' => 'bytes',
                 'Content-Description' => 'File Transfer',
                 'Content-type' => 'application/x-mobipocket-ebook',
-                'Content-Disposition' => 'attachment; filename="'.$this->title.'.mobi"',
+                'Content-Disposition' => 'attachment; filename="' . $this->title . '.mobi"',
                 'Content-Transfer-Encoding' => 'binary',
             ]
         );
@@ -256,7 +256,7 @@ class EntriesExport
          * Front page
          */
         $pdf->AddPage();
-        $intro = '<h1>'.$this->title.'</h1>'.$this->getExportInformation('tcpdf');
+        $intro = '<h1>' . $this->title . '</h1>' . $this->getExportInformation('tcpdf');
 
         $pdf->writeHTMLCell(0, 0, '', '', $intro, 0, 1, 0, true, '', true);
 
@@ -269,7 +269,7 @@ class EntriesExport
             }
 
             $pdf->AddPage();
-            $html = '<h1>'.$entry->getTitle().'</h1>';
+            $html = '<h1>' . $entry->getTitle() . '</h1>';
             $html .= $entry->getContent();
 
             $pdf->writeHTMLCell(0, 0, '', '', $html, 0, 1, 0, true, '', true);
@@ -284,7 +284,7 @@ class EntriesExport
             [
                 'Content-Description' => 'File Transfer',
                 'Content-type' => 'application/pdf',
-                'Content-Disposition' => 'attachment; filename="'.$this->title.'.pdf"',
+                'Content-Disposition' => 'attachment; filename="' . $this->title . '.pdf"',
                 'Content-Transfer-Encoding' => 'binary',
             ]
         );
@@ -330,7 +330,7 @@ class EntriesExport
             200,
             [
                 'Content-type' => 'application/csv',
-                'Content-Disposition' => 'attachment; filename="'.$this->title.'.csv"',
+                'Content-Disposition' => 'attachment; filename="' . $this->title . '.csv"',
                 'Content-Transfer-Encoding' => 'UTF-8',
             ]
         );
@@ -348,7 +348,7 @@ class EntriesExport
             200,
             [
                 'Content-type' => 'application/json',
-                'Content-Disposition' => 'attachment; filename="'.$this->title.'.json"',
+                'Content-Disposition' => 'attachment; filename="' . $this->title . '.json"',
                 'Content-Transfer-Encoding' => 'UTF-8',
             ]
         );
@@ -366,7 +366,7 @@ class EntriesExport
             200,
             [
                 'Content-type' => 'application/xml',
-                'Content-Disposition' => 'attachment; filename="'.$this->title.'.xml"',
+                'Content-Disposition' => 'attachment; filename="' . $this->title . '.xml"',
                 'Content-Transfer-Encoding' => 'UTF-8',
             ]
         );
@@ -382,8 +382,8 @@ class EntriesExport
         $content = '';
         $bar = str_repeat('=', 100);
         foreach ($this->entries as $entry) {
-            $content .= "\n\n".$bar."\n\n".$entry->getTitle()."\n\n".$bar."\n\n";
-            $content .= trim(preg_replace('/\s+/S', ' ', strip_tags($entry->getContent())))."\n\n";
+            $content .= "\n\n" . $bar . "\n\n" . $entry->getTitle() . "\n\n" . $bar . "\n\n";
+            $content .= trim(preg_replace('/\s+/S', ' ', strip_tags($entry->getContent()))) . "\n\n";
         }
 
         return Response::create(
@@ -391,7 +391,7 @@ class EntriesExport
             200,
             [
                 'Content-type' => 'text/plain',
-                'Content-Disposition' => 'attachment; filename="'.$this->title.'.txt"',
+                'Content-Disposition' => 'attachment; filename="' . $this->title . '.txt"',
                 'Content-Transfer-Encoding' => 'UTF-8',
             ]
         );
@@ -427,7 +427,7 @@ class EntriesExport
         $info = str_replace('%EXPORT_METHOD%', $type, $this->footerTemplate);
 
         if ('tcpdf' === $type) {
-            return str_replace('%IMAGE%', '<img src="'.$this->logoPath.'" />', $info);
+            return str_replace('%IMAGE%', '<img src="' . $this->logoPath . '" />', $info);
         }
 
         return str_replace('%IMAGE%', '', $info);

--- a/src/Wallabag/CoreBundle/Helper/HttpClientFactory.php
+++ b/src/Wallabag/CoreBundle/Helper/HttpClientFactory.php
@@ -41,7 +41,7 @@ class HttpClientFactory
      */
     public function buildHttpClient()
     {
-        $this->logger->log('debug', 'Restricted access config enabled?', array('enabled' => (int) $this->restrictedAccess));
+        $this->logger->log('debug', 'Restricted access config enabled?', ['enabled' => (int) $this->restrictedAccess]);
 
         if (0 === (int) $this->restrictedAccess) {
             return;

--- a/src/Wallabag/CoreBundle/Helper/PreparePagerForEntries.php
+++ b/src/Wallabag/CoreBundle/Helper/PreparePagerForEntries.php
@@ -4,9 +4,9 @@ namespace Wallabag\CoreBundle\Helper;
 
 use Pagerfanta\Adapter\AdapterInterface;
 use Pagerfanta\Pagerfanta;
-use Wallabag\UserBundle\Entity\User;
 use Symfony\Component\Routing\Router;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
+use Wallabag\UserBundle\Entity\User;
 
 class PreparePagerForEntries
 {

--- a/src/Wallabag/CoreBundle/Helper/RuleBasedTagger.php
+++ b/src/Wallabag/CoreBundle/Helper/RuleBasedTagger.php
@@ -2,13 +2,13 @@
 
 namespace Wallabag\CoreBundle\Helper;
 
+use Psr\Log\LoggerInterface;
 use RulerZ\RulerZ;
 use Wallabag\CoreBundle\Entity\Entry;
 use Wallabag\CoreBundle\Entity\Tag;
 use Wallabag\CoreBundle\Repository\EntryRepository;
 use Wallabag\CoreBundle\Repository\TagRepository;
 use Wallabag\UserBundle\Entity\User;
-use Psr\Log\LoggerInterface;
 
 class RuleBasedTagger
 {

--- a/src/Wallabag/CoreBundle/Repository/EntryRepository.php
+++ b/src/Wallabag/CoreBundle/Repository/EntryRepository.php
@@ -325,7 +325,7 @@ class EntryRepository extends EntityRepository
             ->where('e.user=:userId')->setParameter('userId', $userId)
         ;
 
-        return $qb->getQuery()->getSingleScalarResult();
+        return (int) $qb->getQuery()->getSingleScalarResult();
     }
 
     /**
@@ -345,7 +345,7 @@ class EntryRepository extends EntityRepository
             ->andWhere('t.id=:tagId')->setParameter('tagId', $tagId)
         ;
 
-        return $qb->getQuery()->getSingleScalarResult();
+        return (int) $qb->getQuery()->getSingleScalarResult();
     }
 
     /**

--- a/src/Wallabag/CoreBundle/Repository/EntryRepository.php
+++ b/src/Wallabag/CoreBundle/Repository/EntryRepository.php
@@ -11,21 +11,6 @@ use Wallabag\CoreBundle\Entity\Tag;
 class EntryRepository extends EntityRepository
 {
     /**
-     * Return a query builder to used by other getBuilderFor* method.
-     *
-     * @param int $userId
-     *
-     * @return QueryBuilder
-     */
-    private function getBuilderByUser($userId)
-    {
-        return $this->createQueryBuilder('e')
-            ->andWhere('e.user = :userId')->setParameter('userId', $userId)
-            ->orderBy('e.createdAt', 'desc')
-        ;
-    }
-
-    /**
      * Retrieves all entries for a user.
      *
      * @param int $userId
@@ -108,7 +93,7 @@ class EntryRepository extends EntityRepository
 
         // We lower() all parts here because PostgreSQL 'LIKE' verb is case-sensitive
         $qb
-            ->andWhere('lower(e.content) LIKE lower(:term) OR lower(e.title) LIKE lower(:term) OR lower(e.url) LIKE lower(:term)')->setParameter('term', '%'.$term.'%')
+            ->andWhere('lower(e.content) LIKE lower(:term) OR lower(e.title) LIKE lower(:term) OR lower(e.url) LIKE lower(:term)')->setParameter('term', '%' . $term . '%')
             ->leftJoin('e.tags', 't')
             ->groupBy('e.id');
 
@@ -158,7 +143,7 @@ class EntryRepository extends EntityRepository
         }
 
         if (null !== $isPublic) {
-            $qb->andWhere('e.uid IS '.(true === $isPublic ? 'NOT' : '').' NULL');
+            $qb->andWhere('e.uid IS ' . (true === $isPublic ? 'NOT' : '') . ' NULL');
         }
 
         if ($since > 0) {
@@ -413,5 +398,20 @@ class EntryRepository extends EntityRepository
             ->andWhere('e.user = :user_id')->setParameter('user_id', $userId)
             ->getQuery()
             ->getResult();
+    }
+
+    /**
+     * Return a query builder to used by other getBuilderFor* method.
+     *
+     * @param int $userId
+     *
+     * @return QueryBuilder
+     */
+    private function getBuilderByUser($userId)
+    {
+        return $this->createQueryBuilder('e')
+            ->andWhere('e.user = :userId')->setParameter('userId', $userId)
+            ->orderBy('e.createdAt', 'desc')
+        ;
     }
 }

--- a/src/Wallabag/CoreBundle/Twig/WallabagExtension.php
+++ b/src/Wallabag/CoreBundle/Twig/WallabagExtension.php
@@ -3,9 +3,9 @@
 namespace Wallabag\CoreBundle\Twig;
 
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
+use Symfony\Component\Translation\TranslatorInterface;
 use Wallabag\CoreBundle\Repository\EntryRepository;
 use Wallabag\CoreBundle\Repository\TagRepository;
-use Symfony\Component\Translation\TranslatorInterface;
 
 class WallabagExtension extends \Twig_Extension implements \Twig_Extension_GlobalsInterface
 {
@@ -33,11 +33,11 @@ class WallabagExtension extends \Twig_Extension implements \Twig_Extension_Globa
 
     public function getFunctions()
     {
-        return array(
+        return [
             new \Twig_SimpleFunction('count_entries', [$this, 'countEntries']),
             new \Twig_SimpleFunction('count_tags', [$this, 'countTags']),
             new \Twig_SimpleFunction('display_stats', [$this, 'displayStats']),
-        );
+        ];
     }
 
     public function removeWww($url)
@@ -64,19 +64,15 @@ class WallabagExtension extends \Twig_Extension implements \Twig_Extension_Globa
             case 'starred':
                 $qb = $this->entryRepository->getBuilderForStarredByUser($user->getId());
                 break;
-
             case 'archive':
                 $qb = $this->entryRepository->getBuilderForArchiveByUser($user->getId());
                 break;
-
             case 'unread':
                 $qb = $this->entryRepository->getBuilderForUnreadByUser($user->getId());
                 break;
-
             case 'all':
                 $qb = $this->entryRepository->getBuilderForAllByUser($user->getId());
                 break;
-
             default:
                 throw new \InvalidArgumentException(sprintf('Type "%s" is not implemented.', $type));
         }
@@ -139,7 +135,7 @@ class WallabagExtension extends \Twig_Extension implements \Twig_Extension_Globa
         $nbDays = (int) $interval->format('%a') ?: 1;
 
         // force setlocale for date translation
-        setlocale(LC_TIME, strtolower($user->getConfig()->getLanguage()).'_'.strtoupper(strtolower($user->getConfig()->getLanguage())));
+        setlocale(LC_TIME, strtolower($user->getConfig()->getLanguage()) . '_' . strtoupper(strtolower($user->getConfig()->getLanguage())));
 
         return $this->translator->trans('footer.stats', [
             '%user_creation%' => strftime('%e %B %Y', $user->getCreatedAt()->getTimestamp()),

--- a/src/Wallabag/ImportBundle/Command/ImportCommand.php
+++ b/src/Wallabag/ImportBundle/Command/ImportCommand.php
@@ -5,8 +5,8 @@ namespace Wallabag\ImportBundle\Command;
 use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
 use Symfony\Component\Config\Definition\Exception\Exception;
 use Symfony\Component\Console\Input\InputArgument;
-use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class ImportCommand extends ContainerAwareCommand
@@ -27,7 +27,7 @@ class ImportCommand extends ContainerAwareCommand
 
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        $output->writeln('Start : '.(new \DateTime())->format('d-m-Y G:i:s').' ---');
+        $output->writeln('Start : ' . (new \DateTime())->format('d-m-Y G:i:s') . ' ---');
 
         if (!file_exists($input->getArgument('filepath'))) {
             throw new Exception(sprintf('File "%s" not found', $input->getArgument('filepath')));
@@ -80,12 +80,12 @@ class ImportCommand extends ContainerAwareCommand
 
         if (true === $res) {
             $summary = $import->getSummary();
-            $output->writeln('<info>'.$summary['imported'].' imported</info>');
-            $output->writeln('<comment>'.$summary['skipped'].' already saved</comment>');
+            $output->writeln('<info>' . $summary['imported'] . ' imported</info>');
+            $output->writeln('<comment>' . $summary['skipped'] . ' already saved</comment>');
         }
 
         $em->clear();
 
-        $output->writeln('End : '.(new \DateTime())->format('d-m-Y G:i:s').' ---');
+        $output->writeln('End : ' . (new \DateTime())->format('d-m-Y G:i:s') . ' ---');
     }
 }

--- a/src/Wallabag/ImportBundle/Command/RedisWorkerCommand.php
+++ b/src/Wallabag/ImportBundle/Command/RedisWorkerCommand.php
@@ -2,13 +2,13 @@
 
 namespace Wallabag\ImportBundle\Command;
 
+use Simpleue\Worker\QueueWorker;
 use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
 use Symfony\Component\Config\Definition\Exception\Exception;
 use Symfony\Component\Console\Input\InputArgument;
-use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
-use Simpleue\Worker\QueueWorker;
 
 class RedisWorkerCommand extends ContainerAwareCommand
 {
@@ -24,18 +24,18 @@ class RedisWorkerCommand extends ContainerAwareCommand
 
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        $output->writeln('Worker started at: '.(new \DateTime())->format('d-m-Y G:i:s'));
+        $output->writeln('Worker started at: ' . (new \DateTime())->format('d-m-Y G:i:s'));
         $output->writeln('Waiting for message ...');
 
         $serviceName = $input->getArgument('serviceName');
 
-        if (!$this->getContainer()->has('wallabag_import.queue.redis.'.$serviceName) || !$this->getContainer()->has('wallabag_import.consumer.redis.'.$serviceName)) {
+        if (!$this->getContainer()->has('wallabag_import.queue.redis.' . $serviceName) || !$this->getContainer()->has('wallabag_import.consumer.redis.' . $serviceName)) {
             throw new Exception(sprintf('No queue or consumer found for service name: "%s"', $input->getArgument('serviceName')));
         }
 
         $worker = new QueueWorker(
-            $this->getContainer()->get('wallabag_import.queue.redis.'.$serviceName),
-            $this->getContainer()->get('wallabag_import.consumer.redis.'.$serviceName),
+            $this->getContainer()->get('wallabag_import.queue.redis.' . $serviceName),
+            $this->getContainer()->get('wallabag_import.consumer.redis.' . $serviceName),
             (int) $input->getOption('maxIterations')
         );
 

--- a/src/Wallabag/ImportBundle/Consumer/AbstractConsumer.php
+++ b/src/Wallabag/ImportBundle/Consumer/AbstractConsumer.php
@@ -3,14 +3,14 @@
 namespace Wallabag\ImportBundle\Consumer;
 
 use Doctrine\ORM\EntityManager;
-use Wallabag\ImportBundle\Import\AbstractImport;
-use Wallabag\UserBundle\Repository\UserRepository;
-use Wallabag\CoreBundle\Entity\Entry;
-use Wallabag\CoreBundle\Entity\Tag;
 use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Wallabag\CoreBundle\Entity\Entry;
+use Wallabag\CoreBundle\Entity\Tag;
 use Wallabag\CoreBundle\Event\EntrySavedEvent;
+use Wallabag\ImportBundle\Import\AbstractImport;
+use Wallabag\UserBundle\Repository\UserRepository;
 
 abstract class AbstractConsumer
 {
@@ -76,7 +76,7 @@ abstract class AbstractConsumer
             return false;
         }
 
-        $this->logger->info('Content with url imported! ('.$entry->getUrl().')');
+        $this->logger->info('Content with url imported! (' . $entry->getUrl() . ')');
 
         return true;
     }

--- a/src/Wallabag/ImportBundle/Controller/BrowserController.php
+++ b/src/Wallabag/ImportBundle/Controller/BrowserController.php
@@ -2,28 +2,14 @@
 
 namespace Wallabag\ImportBundle\Controller;
 
-use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
+use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Wallabag\ImportBundle\Form\Type\UploadImportType;
 
 abstract class BrowserController extends Controller
 {
-    /**
-     * Return the service to handle the import.
-     *
-     * @return \Wallabag\ImportBundle\Import\ImportInterface
-     */
-    abstract protected function getImportService();
-
-     /**
-      * Return the template used for the form.
-      *
-      * @return string
-      */
-     abstract protected function getImportTemplate();
-
     /**
      * @Route("/browser", name="import_browser")
      *
@@ -42,11 +28,11 @@ abstract class BrowserController extends Controller
         if ($form->isSubmitted() && $form->isValid()) {
             $file = $form->get('file')->getData();
             $markAsRead = $form->get('mark_as_read')->getData();
-            $name = $this->getUser()->getId().'.json';
+            $name = $this->getUser()->getId() . '.json';
 
-            if (null !== $file && in_array($file->getClientMimeType(), $this->getParameter('wallabag_import.allow_mimetypes')) && $file->move($this->getParameter('wallabag_import.resource_dir'), $name)) {
+            if (null !== $file && in_array($file->getClientMimeType(), $this->getParameter('wallabag_import.allow_mimetypes'), true) && $file->move($this->getParameter('wallabag_import.resource_dir'), $name)) {
                 $res = $wallabag
-                    ->setFilepath($this->getParameter('wallabag_import.resource_dir').'/'.$name)
+                    ->setFilepath($this->getParameter('wallabag_import.resource_dir') . '/' . $name)
                     ->setMarkAsRead($markAsRead)
                     ->import();
 
@@ -65,7 +51,7 @@ abstract class BrowserController extends Controller
                         ]);
                     }
 
-                    unlink($this->getParameter('wallabag_import.resource_dir').'/'.$name);
+                    unlink($this->getParameter('wallabag_import.resource_dir') . '/' . $name);
                 }
 
                 $this->get('session')->getFlashBag()->add(
@@ -74,12 +60,11 @@ abstract class BrowserController extends Controller
                 );
 
                 return $this->redirect($this->generateUrl('homepage'));
-            } else {
-                $this->get('session')->getFlashBag()->add(
+            }
+            $this->get('session')->getFlashBag()->add(
                     'notice',
                     'flashes.import.notice.failed_on_file'
                 );
-            }
         }
 
         return $this->render($this->getImportTemplate(), [
@@ -87,4 +72,18 @@ abstract class BrowserController extends Controller
             'import' => $wallabag,
         ]);
     }
+
+    /**
+     * Return the service to handle the import.
+     *
+     * @return \Wallabag\ImportBundle\Import\ImportInterface
+     */
+    abstract protected function getImportService();
+
+     /**
+      * Return the template used for the form.
+      *
+      * @return string
+      */
+     abstract protected function getImportTemplate();
 }

--- a/src/Wallabag/ImportBundle/Controller/ChromeController.php
+++ b/src/Wallabag/ImportBundle/Controller/ChromeController.php
@@ -8,6 +8,14 @@ use Symfony\Component\HttpFoundation\Request;
 class ChromeController extends BrowserController
 {
     /**
+     * @Route("/chrome", name="import_chrome")
+     */
+    public function indexAction(Request $request)
+    {
+        return parent::indexAction($request);
+    }
+
+    /**
      * {@inheritdoc}
      */
     protected function getImportService()
@@ -29,13 +37,5 @@ class ChromeController extends BrowserController
     protected function getImportTemplate()
     {
         return 'WallabagImportBundle:Chrome:index.html.twig';
-    }
-
-    /**
-     * @Route("/chrome", name="import_chrome")
-     */
-    public function indexAction(Request $request)
-    {
-        return parent::indexAction($request);
     }
 }

--- a/src/Wallabag/ImportBundle/Controller/FirefoxController.php
+++ b/src/Wallabag/ImportBundle/Controller/FirefoxController.php
@@ -8,6 +8,14 @@ use Symfony\Component\HttpFoundation\Request;
 class FirefoxController extends BrowserController
 {
     /**
+     * @Route("/firefox", name="import_firefox")
+     */
+    public function indexAction(Request $request)
+    {
+        return parent::indexAction($request);
+    }
+
+    /**
      * {@inheritdoc}
      */
     protected function getImportService()
@@ -29,13 +37,5 @@ class FirefoxController extends BrowserController
     protected function getImportTemplate()
     {
         return 'WallabagImportBundle:Firefox:index.html.twig';
-    }
-
-    /**
-     * @Route("/firefox", name="import_firefox")
-     */
-    public function indexAction(Request $request)
-    {
-        return parent::indexAction($request);
     }
 }

--- a/src/Wallabag/ImportBundle/Controller/ImportController.php
+++ b/src/Wallabag/ImportBundle/Controller/ImportController.php
@@ -2,8 +2,8 @@
 
 namespace Wallabag\ImportBundle\Controller;
 
-use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
+use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 
 class ImportController extends Controller
 {
@@ -86,9 +86,9 @@ class ImportController extends Controller
     private function getTotalMessageInRabbitQueue($importService)
     {
         $message = $this
-            ->get('old_sound_rabbit_mq.import_'.$importService.'_consumer')
+            ->get('old_sound_rabbit_mq.import_' . $importService . '_consumer')
             ->getChannel()
-            ->basic_get('wallabag.import.'.$importService);
+            ->basic_get('wallabag.import.' . $importService);
 
         if (null === $message) {
             return 0;

--- a/src/Wallabag/ImportBundle/Controller/InstapaperController.php
+++ b/src/Wallabag/ImportBundle/Controller/InstapaperController.php
@@ -2,8 +2,8 @@
 
 namespace Wallabag\ImportBundle\Controller;
 
-use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
+use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Component\HttpFoundation\Request;
 use Wallabag\ImportBundle\Form\Type\UploadImportType;
 
@@ -29,11 +29,11 @@ class InstapaperController extends Controller
         if ($form->isSubmitted() && $form->isValid()) {
             $file = $form->get('file')->getData();
             $markAsRead = $form->get('mark_as_read')->getData();
-            $name = 'instapaper_'.$this->getUser()->getId().'.csv';
+            $name = 'instapaper_' . $this->getUser()->getId() . '.csv';
 
-            if (null !== $file && in_array($file->getClientMimeType(), $this->getParameter('wallabag_import.allow_mimetypes')) && $file->move($this->getParameter('wallabag_import.resource_dir'), $name)) {
+            if (null !== $file && in_array($file->getClientMimeType(), $this->getParameter('wallabag_import.allow_mimetypes'), true) && $file->move($this->getParameter('wallabag_import.resource_dir'), $name)) {
                 $res = $instapaper
-                    ->setFilepath($this->getParameter('wallabag_import.resource_dir').'/'.$name)
+                    ->setFilepath($this->getParameter('wallabag_import.resource_dir') . '/' . $name)
                     ->setMarkAsRead($markAsRead)
                     ->import();
 
@@ -52,7 +52,7 @@ class InstapaperController extends Controller
                         ]);
                     }
 
-                    unlink($this->getParameter('wallabag_import.resource_dir').'/'.$name);
+                    unlink($this->getParameter('wallabag_import.resource_dir') . '/' . $name);
                 }
 
                 $this->get('session')->getFlashBag()->add(
@@ -61,12 +61,12 @@ class InstapaperController extends Controller
                 );
 
                 return $this->redirect($this->generateUrl('homepage'));
-            } else {
-                $this->get('session')->getFlashBag()->add(
-                    'notice',
-                    'flashes.import.notice.failed_on_file'
-                );
             }
+
+            $this->get('session')->getFlashBag()->add(
+                'notice',
+                'flashes.import.notice.failed_on_file'
+            );
         }
 
         return $this->render('WallabagImportBundle:Instapaper:index.html.twig', [

--- a/src/Wallabag/ImportBundle/Controller/PinboardController.php
+++ b/src/Wallabag/ImportBundle/Controller/PinboardController.php
@@ -2,8 +2,8 @@
 
 namespace Wallabag\ImportBundle\Controller;
 
-use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
+use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Component\HttpFoundation\Request;
 use Wallabag\ImportBundle\Form\Type\UploadImportType;
 
@@ -29,11 +29,11 @@ class PinboardController extends Controller
         if ($form->isSubmitted() && $form->isValid()) {
             $file = $form->get('file')->getData();
             $markAsRead = $form->get('mark_as_read')->getData();
-            $name = 'pinboard_'.$this->getUser()->getId().'.json';
+            $name = 'pinboard_' . $this->getUser()->getId() . '.json';
 
-            if (null !== $file && in_array($file->getClientMimeType(), $this->getParameter('wallabag_import.allow_mimetypes')) && $file->move($this->getParameter('wallabag_import.resource_dir'), $name)) {
+            if (null !== $file && in_array($file->getClientMimeType(), $this->getParameter('wallabag_import.allow_mimetypes'), true) && $file->move($this->getParameter('wallabag_import.resource_dir'), $name)) {
                 $res = $pinboard
-                    ->setFilepath($this->getParameter('wallabag_import.resource_dir').'/'.$name)
+                    ->setFilepath($this->getParameter('wallabag_import.resource_dir') . '/' . $name)
                     ->setMarkAsRead($markAsRead)
                     ->import();
 
@@ -52,7 +52,7 @@ class PinboardController extends Controller
                         ]);
                     }
 
-                    unlink($this->getParameter('wallabag_import.resource_dir').'/'.$name);
+                    unlink($this->getParameter('wallabag_import.resource_dir') . '/' . $name);
                 }
 
                 $this->get('session')->getFlashBag()->add(
@@ -61,12 +61,12 @@ class PinboardController extends Controller
                 );
 
                 return $this->redirect($this->generateUrl('homepage'));
-            } else {
-                $this->get('session')->getFlashBag()->add(
-                    'notice',
-                    'flashes.import.notice.failed_on_file'
-                );
             }
+
+            $this->get('session')->getFlashBag()->add(
+                'notice',
+                'flashes.import.notice.failed_on_file'
+            );
         }
 
         return $this->render('WallabagImportBundle:Pinboard:index.html.twig', [

--- a/src/Wallabag/ImportBundle/Controller/PocketController.php
+++ b/src/Wallabag/ImportBundle/Controller/PocketController.php
@@ -2,33 +2,14 @@
 
 namespace Wallabag\ImportBundle\Controller;
 
-use Symfony\Bundle\FrameworkBundle\Controller\Controller;
-use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
-use Symfony\Component\HttpFoundation\Request;
+use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
 class PocketController extends Controller
 {
-    /**
-     * Return Pocket Import Service with or without RabbitMQ enabled.
-     *
-     * @return \Wallabag\ImportBundle\Import\PocketImport
-     */
-    private function getPocketImportService()
-    {
-        $pocket = $this->get('wallabag_import.pocket.import');
-        $pocket->setUser($this->getUser());
-
-        if ($this->get('craue_config')->get('import_with_rabbitmq')) {
-            $pocket->setProducer($this->get('old_sound_rabbit_mq.import_pocket_producer'));
-        } elseif ($this->get('craue_config')->get('import_with_redis')) {
-            $pocket->setProducer($this->get('wallabag_import.producer.redis.pocket'));
-        }
-
-        return $pocket;
-    }
-
     /**
      * @Route("/pocket", name="import_pocket")
      */
@@ -70,7 +51,7 @@ class PocketController extends Controller
         $this->get('session')->set('mark_as_read', $request->request->get('form')['mark_as_read']);
 
         return $this->redirect(
-            'https://getpocket.com/auth/authorize?request_token='.$requestToken.'&redirect_uri='.$this->generateUrl('import_pocket_callback', [], UrlGeneratorInterface::ABSOLUTE_URL),
+            'https://getpocket.com/auth/authorize?request_token=' . $requestToken . '&redirect_uri=' . $this->generateUrl('import_pocket_callback', [], UrlGeneratorInterface::ABSOLUTE_URL),
             301
         );
     }
@@ -116,5 +97,24 @@ class PocketController extends Controller
         );
 
         return $this->redirect($this->generateUrl('homepage'));
+    }
+
+    /**
+     * Return Pocket Import Service with or without RabbitMQ enabled.
+     *
+     * @return \Wallabag\ImportBundle\Import\PocketImport
+     */
+    private function getPocketImportService()
+    {
+        $pocket = $this->get('wallabag_import.pocket.import');
+        $pocket->setUser($this->getUser());
+
+        if ($this->get('craue_config')->get('import_with_rabbitmq')) {
+            $pocket->setProducer($this->get('old_sound_rabbit_mq.import_pocket_producer'));
+        } elseif ($this->get('craue_config')->get('import_with_redis')) {
+            $pocket->setProducer($this->get('wallabag_import.producer.redis.pocket'));
+        }
+
+        return $pocket;
     }
 }

--- a/src/Wallabag/ImportBundle/Controller/ReadabilityController.php
+++ b/src/Wallabag/ImportBundle/Controller/ReadabilityController.php
@@ -2,8 +2,8 @@
 
 namespace Wallabag\ImportBundle\Controller;
 
-use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
+use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Component\HttpFoundation\Request;
 use Wallabag\ImportBundle\Form\Type\UploadImportType;
 
@@ -29,11 +29,11 @@ class ReadabilityController extends Controller
         if ($form->isSubmitted() && $form->isValid()) {
             $file = $form->get('file')->getData();
             $markAsRead = $form->get('mark_as_read')->getData();
-            $name = 'readability_'.$this->getUser()->getId().'.json';
+            $name = 'readability_' . $this->getUser()->getId() . '.json';
 
-            if (null !== $file && in_array($file->getClientMimeType(), $this->getParameter('wallabag_import.allow_mimetypes')) && $file->move($this->getParameter('wallabag_import.resource_dir'), $name)) {
+            if (null !== $file && in_array($file->getClientMimeType(), $this->getParameter('wallabag_import.allow_mimetypes'), true) && $file->move($this->getParameter('wallabag_import.resource_dir'), $name)) {
                 $res = $readability
-                    ->setFilepath($this->getParameter('wallabag_import.resource_dir').'/'.$name)
+                    ->setFilepath($this->getParameter('wallabag_import.resource_dir') . '/' . $name)
                     ->setMarkAsRead($markAsRead)
                     ->import();
 
@@ -52,7 +52,7 @@ class ReadabilityController extends Controller
                         ]);
                     }
 
-                    unlink($this->getParameter('wallabag_import.resource_dir').'/'.$name);
+                    unlink($this->getParameter('wallabag_import.resource_dir') . '/' . $name);
                 }
 
                 $this->get('session')->getFlashBag()->add(
@@ -61,12 +61,12 @@ class ReadabilityController extends Controller
                 );
 
                 return $this->redirect($this->generateUrl('homepage'));
-            } else {
-                $this->get('session')->getFlashBag()->add(
-                    'notice',
-                    'flashes.import.notice.failed_on_file'
-                );
             }
+
+            $this->get('session')->getFlashBag()->add(
+                'notice',
+                'flashes.import.notice.failed_on_file'
+            );
         }
 
         return $this->render('WallabagImportBundle:Readability:index.html.twig', [

--- a/src/Wallabag/ImportBundle/Controller/WallabagController.php
+++ b/src/Wallabag/ImportBundle/Controller/WallabagController.php
@@ -12,20 +12,6 @@ use Wallabag\ImportBundle\Form\Type\UploadImportType;
 abstract class WallabagController extends Controller
 {
     /**
-     * Return the service to handle the import.
-     *
-     * @return \Wallabag\ImportBundle\Import\ImportInterface
-     */
-    abstract protected function getImportService();
-
-    /**
-     * Return the template used for the form.
-     *
-     * @return string
-     */
-    abstract protected function getImportTemplate();
-
-    /**
      * Handle import request.
      *
      * @param Request $request
@@ -43,11 +29,11 @@ abstract class WallabagController extends Controller
         if ($form->isSubmitted() && $form->isValid()) {
             $file = $form->get('file')->getData();
             $markAsRead = $form->get('mark_as_read')->getData();
-            $name = $this->getUser()->getId().'.json';
+            $name = $this->getUser()->getId() . '.json';
 
-            if (null !== $file && in_array($file->getClientMimeType(), $this->getParameter('wallabag_import.allow_mimetypes')) && $file->move($this->getParameter('wallabag_import.resource_dir'), $name)) {
+            if (null !== $file && in_array($file->getClientMimeType(), $this->getParameter('wallabag_import.allow_mimetypes'), true) && $file->move($this->getParameter('wallabag_import.resource_dir'), $name)) {
                 $res = $wallabag
-                    ->setFilepath($this->getParameter('wallabag_import.resource_dir').'/'.$name)
+                    ->setFilepath($this->getParameter('wallabag_import.resource_dir') . '/' . $name)
                     ->setMarkAsRead($markAsRead)
                     ->import();
 
@@ -66,7 +52,7 @@ abstract class WallabagController extends Controller
                         ]);
                     }
 
-                    unlink($this->getParameter('wallabag_import.resource_dir').'/'.$name);
+                    unlink($this->getParameter('wallabag_import.resource_dir') . '/' . $name);
                 }
 
                 $this->get('session')->getFlashBag()->add(
@@ -75,12 +61,12 @@ abstract class WallabagController extends Controller
                 );
 
                 return $this->redirect($this->generateUrl('homepage'));
-            } else {
-                $this->get('session')->getFlashBag()->add(
-                    'notice',
-                    'flashes.import.notice.failed_on_file'
-                );
             }
+
+            $this->get('session')->getFlashBag()->add(
+                'notice',
+                'flashes.import.notice.failed_on_file'
+            );
         }
 
         return $this->render($this->getImportTemplate(), [
@@ -88,4 +74,18 @@ abstract class WallabagController extends Controller
             'import' => $wallabag,
         ]);
     }
+
+    /**
+     * Return the service to handle the import.
+     *
+     * @return \Wallabag\ImportBundle\Import\ImportInterface
+     */
+    abstract protected function getImportService();
+
+    /**
+     * Return the template used for the form.
+     *
+     * @return string
+     */
+    abstract protected function getImportTemplate();
 }

--- a/src/Wallabag/ImportBundle/Controller/WallabagV1Controller.php
+++ b/src/Wallabag/ImportBundle/Controller/WallabagV1Controller.php
@@ -8,6 +8,14 @@ use Symfony\Component\HttpFoundation\Request;
 class WallabagV1Controller extends WallabagController
 {
     /**
+     * @Route("/wallabag-v1", name="import_wallabag_v1")
+     */
+    public function indexAction(Request $request)
+    {
+        return parent::indexAction($request);
+    }
+
+    /**
      * {@inheritdoc}
      */
     protected function getImportService()
@@ -29,13 +37,5 @@ class WallabagV1Controller extends WallabagController
     protected function getImportTemplate()
     {
         return 'WallabagImportBundle:WallabagV1:index.html.twig';
-    }
-
-    /**
-     * @Route("/wallabag-v1", name="import_wallabag_v1")
-     */
-    public function indexAction(Request $request)
-    {
-        return parent::indexAction($request);
     }
 }

--- a/src/Wallabag/ImportBundle/Controller/WallabagV2Controller.php
+++ b/src/Wallabag/ImportBundle/Controller/WallabagV2Controller.php
@@ -8,6 +8,14 @@ use Symfony\Component\HttpFoundation\Request;
 class WallabagV2Controller extends WallabagController
 {
     /**
+     * @Route("/wallabag-v2", name="import_wallabag_v2")
+     */
+    public function indexAction(Request $request)
+    {
+        return parent::indexAction($request);
+    }
+
+    /**
      * {@inheritdoc}
      */
     protected function getImportService()
@@ -29,13 +37,5 @@ class WallabagV2Controller extends WallabagController
     protected function getImportTemplate()
     {
         return 'WallabagImportBundle:WallabagV2:index.html.twig';
-    }
-
-    /**
-     * @Route("/wallabag-v2", name="import_wallabag_v2")
-     */
-    public function indexAction(Request $request)
-    {
-        return parent::indexAction($request);
     }
 }

--- a/src/Wallabag/ImportBundle/DependencyInjection/WallabagImportExtension.php
+++ b/src/Wallabag/ImportBundle/DependencyInjection/WallabagImportExtension.php
@@ -2,10 +2,10 @@
 
 namespace Wallabag\ImportBundle\DependencyInjection;
 
-use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\Config\FileLocator;
-use Symfony\Component\HttpKernel\DependencyInjection\Extension;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Loader;
+use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 
 class WallabagImportExtension extends Extension
 {
@@ -16,7 +16,7 @@ class WallabagImportExtension extends Extension
         $container->setParameter('wallabag_import.allow_mimetypes', $config['allow_mimetypes']);
         $container->setParameter('wallabag_import.resource_dir', $config['resource_dir']);
 
-        $loader = new Loader\YamlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
+        $loader = new Loader\YamlFileLoader($container, new FileLocator(__DIR__ . '/../Resources/config'));
         $loader->load('services.yml');
     }
 

--- a/src/Wallabag/ImportBundle/Form/Type/UploadImportType.php
+++ b/src/Wallabag/ImportBundle/Form/Type/UploadImportType.php
@@ -3,10 +3,10 @@
 namespace Wallabag\ImportBundle\Form\Type;
 
 use Symfony\Component\Form\AbstractType;
-use Symfony\Component\Form\FormBuilderInterface;
-use Symfony\Component\Form\Extension\Core\Type\SubmitType;
-use Symfony\Component\Form\Extension\Core\Type\FileType;
 use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
+use Symfony\Component\Form\Extension\Core\Type\FileType;
+use Symfony\Component\Form\Extension\Core\Type\SubmitType;
+use Symfony\Component\Form\FormBuilderInterface;
 
 class UploadImportType extends AbstractType
 {

--- a/src/Wallabag/ImportBundle/Import/BrowserImport.php
+++ b/src/Wallabag/ImportBundle/Import/BrowserImport.php
@@ -3,8 +3,8 @@
 namespace Wallabag\ImportBundle\Import;
 
 use Wallabag\CoreBundle\Entity\Entry;
-use Wallabag\UserBundle\Entity\User;
 use Wallabag\CoreBundle\Event\EntrySavedEvent;
+use Wallabag\UserBundle\Entity\User;
 
 abstract class BrowserImport extends AbstractImport
 {
@@ -71,6 +71,80 @@ abstract class BrowserImport extends AbstractImport
         $this->filepath = $filepath;
 
         return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function parseEntry(array $importedEntry)
+    {
+        if ((!array_key_exists('guid', $importedEntry) || (!array_key_exists('id', $importedEntry))) && is_array(reset($importedEntry))) {
+            if ($this->producer) {
+                $this->parseEntriesForProducer($importedEntry);
+
+                return;
+            }
+
+            $this->parseEntries($importedEntry);
+
+            return;
+        }
+
+        if (array_key_exists('children', $importedEntry)) {
+            if ($this->producer) {
+                $this->parseEntriesForProducer($importedEntry['children']);
+
+                return;
+            }
+
+            $this->parseEntries($importedEntry['children']);
+
+            return;
+        }
+
+        if (!array_key_exists('uri', $importedEntry) && !array_key_exists('url', $importedEntry)) {
+            return;
+        }
+
+        $url = array_key_exists('uri', $importedEntry) ? $importedEntry['uri'] : $importedEntry['url'];
+
+        $existingEntry = $this->em
+            ->getRepository('WallabagCoreBundle:Entry')
+            ->findByUrlAndUserId($url, $this->user->getId());
+
+        if (false !== $existingEntry) {
+            ++$this->skippedEntries;
+
+            return;
+        }
+
+        $data = $this->prepareEntry($importedEntry);
+
+        $entry = new Entry($this->user);
+        $entry->setUrl($data['url']);
+        $entry->setTitle($data['title']);
+
+        // update entry with content (in case fetching failed, the given entry will be return)
+        $this->fetchContent($entry, $data['url'], $data);
+
+        if (array_key_exists('tags', $data)) {
+            $this->tagsAssigner->assignTagsToEntry(
+                $entry,
+                $data['tags']
+            );
+        }
+
+        $entry->setArchived($data['is_archived']);
+
+        if (!empty($data['created_at'])) {
+            $dt = new \DateTime();
+            $entry->setCreatedAt($dt->setTimestamp($data['created_at']));
+        }
+
+        $this->em->persist($entry);
+        ++$this->importedEntries;
+
+        return $entry;
     }
 
     /**
@@ -147,80 +221,6 @@ abstract class BrowserImport extends AbstractImport
 
             $this->producer->publish(json_encode($importedEntry));
         }
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function parseEntry(array $importedEntry)
-    {
-        if ((!array_key_exists('guid', $importedEntry) || (!array_key_exists('id', $importedEntry))) && is_array(reset($importedEntry))) {
-            if ($this->producer) {
-                $this->parseEntriesForProducer($importedEntry);
-
-                return;
-            }
-
-            $this->parseEntries($importedEntry);
-
-            return;
-        }
-
-        if (array_key_exists('children', $importedEntry)) {
-            if ($this->producer) {
-                $this->parseEntriesForProducer($importedEntry['children']);
-
-                return;
-            }
-
-            $this->parseEntries($importedEntry['children']);
-
-            return;
-        }
-
-        if (!array_key_exists('uri', $importedEntry) && !array_key_exists('url', $importedEntry)) {
-            return;
-        }
-
-        $url = array_key_exists('uri', $importedEntry) ? $importedEntry['uri'] : $importedEntry['url'];
-
-        $existingEntry = $this->em
-            ->getRepository('WallabagCoreBundle:Entry')
-            ->findByUrlAndUserId($url, $this->user->getId());
-
-        if (false !== $existingEntry) {
-            ++$this->skippedEntries;
-
-            return;
-        }
-
-        $data = $this->prepareEntry($importedEntry);
-
-        $entry = new Entry($this->user);
-        $entry->setUrl($data['url']);
-        $entry->setTitle($data['title']);
-
-        // update entry with content (in case fetching failed, the given entry will be return)
-        $this->fetchContent($entry, $data['url'], $data);
-
-        if (array_key_exists('tags', $data)) {
-            $this->tagsAssigner->assignTagsToEntry(
-                $entry,
-                $data['tags']
-            );
-        }
-
-        $entry->setArchived($data['is_archived']);
-
-        if (!empty($data['created_at'])) {
-            $dt = new \DateTime();
-            $entry->setCreatedAt($dt->setTimestamp($data['created_at']));
-        }
-
-        $this->em->persist($entry);
-        ++$this->importedEntries;
-
-        return $entry;
     }
 
     /**

--- a/src/Wallabag/ImportBundle/Import/ChromeImport.php
+++ b/src/Wallabag/ImportBundle/Import/ChromeImport.php
@@ -45,7 +45,7 @@ class ChromeImport extends BrowserImport
             'created_at' => substr($entry['date_added'], 0, 10),
         ];
 
-        if (array_key_exists('tags', $entry) && $entry['tags'] != '') {
+        if (array_key_exists('tags', $entry) && $entry['tags'] !== '') {
             $data['tags'] = $entry['tags'];
         }
 

--- a/src/Wallabag/ImportBundle/Import/FirefoxImport.php
+++ b/src/Wallabag/ImportBundle/Import/FirefoxImport.php
@@ -45,7 +45,7 @@ class FirefoxImport extends BrowserImport
             'created_at' => substr($entry['dateAdded'], 0, 10),
         ];
 
-        if (array_key_exists('tags', $entry) && $entry['tags'] != '') {
+        if (array_key_exists('tags', $entry) && $entry['tags'] !== '') {
             $data['tags'] = $entry['tags'];
         }
 

--- a/src/Wallabag/ImportBundle/Import/ImportCompilerPass.php
+++ b/src/Wallabag/ImportBundle/Import/ImportCompilerPass.php
@@ -2,8 +2,8 @@
 
 namespace Wallabag\ImportBundle\Import;
 
-use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Reference;
 
 class ImportCompilerPass implements CompilerPassInterface

--- a/src/Wallabag/ImportBundle/Import/InstapaperImport.php
+++ b/src/Wallabag/ImportBundle/Import/InstapaperImport.php
@@ -72,7 +72,7 @@ class InstapaperImport extends AbstractImport
             // BUT it can also be the status (since status = folder in Instapaper)
             // and we don't want archive, unread & starred to become a tag
             $tags = null;
-            if (false === in_array($data[3], ['Archive', 'Unread', 'Starred'])) {
+            if (false === in_array($data[3], ['Archive', 'Unread', 'Starred'], true)) {
                 $tags = [$data[3]];
             }
 

--- a/src/Wallabag/ImportBundle/Import/PocketImport.php
+++ b/src/Wallabag/ImportBundle/Import/PocketImport.php
@@ -8,10 +8,9 @@ use Wallabag\CoreBundle\Entity\Entry;
 
 class PocketImport extends AbstractImport
 {
+    const NB_ELEMENTS = 5000;
     private $client;
     private $accessToken;
-
-    const NB_ELEMENTS = 5000;
 
     /**
      * Only used for test purpose.
@@ -176,7 +175,7 @@ class PocketImport extends AbstractImport
      */
     public function parseEntry(array $importedEntry)
     {
-        $url = isset($importedEntry['resolved_url']) && $importedEntry['resolved_url'] != '' ? $importedEntry['resolved_url'] : $importedEntry['given_url'];
+        $url = isset($importedEntry['resolved_url']) && $importedEntry['resolved_url'] !== '' ? $importedEntry['resolved_url'] : $importedEntry['given_url'];
 
         $existingEntry = $this->em
             ->getRepository('WallabagCoreBundle:Entry')
@@ -195,15 +194,15 @@ class PocketImport extends AbstractImport
         $this->fetchContent($entry, $url);
 
         // 0, 1, 2 - 1 if the item is archived - 2 if the item should be deleted
-        $entry->setArchived($importedEntry['status'] == 1 || $this->markAsRead);
+        $entry->setArchived($importedEntry['status'] === 1 || $this->markAsRead);
 
         // 0 or 1 - 1 If the item is starred
-        $entry->setStarred($importedEntry['favorite'] == 1);
+        $entry->setStarred($importedEntry['favorite'] === 1);
 
         $title = 'Untitled';
-        if (isset($importedEntry['resolved_title']) && $importedEntry['resolved_title'] != '') {
+        if (isset($importedEntry['resolved_title']) && $importedEntry['resolved_title'] !== '') {
             $title = $importedEntry['resolved_title'];
-        } elseif (isset($importedEntry['given_title']) && $importedEntry['given_title'] != '') {
+        } elseif (isset($importedEntry['given_title']) && $importedEntry['given_title'] !== '') {
             $title = $importedEntry['given_title'];
         }
 

--- a/src/Wallabag/ImportBundle/Import/WallabagV1Import.php
+++ b/src/Wallabag/ImportBundle/Import/WallabagV1Import.php
@@ -56,12 +56,12 @@ class WallabagV1Import extends WallabagImport
 
         // In case of a bad fetch in v1, replace title and content with v2 error strings
         // If fetching fails again, they will get this instead of the v1 strings
-        if (in_array($entry['title'], $this->untitled)) {
+        if (in_array($entry['title'], $this->untitled, true)) {
             $data['title'] = $this->fetchingErrorMessageTitle;
             $data['html'] = $this->fetchingErrorMessage;
         }
 
-        if (array_key_exists('tags', $entry) && $entry['tags'] != '') {
+        if (array_key_exists('tags', $entry) && $entry['tags'] !== '') {
             $data['tags'] = $entry['tags'];
         }
 

--- a/src/Wallabag/ImportBundle/Redis/Producer.php
+++ b/src/Wallabag/ImportBundle/Redis/Producer.php
@@ -29,7 +29,7 @@ class Producer implements ProducerInterface
      * @param string $routingKey           NOT USED
      * @param array  $additionalProperties NOT USED
      */
-    public function publish($msgBody, $routingKey = '', $additionalProperties = array())
+    public function publish($msgBody, $routingKey = '', $additionalProperties = [])
     {
         $this->queue->sendJob($msgBody);
     }

--- a/src/Wallabag/ImportBundle/WallabagImportBundle.php
+++ b/src/Wallabag/ImportBundle/WallabagImportBundle.php
@@ -2,8 +2,8 @@
 
 namespace Wallabag\ImportBundle;
 
-use Symfony\Component\HttpKernel\Bundle\Bundle;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\HttpKernel\Bundle\Bundle;
 use Wallabag\ImportBundle\Import\ImportCompilerPass;
 
 class WallabagImportBundle extends Bundle

--- a/src/Wallabag/UserBundle/Controller/ManageController.php
+++ b/src/Wallabag/UserBundle/Controller/ManageController.php
@@ -7,10 +7,10 @@ use FOS\UserBundle\FOSUserEvents;
 use Pagerfanta\Adapter\DoctrineORMAdapter;
 use Pagerfanta\Exception\OutOfRangeCurrentPageException;
 use Pagerfanta\Pagerfanta;
-use Symfony\Component\HttpFoundation\Request;
-use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Method;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
+use Symfony\Bundle\FrameworkBundle\Controller\Controller;
+use Symfony\Component\HttpFoundation\Request;
 use Wallabag\UserBundle\Entity\User;
 use Wallabag\UserBundle\Form\SearchUserType;
 
@@ -48,13 +48,13 @@ class ManageController extends Controller
                 $this->get('translator')->trans('flashes.user.notice.added', ['%username%' => $user->getUsername()])
             );
 
-            return $this->redirectToRoute('user_edit', array('id' => $user->getId()));
+            return $this->redirectToRoute('user_edit', ['id' => $user->getId()]);
         }
 
-        return $this->render('WallabagUserBundle:Manage:new.html.twig', array(
+        return $this->render('WallabagUserBundle:Manage:new.html.twig', [
             'user' => $user,
             'form' => $form->createView(),
-        ));
+        ]);
     }
 
     /**
@@ -79,15 +79,15 @@ class ManageController extends Controller
                 $this->get('translator')->trans('flashes.user.notice.updated', ['%username%' => $user->getUsername()])
             );
 
-            return $this->redirectToRoute('user_edit', array('id' => $user->getId()));
+            return $this->redirectToRoute('user_edit', ['id' => $user->getId()]);
         }
 
-        return $this->render('WallabagUserBundle:Manage:edit.html.twig', array(
+        return $this->render('WallabagUserBundle:Manage:edit.html.twig', [
             'user' => $user,
             'edit_form' => $editForm->createView(),
             'delete_form' => $deleteForm->createView(),
             'twofactor_auth' => $this->getParameter('twofactor_auth'),
-        ));
+        ]);
     }
 
     /**
@@ -113,22 +113,6 @@ class ManageController extends Controller
         }
 
         return $this->redirectToRoute('user_index');
-    }
-
-    /**
-     * Creates a form to delete a User entity.
-     *
-     * @param User $user The User entity
-     *
-     * @return \Symfony\Component\Form\Form The form
-     */
-    private function createDeleteForm(User $user)
-    {
-        return $this->createFormBuilder()
-            ->setAction($this->generateUrl('user_delete', array('id' => $user->getId())))
-            ->setMethod('DELETE')
-            ->getForm()
-        ;
     }
 
     /**
@@ -174,5 +158,21 @@ class ManageController extends Controller
             'searchForm' => $form->createView(),
             'users' => $pagerFanta,
         ]);
+    }
+
+    /**
+     * Creates a form to delete a User entity.
+     *
+     * @param User $user The User entity
+     *
+     * @return \Symfony\Component\Form\Form The form
+     */
+    private function createDeleteForm(User $user)
+    {
+        return $this->createFormBuilder()
+            ->setAction($this->generateUrl('user_delete', ['id' => $user->getId()]))
+            ->setMethod('DELETE')
+            ->getForm()
+        ;
     }
 }

--- a/src/Wallabag/UserBundle/DependencyInjection/WallabagUserExtension.php
+++ b/src/Wallabag/UserBundle/DependencyInjection/WallabagUserExtension.php
@@ -2,10 +2,10 @@
 
 namespace Wallabag\UserBundle\DependencyInjection;
 
-use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\Config\FileLocator;
-use Symfony\Component\HttpKernel\DependencyInjection\Extension;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Loader;
+use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 
 class WallabagUserExtension extends Extension
 {
@@ -14,7 +14,7 @@ class WallabagUserExtension extends Extension
         $configuration = new Configuration();
         $config = $this->processConfiguration($configuration, $configs);
 
-        $loader = new Loader\YamlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
+        $loader = new Loader\YamlFileLoader($container, new FileLocator(__DIR__ . '/../Resources/config'));
         $loader->load('services.yml');
         $container->setParameter('wallabag_user.registration_enabled', $config['registration_enabled']);
     }

--- a/src/Wallabag/UserBundle/Entity/User.php
+++ b/src/Wallabag/UserBundle/Entity/User.php
@@ -4,12 +4,12 @@ namespace Wallabag\UserBundle\Entity;
 
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\ORM\Mapping as ORM;
+use FOS\UserBundle\Model\User as BaseUser;
+use JMS\Serializer\Annotation\Accessor;
 use JMS\Serializer\Annotation\Groups;
 use JMS\Serializer\Annotation\XmlRoot;
-use JMS\Serializer\Annotation\Accessor;
 use Scheb\TwoFactorBundle\Model\Email\TwoFactorInterface;
 use Scheb\TwoFactorBundle\Model\TrustedComputerInterface;
-use FOS\UserBundle\Model\User as BaseUser;
 use Symfony\Bridge\Doctrine\Validator\Constraints\UniqueEntity;
 use Symfony\Component\Security\Core\User\UserInterface;
 use Wallabag\ApiBundle\Entity\Client;
@@ -93,6 +93,21 @@ class User extends BaseUser implements TwoFactorInterface, TrustedComputerInterf
     protected $config;
 
     /**
+     * @var ArrayCollection
+     *
+     * @ORM\OneToMany(targetEntity="Wallabag\ApiBundle\Entity\Client", mappedBy="user", cascade={"remove"})
+     */
+    protected $clients;
+
+    /**
+     * @see getFirstClient() below
+     *
+     * @Groups({"user_api_with_client"})
+     * @Accessor(getter="getFirstClient")
+     */
+    protected $default_client;
+
+    /**
      * @ORM\Column(type="integer", nullable=true)
      */
     private $authCode;
@@ -109,21 +124,6 @@ class User extends BaseUser implements TwoFactorInterface, TrustedComputerInterf
      */
     private $trusted;
 
-    /**
-     * @var ArrayCollection
-     *
-     * @ORM\OneToMany(targetEntity="Wallabag\ApiBundle\Entity\Client", mappedBy="user", cascade={"remove"})
-     */
-    protected $clients;
-
-    /**
-     * @see getFirstClient() below
-     *
-     * @Groups({"user_api_with_client"})
-     * @Accessor(getter="getFirstClient")
-     */
-    protected $default_client;
-
     public function __construct()
     {
         parent::__construct();
@@ -137,7 +137,7 @@ class User extends BaseUser implements TwoFactorInterface, TrustedComputerInterf
      */
     public function timestamps()
     {
-        if (is_null($this->createdAt)) {
+        if (null === $this->createdAt) {
             $this->createdAt = new \DateTime();
         }
 

--- a/src/Wallabag/UserBundle/EventListener/AuthenticationFailureListener.php
+++ b/src/Wallabag/UserBundle/EventListener/AuthenticationFailureListener.php
@@ -35,6 +35,6 @@ class AuthenticationFailureListener implements EventSubscriberInterface
     {
         $request = $this->requestStack->getMasterRequest();
 
-        $this->logger->error('Authentication failure for user "'.$request->request->get('_username').'", from IP "'.$request->getClientIp().'", with UA: "'.$request->server->get('HTTP_USER_AGENT').'".');
+        $this->logger->error('Authentication failure for user "' . $request->request->get('_username') . '", from IP "' . $request->getClientIp() . '", with UA: "' . $request->server->get('HTTP_USER_AGENT') . '".');
     }
 }

--- a/src/Wallabag/UserBundle/EventListener/PasswordResettingListener.php
+++ b/src/Wallabag/UserBundle/EventListener/PasswordResettingListener.php
@@ -2,8 +2,8 @@
 
 namespace Wallabag\UserBundle\EventListener;
 
-use FOS\UserBundle\FOSUserEvents;
 use FOS\UserBundle\Event\FormEvent;
+use FOS\UserBundle\FOSUserEvents;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;

--- a/src/Wallabag/UserBundle/Form/UserType.php
+++ b/src/Wallabag/UserBundle/Form/UserType.php
@@ -3,12 +3,12 @@
 namespace Wallabag\UserBundle\Form;
 
 use Symfony\Component\Form\AbstractType;
-use Symfony\Component\Form\FormBuilderInterface;
-use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
+use Symfony\Component\Form\Extension\Core\Type\EmailType;
 use Symfony\Component\Form\Extension\Core\Type\SubmitType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
-use Symfony\Component\Form\Extension\Core\Type\EmailType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class UserType extends AbstractType
 {
@@ -50,8 +50,8 @@ class UserType extends AbstractType
      */
     public function configureOptions(OptionsResolver $resolver)
     {
-        $resolver->setDefaults(array(
+        $resolver->setDefaults([
             'data_class' => 'Wallabag\UserBundle\Entity\User',
-        ));
+        ]);
     }
 }

--- a/src/Wallabag/UserBundle/Mailer/AuthCodeMailer.php
+++ b/src/Wallabag/UserBundle/Mailer/AuthCodeMailer.php
@@ -2,8 +2,8 @@
 
 namespace Wallabag\UserBundle\Mailer;
 
-use Scheb\TwoFactorBundle\Model\Email\TwoFactorInterface;
 use Scheb\TwoFactorBundle\Mailer\AuthCodeMailerInterface;
+use Scheb\TwoFactorBundle\Model\Email\TwoFactorInterface;
 
 /**
  * Custom mailer for TwoFactorBundle email.

--- a/src/Wallabag/UserBundle/Repository/UserRepository.php
+++ b/src/Wallabag/UserBundle/Repository/UserRepository.php
@@ -63,6 +63,6 @@ class UserRepository extends EntityRepository
     public function getQueryBuilderForSearch($term)
     {
         return $this->createQueryBuilder('u')
-            ->andWhere('lower(u.username) LIKE lower(:term) OR lower(u.email) LIKE lower(:term) OR lower(u.name) LIKE lower(:term)')->setParameter('term', '%'.$term.'%');
+            ->andWhere('lower(u.username) LIKE lower(:term) OR lower(u.email) LIKE lower(:term) OR lower(u.name) LIKE lower(:term)')->setParameter('term', '%' . $term . '%');
     }
 }

--- a/tests/Wallabag/AnnotationBundle/Controller/AnnotationControllerTest.php
+++ b/tests/Wallabag/AnnotationBundle/Controller/AnnotationControllerTest.php
@@ -49,12 +49,12 @@ class AnnotationControllerTest extends WallabagAnnotationTestCase
             $this->logInAs('admin');
         }
 
-        $this->client->request('GET', $prefixUrl.'/'.$entry->getId().'.json');
-        $this->assertEquals(200, $this->client->getResponse()->getStatusCode());
+        $this->client->request('GET', $prefixUrl . '/' . $entry->getId() . '.json');
+        $this->assertSame(200, $this->client->getResponse()->getStatusCode());
 
         $content = json_decode($this->client->getResponse()->getContent(), true);
         $this->assertGreaterThanOrEqual(1, $content['total']);
-        $this->assertEquals($annotation->getText(), $content['rows'][0]['text']);
+        $this->assertSame($annotation->getText(), $content['rows'][0]['text']);
 
         // we need to re-fetch the annotation becase after the flush, it has been "detached" from the entity manager
         $annotation = $em->getRepository('WallabagAnnotationBundle:Annotation')->findAnnotationById($annotation->getId());
@@ -88,16 +88,16 @@ class AnnotationControllerTest extends WallabagAnnotationTestCase
                 ['start' => '', 'startOffset' => 24, 'end' => '', 'endOffset' => 31],
             ],
         ]);
-        $this->client->request('POST', $prefixUrl.'/'.$entry->getId().'.json', [], [], $headers, $content);
+        $this->client->request('POST', $prefixUrl . '/' . $entry->getId() . '.json', [], [], $headers, $content);
 
-        $this->assertEquals(200, $this->client->getResponse()->getStatusCode());
+        $this->assertSame(200, $this->client->getResponse()->getStatusCode());
 
         $content = json_decode($this->client->getResponse()->getContent(), true);
 
-        $this->assertEquals('Big boss', $content['user']);
-        $this->assertEquals('v1.0', $content['annotator_schema_version']);
-        $this->assertEquals('my annotation', $content['text']);
-        $this->assertEquals('my quote', $content['quote']);
+        $this->assertSame('Big boss', $content['user']);
+        $this->assertSame('v1.0', $content['annotator_schema_version']);
+        $this->assertSame('my annotation', $content['text']);
+        $this->assertSame('my quote', $content['quote']);
 
         /** @var Annotation $annotation */
         $annotation = $this->client->getContainer()
@@ -105,7 +105,7 @@ class AnnotationControllerTest extends WallabagAnnotationTestCase
             ->getRepository('WallabagAnnotationBundle:Annotation')
             ->findLastAnnotationByPageId($entry->getId(), 1);
 
-        $this->assertEquals('my annotation', $annotation->getText());
+        $this->assertSame('my annotation', $annotation->getText());
     }
 
     /**
@@ -133,9 +133,9 @@ class AnnotationControllerTest extends WallabagAnnotationTestCase
                 ['start' => '', 'startOffset' => 24, 'end' => '', 'endOffset' => 31],
             ],
         ]);
-        $this->client->request('POST', $prefixUrl.'/'.$entry->getId().'.json', [], [], $headers, $content);
+        $this->client->request('POST', $prefixUrl . '/' . $entry->getId() . '.json', [], [], $headers, $content);
 
-        $this->assertEquals(400, $this->client->getResponse()->getStatusCode());
+        $this->assertSame(400, $this->client->getResponse()->getStatusCode());
     }
 
     /**
@@ -166,21 +166,21 @@ class AnnotationControllerTest extends WallabagAnnotationTestCase
         $content = json_encode([
             'text' => 'a modified annotation',
         ]);
-        $this->client->request('PUT', $prefixUrl.'/'.$annotation->getId().'.json', [], [], $headers, $content);
-        $this->assertEquals(200, $this->client->getResponse()->getStatusCode());
+        $this->client->request('PUT', $prefixUrl . '/' . $annotation->getId() . '.json', [], [], $headers, $content);
+        $this->assertSame(200, $this->client->getResponse()->getStatusCode());
 
         $content = json_decode($this->client->getResponse()->getContent(), true);
 
-        $this->assertEquals('Big boss', $content['user']);
-        $this->assertEquals('v1.0', $content['annotator_schema_version']);
-        $this->assertEquals('a modified annotation', $content['text']);
-        $this->assertEquals('my quote', $content['quote']);
+        $this->assertSame('Big boss', $content['user']);
+        $this->assertSame('v1.0', $content['annotator_schema_version']);
+        $this->assertSame('a modified annotation', $content['text']);
+        $this->assertSame('my quote', $content['quote']);
 
         /** @var Annotation $annotationUpdated */
         $annotationUpdated = $em
             ->getRepository('WallabagAnnotationBundle:Annotation')
             ->findOneById($annotation->getId());
-        $this->assertEquals('a modified annotation', $annotationUpdated->getText());
+        $this->assertSame('a modified annotation', $annotationUpdated->getText());
 
         $em->remove($annotationUpdated);
         $em->flush();
@@ -218,12 +218,12 @@ class AnnotationControllerTest extends WallabagAnnotationTestCase
         $content = json_encode([
             'text' => 'a modified annotation',
         ]);
-        $this->client->request('DELETE', $prefixUrl.'/'.$annotation->getId().'.json', [], [], $headers, $content);
-        $this->assertEquals(200, $this->client->getResponse()->getStatusCode());
+        $this->client->request('DELETE', $prefixUrl . '/' . $annotation->getId() . '.json', [], [], $headers, $content);
+        $this->assertSame(200, $this->client->getResponse()->getStatusCode());
 
         $content = json_decode($this->client->getResponse()->getContent(), true);
 
-        $this->assertEquals('This is my annotation /o/', $content['text']);
+        $this->assertSame('This is my annotation /o/', $content['text']);
 
         $annotationDeleted = $em
             ->getRepository('WallabagAnnotationBundle:Annotation')

--- a/tests/Wallabag/AnnotationBundle/WallabagAnnotationTestCase.php
+++ b/tests/Wallabag/AnnotationBundle/WallabagAnnotationTestCase.php
@@ -52,7 +52,7 @@ abstract class WallabagAnnotationTestCase extends WebTestCase
         $loginManager->logInUser($firewallName, $this->user);
 
         // save the login token into the session and put it in a cookie
-        $container->get('session')->set('_security_'.$firewallName, serialize($container->get('security.token_storage')->getToken()));
+        $container->get('session')->set('_security_' . $firewallName, serialize($container->get('security.token_storage')->getToken()));
         $container->get('session')->save();
 
         $session = $container->get('session');

--- a/tests/Wallabag/ApiBundle/Controller/DeveloperControllerTest.php
+++ b/tests/Wallabag/ApiBundle/Controller/DeveloperControllerTest.php
@@ -15,7 +15,7 @@ class DeveloperControllerTest extends WallabagCoreTestCase
         $nbClients = $em->getRepository('WallabagApiBundle:Client')->findAll();
 
         $crawler = $client->request('GET', '/developer/client/create');
-        $this->assertEquals(200, $client->getResponse()->getStatusCode());
+        $this->assertSame(200, $client->getResponse()->getStatusCode());
 
         $form = $crawler->filter('button[type=submit]')->form();
 
@@ -25,7 +25,7 @@ class DeveloperControllerTest extends WallabagCoreTestCase
 
         $crawler = $client->submit($form, $data);
 
-        $this->assertEquals(200, $client->getResponse()->getStatusCode());
+        $this->assertSame(200, $client->getResponse()->getStatusCode());
 
         $newNbClients = $em->getRepository('WallabagApiBundle:Client')->findAll();
         $this->assertGreaterThan(count($nbClients), count($newNbClients));
@@ -47,7 +47,7 @@ class DeveloperControllerTest extends WallabagCoreTestCase
             'password' => 'mypassword',
         ]);
 
-        $this->assertEquals(200, $client->getResponse()->getStatusCode());
+        $this->assertSame(200, $client->getResponse()->getStatusCode());
 
         $data = json_decode($client->getResponse()->getContent(), true);
         $this->assertArrayHasKey('access_token', $data);
@@ -67,7 +67,7 @@ class DeveloperControllerTest extends WallabagCoreTestCase
             'client_secret' => $apiClient->getSecret(),
         ]);
 
-        $this->assertEquals(200, $client->getResponse()->getStatusCode());
+        $this->assertSame(200, $client->getResponse()->getStatusCode());
 
         $data = json_decode($client->getResponse()->getContent(), true);
         $this->assertArrayHasKey('access_token', $data);
@@ -84,8 +84,8 @@ class DeveloperControllerTest extends WallabagCoreTestCase
         $nbClients = $em->getRepository('WallabagApiBundle:Client')->findAll();
 
         $crawler = $client->request('GET', '/developer');
-        $this->assertEquals(200, $client->getResponse()->getStatusCode());
-        $this->assertEquals(count($nbClients), $crawler->filter('ul[class=collapsible] li')->count());
+        $this->assertSame(200, $client->getResponse()->getStatusCode());
+        $this->assertSame(count($nbClients), $crawler->filter('ul[class=collapsible] li')->count());
     }
 
     public function testDeveloperHowto()
@@ -94,7 +94,7 @@ class DeveloperControllerTest extends WallabagCoreTestCase
         $client = $this->getClient();
 
         $crawler = $client->request('GET', '/developer/howto/first-app');
-        $this->assertEquals(200, $client->getResponse()->getStatusCode());
+        $this->assertSame(200, $client->getResponse()->getStatusCode());
     }
 
     public function testRemoveClient()
@@ -109,8 +109,8 @@ class DeveloperControllerTest extends WallabagCoreTestCase
         $this->assertContains('no_client', $client->getResponse()->getContent());
 
         $this->logInAs('bob');
-        $client->request('GET', '/developer/client/delete/'.$adminApiClient->getId());
-        $this->assertEquals(403, $client->getResponse()->getStatusCode());
+        $client->request('GET', '/developer/client/delete/' . $adminApiClient->getId());
+        $this->assertSame(403, $client->getResponse()->getStatusCode());
 
         // Try to remove the admin's client with the good user
         $this->logInAs('admin');
@@ -123,7 +123,7 @@ class DeveloperControllerTest extends WallabagCoreTestCase
         ;
 
         $client->click($link);
-        $this->assertEquals(302, $client->getResponse()->getStatusCode());
+        $this->assertSame(302, $client->getResponse()->getStatusCode());
 
         $this->assertNull(
             $em->getRepository('WallabagApiBundle:Client')->find($adminApiClient->getId()),
@@ -133,8 +133,8 @@ class DeveloperControllerTest extends WallabagCoreTestCase
 
     /**
      * @param string $username
+     * @param array  $grantTypes
      *
-     * @param array $grantTypes
      * @return Client
      */
     private function createApiClientForUser($username, $grantTypes = ['password'])
@@ -142,7 +142,7 @@ class DeveloperControllerTest extends WallabagCoreTestCase
         $client = $this->getClient();
         $em = $client->getContainer()->get('doctrine.orm.entity_manager');
         $userManager = $client->getContainer()->get('fos_user.user_manager');
-        $user = $userManager->findUserBy(array('username' => $username));
+        $user = $userManager->findUserBy(['username' => $username]);
         $apiClient = new Client($user);
         $apiClient->setName('My app');
         $apiClient->setAllowedGrantTypes($grantTypes);

--- a/tests/Wallabag/ApiBundle/Controller/EntryRestControllerTest.php
+++ b/tests/Wallabag/ApiBundle/Controller/EntryRestControllerTest.php
@@ -21,19 +21,19 @@ class EntryRestControllerTest extends WallabagApiTestCase
             $this->markTestSkipped('No content found in db.');
         }
 
-        $this->client->request('GET', '/api/entries/'.$entry->getId().'.json');
-        $this->assertEquals(200, $this->client->getResponse()->getStatusCode());
+        $this->client->request('GET', '/api/entries/' . $entry->getId() . '.json');
+        $this->assertSame(200, $this->client->getResponse()->getStatusCode());
 
         $content = json_decode($this->client->getResponse()->getContent(), true);
 
-        $this->assertEquals($entry->getTitle(), $content['title']);
-        $this->assertEquals($entry->getUrl(), $content['url']);
+        $this->assertSame($entry->getTitle(), $content['title']);
+        $this->assertSame($entry->getUrl(), $content['url']);
         $this->assertCount(count($entry->getTags()), $content['tags']);
-        $this->assertEquals($entry->getUserName(), $content['user_name']);
-        $this->assertEquals($entry->getUserEmail(), $content['user_email']);
-        $this->assertEquals($entry->getUserId(), $content['user_id']);
+        $this->assertSame($entry->getUserName(), $content['user_name']);
+        $this->assertSame($entry->getUserEmail(), $content['user_email']);
+        $this->assertSame($entry->getUserId(), $content['user_id']);
 
-        $this->assertEquals('application/json', $this->client->getResponse()->headers->get('Content-Type'));
+        $this->assertSame('application/json', $this->client->getResponse()->headers->get('Content-Type'));
     }
 
     public function testExportEntry()
@@ -47,39 +47,39 @@ class EntryRestControllerTest extends WallabagApiTestCase
             $this->markTestSkipped('No content found in db.');
         }
 
-        $this->client->request('GET', '/api/entries/'.$entry->getId().'/export.epub');
-        $this->assertEquals(200, $this->client->getResponse()->getStatusCode());
+        $this->client->request('GET', '/api/entries/' . $entry->getId() . '/export.epub');
+        $this->assertSame(200, $this->client->getResponse()->getStatusCode());
 
         // epub format got the content type in the content
         $this->assertContains('application/epub', $this->client->getResponse()->getContent());
-        $this->assertEquals('application/epub+zip', $this->client->getResponse()->headers->get('Content-Type'));
+        $this->assertSame('application/epub+zip', $this->client->getResponse()->headers->get('Content-Type'));
 
         // re-auth client for mobi
         $client = $this->createAuthorizedClient();
-        $client->request('GET', '/api/entries/'.$entry->getId().'/export.mobi');
-        $this->assertEquals(200, $client->getResponse()->getStatusCode());
+        $client->request('GET', '/api/entries/' . $entry->getId() . '/export.mobi');
+        $this->assertSame(200, $client->getResponse()->getStatusCode());
 
-        $this->assertEquals('application/x-mobipocket-ebook', $client->getResponse()->headers->get('Content-Type'));
+        $this->assertSame('application/x-mobipocket-ebook', $client->getResponse()->headers->get('Content-Type'));
 
         // re-auth client for pdf
         $client = $this->createAuthorizedClient();
-        $client->request('GET', '/api/entries/'.$entry->getId().'/export.pdf');
-        $this->assertEquals(200, $client->getResponse()->getStatusCode());
+        $client->request('GET', '/api/entries/' . $entry->getId() . '/export.pdf');
+        $this->assertSame(200, $client->getResponse()->getStatusCode());
 
         $this->assertContains('PDF-', $client->getResponse()->getContent());
-        $this->assertEquals('application/pdf', $client->getResponse()->headers->get('Content-Type'));
+        $this->assertSame('application/pdf', $client->getResponse()->headers->get('Content-Type'));
 
         // re-auth client for pdf
         $client = $this->createAuthorizedClient();
-        $client->request('GET', '/api/entries/'.$entry->getId().'/export.txt');
-        $this->assertEquals(200, $client->getResponse()->getStatusCode());
+        $client->request('GET', '/api/entries/' . $entry->getId() . '/export.txt');
+        $this->assertSame(200, $client->getResponse()->getStatusCode());
 
         $this->assertContains('text/plain', $client->getResponse()->headers->get('Content-Type'));
 
         // re-auth client for pdf
         $client = $this->createAuthorizedClient();
-        $client->request('GET', '/api/entries/'.$entry->getId().'/export.csv');
-        $this->assertEquals(200, $client->getResponse()->getStatusCode());
+        $client->request('GET', '/api/entries/' . $entry->getId() . '/export.csv');
+        $this->assertSame(200, $client->getResponse()->getStatusCode());
 
         $this->assertContains('application/csv', $client->getResponse()->headers->get('Content-Type'));
     }
@@ -95,26 +95,26 @@ class EntryRestControllerTest extends WallabagApiTestCase
             $this->markTestSkipped('No content found in db.');
         }
 
-        $this->client->request('GET', '/api/entries/'.$entry->getId().'.json');
+        $this->client->request('GET', '/api/entries/' . $entry->getId() . '.json');
 
-        $this->assertEquals(403, $this->client->getResponse()->getStatusCode());
+        $this->assertSame(403, $this->client->getResponse()->getStatusCode());
     }
 
     public function testGetEntries()
     {
         $this->client->request('GET', '/api/entries');
 
-        $this->assertEquals(200, $this->client->getResponse()->getStatusCode());
+        $this->assertSame(200, $this->client->getResponse()->getStatusCode());
 
         $content = json_decode($this->client->getResponse()->getContent(), true);
 
         $this->assertGreaterThanOrEqual(1, count($content));
         $this->assertNotEmpty($content['_embedded']['items']);
         $this->assertGreaterThanOrEqual(1, $content['total']);
-        $this->assertEquals(1, $content['page']);
+        $this->assertSame(1, $content['page']);
         $this->assertGreaterThanOrEqual(1, $content['pages']);
 
-        $this->assertEquals('application/json', $this->client->getResponse()->headers->get('Content-Type'));
+        $this->assertSame('application/json', $this->client->getResponse()->headers->get('Content-Type'));
     }
 
     public function testGetEntriesWithFullOptions()
@@ -131,15 +131,15 @@ class EntryRestControllerTest extends WallabagApiTestCase
             'public' => 0,
         ]);
 
-        $this->assertEquals(200, $this->client->getResponse()->getStatusCode());
+        $this->assertSame(200, $this->client->getResponse()->getStatusCode());
 
         $content = json_decode($this->client->getResponse()->getContent(), true);
 
         $this->assertGreaterThanOrEqual(1, count($content));
         $this->assertArrayHasKey('items', $content['_embedded']);
         $this->assertGreaterThanOrEqual(0, $content['total']);
-        $this->assertEquals(1, $content['page']);
-        $this->assertEquals(2, $content['limit']);
+        $this->assertSame(1, $content['page']);
+        $this->assertSame(2, $content['limit']);
         $this->assertGreaterThanOrEqual(1, $content['pages']);
 
         $this->assertArrayHasKey('_links', $content);
@@ -158,7 +158,7 @@ class EntryRestControllerTest extends WallabagApiTestCase
             $this->assertContains('public=0', $content['_links'][$link]['href']);
         }
 
-        $this->assertEquals('application/json', $this->client->getResponse()->headers->get('Content-Type'));
+        $this->assertSame('application/json', $this->client->getResponse()->headers->get('Content-Type'));
     }
 
     public function testGetEntriesPublicOnly()
@@ -183,15 +183,15 @@ class EntryRestControllerTest extends WallabagApiTestCase
             'public' => 1,
         ]);
 
-        $this->assertEquals(200, $this->client->getResponse()->getStatusCode());
+        $this->assertSame(200, $this->client->getResponse()->getStatusCode());
 
         $content = json_decode($this->client->getResponse()->getContent(), true);
 
         $this->assertGreaterThanOrEqual(1, count($content));
         $this->assertArrayHasKey('items', $content['_embedded']);
         $this->assertGreaterThanOrEqual(1, $content['total']);
-        $this->assertEquals(1, $content['page']);
-        $this->assertEquals(30, $content['limit']);
+        $this->assertSame(1, $content['page']);
+        $this->assertSame(30, $content['limit']);
         $this->assertGreaterThanOrEqual(1, $content['pages']);
 
         $this->assertArrayHasKey('_links', $content);
@@ -204,7 +204,7 @@ class EntryRestControllerTest extends WallabagApiTestCase
             $this->assertContains('public=1', $content['_links'][$link]['href']);
         }
 
-        $this->assertEquals('application/json', $this->client->getResponse()->headers->get('Content-Type'));
+        $this->assertSame('application/json', $this->client->getResponse()->headers->get('Content-Type'));
     }
 
     public function testGetEntriesOnPageTwo()
@@ -214,27 +214,27 @@ class EntryRestControllerTest extends WallabagApiTestCase
             'perPage' => 2,
         ]);
 
-        $this->assertEquals(200, $this->client->getResponse()->getStatusCode());
+        $this->assertSame(200, $this->client->getResponse()->getStatusCode());
 
         $content = json_decode($this->client->getResponse()->getContent(), true);
 
         $this->assertGreaterThanOrEqual(0, $content['total']);
-        $this->assertEquals(2, $content['page']);
-        $this->assertEquals(2, $content['limit']);
+        $this->assertSame(2, $content['page']);
+        $this->assertSame(2, $content['limit']);
     }
 
     public function testGetStarredEntries()
     {
         $this->client->request('GET', '/api/entries', ['starred' => 1, 'sort' => 'updated']);
 
-        $this->assertEquals(200, $this->client->getResponse()->getStatusCode());
+        $this->assertSame(200, $this->client->getResponse()->getStatusCode());
 
         $content = json_decode($this->client->getResponse()->getContent(), true);
 
         $this->assertGreaterThanOrEqual(1, count($content));
         $this->assertNotEmpty($content['_embedded']['items']);
         $this->assertGreaterThanOrEqual(1, $content['total']);
-        $this->assertEquals(1, $content['page']);
+        $this->assertSame(1, $content['page']);
         $this->assertGreaterThanOrEqual(1, $content['pages']);
 
         $this->assertArrayHasKey('_links', $content);
@@ -248,21 +248,21 @@ class EntryRestControllerTest extends WallabagApiTestCase
             $this->assertContains('sort=updated', $content['_links'][$link]['href']);
         }
 
-        $this->assertEquals('application/json', $this->client->getResponse()->headers->get('Content-Type'));
+        $this->assertSame('application/json', $this->client->getResponse()->headers->get('Content-Type'));
     }
 
     public function testGetArchiveEntries()
     {
         $this->client->request('GET', '/api/entries', ['archive' => 1]);
 
-        $this->assertEquals(200, $this->client->getResponse()->getStatusCode());
+        $this->assertSame(200, $this->client->getResponse()->getStatusCode());
 
         $content = json_decode($this->client->getResponse()->getContent(), true);
 
         $this->assertGreaterThanOrEqual(1, count($content));
         $this->assertNotEmpty($content['_embedded']['items']);
         $this->assertGreaterThanOrEqual(1, $content['total']);
-        $this->assertEquals(1, $content['page']);
+        $this->assertSame(1, $content['page']);
         $this->assertGreaterThanOrEqual(1, $content['pages']);
 
         $this->assertArrayHasKey('_links', $content);
@@ -275,21 +275,21 @@ class EntryRestControllerTest extends WallabagApiTestCase
             $this->assertContains('archive=1', $content['_links'][$link]['href']);
         }
 
-        $this->assertEquals('application/json', $this->client->getResponse()->headers->get('Content-Type'));
+        $this->assertSame('application/json', $this->client->getResponse()->headers->get('Content-Type'));
     }
 
     public function testGetTaggedEntries()
     {
         $this->client->request('GET', '/api/entries', ['tags' => 'foo,bar']);
 
-        $this->assertEquals(200, $this->client->getResponse()->getStatusCode());
+        $this->assertSame(200, $this->client->getResponse()->getStatusCode());
 
         $content = json_decode($this->client->getResponse()->getContent(), true);
 
         $this->assertGreaterThanOrEqual(1, count($content));
         $this->assertNotEmpty($content['_embedded']['items']);
         $this->assertGreaterThanOrEqual(1, $content['total']);
-        $this->assertEquals(1, $content['page']);
+        $this->assertSame(1, $content['page']);
         $this->assertGreaterThanOrEqual(1, $content['pages']);
 
         $this->assertArrayHasKey('_links', $content);
@@ -299,24 +299,24 @@ class EntryRestControllerTest extends WallabagApiTestCase
 
         foreach (['self', 'first', 'last'] as $link) {
             $this->assertArrayHasKey('href', $content['_links'][$link]);
-            $this->assertContains('tags='.urlencode('foo,bar'), $content['_links'][$link]['href']);
+            $this->assertContains('tags=' . urlencode('foo,bar'), $content['_links'][$link]['href']);
         }
 
-        $this->assertEquals('application/json', $this->client->getResponse()->headers->get('Content-Type'));
+        $this->assertSame('application/json', $this->client->getResponse()->headers->get('Content-Type'));
     }
 
     public function testGetDatedEntries()
     {
         $this->client->request('GET', '/api/entries', ['since' => 1443274283]);
 
-        $this->assertEquals(200, $this->client->getResponse()->getStatusCode());
+        $this->assertSame(200, $this->client->getResponse()->getStatusCode());
 
         $content = json_decode($this->client->getResponse()->getContent(), true);
 
         $this->assertGreaterThanOrEqual(1, count($content));
         $this->assertNotEmpty($content['_embedded']['items']);
         $this->assertGreaterThanOrEqual(1, $content['total']);
-        $this->assertEquals(1, $content['page']);
+        $this->assertSame(1, $content['page']);
         $this->assertGreaterThanOrEqual(1, $content['pages']);
 
         $this->assertArrayHasKey('_links', $content);
@@ -329,7 +329,7 @@ class EntryRestControllerTest extends WallabagApiTestCase
             $this->assertContains('since=1443274283', $content['_links'][$link]['href']);
         }
 
-        $this->assertEquals('application/json', $this->client->getResponse()->headers->get('Content-Type'));
+        $this->assertSame('application/json', $this->client->getResponse()->headers->get('Content-Type'));
     }
 
     public function testGetDatedSupEntries()
@@ -337,15 +337,15 @@ class EntryRestControllerTest extends WallabagApiTestCase
         $future = new \DateTime(date('Y-m-d H:i:s'));
         $this->client->request('GET', '/api/entries', ['since' => $future->getTimestamp() + 1000]);
 
-        $this->assertEquals(200, $this->client->getResponse()->getStatusCode());
+        $this->assertSame(200, $this->client->getResponse()->getStatusCode());
 
         $content = json_decode($this->client->getResponse()->getContent(), true);
 
         $this->assertGreaterThanOrEqual(1, count($content));
         $this->assertEmpty($content['_embedded']['items']);
-        $this->assertEquals(0, $content['total']);
-        $this->assertEquals(1, $content['page']);
-        $this->assertEquals(1, $content['pages']);
+        $this->assertSame(0, $content['total']);
+        $this->assertSame(1, $content['page']);
+        $this->assertSame(1, $content['pages']);
 
         $this->assertArrayHasKey('_links', $content);
         $this->assertArrayHasKey('self', $content['_links']);
@@ -354,10 +354,10 @@ class EntryRestControllerTest extends WallabagApiTestCase
 
         foreach (['self', 'first', 'last'] as $link) {
             $this->assertArrayHasKey('href', $content['_links'][$link]);
-            $this->assertContains('since='.($future->getTimestamp() + 1000), $content['_links'][$link]['href']);
+            $this->assertContains('since=' . ($future->getTimestamp() + 1000), $content['_links'][$link]['href']);
         }
 
-        $this->assertEquals('application/json', $this->client->getResponse()->headers->get('Content-Type'));
+        $this->assertSame('application/json', $this->client->getResponse()->headers->get('Content-Type'));
     }
 
     public function testDeleteEntry()
@@ -371,19 +371,19 @@ class EntryRestControllerTest extends WallabagApiTestCase
             $this->markTestSkipped('No content found in db.');
         }
 
-        $this->client->request('DELETE', '/api/entries/'.$entry->getId().'.json');
+        $this->client->request('DELETE', '/api/entries/' . $entry->getId() . '.json');
 
-        $this->assertEquals(200, $this->client->getResponse()->getStatusCode());
+        $this->assertSame(200, $this->client->getResponse()->getStatusCode());
 
         $content = json_decode($this->client->getResponse()->getContent(), true);
 
-        $this->assertEquals($entry->getTitle(), $content['title']);
-        $this->assertEquals($entry->getUrl(), $content['url']);
+        $this->assertSame($entry->getTitle(), $content['title']);
+        $this->assertSame($entry->getUrl(), $content['url']);
 
         // We'll try to delete this entry again
-        $this->client->request('DELETE', '/api/entries/'.$entry->getId().'.json');
+        $this->client->request('DELETE', '/api/entries/' . $entry->getId() . '.json');
 
-        $this->assertEquals(404, $this->client->getResponse()->getStatusCode());
+        $this->assertSame(404, $this->client->getResponse()->getStatusCode());
     }
 
     public function testPostEntry()
@@ -399,16 +399,16 @@ class EntryRestControllerTest extends WallabagApiTestCase
             'public' => 1,
         ]);
 
-        $this->assertEquals(200, $this->client->getResponse()->getStatusCode());
+        $this->assertSame(200, $this->client->getResponse()->getStatusCode());
 
         $content = json_decode($this->client->getResponse()->getContent(), true);
 
         $this->assertGreaterThan(0, $content['id']);
-        $this->assertEquals('http://www.lemonde.fr/pixels/article/2015/03/28/plongee-dans-l-univers-d-ingress-le-jeu-de-google-aux-frontieres-du-reel_4601155_4408996.html', $content['url']);
-        $this->assertEquals(false, $content['is_archived']);
-        $this->assertEquals(false, $content['is_starred']);
-        $this->assertEquals('New title for my article', $content['title']);
-        $this->assertEquals(1, $content['user_id']);
+        $this->assertSame('http://www.lemonde.fr/pixels/article/2015/03/28/plongee-dans-l-univers-d-ingress-le-jeu-de-google-aux-frontieres-du-reel_4601155_4408996.html', $content['url']);
+        $this->assertSame(false, $content['is_archived']);
+        $this->assertSame(false, $content['is_starred']);
+        $this->assertSame('New title for my article', $content['title']);
+        $this->assertSame(1, $content['user_id']);
         $this->assertCount(2, $content['tags']);
         $this->assertSame('my content', $content['content']);
         $this->assertSame('de', $content['language']);
@@ -427,14 +427,14 @@ class EntryRestControllerTest extends WallabagApiTestCase
             'tags' => 'google, apple',
         ]);
 
-        $this->assertEquals(200, $this->client->getResponse()->getStatusCode());
+        $this->assertSame(200, $this->client->getResponse()->getStatusCode());
 
         $content = json_decode($this->client->getResponse()->getContent(), true);
 
         $this->assertGreaterThan(0, $content['id']);
-        $this->assertEquals('http://www.lemonde.fr/pixels/article/2015/03/28/plongee-dans-l-univers-d-ingress-le-jeu-de-google-aux-frontieres-du-reel_4601155_4408996.html', $content['url']);
-        $this->assertEquals(true, $content['is_archived']);
-        $this->assertEquals(false, $content['is_starred']);
+        $this->assertSame('http://www.lemonde.fr/pixels/article/2015/03/28/plongee-dans-l-univers-d-ingress-le-jeu-de-google-aux-frontieres-du-reel_4601155_4408996.html', $content['url']);
+        $this->assertSame(true, $content['is_archived']);
+        $this->assertSame(false, $content['is_starred']);
         $this->assertCount(3, $content['tags']);
     }
 
@@ -456,10 +456,10 @@ class EntryRestControllerTest extends WallabagApiTestCase
                 'url' => 'http://www.example.com/',
             ]);
 
-            $this->assertEquals(200, $this->client->getResponse()->getStatusCode());
+            $this->assertSame(200, $this->client->getResponse()->getStatusCode());
             $content = json_decode($this->client->getResponse()->getContent(), true);
             $this->assertGreaterThan(0, $content['id']);
-            $this->assertEquals('http://www.example.com/', $content['url']);
+            $this->assertSame('http://www.example.com/', $content['url']);
         } finally {
             // Remove the created entry to avoid side effects on other tests
             if (isset($content['id'])) {
@@ -479,15 +479,15 @@ class EntryRestControllerTest extends WallabagApiTestCase
             'starred' => '1',
         ]);
 
-        $this->assertEquals(200, $this->client->getResponse()->getStatusCode());
+        $this->assertSame(200, $this->client->getResponse()->getStatusCode());
 
         $content = json_decode($this->client->getResponse()->getContent(), true);
 
         $this->assertGreaterThan(0, $content['id']);
-        $this->assertEquals('http://www.lemonde.fr/idees/article/2016/02/08/preserver-la-liberte-d-expression-sur-les-reseaux-sociaux_4861503_3232.html', $content['url']);
-        $this->assertEquals(true, $content['is_archived']);
-        $this->assertEquals(true, $content['is_starred']);
-        $this->assertEquals(1, $content['user_id']);
+        $this->assertSame('http://www.lemonde.fr/idees/article/2016/02/08/preserver-la-liberte-d-expression-sur-les-reseaux-sociaux_4861503_3232.html', $content['url']);
+        $this->assertSame(true, $content['is_archived']);
+        $this->assertSame(true, $content['is_starred']);
+        $this->assertSame(1, $content['user_id']);
     }
 
     public function testPostArchivedAndStarredEntryWithoutQuotes()
@@ -498,14 +498,14 @@ class EntryRestControllerTest extends WallabagApiTestCase
             'starred' => 1,
         ]);
 
-        $this->assertEquals(200, $this->client->getResponse()->getStatusCode());
+        $this->assertSame(200, $this->client->getResponse()->getStatusCode());
 
         $content = json_decode($this->client->getResponse()->getContent(), true);
 
         $this->assertGreaterThan(0, $content['id']);
-        $this->assertEquals('http://www.lemonde.fr/idees/article/2016/02/08/preserver-la-liberte-d-expression-sur-les-reseaux-sociaux_4861503_3232.html', $content['url']);
-        $this->assertEquals(false, $content['is_archived']);
-        $this->assertEquals(true, $content['is_starred']);
+        $this->assertSame('http://www.lemonde.fr/idees/article/2016/02/08/preserver-la-liberte-d-expression-sur-les-reseaux-sociaux_4861503_3232.html', $content['url']);
+        $this->assertSame(false, $content['is_archived']);
+        $this->assertSame(true, $content['is_starred']);
     }
 
     public function testPatchEntry()
@@ -522,9 +522,9 @@ class EntryRestControllerTest extends WallabagApiTestCase
         // hydrate the tags relations
         $nbTags = count($entry->getTags());
 
-        $this->client->request('PATCH', '/api/entries/'.$entry->getId().'.json', [
+        $this->client->request('PATCH', '/api/entries/' . $entry->getId() . '.json', [
             'title' => 'New awesome title',
-            'tags' => 'new tag '.uniqid(),
+            'tags' => 'new tag ' . uniqid(),
             'starred' => '1',
             'archive' => '0',
             'language' => 'de_AT',
@@ -534,20 +534,20 @@ class EntryRestControllerTest extends WallabagApiTestCase
             'public' => 0,
         ]);
 
-        $this->assertEquals(200, $this->client->getResponse()->getStatusCode());
+        $this->assertSame(200, $this->client->getResponse()->getStatusCode());
 
         $content = json_decode($this->client->getResponse()->getContent(), true);
 
-        $this->assertEquals($entry->getId(), $content['id']);
-        $this->assertEquals($entry->getUrl(), $content['url']);
-        $this->assertEquals('New awesome title', $content['title']);
+        $this->assertSame($entry->getId(), $content['id']);
+        $this->assertSame($entry->getUrl(), $content['url']);
+        $this->assertSame('New awesome title', $content['title']);
         $this->assertGreaterThan($nbTags, count($content['tags']));
-        $this->assertEquals(1, $content['user_id']);
-        $this->assertEquals('de_AT', $content['language']);
-        $this->assertEquals('http://preview.io/picture.jpg', $content['preview_picture']);
+        $this->assertSame(1, $content['user_id']);
+        $this->assertSame('de_AT', $content['language']);
+        $this->assertSame('http://preview.io/picture.jpg', $content['preview_picture']);
         $this->assertContains('sponge', $content['published_by']);
         $this->assertContains('bob', $content['published_by']);
-        $this->assertEquals('awesome', $content['content']);
+        $this->assertSame('awesome', $content['content']);
         $this->assertFalse($content['is_public'], 'Entry is no more shared');
     }
 
@@ -565,23 +565,23 @@ class EntryRestControllerTest extends WallabagApiTestCase
         // hydrate the tags relations
         $nbTags = count($entry->getTags());
 
-        $this->client->request('PATCH', '/api/entries/'.$entry->getId().'.json', [
+        $this->client->request('PATCH', '/api/entries/' . $entry->getId() . '.json', [
             'title' => 'New awesome title',
-            'tags' => 'new tag '.uniqid(),
+            'tags' => 'new tag ' . uniqid(),
             'starred' => 1,
             'archive' => 0,
             'authors' => ['bob', 'sponge'],
         ]);
 
-        $this->assertEquals(200, $this->client->getResponse()->getStatusCode());
+        $this->assertSame(200, $this->client->getResponse()->getStatusCode());
 
         $content = json_decode($this->client->getResponse()->getContent(), true);
 
-        $this->assertEquals($entry->getId(), $content['id']);
-        $this->assertEquals($entry->getUrl(), $content['url']);
-        $this->assertEquals('New awesome title', $content['title']);
+        $this->assertSame($entry->getId(), $content['id']);
+        $this->assertSame($entry->getUrl(), $content['url']);
+        $this->assertSame('New awesome title', $content['title']);
         $this->assertGreaterThan($nbTags, count($content['tags']));
-        $this->assertTrue(empty($content['published_by']), 'Authors were not saved because of an array instead of a string');
+        $this->assertEmpty($content['published_by'], 'Authors were not saved because of an array instead of a string');
     }
 
     public function testGetTagsEntry()
@@ -602,9 +602,9 @@ class EntryRestControllerTest extends WallabagApiTestCase
             $tags[] = ['id' => $tag->getId(), 'label' => $tag->getLabel(), 'slug' => $tag->getSlug()];
         }
 
-        $this->client->request('GET', '/api/entries/'.$entry->getId().'/tags');
+        $this->client->request('GET', '/api/entries/' . $entry->getId() . '/tags');
 
-        $this->assertEquals(json_encode($tags, JSON_HEX_QUOT), $this->client->getResponse()->getContent());
+        $this->assertSame(json_encode($tags, JSON_HEX_QUOT), $this->client->getResponse()->getContent());
     }
 
     public function testPostTagsOnEntry()
@@ -622,14 +622,14 @@ class EntryRestControllerTest extends WallabagApiTestCase
 
         $newTags = 'tag1,tag2,tag3';
 
-        $this->client->request('POST', '/api/entries/'.$entry->getId().'/tags', ['tags' => $newTags]);
+        $this->client->request('POST', '/api/entries/' . $entry->getId() . '/tags', ['tags' => $newTags]);
 
-        $this->assertEquals(200, $this->client->getResponse()->getStatusCode());
+        $this->assertSame(200, $this->client->getResponse()->getStatusCode());
 
         $content = json_decode($this->client->getResponse()->getContent(), true);
 
         $this->assertArrayHasKey('tags', $content);
-        $this->assertEquals($nbTags + 3, count($content['tags']));
+        $this->assertSame($nbTags + 3, count($content['tags']));
 
         $entryDB = $this->client->getContainer()
             ->get('doctrine.orm.entity_manager')
@@ -662,14 +662,14 @@ class EntryRestControllerTest extends WallabagApiTestCase
         $nbTags = count($entry->getTags());
         $tag = $entry->getTags()[0];
 
-        $this->client->request('DELETE', '/api/entries/'.$entry->getId().'/tags/'.$tag->getId().'.json');
+        $this->client->request('DELETE', '/api/entries/' . $entry->getId() . '/tags/' . $tag->getId() . '.json');
 
-        $this->assertEquals(200, $this->client->getResponse()->getStatusCode());
+        $this->assertSame(200, $this->client->getResponse()->getStatusCode());
 
         $content = json_decode($this->client->getResponse()->getContent(), true);
 
         $this->assertArrayHasKey('tags', $content);
-        $this->assertEquals($nbTags - 1, count($content['tags']));
+        $this->assertSame($nbTags - 1, count($content['tags']));
     }
 
     public function testSaveIsArchivedAfterPost()
@@ -687,11 +687,11 @@ class EntryRestControllerTest extends WallabagApiTestCase
             'url' => $entry->getUrl(),
         ]);
 
-        $this->assertEquals(200, $this->client->getResponse()->getStatusCode());
+        $this->assertSame(200, $this->client->getResponse()->getStatusCode());
 
         $content = json_decode($this->client->getResponse()->getContent(), true);
 
-        $this->assertEquals(true, $content['is_archived']);
+        $this->assertSame(true, $content['is_archived']);
     }
 
     public function testSaveIsStarredAfterPost()
@@ -709,11 +709,11 @@ class EntryRestControllerTest extends WallabagApiTestCase
             'url' => $entry->getUrl(),
         ]);
 
-        $this->assertEquals(200, $this->client->getResponse()->getStatusCode());
+        $this->assertSame(200, $this->client->getResponse()->getStatusCode());
 
         $content = json_decode($this->client->getResponse()->getContent(), true);
 
-        $this->assertEquals(true, $content['is_starred']);
+        $this->assertSame(true, $content['is_starred']);
     }
 
     public function testSaveIsArchivedAfterPatch()
@@ -727,15 +727,15 @@ class EntryRestControllerTest extends WallabagApiTestCase
             $this->markTestSkipped('No content found in db.');
         }
 
-        $this->client->request('PATCH', '/api/entries/'.$entry->getId().'.json', [
-            'title' => $entry->getTitle().'++',
+        $this->client->request('PATCH', '/api/entries/' . $entry->getId() . '.json', [
+            'title' => $entry->getTitle() . '++',
         ]);
 
-        $this->assertEquals(200, $this->client->getResponse()->getStatusCode());
+        $this->assertSame(200, $this->client->getResponse()->getStatusCode());
 
         $content = json_decode($this->client->getResponse()->getContent(), true);
 
-        $this->assertEquals(true, $content['is_archived']);
+        $this->assertSame(true, $content['is_archived']);
     }
 
     public function testSaveIsStarredAfterPatch()
@@ -748,15 +748,15 @@ class EntryRestControllerTest extends WallabagApiTestCase
         if (!$entry) {
             $this->markTestSkipped('No content found in db.');
         }
-        $this->client->request('PATCH', '/api/entries/'.$entry->getId().'.json', [
-            'title' => $entry->getTitle().'++',
+        $this->client->request('PATCH', '/api/entries/' . $entry->getId() . '.json', [
+            'title' => $entry->getTitle() . '++',
         ]);
 
-        $this->assertEquals(200, $this->client->getResponse()->getStatusCode());
+        $this->assertSame(200, $this->client->getResponse()->getStatusCode());
 
         $content = json_decode($this->client->getResponse()->getContent(), true);
 
-        $this->assertEquals(true, $content['is_starred']);
+        $this->assertSame(true, $content['is_starred']);
     }
 
     public function dataForEntriesExistWithUrl()
@@ -780,7 +780,7 @@ class EntryRestControllerTest extends WallabagApiTestCase
     {
         $this->client->request('GET', $url);
 
-        $this->assertEquals(200, $this->client->getResponse()->getStatusCode());
+        $this->assertSame(200, $this->client->getResponse()->getStatusCode());
 
         $content = json_decode($this->client->getResponse()->getContent(), true);
 
@@ -791,9 +791,9 @@ class EntryRestControllerTest extends WallabagApiTestCase
     {
         $url1 = 'http://0.0.0.0/entry2';
         $url2 = 'http://0.0.0.0/entry10';
-        $this->client->request('GET', '/api/entries/exists?urls[]='.$url1.'&urls[]='.$url2.'&return_id=1');
+        $this->client->request('GET', '/api/entries/exists?urls[]=' . $url1 . '&urls[]=' . $url2 . '&return_id=1');
 
-        $this->assertEquals(200, $this->client->getResponse()->getStatusCode());
+        $this->assertSame(200, $this->client->getResponse()->getStatusCode());
 
         $content = json_decode($this->client->getResponse()->getContent(), true);
 
@@ -807,9 +807,9 @@ class EntryRestControllerTest extends WallabagApiTestCase
     {
         $url1 = 'http://0.0.0.0/entry2';
         $url2 = 'http://0.0.0.0/entry10';
-        $this->client->request('GET', '/api/entries/exists?urls[]='.$url1.'&urls[]='.$url2);
+        $this->client->request('GET', '/api/entries/exists?urls[]=' . $url1 . '&urls[]=' . $url2);
 
-        $this->assertEquals(200, $this->client->getResponse()->getStatusCode());
+        $this->assertSame(200, $this->client->getResponse()->getStatusCode());
 
         $content = json_decode($this->client->getResponse()->getContent(), true);
 
@@ -823,18 +823,18 @@ class EntryRestControllerTest extends WallabagApiTestCase
     {
         $this->client->request('GET', '/api/entries/exists?url=http://google.com/entry2');
 
-        $this->assertEquals(200, $this->client->getResponse()->getStatusCode());
+        $this->assertSame(200, $this->client->getResponse()->getStatusCode());
 
         $content = json_decode($this->client->getResponse()->getContent(), true);
 
-        $this->assertEquals(false, $content['exists']);
+        $this->assertSame(false, $content['exists']);
     }
 
     public function testGetEntriesExistsWithNoUrl()
     {
         $this->client->request('GET', '/api/entries/exists?url=');
 
-        $this->assertEquals(403, $this->client->getResponse()->getStatusCode());
+        $this->assertSame(403, $this->client->getResponse()->getStatusCode());
     }
 
     public function testReloadEntryErrorWhileFetching()
@@ -847,8 +847,8 @@ class EntryRestControllerTest extends WallabagApiTestCase
             $this->markTestSkipped('No content found in db.');
         }
 
-        $this->client->request('PATCH', '/api/entries/'.$entry->getId().'/reload.json');
-        $this->assertEquals(304, $this->client->getResponse()->getStatusCode());
+        $this->client->request('PATCH', '/api/entries/' . $entry->getId() . '/reload.json');
+        $this->assertSame(304, $this->client->getResponse()->getStatusCode());
     }
 
     public function testReloadEntry()
@@ -863,14 +863,14 @@ class EntryRestControllerTest extends WallabagApiTestCase
 
         $this->setUp();
 
-        $this->client->request('PATCH', '/api/entries/'.$json['id'].'/reload.json');
-        $this->assertEquals(200, $this->client->getResponse()->getStatusCode());
+        $this->client->request('PATCH', '/api/entries/' . $json['id'] . '/reload.json');
+        $this->assertSame(200, $this->client->getResponse()->getStatusCode());
 
         $content = json_decode($this->client->getResponse()->getContent(), true);
 
         $this->assertNotEmpty($content['title']);
 
-        $this->assertEquals('application/json', $this->client->getResponse()->headers->get('Content-Type'));
+        $this->assertSame('application/json', $this->client->getResponse()->headers->get('Content-Type'));
     }
 
     public function testPostEntriesTagsListAction()
@@ -890,14 +890,14 @@ class EntryRestControllerTest extends WallabagApiTestCase
             ],
         ];
 
-        $this->client->request('POST', '/api/entries/tags/lists?list='.json_encode($list));
+        $this->client->request('POST', '/api/entries/tags/lists?list=' . json_encode($list));
 
-        $this->assertEquals(200, $this->client->getResponse()->getStatusCode());
+        $this->assertSame(200, $this->client->getResponse()->getStatusCode());
 
         $content = json_decode($this->client->getResponse()->getContent(), true);
 
         $this->assertInternalType('int', $content[0]['entry']);
-        $this->assertEquals('http://0.0.0.0/entry4', $content[0]['url']);
+        $this->assertSame('http://0.0.0.0/entry4', $content[0]['url']);
 
         $entry = $this->client->getContainer()->get('doctrine.orm.entity_manager')
             ->getRepository('WallabagCoreBundle:Entry')
@@ -926,8 +926,8 @@ class EntryRestControllerTest extends WallabagApiTestCase
             ],
         ];
 
-        $this->client->request('DELETE', '/api/entries/tags/list?list='.json_encode($list));
-        $this->assertEquals(200, $this->client->getResponse()->getStatusCode());
+        $this->client->request('DELETE', '/api/entries/tags/list?list=' . json_encode($list));
+        $this->assertSame(200, $this->client->getResponse()->getStatusCode());
 
         $entry = $em->getRepository('WallabagCoreBundle:Entry')->find($entry->getId());
         $this->assertCount(0, $entry->getTags());
@@ -940,17 +940,17 @@ class EntryRestControllerTest extends WallabagApiTestCase
             'http://0.0.0.0/entry2',
         ];
 
-        $this->client->request('POST', '/api/entries/lists?urls='.json_encode($list));
+        $this->client->request('POST', '/api/entries/lists?urls=' . json_encode($list));
 
-        $this->assertEquals(200, $this->client->getResponse()->getStatusCode());
+        $this->assertSame(200, $this->client->getResponse()->getStatusCode());
 
         $content = json_decode($this->client->getResponse()->getContent(), true);
 
         $this->assertInternalType('int', $content[0]['entry']);
-        $this->assertEquals('http://www.lemonde.fr/musiques/article/2017/04/23/loin-de-la-politique-le-printemps-de-bourges-retombe-en-enfance_5115862_1654986.html', $content[0]['url']);
+        $this->assertSame('http://www.lemonde.fr/musiques/article/2017/04/23/loin-de-la-politique-le-printemps-de-bourges-retombe-en-enfance_5115862_1654986.html', $content[0]['url']);
 
         $this->assertInternalType('int', $content[1]['entry']);
-        $this->assertEquals('http://0.0.0.0/entry2', $content[1]['url']);
+        $this->assertSame('http://0.0.0.0/entry2', $content[1]['url']);
     }
 
     public function testDeleteEntriesListAction()
@@ -965,17 +965,17 @@ class EntryRestControllerTest extends WallabagApiTestCase
             'http://0.0.0.0/test-entry-not-exist',
         ];
 
-        $this->client->request('DELETE', '/api/entries/list?urls='.json_encode($list));
+        $this->client->request('DELETE', '/api/entries/list?urls=' . json_encode($list));
 
-        $this->assertEquals(200, $this->client->getResponse()->getStatusCode());
+        $this->assertSame(200, $this->client->getResponse()->getStatusCode());
 
         $content = json_decode($this->client->getResponse()->getContent(), true);
 
         $this->assertTrue($content[0]['entry']);
-        $this->assertEquals('http://0.0.0.0/test-entry1', $content[0]['url']);
+        $this->assertSame('http://0.0.0.0/test-entry1', $content[0]['url']);
 
         $this->assertFalse($content[1]['entry']);
-        $this->assertEquals('http://0.0.0.0/test-entry-not-exist', $content[1]['url']);
+        $this->assertSame('http://0.0.0.0/test-entry-not-exist', $content[1]['url']);
     }
 
     public function testLimitBulkAction()
@@ -994,9 +994,9 @@ class EntryRestControllerTest extends WallabagApiTestCase
             'http://0.0.0.0/entry1',
         ];
 
-        $this->client->request('POST', '/api/entries/lists?urls='.json_encode($list));
+        $this->client->request('POST', '/api/entries/lists?urls=' . json_encode($list));
 
-        $this->assertEquals(400, $this->client->getResponse()->getStatusCode());
+        $this->assertSame(400, $this->client->getResponse()->getStatusCode());
         $this->assertContains('API limit reached', $this->client->getResponse()->getContent());
     }
 }

--- a/tests/Wallabag/ApiBundle/Controller/EntryRestControllerTest.php
+++ b/tests/Wallabag/ApiBundle/Controller/EntryRestControllerTest.php
@@ -405,8 +405,8 @@ class EntryRestControllerTest extends WallabagApiTestCase
 
         $this->assertGreaterThan(0, $content['id']);
         $this->assertSame('http://www.lemonde.fr/pixels/article/2015/03/28/plongee-dans-l-univers-d-ingress-le-jeu-de-google-aux-frontieres-du-reel_4601155_4408996.html', $content['url']);
-        $this->assertSame(false, $content['is_archived']);
-        $this->assertSame(false, $content['is_starred']);
+        $this->assertSame(0, $content['is_archived']);
+        $this->assertSame(0, $content['is_starred']);
         $this->assertSame('New title for my article', $content['title']);
         $this->assertSame(1, $content['user_id']);
         $this->assertCount(2, $content['tags']);
@@ -433,8 +433,8 @@ class EntryRestControllerTest extends WallabagApiTestCase
 
         $this->assertGreaterThan(0, $content['id']);
         $this->assertSame('http://www.lemonde.fr/pixels/article/2015/03/28/plongee-dans-l-univers-d-ingress-le-jeu-de-google-aux-frontieres-du-reel_4601155_4408996.html', $content['url']);
-        $this->assertSame(true, $content['is_archived']);
-        $this->assertSame(false, $content['is_starred']);
+        $this->assertSame(1, $content['is_archived']);
+        $this->assertSame(0, $content['is_starred']);
         $this->assertCount(3, $content['tags']);
     }
 
@@ -485,8 +485,8 @@ class EntryRestControllerTest extends WallabagApiTestCase
 
         $this->assertGreaterThan(0, $content['id']);
         $this->assertSame('http://www.lemonde.fr/idees/article/2016/02/08/preserver-la-liberte-d-expression-sur-les-reseaux-sociaux_4861503_3232.html', $content['url']);
-        $this->assertSame(true, $content['is_archived']);
-        $this->assertSame(true, $content['is_starred']);
+        $this->assertSame(1, $content['is_archived']);
+        $this->assertSame(1, $content['is_starred']);
         $this->assertSame(1, $content['user_id']);
     }
 
@@ -504,8 +504,8 @@ class EntryRestControllerTest extends WallabagApiTestCase
 
         $this->assertGreaterThan(0, $content['id']);
         $this->assertSame('http://www.lemonde.fr/idees/article/2016/02/08/preserver-la-liberte-d-expression-sur-les-reseaux-sociaux_4861503_3232.html', $content['url']);
-        $this->assertSame(false, $content['is_archived']);
-        $this->assertSame(true, $content['is_starred']);
+        $this->assertSame(0, $content['is_archived']);
+        $this->assertSame(1, $content['is_starred']);
     }
 
     public function testPatchEntry()
@@ -691,7 +691,7 @@ class EntryRestControllerTest extends WallabagApiTestCase
 
         $content = json_decode($this->client->getResponse()->getContent(), true);
 
-        $this->assertSame(true, $content['is_archived']);
+        $this->assertSame(1, $content['is_archived']);
     }
 
     public function testSaveIsStarredAfterPost()
@@ -713,7 +713,7 @@ class EntryRestControllerTest extends WallabagApiTestCase
 
         $content = json_decode($this->client->getResponse()->getContent(), true);
 
-        $this->assertSame(true, $content['is_starred']);
+        $this->assertSame(1, $content['is_starred']);
     }
 
     public function testSaveIsArchivedAfterPatch()
@@ -735,7 +735,7 @@ class EntryRestControllerTest extends WallabagApiTestCase
 
         $content = json_decode($this->client->getResponse()->getContent(), true);
 
-        $this->assertSame(true, $content['is_archived']);
+        $this->assertSame(1, $content['is_archived']);
     }
 
     public function testSaveIsStarredAfterPatch()
@@ -756,7 +756,7 @@ class EntryRestControllerTest extends WallabagApiTestCase
 
         $content = json_decode($this->client->getResponse()->getContent(), true);
 
-        $this->assertSame(true, $content['is_starred']);
+        $this->assertSame(1, $content['is_starred']);
     }
 
     public function dataForEntriesExistWithUrl()

--- a/tests/Wallabag/ApiBundle/Controller/TagRestControllerTest.php
+++ b/tests/Wallabag/ApiBundle/Controller/TagRestControllerTest.php
@@ -11,7 +11,7 @@ class TagRestControllerTest extends WallabagApiTestCase
     {
         $this->client->request('GET', '/api/tags.json');
 
-        $this->assertEquals(200, $this->client->getResponse()->getStatusCode());
+        $this->assertSame(200, $this->client->getResponse()->getStatusCode());
 
         $content = json_decode($this->client->getResponse()->getContent(), true);
 
@@ -33,15 +33,15 @@ class TagRestControllerTest extends WallabagApiTestCase
         $em->flush();
         $em->clear();
 
-        $this->client->request('DELETE', '/api/tags/'.$tag->getId().'.json');
+        $this->client->request('DELETE', '/api/tags/' . $tag->getId() . '.json');
 
-        $this->assertEquals(200, $this->client->getResponse()->getStatusCode());
+        $this->assertSame(200, $this->client->getResponse()->getStatusCode());
 
         $content = json_decode($this->client->getResponse()->getContent(), true);
 
         $this->assertArrayHasKey('label', $content);
-        $this->assertEquals($tag->getLabel(), $content['label']);
-        $this->assertEquals($tag->getSlug(), $content['slug']);
+        $this->assertSame($tag->getLabel(), $content['label']);
+        $this->assertSame($tag->getSlug(), $content['slug']);
 
         $entries = $em->getRepository('WallabagCoreBundle:Entry')
             ->findAllByTagId($this->user->getId(), $tag->getId());
@@ -50,7 +50,7 @@ class TagRestControllerTest extends WallabagApiTestCase
 
         $tag = $em->getRepository('WallabagCoreBundle:Tag')->findOneByLabel($tagLabel);
 
-        $this->assertNull($tag, $tagLabel.' was removed because it begun an orphan tag');
+        $this->assertNull($tag, $tagLabel . ' was removed because it begun an orphan tag');
     }
 
     public function dataForDeletingTagByLabel()
@@ -84,18 +84,18 @@ class TagRestControllerTest extends WallabagApiTestCase
         $em->flush();
 
         if ($useQueryString) {
-            $this->client->request('DELETE', '/api/tag/label.json?tag='.$tag->getLabel());
+            $this->client->request('DELETE', '/api/tag/label.json?tag=' . $tag->getLabel());
         } else {
             $this->client->request('DELETE', '/api/tag/label.json', ['tag' => $tag->getLabel()]);
         }
 
-        $this->assertEquals(200, $this->client->getResponse()->getStatusCode());
+        $this->assertSame(200, $this->client->getResponse()->getStatusCode());
 
         $content = json_decode($this->client->getResponse()->getContent(), true);
 
         $this->assertArrayHasKey('label', $content);
-        $this->assertEquals($tag->getLabel(), $content['label']);
-        $this->assertEquals($tag->getSlug(), $content['slug']);
+        $this->assertSame($tag->getLabel(), $content['label']);
+        $this->assertSame($tag->getSlug(), $content['slug']);
 
         $entries = $this->client->getContainer()
             ->get('doctrine.orm.entity_manager')
@@ -109,7 +109,7 @@ class TagRestControllerTest extends WallabagApiTestCase
     {
         $this->client->request('DELETE', '/api/tag/label.json', ['tag' => 'does not exist']);
 
-        $this->assertEquals(404, $this->client->getResponse()->getStatusCode());
+        $this->assertSame(404, $this->client->getResponse()->getStatusCode());
     }
 
     /**
@@ -140,24 +140,24 @@ class TagRestControllerTest extends WallabagApiTestCase
         $em->flush();
 
         if ($useQueryString) {
-            $this->client->request('DELETE', '/api/tags/label.json?tags='.$tag->getLabel().','.$tag2->getLabel());
+            $this->client->request('DELETE', '/api/tags/label.json?tags=' . $tag->getLabel() . ',' . $tag2->getLabel());
         } else {
-            $this->client->request('DELETE', '/api/tags/label.json', ['tags' => $tag->getLabel().','.$tag2->getLabel()]);
+            $this->client->request('DELETE', '/api/tags/label.json', ['tags' => $tag->getLabel() . ',' . $tag2->getLabel()]);
         }
 
-        $this->assertEquals(200, $this->client->getResponse()->getStatusCode());
+        $this->assertSame(200, $this->client->getResponse()->getStatusCode());
 
         $content = json_decode($this->client->getResponse()->getContent(), true);
 
         $this->assertCount(2, $content);
 
         $this->assertArrayHasKey('label', $content[0]);
-        $this->assertEquals($tag->getLabel(), $content[0]['label']);
-        $this->assertEquals($tag->getSlug(), $content[0]['slug']);
+        $this->assertSame($tag->getLabel(), $content[0]['label']);
+        $this->assertSame($tag->getSlug(), $content[0]['slug']);
 
         $this->assertArrayHasKey('label', $content[1]);
-        $this->assertEquals($tag2->getLabel(), $content[1]['label']);
-        $this->assertEquals($tag2->getSlug(), $content[1]['slug']);
+        $this->assertSame($tag2->getLabel(), $content[1]['label']);
+        $this->assertSame($tag2->getSlug(), $content[1]['slug']);
 
         $entries = $this->client->getContainer()
             ->get('doctrine.orm.entity_manager')
@@ -178,6 +178,6 @@ class TagRestControllerTest extends WallabagApiTestCase
     {
         $this->client->request('DELETE', '/api/tags/label.json', ['tags' => 'does not exist']);
 
-        $this->assertEquals(404, $this->client->getResponse()->getStatusCode());
+        $this->assertSame(404, $this->client->getResponse()->getStatusCode());
     }
 }

--- a/tests/Wallabag/ApiBundle/Controller/UserRestControllerTest.php
+++ b/tests/Wallabag/ApiBundle/Controller/UserRestControllerTest.php
@@ -9,7 +9,7 @@ class UserRestControllerTest extends WallabagApiTestCase
     public function testGetUser()
     {
         $this->client->request('GET', '/api/user.json');
-        $this->assertEquals(200, $this->client->getResponse()->getStatusCode());
+        $this->assertSame(200, $this->client->getResponse()->getStatusCode());
 
         $content = json_decode($this->client->getResponse()->getContent(), true);
 
@@ -20,27 +20,27 @@ class UserRestControllerTest extends WallabagApiTestCase
         $this->assertArrayHasKey('created_at', $content);
         $this->assertArrayHasKey('updated_at', $content);
 
-        $this->assertEquals('bigboss@wallabag.org', $content['email']);
-        $this->assertEquals('Big boss', $content['name']);
-        $this->assertEquals('admin', $content['username']);
+        $this->assertSame('bigboss@wallabag.org', $content['email']);
+        $this->assertSame('Big boss', $content['name']);
+        $this->assertSame('admin', $content['username']);
 
-        $this->assertEquals('application/json', $this->client->getResponse()->headers->get('Content-Type'));
+        $this->assertSame('application/json', $this->client->getResponse()->headers->get('Content-Type'));
     }
 
     public function testGetUserWithoutAuthentication()
     {
         $client = static::createClient();
         $client->request('GET', '/api/user.json');
-        $this->assertEquals(401, $client->getResponse()->getStatusCode());
+        $this->assertSame(401, $client->getResponse()->getStatusCode());
 
         $content = json_decode($client->getResponse()->getContent(), true);
 
         $this->assertArrayHasKey('error', $content);
         $this->assertArrayHasKey('error_description', $content);
 
-        $this->assertEquals('access_denied', $content['error']);
+        $this->assertSame('access_denied', $content['error']);
 
-        $this->assertEquals('application/json', $client->getResponse()->headers->get('Content-Type'));
+        $this->assertSame('application/json', $client->getResponse()->headers->get('Content-Type'));
     }
 
     public function testCreateNewUser()
@@ -52,7 +52,7 @@ class UserRestControllerTest extends WallabagApiTestCase
             'email' => 'wallabag@google.com',
         ]);
 
-        $this->assertEquals(201, $this->client->getResponse()->getStatusCode());
+        $this->assertSame(201, $this->client->getResponse()->getStatusCode());
 
         $content = json_decode($this->client->getResponse()->getContent(), true);
 
@@ -63,15 +63,15 @@ class UserRestControllerTest extends WallabagApiTestCase
         $this->assertArrayHasKey('updated_at', $content);
         $this->assertArrayHasKey('default_client', $content);
 
-        $this->assertEquals('wallabag@google.com', $content['email']);
-        $this->assertEquals('google', $content['username']);
+        $this->assertSame('wallabag@google.com', $content['email']);
+        $this->assertSame('google', $content['username']);
 
         $this->assertArrayHasKey('client_secret', $content['default_client']);
         $this->assertArrayHasKey('client_id', $content['default_client']);
 
-        $this->assertEquals('Default client', $content['default_client']['name']);
+        $this->assertSame('Default client', $content['default_client']['name']);
 
-        $this->assertEquals('application/json', $this->client->getResponse()->headers->get('Content-Type'));
+        $this->assertSame('application/json', $this->client->getResponse()->headers->get('Content-Type'));
 
         $this->client->getContainer()->get('craue_config')->set('api_user_registration', 0);
     }
@@ -88,7 +88,7 @@ class UserRestControllerTest extends WallabagApiTestCase
             'client_name' => 'My client name !!',
         ]);
 
-        $this->assertEquals(201, $client->getResponse()->getStatusCode());
+        $this->assertSame(201, $client->getResponse()->getStatusCode());
 
         $content = json_decode($client->getResponse()->getContent(), true);
 
@@ -99,15 +99,15 @@ class UserRestControllerTest extends WallabagApiTestCase
         $this->assertArrayHasKey('updated_at', $content);
         $this->assertArrayHasKey('default_client', $content);
 
-        $this->assertEquals('wallabag@google.com', $content['email']);
-        $this->assertEquals('google', $content['username']);
+        $this->assertSame('wallabag@google.com', $content['email']);
+        $this->assertSame('google', $content['username']);
 
         $this->assertArrayHasKey('client_secret', $content['default_client']);
         $this->assertArrayHasKey('client_id', $content['default_client']);
 
-        $this->assertEquals('My client name !!', $content['default_client']['name']);
+        $this->assertSame('My client name !!', $content['default_client']['name']);
 
-        $this->assertEquals('application/json', $client->getResponse()->headers->get('Content-Type'));
+        $this->assertSame('application/json', $client->getResponse()->headers->get('Content-Type'));
 
         $client->getContainer()->get('craue_config')->set('api_user_registration', 0);
     }
@@ -122,7 +122,7 @@ class UserRestControllerTest extends WallabagApiTestCase
             'email' => 'bigboss@wallabag.org',
         ]);
 
-        $this->assertEquals(400, $client->getResponse()->getStatusCode());
+        $this->assertSame(400, $client->getResponse()->getStatusCode());
 
         $content = json_decode($client->getResponse()->getContent(), true);
 
@@ -133,10 +133,10 @@ class UserRestControllerTest extends WallabagApiTestCase
         // $this->assertEquals('fos_user.username.already_used', $content['error']['username'][0]);
         // $this->assertEquals('fos_user.email.already_used', $content['error']['email'][0]);
         // This shouldn't be translated ...
-        $this->assertEquals('This value is already used.', $content['error']['username'][0]);
-        $this->assertEquals('This value is already used.', $content['error']['email'][0]);
+        $this->assertSame('This value is already used.', $content['error']['username'][0]);
+        $this->assertSame('This value is already used.', $content['error']['email'][0]);
 
-        $this->assertEquals('application/json', $client->getResponse()->headers->get('Content-Type'));
+        $this->assertSame('application/json', $client->getResponse()->headers->get('Content-Type'));
 
         $client->getContainer()->get('craue_config')->set('api_user_registration', 0);
     }
@@ -151,16 +151,16 @@ class UserRestControllerTest extends WallabagApiTestCase
             'email' => 'facebook@wallabag.org',
         ]);
 
-        $this->assertEquals(400, $client->getResponse()->getStatusCode());
+        $this->assertSame(400, $client->getResponse()->getStatusCode());
 
         $content = json_decode($client->getResponse()->getContent(), true);
 
         $this->assertArrayHasKey('error', $content);
         $this->assertArrayHasKey('password', $content['error']);
 
-        $this->assertEquals('validator.password_too_short', $content['error']['password'][0]);
+        $this->assertSame('validator.password_too_short', $content['error']['password'][0]);
 
-        $this->assertEquals('application/json', $client->getResponse()->headers->get('Content-Type'));
+        $this->assertSame('application/json', $client->getResponse()->headers->get('Content-Type'));
 
         $client->getContainer()->get('craue_config')->set('api_user_registration', 0);
     }
@@ -174,12 +174,12 @@ class UserRestControllerTest extends WallabagApiTestCase
             'email' => 'facebook@wallabag.org',
         ]);
 
-        $this->assertEquals(403, $client->getResponse()->getStatusCode());
+        $this->assertSame(403, $client->getResponse()->getStatusCode());
 
         $content = json_decode($client->getResponse()->getContent(), true);
 
         $this->assertArrayHasKey('error', $content);
 
-        $this->assertEquals('application/json', $client->getResponse()->headers->get('Content-Type'));
+        $this->assertSame('application/json', $client->getResponse()->headers->get('Content-Type'));
     }
 }

--- a/tests/Wallabag/ApiBundle/Controller/WallabagRestControllerTest.php
+++ b/tests/Wallabag/ApiBundle/Controller/WallabagRestControllerTest.php
@@ -12,10 +12,10 @@ class WallabagRestControllerTest extends WallabagApiTestCase
         $client = static::createClient();
         $client->request('GET', '/api/version');
 
-        $this->assertEquals(200, $client->getResponse()->getStatusCode());
+        $this->assertSame(200, $client->getResponse()->getStatusCode());
 
         $content = json_decode($client->getResponse()->getContent(), true);
 
-        $this->assertEquals($client->getContainer()->getParameter('wallabag_core.version'), $content);
+        $this->assertSame($client->getContainer()->getParameter('wallabag_core.version'), $content);
     }
 }

--- a/tests/Wallabag/ApiBundle/WallabagApiTestCase.php
+++ b/tests/Wallabag/ApiBundle/WallabagApiTestCase.php
@@ -40,7 +40,7 @@ abstract class WallabagApiTestCase extends WebTestCase
         $loginManager->logInUser($firewallName, $this->user);
 
         // save the login token into the session and put it in a cookie
-        $container->get('session')->set('_security_'.$firewallName, serialize($container->get('security.token_storage')->getToken()));
+        $container->get('session')->set('_security_' . $firewallName, serialize($container->get('security.token_storage')->getToken()));
         $container->get('session')->save();
 
         $session = $container->get('session');

--- a/tests/Wallabag/CoreBundle/Command/CleanDuplicatesCommandTest.php
+++ b/tests/Wallabag/CoreBundle/Command/CleanDuplicatesCommandTest.php
@@ -4,8 +4,8 @@ namespace Tests\Wallabag\CoreBundle\Command;
 
 use Symfony\Bundle\FrameworkBundle\Console\Application;
 use Symfony\Component\Console\Tester\CommandTester;
-use Wallabag\CoreBundle\Command\CleanDuplicatesCommand;
 use Tests\Wallabag\CoreBundle\WallabagCoreTestCase;
+use Wallabag\CoreBundle\Command\CleanDuplicatesCommand;
 use Wallabag\CoreBundle\Entity\Entry;
 
 class CleanDuplicatesCommandTest extends WallabagCoreTestCase

--- a/tests/Wallabag/CoreBundle/Command/ExportCommandTest.php
+++ b/tests/Wallabag/CoreBundle/Command/ExportCommandTest.php
@@ -4,8 +4,8 @@ namespace Tests\Wallabag\CoreBundle\Command;
 
 use Symfony\Bundle\FrameworkBundle\Console\Application;
 use Symfony\Component\Console\Tester\CommandTester;
-use Wallabag\CoreBundle\Command\ExportCommand;
 use Tests\Wallabag\CoreBundle\WallabagCoreTestCase;
+use Wallabag\CoreBundle\Command\ExportCommand;
 
 class ExportCommandTest extends WallabagCoreTestCase
 {

--- a/tests/Wallabag/CoreBundle/Command/InstallCommandTest.php
+++ b/tests/Wallabag/CoreBundle/Command/InstallCommandTest.php
@@ -11,9 +11,9 @@ use Symfony\Bundle\FrameworkBundle\Console\Application;
 use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Output\NullOutput;
 use Symfony\Component\Console\Tester\CommandTester;
-use Wallabag\CoreBundle\Command\InstallCommand;
 use Tests\Wallabag\CoreBundle\Mock\InstallCommandMock;
 use Tests\Wallabag\CoreBundle\WallabagCoreTestCase;
+use Wallabag\CoreBundle\Command\InstallCommand;
 
 class InstallCommandTest extends WallabagCoreTestCase
 {
@@ -86,9 +86,9 @@ class InstallCommandTest extends WallabagCoreTestCase
         $tester->setInputs([
             'y', // dropping database
             'y', // create super admin
-            'username_'.uniqid('', true), // username
-            'password_'.uniqid('', true), // password
-            'email_'.uniqid('', true).'@wallabag.it', // email
+            'username_' . uniqid('', true), // username
+            'password_' . uniqid('', true), // password
+            'email_' . uniqid('', true) . '@wallabag.it', // email
         ]);
         $tester->execute([
             'command' => $command->getName(),
@@ -111,9 +111,9 @@ class InstallCommandTest extends WallabagCoreTestCase
         $tester = new CommandTester($command);
         $tester->setInputs([
             'y', // create super admin
-            'username_'.uniqid('', true), // username
-            'password_'.uniqid('', true), // password
-            'email_'.uniqid('', true).'@wallabag.it', // email
+            'username_' . uniqid('', true), // username
+            'password_' . uniqid('', true), // password
+            'email_' . uniqid('', true) . '@wallabag.it', // email
         ]);
         $tester->execute([
             'command' => $command->getName(),
@@ -159,9 +159,9 @@ class InstallCommandTest extends WallabagCoreTestCase
         $tester = new CommandTester($command);
         $tester->setInputs([
             'y', // create super admin
-            'username_'.uniqid('', true), // username
-            'password_'.uniqid('', true), // password
-            'email_'.uniqid('', true).'@wallabag.it', // email
+            'username_' . uniqid('', true), // username
+            'password_' . uniqid('', true), // password
+            'email_' . uniqid('', true) . '@wallabag.it', // email
         ]);
         $tester->execute([
             'command' => $command->getName(),

--- a/tests/Wallabag/CoreBundle/Command/TagAllCommandTest.php
+++ b/tests/Wallabag/CoreBundle/Command/TagAllCommandTest.php
@@ -4,8 +4,8 @@ namespace Tests\Wallabag\CoreBundle\Command;
 
 use Symfony\Bundle\FrameworkBundle\Console\Application;
 use Symfony\Component\Console\Tester\CommandTester;
-use Wallabag\CoreBundle\Command\TagAllCommand;
 use Tests\Wallabag\CoreBundle\WallabagCoreTestCase;
+use Wallabag\CoreBundle\Command\TagAllCommand;
 
 class TagAllCommandTest extends WallabagCoreTestCase
 {

--- a/tests/Wallabag/CoreBundle/Controller/ConfigControllerTest.php
+++ b/tests/Wallabag/CoreBundle/Controller/ConfigControllerTest.php
@@ -3,11 +3,11 @@
 namespace tests\Wallabag\CoreBundle\Controller;
 
 use Tests\Wallabag\CoreBundle\WallabagCoreTestCase;
+use Wallabag\AnnotationBundle\Entity\Annotation;
 use Wallabag\CoreBundle\Entity\Config;
-use Wallabag\UserBundle\Entity\User;
 use Wallabag\CoreBundle\Entity\Entry;
 use Wallabag\CoreBundle\Entity\Tag;
-use Wallabag\AnnotationBundle\Entity\Annotation;
+use Wallabag\UserBundle\Entity\User;
 
 class ConfigControllerTest extends WallabagCoreTestCase
 {
@@ -17,7 +17,7 @@ class ConfigControllerTest extends WallabagCoreTestCase
 
         $client->request('GET', '/new');
 
-        $this->assertEquals(302, $client->getResponse()->getStatusCode());
+        $this->assertSame(302, $client->getResponse()->getStatusCode());
         $this->assertContains('login', $client->getResponse()->headers->get('location'));
     }
 
@@ -28,7 +28,7 @@ class ConfigControllerTest extends WallabagCoreTestCase
 
         $crawler = $client->request('GET', '/config');
 
-        $this->assertEquals(200, $client->getResponse()->getStatusCode());
+        $this->assertSame(200, $client->getResponse()->getStatusCode());
 
         $this->assertCount(1, $crawler->filter('button[id=config_save]'));
         $this->assertCount(1, $crawler->filter('button[id=change_passwd_save]'));
@@ -43,7 +43,7 @@ class ConfigControllerTest extends WallabagCoreTestCase
 
         $crawler = $client->request('GET', '/config');
 
-        $this->assertEquals(200, $client->getResponse()->getStatusCode());
+        $this->assertSame(200, $client->getResponse()->getStatusCode());
 
         $form = $crawler->filter('button[id=config_save]')->form();
 
@@ -57,7 +57,7 @@ class ConfigControllerTest extends WallabagCoreTestCase
 
         $client->submit($form, $data);
 
-        $this->assertEquals(302, $client->getResponse()->getStatusCode());
+        $this->assertSame(302, $client->getResponse()->getStatusCode());
 
         $crawler = $client->followRedirect();
 
@@ -131,13 +131,13 @@ class ConfigControllerTest extends WallabagCoreTestCase
 
         $crawler = $client->request('GET', '/config');
 
-        $this->assertEquals(200, $client->getResponse()->getStatusCode());
+        $this->assertSame(200, $client->getResponse()->getStatusCode());
 
         $form = $crawler->filter('button[id=config_save]')->form();
 
         $crawler = $client->submit($form, $data);
 
-        $this->assertEquals(200, $client->getResponse()->getStatusCode());
+        $this->assertSame(200, $client->getResponse()->getStatusCode());
 
         $this->assertGreaterThan(1, $alert = $crawler->filter('body')->extract(['_text']));
         $this->assertContains('This value should not be blank', $alert[0]);
@@ -191,13 +191,13 @@ class ConfigControllerTest extends WallabagCoreTestCase
 
         $crawler = $client->request('GET', '/config');
 
-        $this->assertEquals(200, $client->getResponse()->getStatusCode());
+        $this->assertSame(200, $client->getResponse()->getStatusCode());
 
         $form = $crawler->filter('button[id=change_passwd_save]')->form();
 
         $crawler = $client->submit($form, $data);
 
-        $this->assertEquals(200, $client->getResponse()->getStatusCode());
+        $this->assertSame(200, $client->getResponse()->getStatusCode());
 
         $this->assertGreaterThan(1, $alert = $crawler->filter('body')->extract(['_text']));
         $this->assertContains($expectedMessage, $alert[0]);
@@ -210,7 +210,7 @@ class ConfigControllerTest extends WallabagCoreTestCase
 
         $crawler = $client->request('GET', '/config');
 
-        $this->assertEquals(200, $client->getResponse()->getStatusCode());
+        $this->assertSame(200, $client->getResponse()->getStatusCode());
 
         $form = $crawler->filter('button[id=change_passwd_save]')->form();
 
@@ -222,7 +222,7 @@ class ConfigControllerTest extends WallabagCoreTestCase
 
         $client->submit($form, $data);
 
-        $this->assertEquals(302, $client->getResponse()->getStatusCode());
+        $this->assertSame(302, $client->getResponse()->getStatusCode());
 
         $crawler = $client->followRedirect();
 
@@ -259,13 +259,13 @@ class ConfigControllerTest extends WallabagCoreTestCase
 
         $crawler = $client->request('GET', '/config');
 
-        $this->assertEquals(200, $client->getResponse()->getStatusCode());
+        $this->assertSame(200, $client->getResponse()->getStatusCode());
 
         $form = $crawler->filter('button[id=update_user_save]')->form();
 
         $crawler = $client->submit($form, $data);
 
-        $this->assertEquals(200, $client->getResponse()->getStatusCode());
+        $this->assertSame(200, $client->getResponse()->getStatusCode());
 
         $this->assertGreaterThan(1, $alert = $crawler->filter('body')->extract(['_text']));
         $this->assertContains($expectedMessage, $alert[0]);
@@ -278,7 +278,7 @@ class ConfigControllerTest extends WallabagCoreTestCase
 
         $crawler = $client->request('GET', '/config');
 
-        $this->assertEquals(200, $client->getResponse()->getStatusCode());
+        $this->assertSame(200, $client->getResponse()->getStatusCode());
 
         $form = $crawler->filter('button[id=update_user_save]')->form();
 
@@ -289,7 +289,7 @@ class ConfigControllerTest extends WallabagCoreTestCase
 
         $client->submit($form, $data);
 
-        $this->assertEquals(302, $client->getResponse()->getStatusCode());
+        $this->assertSame(302, $client->getResponse()->getStatusCode());
 
         $crawler = $client->followRedirect();
 
@@ -319,13 +319,13 @@ class ConfigControllerTest extends WallabagCoreTestCase
 
         $crawler = $client->request('GET', '/config');
 
-        $this->assertEquals(200, $client->getResponse()->getStatusCode());
+        $this->assertSame(200, $client->getResponse()->getStatusCode());
 
         $this->assertGreaterThan(1, $body = $crawler->filter('body')->extract(['_text']));
         $this->assertContains('config.form_rss.no_token', $body[0]);
 
         $client->request('GET', '/generate-token');
-        $this->assertEquals(302, $client->getResponse()->getStatusCode());
+        $this->assertSame(302, $client->getResponse()->getStatusCode());
 
         $crawler = $client->followRedirect();
 
@@ -346,7 +346,7 @@ class ConfigControllerTest extends WallabagCoreTestCase
             ['HTTP_X-Requested-With' => 'XMLHttpRequest']
         );
 
-        $this->assertEquals(200, $client->getResponse()->getStatusCode());
+        $this->assertSame(200, $client->getResponse()->getStatusCode());
         $content = json_decode($client->getResponse()->getContent(), true);
         $this->assertArrayHasKey('token', $content);
     }
@@ -358,7 +358,7 @@ class ConfigControllerTest extends WallabagCoreTestCase
 
         $crawler = $client->request('GET', '/config');
 
-        $this->assertEquals(200, $client->getResponse()->getStatusCode());
+        $this->assertSame(200, $client->getResponse()->getStatusCode());
 
         $form = $crawler->filter('button[id=rss_config_save]')->form();
 
@@ -368,7 +368,7 @@ class ConfigControllerTest extends WallabagCoreTestCase
 
         $client->submit($form, $data);
 
-        $this->assertEquals(302, $client->getResponse()->getStatusCode());
+        $this->assertSame(302, $client->getResponse()->getStatusCode());
 
         $crawler = $client->followRedirect();
 
@@ -403,13 +403,13 @@ class ConfigControllerTest extends WallabagCoreTestCase
 
         $crawler = $client->request('GET', '/config');
 
-        $this->assertEquals(200, $client->getResponse()->getStatusCode());
+        $this->assertSame(200, $client->getResponse()->getStatusCode());
 
         $form = $crawler->filter('button[id=rss_config_save]')->form();
 
         $crawler = $client->submit($form, $data);
 
-        $this->assertEquals(200, $client->getResponse()->getStatusCode());
+        $this->assertSame(200, $client->getResponse()->getStatusCode());
 
         $this->assertGreaterThan(1, $alert = $crawler->filter('body')->extract(['_text']));
         $this->assertContains($expectedMessage, $alert[0]);
@@ -423,7 +423,7 @@ class ConfigControllerTest extends WallabagCoreTestCase
 
         $crawler = $client->request('GET', '/config');
 
-        $this->assertEquals(200, $client->getResponse()->getStatusCode());
+        $this->assertSame(200, $client->getResponse()->getStatusCode());
 
         $form = $crawler->filter('button[id=tagging_rule_save]')->form();
 
@@ -434,7 +434,7 @@ class ConfigControllerTest extends WallabagCoreTestCase
 
         $client->submit($form, $data);
 
-        $this->assertEquals(302, $client->getResponse()->getStatusCode());
+        $this->assertSame(302, $client->getResponse()->getStatusCode());
 
         $crawler = $client->followRedirect();
 
@@ -443,7 +443,7 @@ class ConfigControllerTest extends WallabagCoreTestCase
         $editLink = $crawler->filter('.mode_edit')->last()->link();
 
         $crawler = $client->click($editLink);
-        $this->assertEquals(302, $client->getResponse()->getStatusCode());
+        $this->assertSame(302, $client->getResponse()->getStatusCode());
         $this->assertContains('?tagging-rule=', $client->getResponse()->headers->get('location'));
 
         $crawler = $client->followRedirect();
@@ -457,7 +457,7 @@ class ConfigControllerTest extends WallabagCoreTestCase
 
         $client->submit($form, $data);
 
-        $this->assertEquals(302, $client->getResponse()->getStatusCode());
+        $this->assertSame(302, $client->getResponse()->getStatusCode());
 
         $crawler = $client->followRedirect();
 
@@ -468,7 +468,7 @@ class ConfigControllerTest extends WallabagCoreTestCase
         $deleteLink = $crawler->filter('.delete')->last()->link();
 
         $crawler = $client->click($deleteLink);
-        $this->assertEquals(302, $client->getResponse()->getStatusCode());
+        $this->assertSame(302, $client->getResponse()->getStatusCode());
 
         $crawler = $client->followRedirect();
         $this->assertContains('flashes.config.notice.tagging_rules_deleted', $crawler->filter('body')->extract(['_text'])[0]);
@@ -510,13 +510,13 @@ class ConfigControllerTest extends WallabagCoreTestCase
 
         $crawler = $client->request('GET', '/config');
 
-        $this->assertEquals(200, $client->getResponse()->getStatusCode());
+        $this->assertSame(200, $client->getResponse()->getStatusCode());
 
         $form = $crawler->filter('button[id=tagging_rule_save]')->form();
 
         $crawler = $client->submit($form, $data);
 
-        $this->assertEquals(200, $client->getResponse()->getStatusCode());
+        $this->assertSame(200, $client->getResponse()->getStatusCode());
 
         $this->assertGreaterThan(1, $body = $crawler->filter('body')->extract(['_text']));
 
@@ -532,7 +532,7 @@ class ConfigControllerTest extends WallabagCoreTestCase
 
         $crawler = $client->request('GET', '/config');
 
-        $this->assertEquals(200, $client->getResponse()->getStatusCode());
+        $this->assertSame(200, $client->getResponse()->getStatusCode());
 
         $form = $crawler->filter('button[id=tagging_rule_save]')->form();
 
@@ -541,7 +541,7 @@ class ConfigControllerTest extends WallabagCoreTestCase
             'tagging_rule[tags]' => 'cool tag',
         ]);
 
-        $this->assertEquals(200, $client->getResponse()->getStatusCode());
+        $this->assertSame(200, $client->getResponse()->getStatusCode());
 
         $this->assertGreaterThan(1, $body = $crawler->filter('body')->extract(['_text']));
 
@@ -557,9 +557,9 @@ class ConfigControllerTest extends WallabagCoreTestCase
             ->getRepository('WallabagCoreBundle:TaggingRule')
             ->findAll()[0];
 
-        $crawler = $client->request('GET', '/tagging-rule/edit/'.$rule->getId());
+        $crawler = $client->request('GET', '/tagging-rule/edit/' . $rule->getId());
 
-        $this->assertEquals(403, $client->getResponse()->getStatusCode());
+        $this->assertSame(403, $client->getResponse()->getStatusCode());
         $this->assertGreaterThan(1, $body = $crawler->filter('body')->extract(['_text']));
         $this->assertContains('You can not access this tagging rule', $body[0]);
     }
@@ -573,9 +573,9 @@ class ConfigControllerTest extends WallabagCoreTestCase
             ->getRepository('WallabagCoreBundle:TaggingRule')
             ->findAll()[0];
 
-        $crawler = $client->request('GET', '/tagging-rule/edit/'.$rule->getId());
+        $crawler = $client->request('GET', '/tagging-rule/edit/' . $rule->getId());
 
-        $this->assertEquals(403, $client->getResponse()->getStatusCode());
+        $this->assertSame(403, $client->getResponse()->getStatusCode());
         $this->assertGreaterThan(1, $body = $crawler->filter('body')->extract(['_text']));
         $this->assertContains('You can not access this tagging rule', $body[0]);
     }
@@ -591,7 +591,7 @@ class ConfigControllerTest extends WallabagCoreTestCase
 
         $crawler = $client->request('GET', '/config');
 
-        $this->assertEquals(200, $client->getResponse()->getStatusCode());
+        $this->assertSame(200, $client->getResponse()->getStatusCode());
 
         $form = $crawler->filter('button[id=change_passwd_save]')->form();
 
@@ -603,7 +603,7 @@ class ConfigControllerTest extends WallabagCoreTestCase
 
         $client->submit($form, $data);
 
-        $this->assertEquals(302, $client->getResponse()->getStatusCode());
+        $this->assertSame(302, $client->getResponse()->getStatusCode());
         $this->assertContains('flashes.config.notice.password_not_updated_demo', $client->getContainer()->get('session')->getFlashBag()->get('notice')[0]);
 
         $config->set('demo_mode_enabled', 0);
@@ -642,7 +642,7 @@ class ConfigControllerTest extends WallabagCoreTestCase
         $this->assertNotContains('config.form_user.delete.button', $body[0]);
 
         $client->request('GET', '/account/delete');
-        $this->assertEquals(403, $client->getResponse()->getStatusCode());
+        $this->assertSame(403, $client->getResponse()->getStatusCode());
 
         $user = $em
             ->getRepository('WallabagUserBundle:User')
@@ -692,7 +692,7 @@ class ConfigControllerTest extends WallabagCoreTestCase
         // that this entry is also deleted
         $crawler = $client->request('GET', '/new');
 
-        $this->assertEquals(200, $client->getResponse()->getStatusCode());
+        $this->assertSame(200, $client->getResponse()->getStatusCode());
 
         $form = $crawler->filter('form[name=entry]')->form();
         $data = [
@@ -700,14 +700,14 @@ class ConfigControllerTest extends WallabagCoreTestCase
         ];
 
         $client->submit($form, $data);
-        $this->assertEquals(302, $client->getResponse()->getStatusCode());
+        $this->assertSame(302, $client->getResponse()->getStatusCode());
 
         $crawler = $client->request('GET', '/config');
 
         $deleteLink = $crawler->filter('.delete-account')->last()->link();
 
         $client->click($deleteLink);
-        $this->assertEquals(302, $client->getResponse()->getStatusCode());
+        $this->assertSame(302, $client->getResponse()->getStatusCode());
 
         $em = $client->getContainer()->get('doctrine.orm.entity_manager');
         $user = $em
@@ -767,11 +767,11 @@ class ConfigControllerTest extends WallabagCoreTestCase
         // reset annotations
         $crawler = $client->request('GET', '/config#set3');
 
-        $this->assertEquals(200, $client->getResponse()->getStatusCode());
+        $this->assertSame(200, $client->getResponse()->getStatusCode());
 
         $crawler = $client->click($crawler->selectLink('config.reset.annotations')->link());
 
-        $this->assertEquals(302, $client->getResponse()->getStatusCode());
+        $this->assertSame(302, $client->getResponse()->getStatusCode());
         $this->assertContains('flashes.config.notice.annotations_reset', $client->getContainer()->get('session')->getFlashBag()->get('notice')[0]);
 
         $annotationsReset = $em
@@ -783,34 +783,34 @@ class ConfigControllerTest extends WallabagCoreTestCase
         // reset tags
         $crawler = $client->request('GET', '/config#set3');
 
-        $this->assertEquals(200, $client->getResponse()->getStatusCode());
+        $this->assertSame(200, $client->getResponse()->getStatusCode());
 
         $crawler = $client->click($crawler->selectLink('config.reset.tags')->link());
 
-        $this->assertEquals(302, $client->getResponse()->getStatusCode());
+        $this->assertSame(302, $client->getResponse()->getStatusCode());
         $this->assertContains('flashes.config.notice.tags_reset', $client->getContainer()->get('session')->getFlashBag()->get('notice')[0]);
 
         $tagReset = $em
             ->getRepository('WallabagCoreBundle:Tag')
             ->countAllTags($user->getId());
 
-        $this->assertEquals(0, $tagReset, 'Tags were reset');
+        $this->assertSame(0, $tagReset, 'Tags were reset');
 
         // reset entries
         $crawler = $client->request('GET', '/config#set3');
 
-        $this->assertEquals(200, $client->getResponse()->getStatusCode());
+        $this->assertSame(200, $client->getResponse()->getStatusCode());
 
         $crawler = $client->click($crawler->selectLink('config.reset.entries')->link());
 
-        $this->assertEquals(302, $client->getResponse()->getStatusCode());
+        $this->assertSame(302, $client->getResponse()->getStatusCode());
         $this->assertContains('flashes.config.notice.entries_reset', $client->getContainer()->get('session')->getFlashBag()->get('notice')[0]);
 
         $entryReset = $em
             ->getRepository('WallabagCoreBundle:Entry')
             ->countAllEntriesByUser($user->getId());
 
-        $this->assertEquals(0, $entryReset, 'Entries were reset');
+        $this->assertSame(0, $entryReset, 'Entries were reset');
     }
 
     public function testResetArchivedEntries()
@@ -863,24 +863,24 @@ class ConfigControllerTest extends WallabagCoreTestCase
 
         $crawler = $client->request('GET', '/config#set3');
 
-        $this->assertEquals(200, $client->getResponse()->getStatusCode());
+        $this->assertSame(200, $client->getResponse()->getStatusCode());
 
         $crawler = $client->click($crawler->selectLink('config.reset.archived')->link());
 
-        $this->assertEquals(302, $client->getResponse()->getStatusCode());
+        $this->assertSame(302, $client->getResponse()->getStatusCode());
         $this->assertContains('flashes.config.notice.archived_reset', $client->getContainer()->get('session')->getFlashBag()->get('notice')[0]);
 
         $entryReset = $em
             ->getRepository('WallabagCoreBundle:Entry')
             ->countAllEntriesByUser($user->getId());
 
-        $this->assertEquals(1, $entryReset, 'Entries were reset');
+        $this->assertSame(1, $entryReset, 'Entries were reset');
 
         $tagReset = $em
             ->getRepository('WallabagCoreBundle:Tag')
             ->countAllTags($user->getId());
 
-        $this->assertEquals(1, $tagReset, 'Tags were reset');
+        $this->assertSame(1, $tagReset, 'Tags were reset');
 
         $annotationsReset = $em
             ->getRepository('WallabagAnnotationBundle:Annotation')
@@ -920,24 +920,24 @@ class ConfigControllerTest extends WallabagCoreTestCase
 
         $crawler = $client->request('GET', '/config#set3');
 
-        $this->assertEquals(200, $client->getResponse()->getStatusCode());
+        $this->assertSame(200, $client->getResponse()->getStatusCode());
 
         $crawler = $client->click($crawler->selectLink('config.reset.entries')->link());
 
-        $this->assertEquals(302, $client->getResponse()->getStatusCode());
+        $this->assertSame(302, $client->getResponse()->getStatusCode());
         $this->assertContains('flashes.config.notice.entries_reset', $client->getContainer()->get('session')->getFlashBag()->get('notice')[0]);
 
         $entryReset = $em
             ->getRepository('WallabagCoreBundle:Entry')
             ->countAllEntriesByUser($user->getId());
 
-        $this->assertEquals(0, $entryReset, 'Entries were reset');
+        $this->assertSame(0, $entryReset, 'Entries were reset');
 
         $tagReset = $em
             ->getRepository('WallabagCoreBundle:Tag')
             ->countAllTags($user->getId());
 
-        $this->assertEquals(0, $tagReset, 'Tags were reset');
+        $this->assertSame(0, $tagReset, 'Tags were reset');
 
         $annotationsReset = $em
             ->getRepository('WallabagAnnotationBundle:Annotation')

--- a/tests/Wallabag/CoreBundle/Controller/EntryControllerTest.php
+++ b/tests/Wallabag/CoreBundle/Controller/EntryControllerTest.php
@@ -33,7 +33,7 @@ class EntryControllerTest extends WallabagCoreTestCase
 
         $client->request('GET', '/new');
 
-        $this->assertEquals(302, $client->getResponse()->getStatusCode());
+        $this->assertSame(302, $client->getResponse()->getStatusCode());
         $this->assertContains('login', $client->getResponse()->headers->get('location'));
     }
 
@@ -45,14 +45,14 @@ class EntryControllerTest extends WallabagCoreTestCase
         $client->request('GET', '/unread/list');
         $crawler = $client->followRedirect();
 
-        $this->assertEquals(200, $client->getResponse()->getStatusCode());
+        $this->assertSame(200, $client->getResponse()->getStatusCode());
         $this->assertGreaterThan(1, $body = $crawler->filter('body')->extract(['_text']));
         $this->assertContains('quickstart.intro.title', $body[0]);
 
         // Test if quickstart is disabled when user has 1 entry
         $crawler = $client->request('GET', '/new');
 
-        $this->assertEquals(200, $client->getResponse()->getStatusCode());
+        $this->assertSame(200, $client->getResponse()->getStatusCode());
 
         $form = $crawler->filter('form[name=entry]')->form();
 
@@ -61,7 +61,7 @@ class EntryControllerTest extends WallabagCoreTestCase
         ];
 
         $client->submit($form, $data);
-        $this->assertEquals(302, $client->getResponse()->getStatusCode());
+        $this->assertSame(302, $client->getResponse()->getStatusCode());
         $client->followRedirect();
 
         $crawler = $client->request('GET', '/unread/list');
@@ -77,7 +77,7 @@ class EntryControllerTest extends WallabagCoreTestCase
 
         $crawler = $client->request('GET', '/new');
 
-        $this->assertEquals(200, $client->getResponse()->getStatusCode());
+        $this->assertSame(200, $client->getResponse()->getStatusCode());
 
         $this->assertCount(1, $crawler->filter('input[type=url]'));
         $this->assertCount(1, $crawler->filter('form[name=entry]'));
@@ -95,7 +95,7 @@ class EntryControllerTest extends WallabagCoreTestCase
 
         // Good URL
         $client->request('GET', '/bookmarklet', ['url' => $this->url]);
-        $this->assertEquals(302, $client->getResponse()->getStatusCode());
+        $this->assertSame(302, $client->getResponse()->getStatusCode());
         $client->followRedirect();
         $crawler = $client->request('GET', '/');
         $this->assertCount(5, $crawler->filter('div[class=entry]'));
@@ -116,15 +116,15 @@ class EntryControllerTest extends WallabagCoreTestCase
 
         $crawler = $client->request('GET', '/new');
 
-        $this->assertEquals(200, $client->getResponse()->getStatusCode());
+        $this->assertSame(200, $client->getResponse()->getStatusCode());
 
         $form = $crawler->filter('form[name=entry]')->form();
 
         $crawler = $client->submit($form);
 
-        $this->assertEquals(200, $client->getResponse()->getStatusCode());
+        $this->assertSame(200, $client->getResponse()->getStatusCode());
         $this->assertCount(1, $alert = $crawler->filter('form ul li')->extract(['_text']));
-        $this->assertEquals('This value should not be blank.', $alert[0]);
+        $this->assertSame('This value should not be blank.', $alert[0]);
     }
 
     /**
@@ -137,7 +137,7 @@ class EntryControllerTest extends WallabagCoreTestCase
 
         $crawler = $client->request('GET', '/new');
 
-        $this->assertEquals(200, $client->getResponse()->getStatusCode());
+        $this->assertSame(200, $client->getResponse()->getStatusCode());
 
         $form = $crawler->filter('form[name=entry]')->form();
 
@@ -147,7 +147,7 @@ class EntryControllerTest extends WallabagCoreTestCase
 
         $client->submit($form, $data);
 
-        $this->assertEquals(302, $client->getResponse()->getStatusCode());
+        $this->assertSame(302, $client->getResponse()->getStatusCode());
 
         $content = $client->getContainer()
             ->get('doctrine.orm.entity_manager')
@@ -157,11 +157,11 @@ class EntryControllerTest extends WallabagCoreTestCase
         $author = $content->getPublishedBy();
 
         $this->assertInstanceOf('Wallabag\CoreBundle\Entity\Entry', $content);
-        $this->assertEquals($this->url, $content->getUrl());
+        $this->assertSame($this->url, $content->getUrl());
         $this->assertContains('Google', $content->getTitle());
-        $this->assertEquals('fr', $content->getLanguage());
-        $this->assertEquals('2015-03-28 15:37:39', $content->getPublishedAt()->format('Y-m-d H:i:s'));
-        $this->assertEquals('Morgane Tual', $author[0]);
+        $this->assertSame('fr', $content->getLanguage());
+        $this->assertSame('2015-03-28 15:37:39', $content->getPublishedAt()->format('Y-m-d H:i:s'));
+        $this->assertSame('Morgane Tual', $author[0]);
         $this->assertArrayHasKey('x-varnish1', $content->getHeaders());
     }
 
@@ -173,7 +173,7 @@ class EntryControllerTest extends WallabagCoreTestCase
 
         $crawler = $client->request('GET', '/new');
 
-        $this->assertEquals(200, $client->getResponse()->getStatusCode());
+        $this->assertSame(200, $client->getResponse()->getStatusCode());
 
         $form = $crawler->filter('form[name=entry]')->form();
 
@@ -183,7 +183,7 @@ class EntryControllerTest extends WallabagCoreTestCase
 
         $client->submit($form, $data);
 
-        $this->assertEquals(302, $client->getResponse()->getStatusCode());
+        $this->assertSame(302, $client->getResponse()->getStatusCode());
 
         $content = $client->getContainer()
             ->get('doctrine.orm.entity_manager')
@@ -191,10 +191,10 @@ class EntryControllerTest extends WallabagCoreTestCase
             ->findByUrlAndUserId($url, $this->getLoggedInUserId());
 
         $authors = $content->getPublishedBy();
-        $this->assertEquals('2017-04-05 19:26:13', $content->getPublishedAt()->format('Y-m-d H:i:s'));
-        $this->assertEquals('fr', $content->getLanguage());
-        $this->assertEquals('Raphaël Balenieri, correspondant à Pékin', $authors[0]);
-        $this->assertEquals('Frédéric Autran, correspondant à New York', $authors[1]);
+        $this->assertSame('2017-04-05 19:26:13', $content->getPublishedAt()->format('Y-m-d H:i:s'));
+        $this->assertSame('fr', $content->getLanguage());
+        $this->assertSame('Raphaël Balenieri, correspondant à Pékin', $authors[0]);
+        $this->assertSame('Frédéric Autran, correspondant à New York', $authors[1]);
     }
 
     public function testPostNewOkUrlExist()
@@ -210,7 +210,7 @@ class EntryControllerTest extends WallabagCoreTestCase
 
         $crawler = $client->request('GET', '/new');
 
-        $this->assertEquals(200, $client->getResponse()->getStatusCode());
+        $this->assertSame(200, $client->getResponse()->getStatusCode());
 
         $form = $crawler->filter('form[name=entry]')->form();
 
@@ -220,7 +220,7 @@ class EntryControllerTest extends WallabagCoreTestCase
 
         $client->submit($form, $data);
 
-        $this->assertEquals(302, $client->getResponse()->getStatusCode());
+        $this->assertSame(302, $client->getResponse()->getStatusCode());
         $this->assertContains('/view/', $client->getResponse()->getTargetUrl());
     }
 
@@ -233,7 +233,7 @@ class EntryControllerTest extends WallabagCoreTestCase
 
         $crawler = $client->request('GET', '/new');
 
-        $this->assertEquals(200, $client->getResponse()->getStatusCode());
+        $this->assertSame(200, $client->getResponse()->getStatusCode());
 
         $form = $crawler->filter('form[name=entry]')->form();
 
@@ -245,7 +245,7 @@ class EntryControllerTest extends WallabagCoreTestCase
 
         $crawler = $client->request('GET', '/new');
 
-        $this->assertEquals(200, $client->getResponse()->getStatusCode());
+        $this->assertSame(200, $client->getResponse()->getStatusCode());
 
         $form = $crawler->filter('form[name=entry]')->form();
 
@@ -255,7 +255,7 @@ class EntryControllerTest extends WallabagCoreTestCase
 
         $client->submit($form, $data);
 
-        $this->assertEquals(302, $client->getResponse()->getStatusCode());
+        $this->assertSame(302, $client->getResponse()->getStatusCode());
         $this->assertContains('/view/', $client->getResponse()->getTargetUrl());
     }
 
@@ -269,7 +269,7 @@ class EntryControllerTest extends WallabagCoreTestCase
 
         $crawler = $client->request('GET', '/new');
 
-        $this->assertEquals(200, $client->getResponse()->getStatusCode());
+        $this->assertSame(200, $client->getResponse()->getStatusCode());
 
         $form = $crawler->filter('form[name=entry]')->form();
 
@@ -279,7 +279,7 @@ class EntryControllerTest extends WallabagCoreTestCase
 
         $client->submit($form, $data);
 
-        $this->assertEquals(302, $client->getResponse()->getStatusCode());
+        $this->assertSame(302, $client->getResponse()->getStatusCode());
         $this->assertContains('/', $client->getResponse()->getTargetUrl());
 
         $em = $client->getContainer()
@@ -291,7 +291,7 @@ class EntryControllerTest extends WallabagCoreTestCase
 
         $this->assertCount(2, $tags);
         $this->assertContains('wallabag', $tags);
-        $this->assertEquals('en', $entry->getLanguage());
+        $this->assertSame('en', $entry->getLanguage());
 
         $em->remove($entry);
         $em->flush();
@@ -300,7 +300,7 @@ class EntryControllerTest extends WallabagCoreTestCase
         // related https://github.com/wallabag/wallabag/issues/2121
         $crawler = $client->request('GET', '/new');
 
-        $this->assertEquals(200, $client->getResponse()->getStatusCode());
+        $this->assertSame(200, $client->getResponse()->getStatusCode());
 
         $form = $crawler->filter('form[name=entry]')->form();
 
@@ -310,7 +310,7 @@ class EntryControllerTest extends WallabagCoreTestCase
 
         $client->submit($form, $data);
 
-        $this->assertEquals(302, $client->getResponse()->getStatusCode());
+        $this->assertSame(302, $client->getResponse()->getStatusCode());
         $this->assertContains('/', $client->getResponse()->getTargetUrl());
 
         $entry = $em
@@ -333,7 +333,7 @@ class EntryControllerTest extends WallabagCoreTestCase
 
         $client->request('GET', '/archive/list');
 
-        $this->assertEquals(200, $client->getResponse()->getStatusCode());
+        $this->assertSame(200, $client->getResponse()->getStatusCode());
     }
 
     public function testUntagged()
@@ -343,7 +343,7 @@ class EntryControllerTest extends WallabagCoreTestCase
 
         $client->request('GET', '/untagged/list');
 
-        $this->assertEquals(200, $client->getResponse()->getStatusCode());
+        $this->assertSame(200, $client->getResponse()->getStatusCode());
     }
 
     public function testStarred()
@@ -353,7 +353,7 @@ class EntryControllerTest extends WallabagCoreTestCase
 
         $client->request('GET', '/starred/list');
 
-        $this->assertEquals(200, $client->getResponse()->getStatusCode());
+        $this->assertSame(200, $client->getResponse()->getStatusCode());
     }
 
     public function testRangeException()
@@ -363,8 +363,8 @@ class EntryControllerTest extends WallabagCoreTestCase
 
         $client->request('GET', '/all/list/900');
 
-        $this->assertEquals(302, $client->getResponse()->getStatusCode());
-        $this->assertEquals('/all/list', $client->getResponse()->getTargetUrl());
+        $this->assertSame(302, $client->getResponse()->getStatusCode());
+        $this->assertSame('/all/list', $client->getResponse()->getTargetUrl());
     }
 
     public function testView()
@@ -379,9 +379,9 @@ class EntryControllerTest extends WallabagCoreTestCase
         $this->getEntityManager()->persist($entry);
         $this->getEntityManager()->flush();
 
-        $crawler = $client->request('GET', '/view/'.$entry->getId());
+        $crawler = $client->request('GET', '/view/' . $entry->getId());
 
-        $this->assertEquals(200, $client->getResponse()->getStatusCode());
+        $this->assertSame(200, $client->getResponse()->getStatusCode());
         $this->assertGreaterThan(1, $body = $crawler->filter('body')->extract(['_text']));
         $this->assertContains($entry->getTitle(), $body[0]);
     }
@@ -402,9 +402,9 @@ class EntryControllerTest extends WallabagCoreTestCase
         $this->getEntityManager()->flush();
         $this->getEntityManager()->clear();
 
-        $client->request('GET', '/reload/'.$entry->getId());
+        $client->request('GET', '/reload/' . $entry->getId());
 
-        $this->assertEquals(302, $client->getResponse()->getStatusCode());
+        $this->assertSame(302, $client->getResponse()->getStatusCode());
 
         $entry = $this->getEntityManager()
             ->getRepository('WallabagCoreBundle:Entry')
@@ -423,9 +423,9 @@ class EntryControllerTest extends WallabagCoreTestCase
         $this->getEntityManager()->persist($entry);
         $this->getEntityManager()->flush();
 
-        $client->request('GET', '/reload/'.$entry->getId());
+        $client->request('GET', '/reload/' . $entry->getId());
 
-        $this->assertEquals(302, $client->getResponse()->getStatusCode());
+        $this->assertSame(302, $client->getResponse()->getStatusCode());
 
         // force EntityManager to clear previous entity
         // otherwise, retrieve the same entity will retrieve change from the previous request :0
@@ -434,7 +434,7 @@ class EntryControllerTest extends WallabagCoreTestCase
             ->getRepository('WallabagCoreBundle:Entry')
             ->find($entry->getId());
 
-        $this->assertNotEquals($client->getContainer()->getParameter('wallabag_core.fetching_error_message'), $newContent->getContent());
+        $this->assertNotSame($client->getContainer()->getParameter('wallabag_core.fetching_error_message'), $newContent->getContent());
     }
 
     public function testEdit()
@@ -447,9 +447,9 @@ class EntryControllerTest extends WallabagCoreTestCase
         $this->getEntityManager()->persist($entry);
         $this->getEntityManager()->flush();
 
-        $crawler = $client->request('GET', '/edit/'.$entry->getId());
+        $crawler = $client->request('GET', '/edit/' . $entry->getId());
 
-        $this->assertEquals(200, $client->getResponse()->getStatusCode());
+        $this->assertSame(200, $client->getResponse()->getStatusCode());
 
         $this->assertCount(1, $crawler->filter('input[id=entry_title]'));
         $this->assertCount(1, $crawler->filter('button[id=entry_save]'));
@@ -465,9 +465,9 @@ class EntryControllerTest extends WallabagCoreTestCase
         $this->getEntityManager()->persist($entry);
         $this->getEntityManager()->flush();
 
-        $crawler = $client->request('GET', '/edit/'.$entry->getId());
+        $crawler = $client->request('GET', '/edit/' . $entry->getId());
 
-        $this->assertEquals(200, $client->getResponse()->getStatusCode());
+        $this->assertSame(200, $client->getResponse()->getStatusCode());
 
         $form = $crawler->filter('button[type=submit]')->form();
 
@@ -477,7 +477,7 @@ class EntryControllerTest extends WallabagCoreTestCase
 
         $client->submit($form, $data);
 
-        $this->assertEquals(302, $client->getResponse()->getStatusCode());
+        $this->assertSame(302, $client->getResponse()->getStatusCode());
 
         $crawler = $client->followRedirect();
 
@@ -496,16 +496,16 @@ class EntryControllerTest extends WallabagCoreTestCase
         $this->getEntityManager()->flush();
         $this->getEntityManager()->clear();
 
-        $client->request('GET', '/archive/'.$entry->getId());
+        $client->request('GET', '/archive/' . $entry->getId());
 
-        $this->assertEquals(302, $client->getResponse()->getStatusCode());
+        $this->assertSame(302, $client->getResponse()->getStatusCode());
 
         $res = $client->getContainer()
             ->get('doctrine.orm.entity_manager')
             ->getRepository('WallabagCoreBundle:Entry')
             ->find($entry->getId());
 
-        $this->assertEquals($res->isArchived(), true);
+        $this->assertSame($res->isArchived(), true);
     }
 
     public function testToggleStar()
@@ -519,16 +519,16 @@ class EntryControllerTest extends WallabagCoreTestCase
         $this->getEntityManager()->flush();
         $this->getEntityManager()->clear();
 
-        $client->request('GET', '/star/'.$entry->getId());
+        $client->request('GET', '/star/' . $entry->getId());
 
-        $this->assertEquals(302, $client->getResponse()->getStatusCode());
+        $this->assertSame(302, $client->getResponse()->getStatusCode());
 
         $res = $client->getContainer()
             ->get('doctrine.orm.entity_manager')
             ->getRepository('WallabagCoreBundle:Entry')
             ->findOneById($entry->getId());
 
-        $this->assertEquals($res->isStarred(), true);
+        $this->assertSame($res->isStarred(), true);
     }
 
     public function testDelete()
@@ -541,13 +541,13 @@ class EntryControllerTest extends WallabagCoreTestCase
         $this->getEntityManager()->persist($entry);
         $this->getEntityManager()->flush();
 
-        $client->request('GET', '/delete/'.$entry->getId());
+        $client->request('GET', '/delete/' . $entry->getId());
 
-        $this->assertEquals(302, $client->getResponse()->getStatusCode());
+        $this->assertSame(302, $client->getResponse()->getStatusCode());
 
-        $client->request('GET', '/delete/'.$entry->getId());
+        $client->request('GET', '/delete/' . $entry->getId());
 
-        $this->assertEquals(404, $client->getResponse()->getStatusCode());
+        $this->assertSame(404, $client->getResponse()->getStatusCode());
     }
 
     /**
@@ -583,14 +583,14 @@ class EntryControllerTest extends WallabagCoreTestCase
         $em->persist($content);
         $em->flush();
 
-        $client->request('GET', '/view/'.$content->getId());
-        $this->assertEquals(200, $client->getResponse()->getStatusCode());
+        $client->request('GET', '/view/' . $content->getId());
+        $this->assertSame(200, $client->getResponse()->getStatusCode());
 
-        $client->request('GET', '/delete/'.$content->getId());
-        $this->assertEquals(302, $client->getResponse()->getStatusCode());
+        $client->request('GET', '/delete/' . $content->getId());
+        $this->assertSame(302, $client->getResponse()->getStatusCode());
 
         $client->followRedirect();
-        $this->assertEquals(200, $client->getResponse()->getStatusCode());
+        $this->assertSame(200, $client->getResponse()->getStatusCode());
     }
 
     public function testViewOtherUserEntry()
@@ -603,9 +603,9 @@ class EntryControllerTest extends WallabagCoreTestCase
             ->getRepository('WallabagCoreBundle:Entry')
             ->findOneByUsernameAndNotArchived('bob');
 
-        $client->request('GET', '/view/'.$content->getId());
+        $client->request('GET', '/view/' . $content->getId());
 
-        $this->assertEquals(403, $client->getResponse()->getStatusCode());
+        $this->assertSame(403, $client->getResponse()->getStatusCode());
     }
 
     public function testFilterOnReadingTime()
@@ -793,7 +793,7 @@ class EntryControllerTest extends WallabagCoreTestCase
 
         $parameters = '?entry_filter%5BreadingTime%5D%5Bleft_number%5D=&entry_filter%5BreadingTime%5D%5Bright_number%5D=';
 
-        $client->request('GET', 'unread/list'.$parameters);
+        $client->request('GET', 'unread/list' . $parameters);
 
         $this->assertContains($parameters, $client->getResponse()->getContent());
 
@@ -934,16 +934,16 @@ class EntryControllerTest extends WallabagCoreTestCase
         $this->getEntityManager()->clear();
 
         // no uid
-        $client->request('GET', '/share/'.$content->getUid());
-        $this->assertEquals(404, $client->getResponse()->getStatusCode());
+        $client->request('GET', '/share/' . $content->getUid());
+        $this->assertSame(404, $client->getResponse()->getStatusCode());
 
         // generating the uid
-        $client->request('GET', '/share/'.$content->getId());
-        $this->assertEquals(302, $client->getResponse()->getStatusCode());
+        $client->request('GET', '/share/' . $content->getId());
+        $this->assertSame(302, $client->getResponse()->getStatusCode());
 
         // follow link with uid
         $crawler = $client->followRedirect();
-        $this->assertEquals(200, $client->getResponse()->getStatusCode());
+        $this->assertSame(200, $client->getResponse()->getStatusCode());
         $this->assertContains('max-age=25200', $client->getResponse()->headers->get('cache-control'));
         $this->assertContains('public', $client->getResponse()->headers->get('cache-control'));
         $this->assertContains('s-maxage=25200', $client->getResponse()->headers->get('cache-control'));
@@ -955,19 +955,19 @@ class EntryControllerTest extends WallabagCoreTestCase
 
         // sharing is now disabled
         $client->getContainer()->get('craue_config')->set('share_public', 0);
-        $client->request('GET', '/share/'.$content->getUid());
-        $this->assertEquals(404, $client->getResponse()->getStatusCode());
+        $client->request('GET', '/share/' . $content->getUid());
+        $this->assertSame(404, $client->getResponse()->getStatusCode());
 
-        $client->request('GET', '/view/'.$content->getId());
+        $client->request('GET', '/view/' . $content->getId());
         $this->assertContains('no-cache', $client->getResponse()->headers->get('cache-control'));
 
         // removing the share
-        $client->request('GET', '/share/delete/'.$content->getId());
-        $this->assertEquals(302, $client->getResponse()->getStatusCode());
+        $client->request('GET', '/share/delete/' . $content->getId());
+        $this->assertSame(302, $client->getResponse()->getStatusCode());
 
         // share is now disable
-        $client->request('GET', '/share/'.$content->getUid());
-        $this->assertEquals(404, $client->getResponse()->getStatusCode());
+        $client->request('GET', '/share/' . $content->getUid());
+        $this->assertSame(404, $client->getResponse()->getStatusCode());
     }
 
     public function testNewEntryWithDownloadImagesEnabled()
@@ -981,7 +981,7 @@ class EntryControllerTest extends WallabagCoreTestCase
 
         $crawler = $client->request('GET', '/new');
 
-        $this->assertEquals(200, $client->getResponse()->getStatusCode());
+        $this->assertSame(200, $client->getResponse()->getStatusCode());
 
         $form = $crawler->filter('form[name=entry]')->form();
 
@@ -991,7 +991,7 @@ class EntryControllerTest extends WallabagCoreTestCase
 
         $client->submit($form, $data);
 
-        $this->assertEquals(302, $client->getResponse()->getStatusCode());
+        $this->assertSame(302, $client->getResponse()->getStatusCode());
 
         $em = $client->getContainer()
             ->get('doctrine.orm.entity_manager');
@@ -1001,7 +1001,7 @@ class EntryControllerTest extends WallabagCoreTestCase
             ->findByUrlAndUserId($url, $this->getLoggedInUserId());
 
         $this->assertInstanceOf('Wallabag\CoreBundle\Entity\Entry', $entry);
-        $this->assertEquals($url, $entry->getUrl());
+        $this->assertSame($url, $entry->getUrl());
         $this->assertContains('Perpignan', $entry->getTitle());
         // instead of checking for the filename (which might change) check that the image is now local
         $this->assertContains('https://your-wallabag-url-instance.com/assets/images/', $entry->getContent());
@@ -1023,7 +1023,7 @@ class EntryControllerTest extends WallabagCoreTestCase
 
         $crawler = $client->request('GET', '/new');
 
-        $this->assertEquals(200, $client->getResponse()->getStatusCode());
+        $this->assertSame(200, $client->getResponse()->getStatusCode());
 
         $form = $crawler->filter('form[name=entry]')->form();
 
@@ -1033,16 +1033,16 @@ class EntryControllerTest extends WallabagCoreTestCase
 
         $client->submit($form, $data);
 
-        $this->assertEquals(302, $client->getResponse()->getStatusCode());
+        $this->assertSame(302, $client->getResponse()->getStatusCode());
 
         $content = $client->getContainer()
             ->get('doctrine.orm.entity_manager')
             ->getRepository('WallabagCoreBundle:Entry')
             ->findByUrlAndUserId($url, $this->getLoggedInUserId());
 
-        $client->request('GET', '/delete/'.$content->getId());
+        $client->request('GET', '/delete/' . $content->getId());
 
-        $this->assertEquals(302, $client->getResponse()->getStatusCode());
+        $this->assertSame(302, $client->getResponse()->getStatusCode());
 
         $client->getContainer()->get('craue_config')->set('download_images_enabled', 0);
     }
@@ -1063,11 +1063,11 @@ class EntryControllerTest extends WallabagCoreTestCase
 
         $this->getEntityManager()->flush();
 
-        $client->request('GET', '/view/'.$entry->getId());
-        $client->request('GET', '/archive/'.$entry->getId());
+        $client->request('GET', '/view/' . $entry->getId());
+        $client->request('GET', '/archive/' . $entry->getId());
 
-        $this->assertEquals(302, $client->getResponse()->getStatusCode());
-        $this->assertEquals('/', $client->getResponse()->headers->get('location'));
+        $this->assertSame(302, $client->getResponse()->getStatusCode());
+        $this->assertSame('/', $client->getResponse()->headers->get('location'));
     }
 
     public function testRedirectToCurrentPage()
@@ -1086,11 +1086,11 @@ class EntryControllerTest extends WallabagCoreTestCase
 
         $this->getEntityManager()->flush();
 
-        $client->request('GET', '/view/'.$entry->getId());
-        $client->request('GET', '/archive/'.$entry->getId());
+        $client->request('GET', '/view/' . $entry->getId());
+        $client->request('GET', '/archive/' . $entry->getId());
 
-        $this->assertEquals(302, $client->getResponse()->getStatusCode());
-        $this->assertContains('/view/'.$entry->getId(), $client->getResponse()->headers->get('location'));
+        $this->assertSame(302, $client->getResponse()->getStatusCode());
+        $this->assertContains('/view/' . $entry->getId(), $client->getResponse()->headers->get('location'));
     }
 
     public function testFilterOnHttpStatus()
@@ -1213,7 +1213,7 @@ class EntryControllerTest extends WallabagCoreTestCase
         $crawler = $client->submit($form, $data);
 
         $this->assertCount(1, $crawler->filter('div[class=entry]'));
-        $client->request('GET', '/delete/'.$entry->getId());
+        $client->request('GET', '/delete/' . $entry->getId());
 
         // test on list of all articles
         $crawler = $client->request('GET', '/all/list');
@@ -1315,7 +1315,7 @@ class EntryControllerTest extends WallabagCoreTestCase
 
         $crawler = $client->request('GET', '/new');
 
-        $this->assertEquals(200, $client->getResponse()->getStatusCode());
+        $this->assertSame(200, $client->getResponse()->getStatusCode());
 
         $form = $crawler->filter('form[name=entry]')->form();
 
@@ -1325,7 +1325,7 @@ class EntryControllerTest extends WallabagCoreTestCase
 
         $client->submit($form, $data);
 
-        $this->assertEquals(302, $client->getResponse()->getStatusCode());
+        $this->assertSame(302, $client->getResponse()->getStatusCode());
 
         $content = $client->getContainer()
             ->get('doctrine.orm.entity_manager')
@@ -1333,8 +1333,8 @@ class EntryControllerTest extends WallabagCoreTestCase
             ->findByUrlAndUserId($url, $this->getLoggedInUserId());
 
         $this->assertInstanceOf('Wallabag\CoreBundle\Entity\Entry', $content);
-        $this->assertEquals($url, $content->getUrl());
-        $this->assertEquals($expectedLanguage, $content->getLanguage());
+        $this->assertSame($url, $content->getUrl());
+        $this->assertSame($expectedLanguage, $content->getLanguage());
     }
 
     /**
@@ -1362,7 +1362,7 @@ class EntryControllerTest extends WallabagCoreTestCase
 
         $crawler = $client->request('GET', '/new');
 
-        $this->assertEquals(200, $client->getResponse()->getStatusCode());
+        $this->assertSame(200, $client->getResponse()->getStatusCode());
 
         $form = $crawler->filter('form[name=entry]')->form();
 
@@ -1372,11 +1372,11 @@ class EntryControllerTest extends WallabagCoreTestCase
 
         $client->submit($form, $data);
 
-        $this->assertEquals(302, $client->getResponse()->getStatusCode());
+        $this->assertSame(302, $client->getResponse()->getStatusCode());
 
         $crawler = $client->followRedirect();
 
-        $this->assertEquals(200, $client->getResponse()->getStatusCode());
+        $this->assertSame(200, $client->getResponse()->getStatusCode());
         $this->assertContains('flashes.entry.notice.entry_saved', $crawler->filter('body')->extract(['_text'])[0]);
 
         $content = $em

--- a/tests/Wallabag/CoreBundle/Controller/EntryControllerTest.php
+++ b/tests/Wallabag/CoreBundle/Controller/EntryControllerTest.php
@@ -43,6 +43,7 @@ class EntryControllerTest extends WallabagCoreTestCase
         $client = $this->getClient();
 
         $client->request('GET', '/unread/list');
+        $this->assertSame(302, $client->getResponse()->getStatusCode());
         $crawler = $client->followRedirect();
 
         $this->assertSame(200, $client->getResponse()->getStatusCode());
@@ -505,7 +506,7 @@ class EntryControllerTest extends WallabagCoreTestCase
             ->getRepository('WallabagCoreBundle:Entry')
             ->find($entry->getId());
 
-        $this->assertSame($res->isArchived(), true);
+        $this->assertSame(1, $res->isArchived());
     }
 
     public function testToggleStar()
@@ -528,7 +529,7 @@ class EntryControllerTest extends WallabagCoreTestCase
             ->getRepository('WallabagCoreBundle:Entry')
             ->findOneById($entry->getId());
 
-        $this->assertSame($res->isStarred(), true);
+        $this->assertSame(1, $res->isStarred());
     }
 
     public function testDelete()
@@ -1004,7 +1005,7 @@ class EntryControllerTest extends WallabagCoreTestCase
         $this->assertSame($url, $entry->getUrl());
         $this->assertContains('Perpignan', $entry->getTitle());
         // instead of checking for the filename (which might change) check that the image is now local
-        $this->assertContains('https://your-wallabag-url-instance.com/assets/images/', $entry->getContent());
+        $this->assertContains($client->getContainer()->getParameter('domain_name') . '/assets/images/', $entry->getContent());
 
         $client->getContainer()->get('craue_config')->set('download_images_enabled', 0);
     }
@@ -1296,7 +1297,7 @@ class EntryControllerTest extends WallabagCoreTestCase
             ],
             'fucked_list_of_languages' => [
                 'http://geocatalog.webservice-energy.org/geonetwork/srv/eng/main.home',
-                '',
+                null,
             ],
             'es-ES' => [
                 'http://www.muylinux.com/2015/04/17/odf-reino-unido-microsoft-google',

--- a/tests/Wallabag/CoreBundle/Controller/ExportControllerTest.php
+++ b/tests/Wallabag/CoreBundle/Controller/ExportControllerTest.php
@@ -12,7 +12,7 @@ class ExportControllerTest extends WallabagCoreTestCase
 
         $client->request('GET', '/export/unread.csv');
 
-        $this->assertEquals(302, $client->getResponse()->getStatusCode());
+        $this->assertSame(302, $client->getResponse()->getStatusCode());
         $this->assertContains('login', $client->getResponse()->headers->get('location'));
     }
 
@@ -23,7 +23,7 @@ class ExportControllerTest extends WallabagCoreTestCase
 
         $client->request('GET', '/export/awesomeness.epub');
 
-        $this->assertEquals(404, $client->getResponse()->getStatusCode());
+        $this->assertSame(404, $client->getResponse()->getStatusCode());
     }
 
     public function testUnknownFormatExport()
@@ -33,7 +33,7 @@ class ExportControllerTest extends WallabagCoreTestCase
 
         $client->request('GET', '/export/unread.xslx');
 
-        $this->assertEquals(404, $client->getResponse()->getStatusCode());
+        $this->assertSame(404, $client->getResponse()->getStatusCode());
     }
 
     public function testUnsupportedFormatExport()
@@ -42,15 +42,15 @@ class ExportControllerTest extends WallabagCoreTestCase
         $client = $this->getClient();
 
         $client->request('GET', '/export/unread.doc');
-        $this->assertEquals(404, $client->getResponse()->getStatusCode());
+        $this->assertSame(404, $client->getResponse()->getStatusCode());
 
         $content = $client->getContainer()
             ->get('doctrine.orm.entity_manager')
             ->getRepository('WallabagCoreBundle:Entry')
             ->findOneByUsernameAndNotArchived('admin');
 
-        $client->request('GET', '/export/'.$content->getId().'.doc');
-        $this->assertEquals(404, $client->getResponse()->getStatusCode());
+        $client->request('GET', '/export/' . $content->getId() . '.doc');
+        $this->assertSame(404, $client->getResponse()->getStatusCode());
     }
 
     public function testBadEntryId()
@@ -60,7 +60,7 @@ class ExportControllerTest extends WallabagCoreTestCase
 
         $client->request('GET', '/export/0.mobi');
 
-        $this->assertEquals(404, $client->getResponse()->getStatusCode());
+        $this->assertSame(404, $client->getResponse()->getStatusCode());
     }
 
     public function testEpubExport()
@@ -72,12 +72,12 @@ class ExportControllerTest extends WallabagCoreTestCase
         $crawler = $client->request('GET', '/export/archive.epub');
         ob_end_clean();
 
-        $this->assertEquals(200, $client->getResponse()->getStatusCode());
+        $this->assertSame(200, $client->getResponse()->getStatusCode());
 
         $headers = $client->getResponse()->headers;
-        $this->assertEquals('application/epub+zip', $headers->get('content-type'));
-        $this->assertEquals('attachment; filename="Archive articles.epub"', $headers->get('content-disposition'));
-        $this->assertEquals('binary', $headers->get('content-transfer-encoding'));
+        $this->assertSame('application/epub+zip', $headers->get('content-type'));
+        $this->assertSame('attachment; filename="Archive articles.epub"', $headers->get('content-disposition'));
+        $this->assertSame('binary', $headers->get('content-transfer-encoding'));
     }
 
     public function testMobiExport()
@@ -91,15 +91,15 @@ class ExportControllerTest extends WallabagCoreTestCase
             ->findOneByUsernameAndNotArchived('admin');
 
         ob_start();
-        $crawler = $client->request('GET', '/export/'.$content->getId().'.mobi');
+        $crawler = $client->request('GET', '/export/' . $content->getId() . '.mobi');
         ob_end_clean();
 
-        $this->assertEquals(200, $client->getResponse()->getStatusCode());
+        $this->assertSame(200, $client->getResponse()->getStatusCode());
 
         $headers = $client->getResponse()->headers;
-        $this->assertEquals('application/x-mobipocket-ebook', $headers->get('content-type'));
-        $this->assertEquals('attachment; filename="'.preg_replace('/[^A-Za-z0-9\-]/', '', $content->getTitle()).'.mobi"', $headers->get('content-disposition'));
-        $this->assertEquals('binary', $headers->get('content-transfer-encoding'));
+        $this->assertSame('application/x-mobipocket-ebook', $headers->get('content-type'));
+        $this->assertSame('attachment; filename="' . preg_replace('/[^A-Za-z0-9\-]/', '', $content->getTitle()) . '.mobi"', $headers->get('content-disposition'));
+        $this->assertSame('binary', $headers->get('content-transfer-encoding'));
     }
 
     public function testPdfExport()
@@ -111,23 +111,23 @@ class ExportControllerTest extends WallabagCoreTestCase
         $crawler = $client->request('GET', '/export/all.pdf');
         ob_end_clean();
 
-        $this->assertEquals(200, $client->getResponse()->getStatusCode());
+        $this->assertSame(200, $client->getResponse()->getStatusCode());
 
         $headers = $client->getResponse()->headers;
-        $this->assertEquals('application/pdf', $headers->get('content-type'));
-        $this->assertEquals('attachment; filename="All articles.pdf"', $headers->get('content-disposition'));
-        $this->assertEquals('binary', $headers->get('content-transfer-encoding'));
+        $this->assertSame('application/pdf', $headers->get('content-type'));
+        $this->assertSame('attachment; filename="All articles.pdf"', $headers->get('content-disposition'));
+        $this->assertSame('binary', $headers->get('content-transfer-encoding'));
 
         ob_start();
         $crawler = $client->request('GET', '/export/tag_entries.pdf?tag=foo-bar');
         ob_end_clean();
 
-        $this->assertEquals(200, $client->getResponse()->getStatusCode());
+        $this->assertSame(200, $client->getResponse()->getStatusCode());
 
         $headers = $client->getResponse()->headers;
-        $this->assertEquals('application/pdf', $headers->get('content-type'));
-        $this->assertEquals('attachment; filename="Tag_entries articles.pdf"', $headers->get('content-disposition'));
-        $this->assertEquals('binary', $headers->get('content-transfer-encoding'));
+        $this->assertSame('application/pdf', $headers->get('content-type'));
+        $this->assertSame('attachment; filename="Tag_entries articles.pdf"', $headers->get('content-disposition'));
+        $this->assertSame('binary', $headers->get('content-transfer-encoding'));
     }
 
     public function testTxtExport()
@@ -139,12 +139,12 @@ class ExportControllerTest extends WallabagCoreTestCase
         $crawler = $client->request('GET', '/export/all.txt');
         ob_end_clean();
 
-        $this->assertEquals(200, $client->getResponse()->getStatusCode());
+        $this->assertSame(200, $client->getResponse()->getStatusCode());
 
         $headers = $client->getResponse()->headers;
-        $this->assertEquals('text/plain; charset=UTF-8', $headers->get('content-type'));
-        $this->assertEquals('attachment; filename="All articles.txt"', $headers->get('content-disposition'));
-        $this->assertEquals('UTF-8', $headers->get('content-transfer-encoding'));
+        $this->assertSame('text/plain; charset=UTF-8', $headers->get('content-type'));
+        $this->assertSame('attachment; filename="All articles.txt"', $headers->get('content-disposition'));
+        $this->assertSame('UTF-8', $headers->get('content-transfer-encoding'));
     }
 
     public function testCsvExport()
@@ -169,19 +169,19 @@ class ExportControllerTest extends WallabagCoreTestCase
         $crawler = $client->request('GET', '/export/archive.csv');
         ob_end_clean();
 
-        $this->assertEquals(200, $client->getResponse()->getStatusCode());
+        $this->assertSame(200, $client->getResponse()->getStatusCode());
 
         $headers = $client->getResponse()->headers;
-        $this->assertEquals('application/csv', $headers->get('content-type'));
-        $this->assertEquals('attachment; filename="Archive articles.csv"', $headers->get('content-disposition'));
-        $this->assertEquals('UTF-8', $headers->get('content-transfer-encoding'));
+        $this->assertSame('application/csv', $headers->get('content-type'));
+        $this->assertSame('attachment; filename="Archive articles.csv"', $headers->get('content-disposition'));
+        $this->assertSame('UTF-8', $headers->get('content-transfer-encoding'));
 
         $csv = str_getcsv($client->getResponse()->getContent(), "\n");
 
         $this->assertGreaterThan(1, $csv);
         // +1 for title line
-        $this->assertEquals(count($contentInDB) + 1, count($csv));
-        $this->assertEquals('Title;URL;Content;Tags;"MIME Type";Language;"Creation date"', $csv[0]);
+        $this->assertSame(count($contentInDB) + 1, count($csv));
+        $this->assertSame('Title;URL;Content;Tags;"MIME Type";Language;"Creation date"', $csv[0]);
         $this->assertContains($contentInDB[0]['title'], $csv[1]);
         $this->assertContains($contentInDB[0]['url'], $csv[1]);
         $this->assertContains($contentInDB[0]['content'], $csv[1]);
@@ -205,15 +205,15 @@ class ExportControllerTest extends WallabagCoreTestCase
             ->findByUrlAndUserId('http://0.0.0.0/entry1', $this->getLoggedInUserId());
 
         ob_start();
-        $crawler = $client->request('GET', '/export/'.$contentInDB->getId().'.json');
+        $crawler = $client->request('GET', '/export/' . $contentInDB->getId() . '.json');
         ob_end_clean();
 
-        $this->assertEquals(200, $client->getResponse()->getStatusCode());
+        $this->assertSame(200, $client->getResponse()->getStatusCode());
 
         $headers = $client->getResponse()->headers;
-        $this->assertEquals('application/json', $headers->get('content-type'));
-        $this->assertEquals('attachment; filename="'.$contentInDB->getTitle().'.json"', $headers->get('content-disposition'));
-        $this->assertEquals('UTF-8', $headers->get('content-transfer-encoding'));
+        $this->assertSame('application/json', $headers->get('content-type'));
+        $this->assertSame('attachment; filename="' . $contentInDB->getTitle() . '.json"', $headers->get('content-disposition'));
+        $this->assertSame('UTF-8', $headers->get('content-transfer-encoding'));
 
         $content = json_decode($client->getResponse()->getContent(), true);
         $this->assertArrayHasKey('id', $content[0]);
@@ -230,16 +230,16 @@ class ExportControllerTest extends WallabagCoreTestCase
         $this->assertArrayHasKey('created_at', $content[0]);
         $this->assertArrayHasKey('updated_at', $content[0]);
 
-        $this->assertEquals($contentInDB->isArchived(), $content[0]['is_archived']);
-        $this->assertEquals($contentInDB->isStarred(), $content[0]['is_starred']);
-        $this->assertEquals($contentInDB->getTitle(), $content[0]['title']);
-        $this->assertEquals($contentInDB->getUrl(), $content[0]['url']);
-        $this->assertEquals([['text' => 'This is my annotation /o/', 'quote' => 'content']], $content[0]['annotations']);
-        $this->assertEquals($contentInDB->getMimetype(), $content[0]['mimetype']);
-        $this->assertEquals($contentInDB->getLanguage(), $content[0]['language']);
-        $this->assertEquals($contentInDB->getReadingtime(), $content[0]['reading_time']);
-        $this->assertEquals($contentInDB->getDomainname(), $content[0]['domain_name']);
-        $this->assertEquals(['foo bar', 'baz'], $content[0]['tags']);
+        $this->assertSame($contentInDB->isArchived(), $content[0]['is_archived']);
+        $this->assertSame($contentInDB->isStarred(), $content[0]['is_starred']);
+        $this->assertSame($contentInDB->getTitle(), $content[0]['title']);
+        $this->assertSame($contentInDB->getUrl(), $content[0]['url']);
+        $this->assertSame([['text' => 'This is my annotation /o/', 'quote' => 'content']], $content[0]['annotations']);
+        $this->assertSame($contentInDB->getMimetype(), $content[0]['mimetype']);
+        $this->assertSame($contentInDB->getLanguage(), $content[0]['language']);
+        $this->assertSame($contentInDB->getReadingtime(), $content[0]['reading_time']);
+        $this->assertSame($contentInDB->getDomainname(), $content[0]['domain_name']);
+        $this->assertSame(['foo bar', 'baz'], $content[0]['tags']);
     }
 
     public function testXmlExport()
@@ -262,16 +262,16 @@ class ExportControllerTest extends WallabagCoreTestCase
         $crawler = $client->request('GET', '/export/unread.xml');
         ob_end_clean();
 
-        $this->assertEquals(200, $client->getResponse()->getStatusCode());
+        $this->assertSame(200, $client->getResponse()->getStatusCode());
 
         $headers = $client->getResponse()->headers;
-        $this->assertEquals('application/xml', $headers->get('content-type'));
-        $this->assertEquals('attachment; filename="Unread articles.xml"', $headers->get('content-disposition'));
-        $this->assertEquals('UTF-8', $headers->get('content-transfer-encoding'));
+        $this->assertSame('application/xml', $headers->get('content-type'));
+        $this->assertSame('attachment; filename="Unread articles.xml"', $headers->get('content-disposition'));
+        $this->assertSame('UTF-8', $headers->get('content-transfer-encoding'));
 
         $content = new \SimpleXMLElement($client->getResponse()->getContent());
         $this->assertGreaterThan(0, $content->count());
-        $this->assertEquals(count($contentInDB), $content->count());
+        $this->assertSame(count($contentInDB), $content->count());
         $this->assertNotEmpty('id', (string) $content->entry[0]->id);
         $this->assertNotEmpty('title', (string) $content->entry[0]->title);
         $this->assertNotEmpty('url', (string) $content->entry[0]->url);

--- a/tests/Wallabag/CoreBundle/Controller/ExportControllerTest.php
+++ b/tests/Wallabag/CoreBundle/Controller/ExportControllerTest.php
@@ -230,8 +230,8 @@ class ExportControllerTest extends WallabagCoreTestCase
         $this->assertArrayHasKey('created_at', $content[0]);
         $this->assertArrayHasKey('updated_at', $content[0]);
 
-        $this->assertSame($contentInDB->isArchived(), $content[0]['is_archived']);
-        $this->assertSame($contentInDB->isStarred(), $content[0]['is_starred']);
+        $this->assertSame((int) $contentInDB->isArchived(), $content[0]['is_archived']);
+        $this->assertSame((int) $contentInDB->isStarred(), $content[0]['is_starred']);
         $this->assertSame($contentInDB->getTitle(), $content[0]['title']);
         $this->assertSame($contentInDB->getUrl(), $content[0]['url']);
         $this->assertSame([['text' => 'This is my annotation /o/', 'quote' => 'content']], $content[0]['annotations']);

--- a/tests/Wallabag/CoreBundle/Controller/RssControllerTest.php
+++ b/tests/Wallabag/CoreBundle/Controller/RssControllerTest.php
@@ -16,36 +16,36 @@ class RssControllerTest extends WallabagCoreTestCase
         if (null === $nb) {
             $this->assertGreaterThan(0, $xpath->query('//item')->length);
         } else {
-            $this->assertEquals($nb, $xpath->query('//item')->length);
+            $this->assertSame($nb, $xpath->query('//item')->length);
         }
 
-        $this->assertEquals(1, $xpath->query('/rss')->length);
-        $this->assertEquals(1, $xpath->query('/rss/channel')->length);
+        $this->assertSame(1, $xpath->query('/rss')->length);
+        $this->assertSame(1, $xpath->query('/rss/channel')->length);
 
-        $this->assertEquals(1, $xpath->query('/rss/channel/title')->length);
-        $this->assertEquals('wallabag - '.$type.' feed', $xpath->query('/rss/channel/title')->item(0)->nodeValue);
+        $this->assertSame(1, $xpath->query('/rss/channel/title')->length);
+        $this->assertSame('wallabag - ' . $type . ' feed', $xpath->query('/rss/channel/title')->item(0)->nodeValue);
 
-        $this->assertEquals(1, $xpath->query('/rss/channel/pubDate')->length);
+        $this->assertSame(1, $xpath->query('/rss/channel/pubDate')->length);
 
-        $this->assertEquals(1, $xpath->query('/rss/channel/generator')->length);
-        $this->assertEquals('wallabag', $xpath->query('/rss/channel/generator')->item(0)->nodeValue);
+        $this->assertSame(1, $xpath->query('/rss/channel/generator')->length);
+        $this->assertSame('wallabag', $xpath->query('/rss/channel/generator')->item(0)->nodeValue);
 
-        $this->assertEquals(1, $xpath->query('/rss/channel/description')->length);
-        $this->assertEquals('wallabag '.$type.' elements', $xpath->query('/rss/channel/description')->item(0)->nodeValue);
+        $this->assertSame(1, $xpath->query('/rss/channel/description')->length);
+        $this->assertSame('wallabag ' . $type . ' elements', $xpath->query('/rss/channel/description')->item(0)->nodeValue);
 
-        $this->assertEquals(1, $xpath->query('/rss/channel/link[@rel="self"]')->length);
-        $this->assertContains($urlPagination.'.xml', $xpath->query('/rss/channel/link[@rel="self"]')->item(0)->getAttribute('href'));
+        $this->assertSame(1, $xpath->query('/rss/channel/link[@rel="self"]')->length);
+        $this->assertContains($urlPagination . '.xml', $xpath->query('/rss/channel/link[@rel="self"]')->item(0)->getAttribute('href'));
 
-        $this->assertEquals(1, $xpath->query('/rss/channel/link[@rel="last"]')->length);
-        $this->assertContains($urlPagination.'.xml?page=', $xpath->query('/rss/channel/link[@rel="last"]')->item(0)->getAttribute('href'));
+        $this->assertSame(1, $xpath->query('/rss/channel/link[@rel="last"]')->length);
+        $this->assertContains($urlPagination . '.xml?page=', $xpath->query('/rss/channel/link[@rel="last"]')->item(0)->getAttribute('href'));
 
         foreach ($xpath->query('//item') as $item) {
-            $this->assertEquals(1, $xpath->query('title', $item)->length);
-            $this->assertEquals(1, $xpath->query('source', $item)->length);
-            $this->assertEquals(1, $xpath->query('link', $item)->length);
-            $this->assertEquals(1, $xpath->query('guid', $item)->length);
-            $this->assertEquals(1, $xpath->query('pubDate', $item)->length);
-            $this->assertEquals(1, $xpath->query('description', $item)->length);
+            $this->assertSame(1, $xpath->query('title', $item)->length);
+            $this->assertSame(1, $xpath->query('source', $item)->length);
+            $this->assertSame(1, $xpath->query('link', $item)->length);
+            $this->assertSame(1, $xpath->query('guid', $item)->length);
+            $this->assertSame(1, $xpath->query('pubDate', $item)->length);
+            $this->assertSame(1, $xpath->query('description', $item)->length);
         }
     }
 
@@ -73,7 +73,7 @@ class RssControllerTest extends WallabagCoreTestCase
 
         $client->request('GET', $url);
 
-        $this->assertEquals(404, $client->getResponse()->getStatusCode());
+        $this->assertSame(404, $client->getResponse()->getStatusCode());
     }
 
     public function testUnread()
@@ -92,7 +92,7 @@ class RssControllerTest extends WallabagCoreTestCase
 
         $client->request('GET', '/admin/SUPERTOKEN/unread.xml');
 
-        $this->assertEquals(200, $client->getResponse()->getStatusCode());
+        $this->assertSame(200, $client->getResponse()->getStatusCode());
 
         $this->validateDom($client->getResponse()->getContent(), 'unread', 'unread', 2);
     }
@@ -114,7 +114,7 @@ class RssControllerTest extends WallabagCoreTestCase
         $client = $this->getClient();
         $client->request('GET', '/admin/SUPERTOKEN/starred.xml');
 
-        $this->assertEquals(200, $client->getResponse()->getStatusCode(), 1);
+        $this->assertSame(200, $client->getResponse()->getStatusCode(), 1);
 
         $this->validateDom($client->getResponse()->getContent(), 'starred', 'starred');
     }
@@ -136,7 +136,7 @@ class RssControllerTest extends WallabagCoreTestCase
         $client = $this->getClient();
         $client->request('GET', '/admin/SUPERTOKEN/archive.xml');
 
-        $this->assertEquals(200, $client->getResponse()->getStatusCode());
+        $this->assertSame(200, $client->getResponse()->getStatusCode());
 
         $this->validateDom($client->getResponse()->getContent(), 'archive', 'archive');
     }
@@ -158,15 +158,15 @@ class RssControllerTest extends WallabagCoreTestCase
         $client = $this->getClient();
 
         $client->request('GET', '/admin/SUPERTOKEN/unread.xml');
-        $this->assertEquals(200, $client->getResponse()->getStatusCode());
+        $this->assertSame(200, $client->getResponse()->getStatusCode());
         $this->validateDom($client->getResponse()->getContent(), 'unread', 'unread');
 
         $client->request('GET', '/admin/SUPERTOKEN/unread.xml?page=2');
-        $this->assertEquals(200, $client->getResponse()->getStatusCode());
+        $this->assertSame(200, $client->getResponse()->getStatusCode());
         $this->validateDom($client->getResponse()->getContent(), 'unread', 'unread');
 
         $client->request('GET', '/admin/SUPERTOKEN/unread.xml?page=3000');
-        $this->assertEquals(302, $client->getResponse()->getStatusCode());
+        $this->assertSame(302, $client->getResponse()->getStatusCode());
     }
 
     public function testTags()
@@ -186,11 +186,11 @@ class RssControllerTest extends WallabagCoreTestCase
         $client = $this->getClient();
         $client->request('GET', '/admin/SUPERTOKEN/tags/foo-bar.xml');
 
-        $this->assertEquals(200, $client->getResponse()->getStatusCode());
+        $this->assertSame(200, $client->getResponse()->getStatusCode());
 
         $this->validateDom($client->getResponse()->getContent(), 'tag (foo bar)', 'tags/foo-bar');
 
         $client->request('GET', '/admin/SUPERTOKEN/tags/foo-bar.xml?page=3000');
-        $this->assertEquals(302, $client->getResponse()->getStatusCode());
+        $this->assertSame(302, $client->getResponse()->getStatusCode());
     }
 }

--- a/tests/Wallabag/CoreBundle/Controller/SettingsControllerTest.php
+++ b/tests/Wallabag/CoreBundle/Controller/SettingsControllerTest.php
@@ -17,7 +17,7 @@ class SettingsControllerTest extends WallabagCoreTestCase
 
         $crawler = $client->request('GET', '/settings');
 
-        $this->assertEquals(200, $client->getResponse()->getStatusCode());
+        $this->assertSame(200, $client->getResponse()->getStatusCode());
     }
 
     public function testSettingsWithNormalUser()
@@ -27,6 +27,6 @@ class SettingsControllerTest extends WallabagCoreTestCase
 
         $crawler = $client->request('GET', '/settings');
 
-        $this->assertEquals(403, $client->getResponse()->getStatusCode());
+        $this->assertSame(403, $client->getResponse()->getStatusCode());
     }
 }

--- a/tests/Wallabag/CoreBundle/Controller/SiteCredentialControllerTest.php
+++ b/tests/Wallabag/CoreBundle/Controller/SiteCredentialControllerTest.php
@@ -15,7 +15,7 @@ class SiteCredentialControllerTest extends WallabagCoreTestCase
 
         $crawler = $client->request('GET', '/site-credentials/');
 
-        $this->assertEquals(200, $client->getResponse()->getStatusCode());
+        $this->assertSame(200, $client->getResponse()->getStatusCode());
 
         $body = $crawler->filter('body')->extract(['_text'])[0];
 
@@ -30,7 +30,7 @@ class SiteCredentialControllerTest extends WallabagCoreTestCase
 
         $crawler = $client->request('GET', '/site-credentials/new');
 
-        $this->assertEquals(200, $client->getResponse()->getStatusCode());
+        $this->assertSame(200, $client->getResponse()->getStatusCode());
 
         $body = $crawler->filter('body')->extract(['_text'])[0];
 
@@ -47,7 +47,7 @@ class SiteCredentialControllerTest extends WallabagCoreTestCase
 
         $client->submit($form, $data);
 
-        $this->assertEquals(302, $client->getResponse()->getStatusCode());
+        $this->assertSame(302, $client->getResponse()->getStatusCode());
 
         $crawler = $client->followRedirect();
 
@@ -61,9 +61,9 @@ class SiteCredentialControllerTest extends WallabagCoreTestCase
 
         $credential = $this->createSiteCredential($client);
 
-        $crawler = $client->request('GET', '/site-credentials/'.$credential->getId().'/edit');
+        $crawler = $client->request('GET', '/site-credentials/' . $credential->getId() . '/edit');
 
-        $this->assertEquals(200, $client->getResponse()->getStatusCode());
+        $this->assertSame(200, $client->getResponse()->getStatusCode());
 
         $body = $crawler->filter('body')->extract(['_text'])[0];
 
@@ -80,7 +80,7 @@ class SiteCredentialControllerTest extends WallabagCoreTestCase
 
         $client->submit($form, $data);
 
-        $this->assertEquals(302, $client->getResponse()->getStatusCode());
+        $this->assertSame(302, $client->getResponse()->getStatusCode());
 
         $crawler = $client->followRedirect();
 
@@ -96,9 +96,9 @@ class SiteCredentialControllerTest extends WallabagCoreTestCase
 
         $this->logInAs('bob');
 
-        $client->request('GET', '/site-credentials/'.$credential->getId().'/edit');
+        $client->request('GET', '/site-credentials/' . $credential->getId() . '/edit');
 
-        $this->assertEquals(403, $client->getResponse()->getStatusCode());
+        $this->assertSame(403, $client->getResponse()->getStatusCode());
     }
 
     public function testDeleteSiteCredential()
@@ -108,15 +108,15 @@ class SiteCredentialControllerTest extends WallabagCoreTestCase
 
         $credential = $this->createSiteCredential($client);
 
-        $crawler = $client->request('GET', '/site-credentials/'.$credential->getId().'/edit');
+        $crawler = $client->request('GET', '/site-credentials/' . $credential->getId() . '/edit');
 
-        $this->assertEquals(200, $client->getResponse()->getStatusCode());
+        $this->assertSame(200, $client->getResponse()->getStatusCode());
 
         $deleteForm = $crawler->filter('body')->selectButton('site_credential.form.delete')->form();
 
         $client->submit($deleteForm, []);
 
-        $this->assertEquals(302, $client->getResponse()->getStatusCode());
+        $this->assertSame(302, $client->getResponse()->getStatusCode());
 
         $crawler = $client->followRedirect();
 

--- a/tests/Wallabag/CoreBundle/Controller/StaticControllerTest.php
+++ b/tests/Wallabag/CoreBundle/Controller/StaticControllerTest.php
@@ -13,7 +13,7 @@ class StaticControllerTest extends WallabagCoreTestCase
 
         $client->request('GET', '/about');
 
-        $this->assertEquals(200, $client->getResponse()->getStatusCode());
+        $this->assertSame(200, $client->getResponse()->getStatusCode());
     }
 
     public function testHowto()
@@ -23,6 +23,6 @@ class StaticControllerTest extends WallabagCoreTestCase
 
         $client->request('GET', '/howto');
 
-        $this->assertEquals(200, $client->getResponse()->getStatusCode());
+        $this->assertSame(200, $client->getResponse()->getStatusCode());
     }
 }

--- a/tests/Wallabag/CoreBundle/Controller/TagControllerTest.php
+++ b/tests/Wallabag/CoreBundle/Controller/TagControllerTest.php
@@ -17,7 +17,7 @@ class TagControllerTest extends WallabagCoreTestCase
 
         $client->request('GET', '/tag/list');
 
-        $this->assertEquals(200, $client->getResponse()->getStatusCode());
+        $this->assertSame(200, $client->getResponse()->getStatusCode());
     }
 
     public function testAddTagToEntry()
@@ -31,7 +31,7 @@ class TagControllerTest extends WallabagCoreTestCase
         $this->getEntityManager()->flush();
         $this->getEntityManager()->clear();
 
-        $crawler = $client->request('GET', '/view/'.$entry->getId());
+        $crawler = $client->request('GET', '/view/' . $entry->getId());
 
         $form = $crawler->filter('form[name=tag]')->form();
 
@@ -40,7 +40,7 @@ class TagControllerTest extends WallabagCoreTestCase
         ];
 
         $client->submit($form, $data);
-        $this->assertEquals(302, $client->getResponse()->getStatusCode());
+        $this->assertSame(302, $client->getResponse()->getStatusCode());
 
         // be sure to reload the entry
         $entry = $this->getEntityManager()->getRepository(Entry::class)->find($entry->getId());
@@ -48,7 +48,7 @@ class TagControllerTest extends WallabagCoreTestCase
 
         // tag already exists and already assigned
         $client->submit($form, $data);
-        $this->assertEquals(302, $client->getResponse()->getStatusCode());
+        $this->assertSame(302, $client->getResponse()->getStatusCode());
 
         $entry = $this->getEntityManager()->getRepository(Entry::class)->find($entry->getId());
         $this->assertCount(1, $entry->getTags());
@@ -59,7 +59,7 @@ class TagControllerTest extends WallabagCoreTestCase
         ];
 
         $client->submit($form, $data);
-        $this->assertEquals(302, $client->getResponse()->getStatusCode());
+        $this->assertSame(302, $client->getResponse()->getStatusCode());
 
         $entry = $this->getEntityManager()->getRepository(Entry::class)->find($entry->getId());
         $this->assertCount(2, $entry->getTags());
@@ -75,7 +75,7 @@ class TagControllerTest extends WallabagCoreTestCase
             ->getRepository('WallabagCoreBundle:Entry')
             ->findByUrlAndUserId('http://0.0.0.0/entry2', $this->getLoggedInUserId());
 
-        $crawler = $client->request('GET', '/view/'.$entry->getId());
+        $crawler = $client->request('GET', '/view/' . $entry->getId());
 
         $form = $crawler->filter('form[name=tag]')->form();
 
@@ -84,7 +84,7 @@ class TagControllerTest extends WallabagCoreTestCase
         ];
 
         $client->submit($form, $data);
-        $this->assertEquals(302, $client->getResponse()->getStatusCode());
+        $this->assertSame(302, $client->getResponse()->getStatusCode());
 
         $newEntry = $client->getContainer()
             ->get('doctrine.orm.entity_manager')
@@ -97,8 +97,8 @@ class TagControllerTest extends WallabagCoreTestCase
         }
 
         $this->assertGreaterThanOrEqual(2, count($tags));
-        $this->assertNotFalse(array_search('foo2', $tags), 'Tag foo2 is assigned to the entry');
-        $this->assertNotFalse(array_search('bar2', $tags), 'Tag bar2 is assigned to the entry');
+        $this->assertNotFalse(array_search('foo2', $tags, true), 'Tag foo2 is assigned to the entry');
+        $this->assertNotFalse(array_search('bar2', $tags, true), 'Tag bar2 is assigned to the entry');
     }
 
     public function testRemoveTagFromEntry()
@@ -116,27 +116,27 @@ class TagControllerTest extends WallabagCoreTestCase
         $this->getEntityManager()->clear();
 
         // We make a first request to set an history and test redirection after tag deletion
-        $client->request('GET', '/view/'.$entry->getId());
+        $client->request('GET', '/view/' . $entry->getId());
         $entryUri = $client->getRequest()->getUri();
-        $client->request('GET', '/remove-tag/'.$entry->getId().'/'.$tag->getId());
+        $client->request('GET', '/remove-tag/' . $entry->getId() . '/' . $tag->getId());
 
-        $this->assertEquals(302, $client->getResponse()->getStatusCode());
-        $this->assertEquals($entryUri, $client->getResponse()->getTargetUrl());
+        $this->assertSame(302, $client->getResponse()->getStatusCode());
+        $this->assertSame($entryUri, $client->getResponse()->getTargetUrl());
 
         // re-retrieve the entry to be sure to get fresh data from database (mostly for tags)
         $entry = $this->getEntityManager()->getRepository(Entry::class)->find($entry->getId());
         $this->assertNotContains($this->tagName, $entry->getTags());
 
-        $client->request('GET', '/remove-tag/'.$entry->getId().'/'.$tag->getId());
+        $client->request('GET', '/remove-tag/' . $entry->getId() . '/' . $tag->getId());
 
-        $this->assertEquals(404, $client->getResponse()->getStatusCode());
+        $this->assertSame(404, $client->getResponse()->getStatusCode());
 
         $tag = $client->getContainer()
             ->get('doctrine.orm.entity_manager')
             ->getRepository('WallabagCoreBundle:Tag')
             ->findOneByLabel($this->tagName);
 
-        $this->assertNull($tag, $this->tagName.' was removed because it begun an orphan tag');
+        $this->assertNull($tag, $this->tagName . ' was removed because it begun an orphan tag');
     }
 
     public function testShowEntriesForTagAction()
@@ -165,9 +165,9 @@ class TagControllerTest extends WallabagCoreTestCase
             ->getRepository('WallabagCoreBundle:Tag')
             ->findOneByEntryAndTagLabel($entry, $this->tagName);
 
-        $crawler = $client->request('GET', '/tag/list/'.$tag->getSlug());
+        $crawler = $client->request('GET', '/tag/list/' . $tag->getSlug());
 
-        $this->assertEquals(200, $client->getResponse()->getStatusCode());
+        $this->assertSame(200, $client->getResponse()->getStatusCode());
         $this->assertCount(1, $crawler->filter('[id*="entry-"]'));
 
         $entry->removeTag($tag);

--- a/tests/Wallabag/CoreBundle/Event/Listener/LocaleListenerTest.php
+++ b/tests/Wallabag/CoreBundle/Event/Listener/LocaleListenerTest.php
@@ -13,15 +13,6 @@ use Wallabag\CoreBundle\Event\Listener\LocaleListener;
 
 class LocaleListenerTest extends \PHPUnit_Framework_TestCase
 {
-    private function getEvent(Request $request)
-    {
-        $kernel = $this->getMockBuilder('Symfony\Component\HttpKernel\HttpKernelInterface')
-            ->disableOriginalConstructor()
-            ->getMock();
-
-        return new GetResponseEvent($kernel, $request, HttpKernelInterface::MASTER_REQUEST);
-    }
-
     public function testWithoutSession()
     {
         $request = Request::create('/');
@@ -30,7 +21,7 @@ class LocaleListenerTest extends \PHPUnit_Framework_TestCase
         $event = $this->getEvent($request);
 
         $listener->onKernelRequest($event);
-        $this->assertEquals('en', $request->getLocale());
+        $this->assertSame('en', $request->getLocale());
     }
 
     public function testWithPreviousSession()
@@ -44,7 +35,7 @@ class LocaleListenerTest extends \PHPUnit_Framework_TestCase
         $event = $this->getEvent($request);
 
         $listener->onKernelRequest($event);
-        $this->assertEquals('fr', $request->getLocale());
+        $this->assertSame('fr', $request->getLocale());
     }
 
     public function testLocaleFromRequestAttribute()
@@ -59,8 +50,8 @@ class LocaleListenerTest extends \PHPUnit_Framework_TestCase
         $event = $this->getEvent($request);
 
         $listener->onKernelRequest($event);
-        $this->assertEquals('en', $request->getLocale());
-        $this->assertEquals('es', $request->getSession()->get('_locale'));
+        $this->assertSame('en', $request->getLocale());
+        $this->assertSame('es', $request->getSession()->get('_locale'));
     }
 
     public function testSubscribedEvents()
@@ -81,6 +72,15 @@ class LocaleListenerTest extends \PHPUnit_Framework_TestCase
             $event
         );
 
-        $this->assertEquals('fr', $request->getLocale());
+        $this->assertSame('fr', $request->getLocale());
+    }
+
+    private function getEvent(Request $request)
+    {
+        $kernel = $this->getMockBuilder('Symfony\Component\HttpKernel\HttpKernelInterface')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        return new GetResponseEvent($kernel, $request, HttpKernelInterface::MASTER_REQUEST);
     }
 }

--- a/tests/Wallabag/CoreBundle/Event/Listener/UserLocaleListenerTest.php
+++ b/tests/Wallabag/CoreBundle/Event/Listener/UserLocaleListenerTest.php
@@ -53,6 +53,6 @@ class UserLocaleListenerTest extends \PHPUnit_Framework_TestCase
 
         $listener->onInteractiveLogin($event);
 
-        $this->assertSame('', $session->get('_locale'));
+        $this->assertNull($session->get('_locale'));
     }
 }

--- a/tests/Wallabag/CoreBundle/Event/Listener/UserLocaleListenerTest.php
+++ b/tests/Wallabag/CoreBundle/Event/Listener/UserLocaleListenerTest.php
@@ -32,7 +32,7 @@ class UserLocaleListenerTest extends \PHPUnit_Framework_TestCase
 
         $listener->onInteractiveLogin($event);
 
-        $this->assertEquals('fr', $session->get('_locale'));
+        $this->assertSame('fr', $session->get('_locale'));
     }
 
     public function testWithoutLanguage()
@@ -53,6 +53,6 @@ class UserLocaleListenerTest extends \PHPUnit_Framework_TestCase
 
         $listener->onInteractiveLogin($event);
 
-        $this->assertEquals('', $session->get('_locale'));
+        $this->assertSame('', $session->get('_locale'));
     }
 }

--- a/tests/Wallabag/CoreBundle/Event/Subscriber/TablePrefixSubscriberTest.php
+++ b/tests/Wallabag/CoreBundle/Event/Subscriber/TablePrefixSubscriberTest.php
@@ -46,12 +46,12 @@ class TablePrefixSubscriberTest extends \PHPUnit_Framework_TestCase
 
         $metaDataEvent = new LoadClassMetadataEventArgs($metaClass, $em);
 
-        $this->assertEquals($tableNameExpected, $metaDataEvent->getClassMetadata()->getTableName());
+        $this->assertSame($tableNameExpected, $metaDataEvent->getClassMetadata()->getTableName());
 
         $subscriber->loadClassMetadata($metaDataEvent);
 
-        $this->assertEquals($finalTableName, $metaDataEvent->getClassMetadata()->getTableName());
-        $this->assertEquals($finalTableNameQuoted, $metaDataEvent->getClassMetadata()->getQuotedTableName($platform));
+        $this->assertSame($finalTableName, $metaDataEvent->getClassMetadata()->getTableName());
+        $this->assertSame($finalTableNameQuoted, $metaDataEvent->getClassMetadata()->getQuotedTableName($platform));
     }
 
     /**
@@ -75,8 +75,8 @@ class TablePrefixSubscriberTest extends \PHPUnit_Framework_TestCase
 
         $evm->dispatchEvent('loadClassMetadata', $metaDataEvent);
 
-        $this->assertEquals($finalTableName, $metaDataEvent->getClassMetadata()->getTableName());
-        $this->assertEquals($finalTableNameQuoted, $metaDataEvent->getClassMetadata()->getQuotedTableName($platform));
+        $this->assertSame($finalTableName, $metaDataEvent->getClassMetadata()->getTableName());
+        $this->assertSame($finalTableNameQuoted, $metaDataEvent->getClassMetadata()->getQuotedTableName($platform));
     }
 
     public function testPrefixManyToMany()
@@ -103,12 +103,12 @@ class TablePrefixSubscriberTest extends \PHPUnit_Framework_TestCase
 
         $metaDataEvent = new LoadClassMetadataEventArgs($metaClass, $em);
 
-        $this->assertEquals('entry', $metaDataEvent->getClassMetadata()->getTableName());
+        $this->assertSame('entry', $metaDataEvent->getClassMetadata()->getTableName());
 
         $subscriber->loadClassMetadata($metaDataEvent);
 
-        $this->assertEquals('yo_entry', $metaDataEvent->getClassMetadata()->getTableName());
-        $this->assertEquals('yo_entry_tag', $metaDataEvent->getClassMetadata()->associationMappings['tags']['joinTable']['name']);
-        $this->assertEquals('yo_entry', $metaDataEvent->getClassMetadata()->getQuotedTableName(new \Doctrine\DBAL\Platforms\MySqlPlatform()));
+        $this->assertSame('yo_entry', $metaDataEvent->getClassMetadata()->getTableName());
+        $this->assertSame('yo_entry_tag', $metaDataEvent->getClassMetadata()->associationMappings['tags']['joinTable']['name']);
+        $this->assertSame('yo_entry', $metaDataEvent->getClassMetadata()->getQuotedTableName(new \Doctrine\DBAL\Platforms\MySqlPlatform()));
     }
 }

--- a/tests/Wallabag/CoreBundle/GuzzleSiteAuthenticator/GrabySiteConfigBuilderTest.php
+++ b/tests/Wallabag/CoreBundle/GuzzleSiteAuthenticator/GrabySiteConfigBuilderTest.php
@@ -2,7 +2,6 @@
 
 namespace Tests\Wallabag\CoreBundle\GuzzleSiteAuthenticator;
 
-use BD\GuzzleSiteAuthenticator\SiteConfig\SiteConfig;
 use Graby\SiteConfig\SiteConfig as GrabySiteConfig;
 use Monolog\Handler\TestHandler;
 use Monolog\Logger;
@@ -68,20 +67,15 @@ class GrabySiteConfigBuilderTest extends \PHPUnit_Framework_TestCase
 
         $config = $this->builder->buildForHost('www.example.com');
 
-        $this->assertSame(
-            new SiteConfig([
-                'host' => 'example.com',
-                'requiresLogin' => true,
-                'loginUri' => 'http://www.example.com/login',
-                'usernameField' => 'login',
-                'passwordField' => 'password',
-                'extraFields' => ['field' => 'value'],
-                'notLoggedInXpath' => '//div[@class="need-login"]',
-                'username' => 'foo',
-                'password' => 'bar',
-            ]),
-            $config
-        );
+        $this->assertSame('example.com', $config->getHost());
+        $this->assertSame(true, $config->requiresLogin());
+        $this->assertSame('http://www.example.com/login', $config->getLoginUri());
+        $this->assertSame('login', $config->getUsernameField());
+        $this->assertSame('password', $config->getPasswordField());
+        $this->assertSame(['field' => 'value'], $config->getExtraFields());
+        $this->assertSame('//div[@class="need-login"]', $config->getNotLoggedInXpath());
+        $this->assertSame('foo', $config->getUsername());
+        $this->assertSame('bar', $config->getPassword());
 
         $records = $handler->getRecords();
 

--- a/tests/Wallabag/CoreBundle/GuzzleSiteAuthenticator/GrabySiteConfigBuilderTest.php
+++ b/tests/Wallabag/CoreBundle/GuzzleSiteAuthenticator/GrabySiteConfigBuilderTest.php
@@ -2,13 +2,13 @@
 
 namespace Tests\Wallabag\CoreBundle\GuzzleSiteAuthenticator;
 
-use Monolog\Handler\TestHandler;
-use Monolog\Logger;
 use BD\GuzzleSiteAuthenticator\SiteConfig\SiteConfig;
 use Graby\SiteConfig\SiteConfig as GrabySiteConfig;
-use Wallabag\CoreBundle\GuzzleSiteAuthenticator\GrabySiteConfigBuilder;
-use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
+use Monolog\Handler\TestHandler;
+use Monolog\Logger;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorage;
+use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
+use Wallabag\CoreBundle\GuzzleSiteAuthenticator\GrabySiteConfigBuilder;
 
 class GrabySiteConfigBuilderTest extends \PHPUnit_Framework_TestCase
 {
@@ -68,7 +68,7 @@ class GrabySiteConfigBuilderTest extends \PHPUnit_Framework_TestCase
 
         $config = $this->builder->buildForHost('www.example.com');
 
-        $this->assertEquals(
+        $this->assertSame(
             new SiteConfig([
                 'host' => 'example.com',
                 'requiresLogin' => true,

--- a/tests/Wallabag/CoreBundle/Helper/ContentProxyTest.php
+++ b/tests/Wallabag/CoreBundle/Helper/ContentProxyTest.php
@@ -51,7 +51,7 @@ class ContentProxyTest extends \PHPUnit_Framework_TestCase
         $this->assertEmpty($entry->getMimetype());
         $this->assertEmpty($entry->getLanguage());
         $this->assertSame(0.0, $entry->getReadingTime());
-        $this->assertSame(false, $entry->getDomainName());
+        $this->assertSame(null, $entry->getDomainName());
     }
 
     public function testWithEmptyContent()

--- a/tests/Wallabag/CoreBundle/Helper/ContentProxyTest.php
+++ b/tests/Wallabag/CoreBundle/Helper/ContentProxyTest.php
@@ -2,18 +2,18 @@
 
 namespace Tests\Wallabag\CoreBundle\Helper;
 
-use Psr\Log\NullLogger;
-use Monolog\Logger;
+use Graby\Graby;
 use Monolog\Handler\TestHandler;
-use Wallabag\CoreBundle\Helper\ContentProxy;
+use Monolog\Logger;
+use Psr\Log\NullLogger;
+use Symfony\Component\Validator\ConstraintViolation;
+use Symfony\Component\Validator\ConstraintViolationList;
+use Symfony\Component\Validator\Validator\RecursiveValidator;
 use Wallabag\CoreBundle\Entity\Entry;
 use Wallabag\CoreBundle\Entity\Tag;
-use Wallabag\UserBundle\Entity\User;
+use Wallabag\CoreBundle\Helper\ContentProxy;
 use Wallabag\CoreBundle\Helper\RuleBasedTagger;
-use Graby\Graby;
-use Symfony\Component\Validator\Validator\RecursiveValidator;
-use Symfony\Component\Validator\ConstraintViolationList;
-use Symfony\Component\Validator\ConstraintViolation;
+use Wallabag\UserBundle\Entity\User;
 
 class ContentProxyTest extends \PHPUnit_Framework_TestCase
 {
@@ -44,14 +44,14 @@ class ContentProxyTest extends \PHPUnit_Framework_TestCase
         $entry = new Entry(new User());
         $proxy->updateEntry($entry, 'http://user@:80');
 
-        $this->assertEquals('http://user@:80', $entry->getUrl());
+        $this->assertSame('http://user@:80', $entry->getUrl());
         $this->assertEmpty($entry->getTitle());
-        $this->assertEquals($this->fetchingErrorMessage, $entry->getContent());
+        $this->assertSame($this->fetchingErrorMessage, $entry->getContent());
         $this->assertEmpty($entry->getPreviewPicture());
         $this->assertEmpty($entry->getMimetype());
         $this->assertEmpty($entry->getLanguage());
-        $this->assertEquals(0.0, $entry->getReadingTime());
-        $this->assertEquals(false, $entry->getDomainName());
+        $this->assertSame(0.0, $entry->getReadingTime());
+        $this->assertSame(false, $entry->getDomainName());
     }
 
     public function testWithEmptyContent()
@@ -79,14 +79,14 @@ class ContentProxyTest extends \PHPUnit_Framework_TestCase
         $entry = new Entry(new User());
         $proxy->updateEntry($entry, 'http://0.0.0.0');
 
-        $this->assertEquals('http://0.0.0.0', $entry->getUrl());
+        $this->assertSame('http://0.0.0.0', $entry->getUrl());
         $this->assertEmpty($entry->getTitle());
-        $this->assertEquals($this->fetchingErrorMessage, $entry->getContent());
+        $this->assertSame($this->fetchingErrorMessage, $entry->getContent());
         $this->assertEmpty($entry->getPreviewPicture());
         $this->assertEmpty($entry->getMimetype());
         $this->assertEmpty($entry->getLanguage());
-        $this->assertEquals(0.0, $entry->getReadingTime());
-        $this->assertEquals('0.0.0.0', $entry->getDomainName());
+        $this->assertSame(0.0, $entry->getReadingTime());
+        $this->assertSame('0.0.0.0', $entry->getDomainName());
     }
 
     public function testWithEmptyContentButOG()
@@ -119,15 +119,15 @@ class ContentProxyTest extends \PHPUnit_Framework_TestCase
         $entry = new Entry(new User());
         $proxy->updateEntry($entry, 'http://domain.io');
 
-        $this->assertEquals('http://domain.io', $entry->getUrl());
-        $this->assertEquals('my title', $entry->getTitle());
-        $this->assertEquals($this->fetchingErrorMessage.'<p><i>But we found a short description: </i></p>desc', $entry->getContent());
+        $this->assertSame('http://domain.io', $entry->getUrl());
+        $this->assertSame('my title', $entry->getTitle());
+        $this->assertSame($this->fetchingErrorMessage . '<p><i>But we found a short description: </i></p>desc', $entry->getContent());
         $this->assertEmpty($entry->getPreviewPicture());
         $this->assertEmpty($entry->getLanguage());
         $this->assertEmpty($entry->getHttpStatus());
         $this->assertEmpty($entry->getMimetype());
-        $this->assertEquals(0.0, $entry->getReadingTime());
-        $this->assertEquals('domain.io', $entry->getDomainName());
+        $this->assertSame(0.0, $entry->getReadingTime());
+        $this->assertSame('domain.io', $entry->getDomainName());
     }
 
     public function testWithContent()
@@ -161,15 +161,15 @@ class ContentProxyTest extends \PHPUnit_Framework_TestCase
         $entry = new Entry(new User());
         $proxy->updateEntry($entry, 'http://0.0.0.0');
 
-        $this->assertEquals('http://1.1.1.1', $entry->getUrl());
-        $this->assertEquals('this is my title', $entry->getTitle());
+        $this->assertSame('http://1.1.1.1', $entry->getUrl());
+        $this->assertSame('this is my title', $entry->getTitle());
         $this->assertContains('this is my content', $entry->getContent());
-        $this->assertEquals('http://3.3.3.3/cover.jpg', $entry->getPreviewPicture());
-        $this->assertEquals('text/html', $entry->getMimetype());
-        $this->assertEquals('fr', $entry->getLanguage());
-        $this->assertEquals('200', $entry->getHttpStatus());
-        $this->assertEquals(4.0, $entry->getReadingTime());
-        $this->assertEquals('1.1.1.1', $entry->getDomainName());
+        $this->assertSame('http://3.3.3.3/cover.jpg', $entry->getPreviewPicture());
+        $this->assertSame('text/html', $entry->getMimetype());
+        $this->assertSame('fr', $entry->getLanguage());
+        $this->assertSame('200', $entry->getHttpStatus());
+        $this->assertSame(4.0, $entry->getReadingTime());
+        $this->assertSame('1.1.1.1', $entry->getDomainName());
     }
 
     public function testWithContentAndNoOgImage()
@@ -203,15 +203,15 @@ class ContentProxyTest extends \PHPUnit_Framework_TestCase
         $entry = new Entry(new User());
         $proxy->updateEntry($entry, 'http://0.0.0.0');
 
-        $this->assertEquals('http://1.1.1.1', $entry->getUrl());
-        $this->assertEquals('this is my title', $entry->getTitle());
+        $this->assertSame('http://1.1.1.1', $entry->getUrl());
+        $this->assertSame('this is my title', $entry->getTitle());
         $this->assertContains('this is my content', $entry->getContent());
         $this->assertNull($entry->getPreviewPicture());
-        $this->assertEquals('text/html', $entry->getMimetype());
-        $this->assertEquals('fr', $entry->getLanguage());
-        $this->assertEquals('200', $entry->getHttpStatus());
-        $this->assertEquals(4.0, $entry->getReadingTime());
-        $this->assertEquals('1.1.1.1', $entry->getDomainName());
+        $this->assertSame('text/html', $entry->getMimetype());
+        $this->assertSame('fr', $entry->getLanguage());
+        $this->assertSame('200', $entry->getHttpStatus());
+        $this->assertSame(4.0, $entry->getReadingTime());
+        $this->assertSame('1.1.1.1', $entry->getDomainName());
     }
 
     public function testWithContentAndBadLanguage()
@@ -248,14 +248,14 @@ class ContentProxyTest extends \PHPUnit_Framework_TestCase
         $entry = new Entry(new User());
         $proxy->updateEntry($entry, 'http://0.0.0.0');
 
-        $this->assertEquals('http://1.1.1.1', $entry->getUrl());
-        $this->assertEquals('this is my title', $entry->getTitle());
+        $this->assertSame('http://1.1.1.1', $entry->getUrl());
+        $this->assertSame('this is my title', $entry->getTitle());
         $this->assertContains('this is my content', $entry->getContent());
-        $this->assertEquals('text/html', $entry->getMimetype());
+        $this->assertSame('text/html', $entry->getMimetype());
         $this->assertNull($entry->getLanguage());
-        $this->assertEquals('200', $entry->getHttpStatus());
-        $this->assertEquals(4.0, $entry->getReadingTime());
-        $this->assertEquals('1.1.1.1', $entry->getDomainName());
+        $this->assertSame('200', $entry->getHttpStatus());
+        $this->assertSame(4.0, $entry->getReadingTime());
+        $this->assertSame('1.1.1.1', $entry->getDomainName());
     }
 
     public function testWithContentAndBadOgImage()
@@ -297,15 +297,15 @@ class ContentProxyTest extends \PHPUnit_Framework_TestCase
         $entry = new Entry(new User());
         $proxy->updateEntry($entry, 'http://0.0.0.0');
 
-        $this->assertEquals('http://1.1.1.1', $entry->getUrl());
-        $this->assertEquals('this is my title', $entry->getTitle());
+        $this->assertSame('http://1.1.1.1', $entry->getUrl());
+        $this->assertSame('this is my title', $entry->getTitle());
         $this->assertContains('this is my content', $entry->getContent());
         $this->assertNull($entry->getPreviewPicture());
-        $this->assertEquals('text/html', $entry->getMimetype());
-        $this->assertEquals('fr', $entry->getLanguage());
-        $this->assertEquals('200', $entry->getHttpStatus());
-        $this->assertEquals(4.0, $entry->getReadingTime());
-        $this->assertEquals('1.1.1.1', $entry->getDomainName());
+        $this->assertSame('text/html', $entry->getMimetype());
+        $this->assertSame('fr', $entry->getLanguage());
+        $this->assertSame('200', $entry->getHttpStatus());
+        $this->assertSame(4.0, $entry->getReadingTime());
+        $this->assertSame('1.1.1.1', $entry->getDomainName());
     }
 
     public function testWithForcedContent()
@@ -333,14 +333,14 @@ class ContentProxyTest extends \PHPUnit_Framework_TestCase
             ]
         );
 
-        $this->assertEquals('http://1.1.1.1', $entry->getUrl());
-        $this->assertEquals('this is my title', $entry->getTitle());
+        $this->assertSame('http://1.1.1.1', $entry->getUrl());
+        $this->assertSame('this is my title', $entry->getTitle());
         $this->assertContains('this is my content', $entry->getContent());
-        $this->assertEquals('text/html', $entry->getMimetype());
-        $this->assertEquals('fr', $entry->getLanguage());
-        $this->assertEquals(4.0, $entry->getReadingTime());
-        $this->assertEquals('1.1.1.1', $entry->getDomainName());
-        $this->assertEquals('24/03/2014', $entry->getPublishedAt()->format('d/m/Y'));
+        $this->assertSame('text/html', $entry->getMimetype());
+        $this->assertSame('fr', $entry->getLanguage());
+        $this->assertSame(4.0, $entry->getReadingTime());
+        $this->assertSame('1.1.1.1', $entry->getDomainName());
+        $this->assertSame('24/03/2014', $entry->getPublishedAt()->format('d/m/Y'));
         $this->assertContains('Jeremy', $entry->getPublishedBy());
         $this->assertContains('Nico', $entry->getPublishedBy());
         $this->assertContains('Thomas', $entry->getPublishedBy());
@@ -371,14 +371,14 @@ class ContentProxyTest extends \PHPUnit_Framework_TestCase
             ]
         );
 
-        $this->assertEquals('http://1.1.1.1', $entry->getUrl());
-        $this->assertEquals('this is my title', $entry->getTitle());
+        $this->assertSame('http://1.1.1.1', $entry->getUrl());
+        $this->assertSame('this is my title', $entry->getTitle());
         $this->assertContains('this is my content', $entry->getContent());
-        $this->assertEquals('text/html', $entry->getMimetype());
-        $this->assertEquals('fr', $entry->getLanguage());
-        $this->assertEquals(4.0, $entry->getReadingTime());
-        $this->assertEquals('1.1.1.1', $entry->getDomainName());
-        $this->assertEquals('08/09/2016', $entry->getPublishedAt()->format('d/m/Y'));
+        $this->assertSame('text/html', $entry->getMimetype());
+        $this->assertSame('fr', $entry->getLanguage());
+        $this->assertSame(4.0, $entry->getReadingTime());
+        $this->assertSame('1.1.1.1', $entry->getDomainName());
+        $this->assertSame('08/09/2016', $entry->getPublishedAt()->format('d/m/Y'));
     }
 
     public function testWithForcedContentAndBadDate()
@@ -406,13 +406,13 @@ class ContentProxyTest extends \PHPUnit_Framework_TestCase
             ]
         );
 
-        $this->assertEquals('http://1.1.1.1', $entry->getUrl());
-        $this->assertEquals('this is my title', $entry->getTitle());
+        $this->assertSame('http://1.1.1.1', $entry->getUrl());
+        $this->assertSame('this is my title', $entry->getTitle());
         $this->assertContains('this is my content', $entry->getContent());
-        $this->assertEquals('text/html', $entry->getMimetype());
-        $this->assertEquals('fr', $entry->getLanguage());
-        $this->assertEquals(4.0, $entry->getReadingTime());
-        $this->assertEquals('1.1.1.1', $entry->getDomainName());
+        $this->assertSame('text/html', $entry->getMimetype());
+        $this->assertSame('fr', $entry->getLanguage());
+        $this->assertSame(4.0, $entry->getReadingTime());
+        $this->assertSame('1.1.1.1', $entry->getDomainName());
         $this->assertNull($entry->getPublishedAt());
 
         $records = $handler->getRecords();
@@ -488,14 +488,14 @@ class ContentProxyTest extends \PHPUnit_Framework_TestCase
             ]
         );
 
-        $this->assertEquals('http://1.1.1.1', $entry->getUrl());
-        $this->assertEquals('this is my title', $entry->getTitle());
+        $this->assertSame('http://1.1.1.1', $entry->getUrl());
+        $this->assertSame('this is my title', $entry->getTitle());
         $this->assertNotContains($escapedString, $entry->getContent());
-        $this->assertEquals('http://3.3.3.3/cover.jpg', $entry->getPreviewPicture());
-        $this->assertEquals('text/html', $entry->getMimetype());
-        $this->assertEquals('fr', $entry->getLanguage());
-        $this->assertEquals('200', $entry->getHttpStatus());
-        $this->assertEquals('1.1.1.1', $entry->getDomainName());
+        $this->assertSame('http://3.3.3.3/cover.jpg', $entry->getPreviewPicture());
+        $this->assertSame('text/html', $entry->getMimetype());
+        $this->assertSame('fr', $entry->getLanguage());
+        $this->assertSame('200', $entry->getHttpStatus());
+        $this->assertSame('1.1.1.1', $entry->getDomainName());
     }
 
     private function getTaggerMock()

--- a/tests/Wallabag/CoreBundle/Helper/CryptoProxyTest.php
+++ b/tests/Wallabag/CoreBundle/Helper/CryptoProxyTest.php
@@ -2,9 +2,9 @@
 
 namespace Tests\Wallabag\CoreBundle\Helper;
 
-use Psr\Log\NullLogger;
-use Monolog\Logger;
 use Monolog\Handler\TestHandler;
+use Monolog\Logger;
+use Psr\Log\NullLogger;
 use Wallabag\CoreBundle\Helper\CryptoProxy;
 
 class CryptoProxyTest extends \PHPUnit_Framework_TestCase
@@ -14,7 +14,7 @@ class CryptoProxyTest extends \PHPUnit_Framework_TestCase
         $logHandler = new TestHandler();
         $logger = new Logger('test', [$logHandler]);
 
-        $crypto = new CryptoProxy(sys_get_temp_dir().'/'.uniqid('', true).'.txt', $logger);
+        $crypto = new CryptoProxy(sys_get_temp_dir() . '/' . uniqid('', true) . '.txt', $logger);
         $crypted = $crypto->crypt('test');
         $decrypted = $crypto->decrypt($crypted);
 
@@ -27,14 +27,14 @@ class CryptoProxyTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException RuntimeException
+     * @expectedException \RuntimeException
      * @expectedExceptionMessage Decrypt fail
      *
      * @return [type] [description]
      */
     public function testDecryptBadValue()
     {
-        $crypto = new CryptoProxy(sys_get_temp_dir().'/'.uniqid('', true).'.txt', new NullLogger());
+        $crypto = new CryptoProxy(sys_get_temp_dir() . '/' . uniqid('', true) . '.txt', new NullLogger());
         $crypto->decrypt('badvalue');
     }
 }

--- a/tests/Wallabag/CoreBundle/Helper/DownloadImagesTest.php
+++ b/tests/Wallabag/CoreBundle/Helper/DownloadImagesTest.php
@@ -2,13 +2,13 @@
 
 namespace Tests\Wallabag\CoreBundle\Helper;
 
-use Wallabag\CoreBundle\Helper\DownloadImages;
-use Monolog\Logger;
-use Monolog\Handler\TestHandler;
 use GuzzleHttp\Client;
-use GuzzleHttp\Subscriber\Mock;
 use GuzzleHttp\Message\Response;
 use GuzzleHttp\Stream\Stream;
+use GuzzleHttp\Subscriber\Mock;
+use Monolog\Handler\TestHandler;
+use Monolog\Logger;
+use Wallabag\CoreBundle\Helper\DownloadImages;
 
 class DownloadImagesTest extends \PHPUnit_Framework_TestCase
 {
@@ -34,15 +34,15 @@ class DownloadImagesTest extends \PHPUnit_Framework_TestCase
         $client = new Client();
 
         $mock = new Mock([
-            new Response(200, ['content-type' => 'image/png'], Stream::factory(file_get_contents(__DIR__.'/../fixtures/unnamed.png'))),
+            new Response(200, ['content-type' => 'image/png'], Stream::factory(file_get_contents(__DIR__ . '/../fixtures/unnamed.png'))),
         ]);
 
         $client->getEmitter()->attach($mock);
 
         $logHandler = new TestHandler();
-        $logger = new Logger('test', array($logHandler));
+        $logger = new Logger('test', [$logHandler]);
 
-        $download = new DownloadImages($client, sys_get_temp_dir().'/wallabag_test', 'http://wallabag.io/', $logger);
+        $download = new DownloadImages($client, sys_get_temp_dir() . '/wallabag_test', 'http://wallabag.io/', $logger);
 
         $res = $download->processHtml(123, $html, $url);
 
@@ -61,9 +61,9 @@ class DownloadImagesTest extends \PHPUnit_Framework_TestCase
         $client->getEmitter()->attach($mock);
 
         $logHandler = new TestHandler();
-        $logger = new Logger('test', array($logHandler));
+        $logger = new Logger('test', [$logHandler]);
 
-        $download = new DownloadImages($client, sys_get_temp_dir().'/wallabag_test', 'http://wallabag.io/', $logger);
+        $download = new DownloadImages($client, sys_get_temp_dir() . '/wallabag_test', 'http://wallabag.io/', $logger);
         $res = $download->processHtml(123, '<div><img src="http://i.imgur.com/T9qgcHc.jpg" /></div>', 'http://imgur.com/gallery/WxtWY');
 
         $this->assertContains('http://i.imgur.com/T9qgcHc.jpg', $res, 'Image were not replace because of content-type');
@@ -87,18 +87,18 @@ class DownloadImagesTest extends \PHPUnit_Framework_TestCase
         $client = new Client();
 
         $mock = new Mock([
-            new Response(200, ['content-type' => $header], Stream::factory(file_get_contents(__DIR__.'/../fixtures/unnamed.png'))),
+            new Response(200, ['content-type' => $header], Stream::factory(file_get_contents(__DIR__ . '/../fixtures/unnamed.png'))),
         ]);
 
         $client->getEmitter()->attach($mock);
 
         $logHandler = new TestHandler();
-        $logger = new Logger('test', array($logHandler));
+        $logger = new Logger('test', [$logHandler]);
 
-        $download = new DownloadImages($client, sys_get_temp_dir().'/wallabag_test', 'http://wallabag.io/', $logger);
+        $download = new DownloadImages($client, sys_get_temp_dir() . '/wallabag_test', 'http://wallabag.io/', $logger);
         $res = $download->processSingleImage(123, 'T9qgcHc.jpg', 'http://imgur.com/gallery/WxtWY');
 
-        $this->assertContains('/assets/images/9/b/9b0ead26/ebe60399.'.$extension, $res);
+        $this->assertContains('/assets/images/9/b/9b0ead26/ebe60399.' . $extension, $res);
     }
 
     public function testProcessSingleImageWithBadUrl()
@@ -112,9 +112,9 @@ class DownloadImagesTest extends \PHPUnit_Framework_TestCase
         $client->getEmitter()->attach($mock);
 
         $logHandler = new TestHandler();
-        $logger = new Logger('test', array($logHandler));
+        $logger = new Logger('test', [$logHandler]);
 
-        $download = new DownloadImages($client, sys_get_temp_dir().'/wallabag_test', 'http://wallabag.io/', $logger);
+        $download = new DownloadImages($client, sys_get_temp_dir() . '/wallabag_test', 'http://wallabag.io/', $logger);
         $res = $download->processSingleImage(123, 'T9qgcHc.jpg', 'http://imgur.com/gallery/WxtWY');
 
         $this->assertFalse($res, 'Image can not be found, so it will not be replaced');
@@ -131,9 +131,9 @@ class DownloadImagesTest extends \PHPUnit_Framework_TestCase
         $client->getEmitter()->attach($mock);
 
         $logHandler = new TestHandler();
-        $logger = new Logger('test', array($logHandler));
+        $logger = new Logger('test', [$logHandler]);
 
-        $download = new DownloadImages($client, sys_get_temp_dir().'/wallabag_test', 'http://wallabag.io/', $logger);
+        $download = new DownloadImages($client, sys_get_temp_dir() . '/wallabag_test', 'http://wallabag.io/', $logger);
         $res = $download->processSingleImage(123, 'http://i.imgur.com/T9qgcHc.jpg', 'http://imgur.com/gallery/WxtWY');
 
         $this->assertFalse($res, 'Image can not be loaded, so it will not be replaced');
@@ -144,15 +144,15 @@ class DownloadImagesTest extends \PHPUnit_Framework_TestCase
         $client = new Client();
 
         $mock = new Mock([
-            new Response(200, ['content-type' => 'image/png'], Stream::factory(file_get_contents(__DIR__.'/../fixtures/unnamed.png'))),
+            new Response(200, ['content-type' => 'image/png'], Stream::factory(file_get_contents(__DIR__ . '/../fixtures/unnamed.png'))),
         ]);
 
         $client->getEmitter()->attach($mock);
 
         $logHandler = new TestHandler();
-        $logger = new Logger('test', array($logHandler));
+        $logger = new Logger('test', [$logHandler]);
 
-        $download = new DownloadImages($client, sys_get_temp_dir().'/wallabag_test', 'http://wallabag.io/', $logger);
+        $download = new DownloadImages($client, sys_get_temp_dir() . '/wallabag_test', 'http://wallabag.io/', $logger);
         $res = $download->processSingleImage(123, '/i.imgur.com/T9qgcHc.jpg', 'imgur.com/gallery/WxtWY');
 
         $this->assertFalse($res, 'Absolute image can not be determined, so it will not be replaced');
@@ -163,15 +163,15 @@ class DownloadImagesTest extends \PHPUnit_Framework_TestCase
         $client = new Client();
 
         $mock = new Mock([
-            new Response(200, ['content-type' => null], Stream::factory(file_get_contents(__DIR__.'/../fixtures/image-no-content-type.jpg'))),
+            new Response(200, ['content-type' => null], Stream::factory(file_get_contents(__DIR__ . '/../fixtures/image-no-content-type.jpg'))),
         ]);
 
         $client->getEmitter()->attach($mock);
 
         $logHandler = new TestHandler();
-        $logger = new Logger('test', array($logHandler));
+        $logger = new Logger('test', [$logHandler]);
 
-        $download = new DownloadImages($client, sys_get_temp_dir().'/wallabag_test', 'http://wallabag.io/', $logger);
+        $download = new DownloadImages($client, sys_get_temp_dir() . '/wallabag_test', 'http://wallabag.io/', $logger);
 
         $res = $download->processSingleImage(
             123,

--- a/tests/Wallabag/CoreBundle/Helper/RedirectTest.php
+++ b/tests/Wallabag/CoreBundle/Helper/RedirectTest.php
@@ -2,11 +2,11 @@
 
 namespace Tests\Wallabag\CoreBundle\Helper;
 
-use Wallabag\CoreBundle\Entity\Config;
-use Wallabag\UserBundle\Entity\User;
-use Wallabag\CoreBundle\Helper\Redirect;
-use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorage;
+use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
+use Wallabag\CoreBundle\Entity\Config;
+use Wallabag\CoreBundle\Helper\Redirect;
+use Wallabag\UserBundle\Entity\User;
 
 class RedirectTest extends \PHPUnit_Framework_TestCase
 {
@@ -56,21 +56,21 @@ class RedirectTest extends \PHPUnit_Framework_TestCase
     {
         $redirectUrl = $this->redirect->to(null, 'fallback');
 
-        $this->assertEquals('fallback', $redirectUrl);
+        $this->assertSame('fallback', $redirectUrl);
     }
 
     public function testRedirectToNullWithoutFallback()
     {
         $redirectUrl = $this->redirect->to(null);
 
-        $this->assertEquals($this->routerMock->generate('homepage'), $redirectUrl);
+        $this->assertSame($this->routerMock->generate('homepage'), $redirectUrl);
     }
 
     public function testRedirectToValidUrl()
     {
         $redirectUrl = $this->redirect->to('/unread/list');
 
-        $this->assertEquals('/unread/list', $redirectUrl);
+        $this->assertSame('/unread/list', $redirectUrl);
     }
 
     public function testWithNotLoggedUser()
@@ -78,7 +78,7 @@ class RedirectTest extends \PHPUnit_Framework_TestCase
         $redirect = new Redirect($this->routerMock, new TokenStorage());
         $redirectUrl = $redirect->to('/unread/list');
 
-        $this->assertEquals('/unread/list', $redirectUrl);
+        $this->assertSame('/unread/list', $redirectUrl);
     }
 
     public function testUserForRedirectToHomepage()
@@ -87,7 +87,7 @@ class RedirectTest extends \PHPUnit_Framework_TestCase
 
         $redirectUrl = $this->redirect->to('/unread/list');
 
-        $this->assertEquals($this->routerMock->generate('homepage'), $redirectUrl);
+        $this->assertSame($this->routerMock->generate('homepage'), $redirectUrl);
     }
 
     public function testUserForRedirectWithIgnoreActionMarkAsRead()
@@ -96,7 +96,7 @@ class RedirectTest extends \PHPUnit_Framework_TestCase
 
         $redirectUrl = $this->redirect->to('/unread/list', '', true);
 
-        $this->assertEquals('/unread/list', $redirectUrl);
+        $this->assertSame('/unread/list', $redirectUrl);
     }
 
     public function testUserForRedirectNullWithFallbackWithIgnoreActionMarkAsRead()
@@ -105,6 +105,6 @@ class RedirectTest extends \PHPUnit_Framework_TestCase
 
         $redirectUrl = $this->redirect->to(null, 'fallback', true);
 
-        $this->assertEquals('fallback', $redirectUrl);
+        $this->assertSame('fallback', $redirectUrl);
     }
 }

--- a/tests/Wallabag/CoreBundle/Helper/RuleBasedTaggerTest.php
+++ b/tests/Wallabag/CoreBundle/Helper/RuleBasedTaggerTest.php
@@ -182,7 +182,7 @@ class RuleBasedTaggerTest extends \PHPUnit_Framework_TestCase
             $tags = $entry->getTags();
 
             $this->assertCount(1, $tags);
-            $this->assertEquals('hey', $tags[0]->getLabel());
+            $this->assertSame('hey', $tags[0]->getLabel());
         }
     }
 

--- a/tests/Wallabag/CoreBundle/Helper/TagsAssignerTest.php
+++ b/tests/Wallabag/CoreBundle/Helper/TagsAssignerTest.php
@@ -5,8 +5,8 @@ namespace Tests\Wallabag\CoreBundle\Helper;
 use Wallabag\CoreBundle\Entity\Entry;
 use Wallabag\CoreBundle\Entity\Tag;
 use Wallabag\CoreBundle\Helper\TagsAssigner;
-use Wallabag\UserBundle\Entity\User;
 use Wallabag\CoreBundle\Repository\TagRepository;
+use Wallabag\UserBundle\Entity\User;
 
 class TagsAssignerTest extends \PHPUnit_Framework_TestCase
 {
@@ -20,8 +20,8 @@ class TagsAssignerTest extends \PHPUnit_Framework_TestCase
         $tagsAssigner->assignTagsToEntry($entry, ['   tag1', 'tag2   ']);
 
         $this->assertCount(2, $entry->getTags());
-        $this->assertEquals('tag1', $entry->getTags()[0]->getLabel());
-        $this->assertEquals('tag2', $entry->getTags()[1]->getLabel());
+        $this->assertSame('tag1', $entry->getTags()[0]->getLabel());
+        $this->assertSame('tag2', $entry->getTags()[1]->getLabel());
     }
 
     public function testAssignTagsWithString()
@@ -34,8 +34,8 @@ class TagsAssignerTest extends \PHPUnit_Framework_TestCase
         $tagsAssigner->assignTagsToEntry($entry, 'tag1, tag2');
 
         $this->assertCount(2, $entry->getTags());
-        $this->assertEquals('tag1', $entry->getTags()[0]->getLabel());
-        $this->assertEquals('tag2', $entry->getTags()[1]->getLabel());
+        $this->assertSame('tag1', $entry->getTags()[0]->getLabel());
+        $this->assertSame('tag2', $entry->getTags()[1]->getLabel());
     }
 
     public function testAssignTagsWithEmptyArray()
@@ -76,8 +76,8 @@ class TagsAssignerTest extends \PHPUnit_Framework_TestCase
         $tagsAssigner->assignTagsToEntry($entry, 'tag1, tag2');
 
         $this->assertCount(2, $entry->getTags());
-        $this->assertEquals('tag1', $entry->getTags()[0]->getLabel());
-        $this->assertEquals('tag2', $entry->getTags()[1]->getLabel());
+        $this->assertSame('tag1', $entry->getTags()[0]->getLabel());
+        $this->assertSame('tag2', $entry->getTags()[1]->getLabel());
     }
 
     public function testAssignTagsNotFlushed()
@@ -96,7 +96,7 @@ class TagsAssignerTest extends \PHPUnit_Framework_TestCase
         $tagsAssigner->assignTagsToEntry($entry, 'tag1', [$tagEntity]);
 
         $this->assertCount(1, $entry->getTags());
-        $this->assertEquals('tag1', $entry->getTags()[0]->getLabel());
+        $this->assertSame('tag1', $entry->getTags()[0]->getLabel());
     }
 
     private function getTagRepositoryMock()

--- a/tests/Wallabag/CoreBundle/ParamConverter/UsernameRssTokenConverterTest.php
+++ b/tests/Wallabag/CoreBundle/ParamConverter/UsernameRssTokenConverterTest.php
@@ -212,6 +212,6 @@ class UsernameRssTokenConverterTest extends \PHPUnit_Framework_TestCase
 
         $converter->apply($request, $params);
 
-        $this->assertEquals($user, $request->attributes->get('user'));
+        $this->assertSame($user, $request->attributes->get('user'));
     }
 }

--- a/tests/Wallabag/CoreBundle/Tools/UtilsTest.php
+++ b/tests/Wallabag/CoreBundle/Tools/UtilsTest.php
@@ -18,7 +18,7 @@ class UtilsTest extends \PHPUnit_Framework_TestCase
     public function examples()
     {
         $examples = [];
-        $finder = (new Finder())->in(__DIR__.'/samples');
+        $finder = (new Finder())->in(__DIR__ . '/samples');
         foreach ($finder->getIterator() as $file) {
             $examples[] = [$file->getContents(), 1];
         }

--- a/tests/Wallabag/CoreBundle/Twig/WallabagExtensionTest.php
+++ b/tests/Wallabag/CoreBundle/Twig/WallabagExtensionTest.php
@@ -26,8 +26,8 @@ class WallabagExtensionTest extends \PHPUnit_Framework_TestCase
 
         $extension = new WallabagExtension($entryRepository, $tagRepository, $tokenStorage, 0, $translator);
 
-        $this->assertEquals('lemonde.fr', $extension->removeWww('www.lemonde.fr'));
-        $this->assertEquals('lemonde.fr', $extension->removeWww('lemonde.fr'));
-        $this->assertEquals('gist.github.com', $extension->removeWww('gist.github.com'));
+        $this->assertSame('lemonde.fr', $extension->removeWww('www.lemonde.fr'));
+        $this->assertSame('lemonde.fr', $extension->removeWww('lemonde.fr'));
+        $this->assertSame('gist.github.com', $extension->removeWww('gist.github.com'));
     }
 }

--- a/tests/Wallabag/CoreBundle/WallabagCoreTestCase.php
+++ b/tests/Wallabag/CoreBundle/WallabagCoreTestCase.php
@@ -18,16 +18,16 @@ abstract class WallabagCoreTestCase extends WebTestCase
      */
     private $client = null;
 
-    public function getClient()
-    {
-        return $this->client;
-    }
-
     public function setUp()
     {
         parent::setUp();
 
         $this->client = static::createClient();
+    }
+
+    public function getClient()
+    {
+        return $this->client;
     }
 
     public function resetDatabase(Client $client)
@@ -83,10 +83,10 @@ abstract class WallabagCoreTestCase extends WebTestCase
         $loginManager = $container->get('fos_user.security.login_manager');
         $firewallName = $container->getParameter('fos_user.firewall_name');
 
-        $user = $userManager->findUserBy(array('username' => $username));
+        $user = $userManager->findUserBy(['username' => $username]);
         $loginManager->logInUser($firewallName, $user);
 
-        $session->set('_security_'.$firewallName, serialize($container->get('security.token_storage')->getToken()));
+        $session->set('_security_' . $firewallName, serialize($container->get('security.token_storage')->getToken()));
         $session->save();
 
         $cookie = new Cookie($session->getName(), $session->getId());

--- a/tests/Wallabag/ImportBundle/Command/ImportCommandTest.php
+++ b/tests/Wallabag/ImportBundle/Command/ImportCommandTest.php
@@ -4,8 +4,8 @@ namespace Tests\Wallabag\ImportBundle\Command;
 
 use Symfony\Bundle\FrameworkBundle\Console\Application;
 use Symfony\Component\Console\Tester\CommandTester;
-use Wallabag\ImportBundle\Command\ImportCommand;
 use Tests\Wallabag\CoreBundle\WallabagCoreTestCase;
+use Wallabag\ImportBundle\Command\ImportCommand;
 
 class ImportCommandTest extends WallabagCoreTestCase
 {
@@ -74,7 +74,7 @@ class ImportCommandTest extends WallabagCoreTestCase
         $tester->execute([
             'command' => $command->getName(),
             'username' => 'admin',
-            'filepath' => $application->getKernel()->getContainer()->getParameter('kernel.root_dir').'/../tests/Wallabag/ImportBundle/fixtures/wallabag-v2-read.json',
+            'filepath' => $application->getKernel()->getContainer()->getParameter('kernel.root_dir') . '/../tests/Wallabag/ImportBundle/fixtures/wallabag-v2-read.json',
             '--importer' => 'v2',
         ]);
 
@@ -93,7 +93,7 @@ class ImportCommandTest extends WallabagCoreTestCase
         $tester->execute([
             'command' => $command->getName(),
             'username' => 1,
-            'filepath' => $application->getKernel()->getContainer()->getParameter('kernel.root_dir').'/../tests/Wallabag/ImportBundle/fixtures/wallabag-v2-read.json',
+            'filepath' => $application->getKernel()->getContainer()->getParameter('kernel.root_dir') . '/../tests/Wallabag/ImportBundle/fixtures/wallabag-v2-read.json',
             '--useUserId' => true,
             '--importer' => 'v2',
         ]);

--- a/tests/Wallabag/ImportBundle/Command/RedisWorkerCommandTest.php
+++ b/tests/Wallabag/ImportBundle/Command/RedisWorkerCommandTest.php
@@ -2,11 +2,11 @@
 
 namespace Tests\Wallabag\ImportBundle\Command;
 
+use M6Web\Component\RedisMock\RedisMockFactory;
 use Symfony\Bundle\FrameworkBundle\Console\Application;
 use Symfony\Component\Console\Tester\CommandTester;
-use Wallabag\ImportBundle\Command\RedisWorkerCommand;
 use Tests\Wallabag\CoreBundle\WallabagCoreTestCase;
-use M6Web\Component\RedisMock\RedisMockFactory;
+use Wallabag\ImportBundle\Command\RedisWorkerCommand;
 
 class RedisWorkerCommandTest extends WallabagCoreTestCase
 {

--- a/tests/Wallabag/ImportBundle/Consumer/AMQPEntryConsumerTest.php
+++ b/tests/Wallabag/ImportBundle/Consumer/AMQPEntryConsumerTest.php
@@ -2,10 +2,10 @@
 
 namespace Tests\Wallabag\ImportBundle\Consumer\AMQP;
 
-use Wallabag\ImportBundle\Consumer\AMQPEntryConsumer;
 use PhpAmqpLib\Message\AMQPMessage;
-use Wallabag\UserBundle\Entity\User;
 use Wallabag\CoreBundle\Entity\Entry;
+use Wallabag\ImportBundle\Consumer\AMQPEntryConsumer;
+use Wallabag\UserBundle\Entity\User;
 
 class AMQPEntryConsumerTest extends \PHPUnit_Framework_TestCase
 {

--- a/tests/Wallabag/ImportBundle/Consumer/RedisEntryConsumerTest.php
+++ b/tests/Wallabag/ImportBundle/Consumer/RedisEntryConsumerTest.php
@@ -2,9 +2,9 @@
 
 namespace Tests\Wallabag\ImportBundle\Consumer\AMQP;
 
+use Wallabag\CoreBundle\Entity\Entry;
 use Wallabag\ImportBundle\Consumer\RedisEntryConsumer;
 use Wallabag\UserBundle\Entity\User;
-use Wallabag\CoreBundle\Entity\Entry;
 
 class RedisEntryConsumerTest extends \PHPUnit_Framework_TestCase
 {

--- a/tests/Wallabag/ImportBundle/Controller/ChromeControllerTest.php
+++ b/tests/Wallabag/ImportBundle/Controller/ChromeControllerTest.php
@@ -2,8 +2,8 @@
 
 namespace Tests\Wallabag\ImportBundle\Controller;
 
-use Tests\Wallabag\CoreBundle\WallabagCoreTestCase;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
+use Tests\Wallabag\CoreBundle\WallabagCoreTestCase;
 
 class ChromeControllerTest extends WallabagCoreTestCase
 {
@@ -14,9 +14,9 @@ class ChromeControllerTest extends WallabagCoreTestCase
 
         $crawler = $client->request('GET', '/import/chrome');
 
-        $this->assertEquals(200, $client->getResponse()->getStatusCode());
-        $this->assertEquals(1, $crawler->filter('form[name=upload_import_file] > button[type=submit]')->count());
-        $this->assertEquals(1, $crawler->filter('input[type=file]')->count());
+        $this->assertSame(200, $client->getResponse()->getStatusCode());
+        $this->assertSame(1, $crawler->filter('form[name=upload_import_file] > button[type=submit]')->count());
+        $this->assertSame(1, $crawler->filter('input[type=file]')->count());
     }
 
     public function testImportChromeWithRabbitEnabled()
@@ -28,9 +28,9 @@ class ChromeControllerTest extends WallabagCoreTestCase
 
         $crawler = $client->request('GET', '/import/chrome');
 
-        $this->assertEquals(200, $client->getResponse()->getStatusCode());
-        $this->assertEquals(1, $crawler->filter('form[name=upload_import_file] > button[type=submit]')->count());
-        $this->assertEquals(1, $crawler->filter('input[type=file]')->count());
+        $this->assertSame(200, $client->getResponse()->getStatusCode());
+        $this->assertSame(1, $crawler->filter('form[name=upload_import_file] > button[type=submit]')->count());
+        $this->assertSame(1, $crawler->filter('input[type=file]')->count());
 
         $client->getContainer()->get('craue_config')->set('import_with_rabbitmq', 0);
     }
@@ -49,7 +49,7 @@ class ChromeControllerTest extends WallabagCoreTestCase
 
         $client->submit($form, $data);
 
-        $this->assertEquals(200, $client->getResponse()->getStatusCode());
+        $this->assertSame(200, $client->getResponse()->getStatusCode());
     }
 
     public function testImportChromeWithRedisEnabled()
@@ -61,13 +61,13 @@ class ChromeControllerTest extends WallabagCoreTestCase
 
         $crawler = $client->request('GET', '/import/chrome');
 
-        $this->assertEquals(200, $client->getResponse()->getStatusCode());
-        $this->assertEquals(1, $crawler->filter('form[name=upload_import_file] > button[type=submit]')->count());
-        $this->assertEquals(1, $crawler->filter('input[type=file]')->count());
+        $this->assertSame(200, $client->getResponse()->getStatusCode());
+        $this->assertSame(1, $crawler->filter('form[name=upload_import_file] > button[type=submit]')->count());
+        $this->assertSame(1, $crawler->filter('input[type=file]')->count());
 
         $form = $crawler->filter('form[name=upload_import_file] > button[type=submit]')->form();
 
-        $file = new UploadedFile(__DIR__.'/../fixtures/chrome-bookmarks', 'Bookmarks');
+        $file = new UploadedFile(__DIR__ . '/../fixtures/chrome-bookmarks', 'Bookmarks');
 
         $data = [
             'upload_import_file[file]' => $file,
@@ -75,7 +75,7 @@ class ChromeControllerTest extends WallabagCoreTestCase
 
         $client->submit($form, $data);
 
-        $this->assertEquals(302, $client->getResponse()->getStatusCode());
+        $this->assertSame(302, $client->getResponse()->getStatusCode());
 
         $crawler = $client->followRedirect();
 
@@ -95,7 +95,7 @@ class ChromeControllerTest extends WallabagCoreTestCase
         $crawler = $client->request('GET', '/import/chrome');
         $form = $crawler->filter('form[name=upload_import_file] > button[type=submit]')->form();
 
-        $file = new UploadedFile(__DIR__.'/../fixtures/chrome-bookmarks', 'Bookmarks');
+        $file = new UploadedFile(__DIR__ . '/../fixtures/chrome-bookmarks', 'Bookmarks');
 
         $data = [
             'upload_import_file[file]' => $file,
@@ -103,7 +103,7 @@ class ChromeControllerTest extends WallabagCoreTestCase
 
         $client->submit($form, $data);
 
-        $this->assertEquals(302, $client->getResponse()->getStatusCode());
+        $this->assertSame(302, $client->getResponse()->getStatusCode());
 
         $crawler = $client->followRedirect();
 
@@ -120,11 +120,11 @@ class ChromeControllerTest extends WallabagCoreTestCase
 
         $this->assertNotEmpty($content->getPreviewPicture(), 'Preview picture for http://www.usinenouvelle.com is ok');
         $this->assertNotEmpty($content->getLanguage(), 'Language for http://www.usinenouvelle.com is ok');
-        $this->assertEquals(1, count($content->getTags()));
+        $this->assertSame(1, count($content->getTags()));
 
         $createdAt = $content->getCreatedAt();
-        $this->assertEquals('2011', $createdAt->format('Y'));
-        $this->assertEquals('07', $createdAt->format('m'));
+        $this->assertSame('2011', $createdAt->format('Y'));
+        $this->assertSame('07', $createdAt->format('m'));
     }
 
     public function testImportWallabagWithEmptyFile()
@@ -135,7 +135,7 @@ class ChromeControllerTest extends WallabagCoreTestCase
         $crawler = $client->request('GET', '/import/chrome');
         $form = $crawler->filter('form[name=upload_import_file] > button[type=submit]')->form();
 
-        $file = new UploadedFile(__DIR__.'/../fixtures/test.txt', 'test.txt');
+        $file = new UploadedFile(__DIR__ . '/../fixtures/test.txt', 'test.txt');
 
         $data = [
             'upload_import_file[file]' => $file,
@@ -143,7 +143,7 @@ class ChromeControllerTest extends WallabagCoreTestCase
 
         $client->submit($form, $data);
 
-        $this->assertEquals(302, $client->getResponse()->getStatusCode());
+        $this->assertSame(302, $client->getResponse()->getStatusCode());
 
         $crawler = $client->followRedirect();
 

--- a/tests/Wallabag/ImportBundle/Controller/FirefoxControllerTest.php
+++ b/tests/Wallabag/ImportBundle/Controller/FirefoxControllerTest.php
@@ -2,8 +2,8 @@
 
 namespace Tests\Wallabag\ImportBundle\Controller;
 
-use Tests\Wallabag\CoreBundle\WallabagCoreTestCase;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
+use Tests\Wallabag\CoreBundle\WallabagCoreTestCase;
 
 class FirefoxControllerTest extends WallabagCoreTestCase
 {
@@ -14,9 +14,9 @@ class FirefoxControllerTest extends WallabagCoreTestCase
 
         $crawler = $client->request('GET', '/import/firefox');
 
-        $this->assertEquals(200, $client->getResponse()->getStatusCode());
-        $this->assertEquals(1, $crawler->filter('form[name=upload_import_file] > button[type=submit]')->count());
-        $this->assertEquals(1, $crawler->filter('input[type=file]')->count());
+        $this->assertSame(200, $client->getResponse()->getStatusCode());
+        $this->assertSame(1, $crawler->filter('form[name=upload_import_file] > button[type=submit]')->count());
+        $this->assertSame(1, $crawler->filter('input[type=file]')->count());
     }
 
     public function testImportFirefoxWithRabbitEnabled()
@@ -28,9 +28,9 @@ class FirefoxControllerTest extends WallabagCoreTestCase
 
         $crawler = $client->request('GET', '/import/firefox');
 
-        $this->assertEquals(200, $client->getResponse()->getStatusCode());
-        $this->assertEquals(1, $crawler->filter('form[name=upload_import_file] > button[type=submit]')->count());
-        $this->assertEquals(1, $crawler->filter('input[type=file]')->count());
+        $this->assertSame(200, $client->getResponse()->getStatusCode());
+        $this->assertSame(1, $crawler->filter('form[name=upload_import_file] > button[type=submit]')->count());
+        $this->assertSame(1, $crawler->filter('input[type=file]')->count());
 
         $client->getContainer()->get('craue_config')->set('import_with_rabbitmq', 0);
     }
@@ -49,7 +49,7 @@ class FirefoxControllerTest extends WallabagCoreTestCase
 
         $client->submit($form, $data);
 
-        $this->assertEquals(200, $client->getResponse()->getStatusCode());
+        $this->assertSame(200, $client->getResponse()->getStatusCode());
     }
 
     public function testImportFirefoxWithRedisEnabled()
@@ -61,13 +61,13 @@ class FirefoxControllerTest extends WallabagCoreTestCase
 
         $crawler = $client->request('GET', '/import/firefox');
 
-        $this->assertEquals(200, $client->getResponse()->getStatusCode());
-        $this->assertEquals(1, $crawler->filter('form[name=upload_import_file] > button[type=submit]')->count());
-        $this->assertEquals(1, $crawler->filter('input[type=file]')->count());
+        $this->assertSame(200, $client->getResponse()->getStatusCode());
+        $this->assertSame(1, $crawler->filter('form[name=upload_import_file] > button[type=submit]')->count());
+        $this->assertSame(1, $crawler->filter('input[type=file]')->count());
 
         $form = $crawler->filter('form[name=upload_import_file] > button[type=submit]')->form();
 
-        $file = new UploadedFile(__DIR__.'/../fixtures/firefox-bookmarks.json', 'Bookmarks');
+        $file = new UploadedFile(__DIR__ . '/../fixtures/firefox-bookmarks.json', 'Bookmarks');
 
         $data = [
             'upload_import_file[file]' => $file,
@@ -75,7 +75,7 @@ class FirefoxControllerTest extends WallabagCoreTestCase
 
         $client->submit($form, $data);
 
-        $this->assertEquals(302, $client->getResponse()->getStatusCode());
+        $this->assertSame(302, $client->getResponse()->getStatusCode());
 
         $crawler = $client->followRedirect();
 
@@ -95,7 +95,7 @@ class FirefoxControllerTest extends WallabagCoreTestCase
         $crawler = $client->request('GET', '/import/firefox');
         $form = $crawler->filter('form[name=upload_import_file] > button[type=submit]')->form();
 
-        $file = new UploadedFile(__DIR__.'/../fixtures/firefox-bookmarks.json', 'Bookmarks');
+        $file = new UploadedFile(__DIR__ . '/../fixtures/firefox-bookmarks.json', 'Bookmarks');
 
         $data = [
             'upload_import_file[file]' => $file,
@@ -103,7 +103,7 @@ class FirefoxControllerTest extends WallabagCoreTestCase
 
         $client->submit($form, $data);
 
-        $this->assertEquals(302, $client->getResponse()->getStatusCode());
+        $this->assertSame(302, $client->getResponse()->getStatusCode());
 
         $crawler = $client->followRedirect();
 
@@ -121,7 +121,7 @@ class FirefoxControllerTest extends WallabagCoreTestCase
         $this->assertNotEmpty($content->getMimetype(), 'Mimetype for http://lexpansion.lexpress.fr is ok');
         $this->assertNotEmpty($content->getPreviewPicture(), 'Preview picture for http://lexpansion.lexpress.fr is ok');
         $this->assertNotEmpty($content->getLanguage(), 'Language for http://lexpansion.lexpress.fr is ok');
-        $this->assertEquals(3, count($content->getTags()));
+        $this->assertSame(3, count($content->getTags()));
 
         $content = $client->getContainer()
             ->get('doctrine.orm.entity_manager')
@@ -136,8 +136,8 @@ class FirefoxControllerTest extends WallabagCoreTestCase
         $this->assertEmpty($content->getLanguage(), 'Language for https://stackoverflow.com is ok');
 
         $createdAt = $content->getCreatedAt();
-        $this->assertEquals('2013', $createdAt->format('Y'));
-        $this->assertEquals('12', $createdAt->format('m'));
+        $this->assertSame('2013', $createdAt->format('Y'));
+        $this->assertSame('12', $createdAt->format('m'));
     }
 
     public function testImportWallabagWithEmptyFile()
@@ -148,7 +148,7 @@ class FirefoxControllerTest extends WallabagCoreTestCase
         $crawler = $client->request('GET', '/import/firefox');
         $form = $crawler->filter('form[name=upload_import_file] > button[type=submit]')->form();
 
-        $file = new UploadedFile(__DIR__.'/../fixtures/test.txt', 'test.txt');
+        $file = new UploadedFile(__DIR__ . '/../fixtures/test.txt', 'test.txt');
 
         $data = [
             'upload_import_file[file]' => $file,
@@ -156,7 +156,7 @@ class FirefoxControllerTest extends WallabagCoreTestCase
 
         $client->submit($form, $data);
 
-        $this->assertEquals(302, $client->getResponse()->getStatusCode());
+        $this->assertSame(302, $client->getResponse()->getStatusCode());
 
         $crawler = $client->followRedirect();
 

--- a/tests/Wallabag/ImportBundle/Controller/ImportControllerTest.php
+++ b/tests/Wallabag/ImportBundle/Controller/ImportControllerTest.php
@@ -12,7 +12,7 @@ class ImportControllerTest extends WallabagCoreTestCase
 
         $client->request('GET', '/import/');
 
-        $this->assertEquals(302, $client->getResponse()->getStatusCode());
+        $this->assertSame(302, $client->getResponse()->getStatusCode());
         $this->assertContains('login', $client->getResponse()->headers->get('location'));
     }
 
@@ -23,7 +23,7 @@ class ImportControllerTest extends WallabagCoreTestCase
 
         $crawler = $client->request('GET', '/import/');
 
-        $this->assertEquals(200, $client->getResponse()->getStatusCode());
-        $this->assertEquals(8, $crawler->filter('blockquote')->count());
+        $this->assertSame(200, $client->getResponse()->getStatusCode());
+        $this->assertSame(8, $crawler->filter('blockquote')->count());
     }
 }

--- a/tests/Wallabag/ImportBundle/Controller/InstapaperControllerTest.php
+++ b/tests/Wallabag/ImportBundle/Controller/InstapaperControllerTest.php
@@ -2,8 +2,8 @@
 
 namespace Tests\Wallabag\ImportBundle\Controller;
 
-use Tests\Wallabag\CoreBundle\WallabagCoreTestCase;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
+use Tests\Wallabag\CoreBundle\WallabagCoreTestCase;
 
 class InstapaperControllerTest extends WallabagCoreTestCase
 {
@@ -14,9 +14,9 @@ class InstapaperControllerTest extends WallabagCoreTestCase
 
         $crawler = $client->request('GET', '/import/instapaper');
 
-        $this->assertEquals(200, $client->getResponse()->getStatusCode());
-        $this->assertEquals(1, $crawler->filter('form[name=upload_import_file] > button[type=submit]')->count());
-        $this->assertEquals(1, $crawler->filter('input[type=file]')->count());
+        $this->assertSame(200, $client->getResponse()->getStatusCode());
+        $this->assertSame(1, $crawler->filter('form[name=upload_import_file] > button[type=submit]')->count());
+        $this->assertSame(1, $crawler->filter('input[type=file]')->count());
     }
 
     public function testImportInstapaperWithRabbitEnabled()
@@ -28,9 +28,9 @@ class InstapaperControllerTest extends WallabagCoreTestCase
 
         $crawler = $client->request('GET', '/import/instapaper');
 
-        $this->assertEquals(200, $client->getResponse()->getStatusCode());
-        $this->assertEquals(1, $crawler->filter('form[name=upload_import_file] > button[type=submit]')->count());
-        $this->assertEquals(1, $crawler->filter('input[type=file]')->count());
+        $this->assertSame(200, $client->getResponse()->getStatusCode());
+        $this->assertSame(1, $crawler->filter('form[name=upload_import_file] > button[type=submit]')->count());
+        $this->assertSame(1, $crawler->filter('input[type=file]')->count());
 
         $client->getContainer()->get('craue_config')->set('import_with_rabbitmq', 0);
     }
@@ -49,7 +49,7 @@ class InstapaperControllerTest extends WallabagCoreTestCase
 
         $client->submit($form, $data);
 
-        $this->assertEquals(200, $client->getResponse()->getStatusCode());
+        $this->assertSame(200, $client->getResponse()->getStatusCode());
     }
 
     public function testImportInstapaperWithRedisEnabled()
@@ -61,13 +61,13 @@ class InstapaperControllerTest extends WallabagCoreTestCase
 
         $crawler = $client->request('GET', '/import/instapaper');
 
-        $this->assertEquals(200, $client->getResponse()->getStatusCode());
-        $this->assertEquals(1, $crawler->filter('form[name=upload_import_file] > button[type=submit]')->count());
-        $this->assertEquals(1, $crawler->filter('input[type=file]')->count());
+        $this->assertSame(200, $client->getResponse()->getStatusCode());
+        $this->assertSame(1, $crawler->filter('form[name=upload_import_file] > button[type=submit]')->count());
+        $this->assertSame(1, $crawler->filter('input[type=file]')->count());
 
         $form = $crawler->filter('form[name=upload_import_file] > button[type=submit]')->form();
 
-        $file = new UploadedFile(__DIR__.'/../fixtures/instapaper-export.csv', 'instapaper.csv');
+        $file = new UploadedFile(__DIR__ . '/../fixtures/instapaper-export.csv', 'instapaper.csv');
 
         $data = [
             'upload_import_file[file]' => $file,
@@ -75,7 +75,7 @@ class InstapaperControllerTest extends WallabagCoreTestCase
 
         $client->submit($form, $data);
 
-        $this->assertEquals(302, $client->getResponse()->getStatusCode());
+        $this->assertSame(302, $client->getResponse()->getStatusCode());
 
         $crawler = $client->followRedirect();
 
@@ -95,7 +95,7 @@ class InstapaperControllerTest extends WallabagCoreTestCase
         $crawler = $client->request('GET', '/import/instapaper');
         $form = $crawler->filter('form[name=upload_import_file] > button[type=submit]')->form();
 
-        $file = new UploadedFile(__DIR__.'/../fixtures/instapaper-export.csv', 'instapaper.csv');
+        $file = new UploadedFile(__DIR__ . '/../fixtures/instapaper-export.csv', 'instapaper.csv');
 
         $data = [
             'upload_import_file[file]' => $file,
@@ -103,7 +103,7 @@ class InstapaperControllerTest extends WallabagCoreTestCase
 
         $client->submit($form, $data);
 
-        $this->assertEquals(302, $client->getResponse()->getStatusCode());
+        $this->assertSame(302, $client->getResponse()->getStatusCode());
 
         $crawler = $client->followRedirect();
 
@@ -122,7 +122,7 @@ class InstapaperControllerTest extends WallabagCoreTestCase
         $this->assertNotEmpty($content->getPreviewPicture(), 'Preview picture for http://www.liberation.fr is ok');
         $this->assertNotEmpty($content->getLanguage(), 'Language for http://www.liberation.fr is ok');
         $this->assertContains('foot', $content->getTags(), 'It includes the "foot" tag');
-        $this->assertEquals(1, count($content->getTags()));
+        $this->assertSame(1, count($content->getTags()));
         $this->assertInstanceOf(\DateTime::class, $content->getCreatedAt());
 
         $content = $client->getContainer()
@@ -136,7 +136,7 @@ class InstapaperControllerTest extends WallabagCoreTestCase
         $this->assertContains('foot', $content->getTags());
         $this->assertContains('test_tag', $content->getTags());
 
-        $this->assertEquals(2, count($content->getTags()));
+        $this->assertSame(2, count($content->getTags()));
     }
 
     public function testImportInstapaperWithFileAndMarkAllAsRead()
@@ -147,7 +147,7 @@ class InstapaperControllerTest extends WallabagCoreTestCase
         $crawler = $client->request('GET', '/import/instapaper');
         $form = $crawler->filter('form[name=upload_import_file] > button[type=submit]')->form();
 
-        $file = new UploadedFile(__DIR__.'/../fixtures/instapaper-export.csv', 'instapaper-read.csv');
+        $file = new UploadedFile(__DIR__ . '/../fixtures/instapaper-export.csv', 'instapaper-read.csv');
 
         $data = [
             'upload_import_file[file]' => $file,
@@ -156,7 +156,7 @@ class InstapaperControllerTest extends WallabagCoreTestCase
 
         $client->submit($form, $data);
 
-        $this->assertEquals(302, $client->getResponse()->getStatusCode());
+        $this->assertSame(302, $client->getResponse()->getStatusCode());
 
         $crawler = $client->followRedirect();
 
@@ -192,7 +192,7 @@ class InstapaperControllerTest extends WallabagCoreTestCase
         $crawler = $client->request('GET', '/import/instapaper');
         $form = $crawler->filter('form[name=upload_import_file] > button[type=submit]')->form();
 
-        $file = new UploadedFile(__DIR__.'/../fixtures/test.txt', 'test.txt');
+        $file = new UploadedFile(__DIR__ . '/../fixtures/test.txt', 'test.txt');
 
         $data = [
             'upload_import_file[file]' => $file,
@@ -200,7 +200,7 @@ class InstapaperControllerTest extends WallabagCoreTestCase
 
         $client->submit($form, $data);
 
-        $this->assertEquals(302, $client->getResponse()->getStatusCode());
+        $this->assertSame(302, $client->getResponse()->getStatusCode());
 
         $crawler = $client->followRedirect();
 

--- a/tests/Wallabag/ImportBundle/Controller/PinboardControllerTest.php
+++ b/tests/Wallabag/ImportBundle/Controller/PinboardControllerTest.php
@@ -2,8 +2,8 @@
 
 namespace Tests\Wallabag\ImportBundle\Controller;
 
-use Tests\Wallabag\CoreBundle\WallabagCoreTestCase;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
+use Tests\Wallabag\CoreBundle\WallabagCoreTestCase;
 
 class PinboardControllerTest extends WallabagCoreTestCase
 {
@@ -14,9 +14,9 @@ class PinboardControllerTest extends WallabagCoreTestCase
 
         $crawler = $client->request('GET', '/import/pinboard');
 
-        $this->assertEquals(200, $client->getResponse()->getStatusCode());
-        $this->assertEquals(1, $crawler->filter('form[name=upload_import_file] > button[type=submit]')->count());
-        $this->assertEquals(1, $crawler->filter('input[type=file]')->count());
+        $this->assertSame(200, $client->getResponse()->getStatusCode());
+        $this->assertSame(1, $crawler->filter('form[name=upload_import_file] > button[type=submit]')->count());
+        $this->assertSame(1, $crawler->filter('input[type=file]')->count());
     }
 
     public function testImportPinboardWithRabbitEnabled()
@@ -28,9 +28,9 @@ class PinboardControllerTest extends WallabagCoreTestCase
 
         $crawler = $client->request('GET', '/import/pinboard');
 
-        $this->assertEquals(200, $client->getResponse()->getStatusCode());
-        $this->assertEquals(1, $crawler->filter('form[name=upload_import_file] > button[type=submit]')->count());
-        $this->assertEquals(1, $crawler->filter('input[type=file]')->count());
+        $this->assertSame(200, $client->getResponse()->getStatusCode());
+        $this->assertSame(1, $crawler->filter('form[name=upload_import_file] > button[type=submit]')->count());
+        $this->assertSame(1, $crawler->filter('input[type=file]')->count());
 
         $client->getContainer()->get('craue_config')->set('import_with_rabbitmq', 0);
     }
@@ -49,7 +49,7 @@ class PinboardControllerTest extends WallabagCoreTestCase
 
         $client->submit($form, $data);
 
-        $this->assertEquals(200, $client->getResponse()->getStatusCode());
+        $this->assertSame(200, $client->getResponse()->getStatusCode());
     }
 
     public function testImportPinboardWithRedisEnabled()
@@ -61,13 +61,13 @@ class PinboardControllerTest extends WallabagCoreTestCase
 
         $crawler = $client->request('GET', '/import/pinboard');
 
-        $this->assertEquals(200, $client->getResponse()->getStatusCode());
-        $this->assertEquals(1, $crawler->filter('form[name=upload_import_file] > button[type=submit]')->count());
-        $this->assertEquals(1, $crawler->filter('input[type=file]')->count());
+        $this->assertSame(200, $client->getResponse()->getStatusCode());
+        $this->assertSame(1, $crawler->filter('form[name=upload_import_file] > button[type=submit]')->count());
+        $this->assertSame(1, $crawler->filter('input[type=file]')->count());
 
         $form = $crawler->filter('form[name=upload_import_file] > button[type=submit]')->form();
 
-        $file = new UploadedFile(__DIR__.'/../fixtures/pinboard_export', 'pinboard.json');
+        $file = new UploadedFile(__DIR__ . '/../fixtures/pinboard_export', 'pinboard.json');
 
         $data = [
             'upload_import_file[file]' => $file,
@@ -75,7 +75,7 @@ class PinboardControllerTest extends WallabagCoreTestCase
 
         $client->submit($form, $data);
 
-        $this->assertEquals(302, $client->getResponse()->getStatusCode());
+        $this->assertSame(302, $client->getResponse()->getStatusCode());
 
         $crawler = $client->followRedirect();
 
@@ -95,7 +95,7 @@ class PinboardControllerTest extends WallabagCoreTestCase
         $crawler = $client->request('GET', '/import/pinboard');
         $form = $crawler->filter('form[name=upload_import_file] > button[type=submit]')->form();
 
-        $file = new UploadedFile(__DIR__.'/../fixtures/pinboard_export', 'pinboard.json');
+        $file = new UploadedFile(__DIR__ . '/../fixtures/pinboard_export', 'pinboard.json');
 
         $data = [
             'upload_import_file[file]' => $file,
@@ -103,7 +103,7 @@ class PinboardControllerTest extends WallabagCoreTestCase
 
         $client->submit($form, $data);
 
-        $this->assertEquals(302, $client->getResponse()->getStatusCode());
+        $this->assertSame(302, $client->getResponse()->getStatusCode());
 
         $crawler = $client->followRedirect();
 
@@ -126,10 +126,10 @@ class PinboardControllerTest extends WallabagCoreTestCase
         $this->assertContains('foot', $tags, 'It includes the "foot" tag');
         $this->assertContains('varnish', $tags, 'It includes the "varnish" tag');
         $this->assertContains('PHP', $tags, 'It includes the "PHP" tag');
-        $this->assertEquals(3, count($tags));
+        $this->assertSame(3, count($tags));
 
         $this->assertInstanceOf(\DateTime::class, $content->getCreatedAt());
-        $this->assertEquals('2016-10-26', $content->getCreatedAt()->format('Y-m-d'));
+        $this->assertSame('2016-10-26', $content->getCreatedAt()->format('Y-m-d'));
     }
 
     public function testImportPinboardWithFileAndMarkAllAsRead()
@@ -140,7 +140,7 @@ class PinboardControllerTest extends WallabagCoreTestCase
         $crawler = $client->request('GET', '/import/pinboard');
         $form = $crawler->filter('form[name=upload_import_file] > button[type=submit]')->form();
 
-        $file = new UploadedFile(__DIR__.'/../fixtures/pinboard_export', 'pinboard-read.json');
+        $file = new UploadedFile(__DIR__ . '/../fixtures/pinboard_export', 'pinboard-read.json');
 
         $data = [
             'upload_import_file[file]' => $file,
@@ -149,7 +149,7 @@ class PinboardControllerTest extends WallabagCoreTestCase
 
         $client->submit($form, $data);
 
-        $this->assertEquals(302, $client->getResponse()->getStatusCode());
+        $this->assertSame(302, $client->getResponse()->getStatusCode());
 
         $crawler = $client->followRedirect();
 
@@ -185,7 +185,7 @@ class PinboardControllerTest extends WallabagCoreTestCase
         $crawler = $client->request('GET', '/import/pinboard');
         $form = $crawler->filter('form[name=upload_import_file] > button[type=submit]')->form();
 
-        $file = new UploadedFile(__DIR__.'/../fixtures/test.txt', 'test.txt');
+        $file = new UploadedFile(__DIR__ . '/../fixtures/test.txt', 'test.txt');
 
         $data = [
             'upload_import_file[file]' => $file,
@@ -193,7 +193,7 @@ class PinboardControllerTest extends WallabagCoreTestCase
 
         $client->submit($form, $data);
 
-        $this->assertEquals(302, $client->getResponse()->getStatusCode());
+        $this->assertSame(302, $client->getResponse()->getStatusCode());
 
         $crawler = $client->followRedirect();
 

--- a/tests/Wallabag/ImportBundle/Controller/PocketControllerTest.php
+++ b/tests/Wallabag/ImportBundle/Controller/PocketControllerTest.php
@@ -13,8 +13,8 @@ class PocketControllerTest extends WallabagCoreTestCase
 
         $crawler = $client->request('GET', '/import/pocket');
 
-        $this->assertEquals(200, $client->getResponse()->getStatusCode());
-        $this->assertEquals(1, $crawler->filter('button[type=submit]')->count());
+        $this->assertSame(200, $client->getResponse()->getStatusCode());
+        $this->assertSame(1, $crawler->filter('button[type=submit]')->count());
     }
 
     public function testImportPocketWithRabbitEnabled()
@@ -26,8 +26,8 @@ class PocketControllerTest extends WallabagCoreTestCase
 
         $crawler = $client->request('GET', '/import/pocket');
 
-        $this->assertEquals(200, $client->getResponse()->getStatusCode());
-        $this->assertEquals(1, $crawler->filter('button[type=submit]')->count());
+        $this->assertSame(200, $client->getResponse()->getStatusCode());
+        $this->assertSame(1, $crawler->filter('button[type=submit]')->count());
 
         $client->getContainer()->get('craue_config')->set('import_with_rabbitmq', 0);
     }
@@ -42,8 +42,8 @@ class PocketControllerTest extends WallabagCoreTestCase
 
         $crawler = $client->request('GET', '/import/pocket');
 
-        $this->assertEquals(200, $client->getResponse()->getStatusCode());
-        $this->assertEquals(1, $crawler->filter('button[type=submit]')->count());
+        $this->assertSame(200, $client->getResponse()->getStatusCode());
+        $this->assertSame(1, $crawler->filter('button[type=submit]')->count());
 
         $client->getContainer()->get('craue_config')->set('import_with_redis', 0);
     }
@@ -55,7 +55,7 @@ class PocketControllerTest extends WallabagCoreTestCase
 
         $client->request('GET', '/import/pocket/auth');
 
-        $this->assertEquals(302, $client->getResponse()->getStatusCode());
+        $this->assertSame(302, $client->getResponse()->getStatusCode());
     }
 
     public function testImportPocketAuth()
@@ -76,7 +76,7 @@ class PocketControllerTest extends WallabagCoreTestCase
 
         $client->request('GET', '/import/pocket/auth');
 
-        $this->assertEquals(301, $client->getResponse()->getStatusCode());
+        $this->assertSame(301, $client->getResponse()->getStatusCode());
         $this->assertContains('getpocket.com/auth/authorize', $client->getResponse()->headers->get('location'));
     }
 
@@ -98,9 +98,9 @@ class PocketControllerTest extends WallabagCoreTestCase
 
         $client->request('GET', '/import/pocket/callback');
 
-        $this->assertEquals(302, $client->getResponse()->getStatusCode());
+        $this->assertSame(302, $client->getResponse()->getStatusCode());
         $this->assertContains('/', $client->getResponse()->headers->get('location'), 'Import is ok, redirect to homepage');
-        $this->assertEquals('flashes.import.notice.failed', $client->getContainer()->get('session')->getFlashBag()->peek('notice')[0]);
+        $this->assertSame('flashes.import.notice.failed', $client->getContainer()->get('session')->getFlashBag()->peek('notice')[0]);
     }
 
     public function testImportPocketCallback()
@@ -132,8 +132,8 @@ class PocketControllerTest extends WallabagCoreTestCase
 
         $client->request('GET', '/import/pocket/callback');
 
-        $this->assertEquals(302, $client->getResponse()->getStatusCode());
+        $this->assertSame(302, $client->getResponse()->getStatusCode());
         $this->assertContains('/', $client->getResponse()->headers->get('location'), 'Import is ok, redirect to homepage');
-        $this->assertEquals('flashes.import.notice.summary', $client->getContainer()->get('session')->getFlashBag()->peek('notice')[0]);
+        $this->assertSame('flashes.import.notice.summary', $client->getContainer()->get('session')->getFlashBag()->peek('notice')[0]);
     }
 }

--- a/tests/Wallabag/ImportBundle/Controller/ReadabilityControllerTest.php
+++ b/tests/Wallabag/ImportBundle/Controller/ReadabilityControllerTest.php
@@ -2,8 +2,8 @@
 
 namespace Tests\Wallabag\ImportBundle\Controller;
 
-use Tests\Wallabag\CoreBundle\WallabagCoreTestCase;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
+use Tests\Wallabag\CoreBundle\WallabagCoreTestCase;
 
 class ReadabilityControllerTest extends WallabagCoreTestCase
 {
@@ -14,9 +14,9 @@ class ReadabilityControllerTest extends WallabagCoreTestCase
 
         $crawler = $client->request('GET', '/import/readability');
 
-        $this->assertEquals(200, $client->getResponse()->getStatusCode());
-        $this->assertEquals(1, $crawler->filter('form[name=upload_import_file] > button[type=submit]')->count());
-        $this->assertEquals(1, $crawler->filter('input[type=file]')->count());
+        $this->assertSame(200, $client->getResponse()->getStatusCode());
+        $this->assertSame(1, $crawler->filter('form[name=upload_import_file] > button[type=submit]')->count());
+        $this->assertSame(1, $crawler->filter('input[type=file]')->count());
     }
 
     public function testImportReadabilityWithRabbitEnabled()
@@ -28,9 +28,9 @@ class ReadabilityControllerTest extends WallabagCoreTestCase
 
         $crawler = $client->request('GET', '/import/readability');
 
-        $this->assertEquals(200, $client->getResponse()->getStatusCode());
-        $this->assertEquals(1, $crawler->filter('form[name=upload_import_file] > button[type=submit]')->count());
-        $this->assertEquals(1, $crawler->filter('input[type=file]')->count());
+        $this->assertSame(200, $client->getResponse()->getStatusCode());
+        $this->assertSame(1, $crawler->filter('form[name=upload_import_file] > button[type=submit]')->count());
+        $this->assertSame(1, $crawler->filter('input[type=file]')->count());
 
         $client->getContainer()->get('craue_config')->set('import_with_rabbitmq', 0);
     }
@@ -49,7 +49,7 @@ class ReadabilityControllerTest extends WallabagCoreTestCase
 
         $client->submit($form, $data);
 
-        $this->assertEquals(200, $client->getResponse()->getStatusCode());
+        $this->assertSame(200, $client->getResponse()->getStatusCode());
     }
 
     public function testImportReadabilityWithRedisEnabled()
@@ -61,13 +61,13 @@ class ReadabilityControllerTest extends WallabagCoreTestCase
 
         $crawler = $client->request('GET', '/import/readability');
 
-        $this->assertEquals(200, $client->getResponse()->getStatusCode());
-        $this->assertEquals(1, $crawler->filter('form[name=upload_import_file] > button[type=submit]')->count());
-        $this->assertEquals(1, $crawler->filter('input[type=file]')->count());
+        $this->assertSame(200, $client->getResponse()->getStatusCode());
+        $this->assertSame(1, $crawler->filter('form[name=upload_import_file] > button[type=submit]')->count());
+        $this->assertSame(1, $crawler->filter('input[type=file]')->count());
 
         $form = $crawler->filter('form[name=upload_import_file] > button[type=submit]')->form();
 
-        $file = new UploadedFile(__DIR__.'/../fixtures/readability.json', 'readability.json');
+        $file = new UploadedFile(__DIR__ . '/../fixtures/readability.json', 'readability.json');
 
         $data = [
             'upload_import_file[file]' => $file,
@@ -75,7 +75,7 @@ class ReadabilityControllerTest extends WallabagCoreTestCase
 
         $client->submit($form, $data);
 
-        $this->assertEquals(302, $client->getResponse()->getStatusCode());
+        $this->assertSame(302, $client->getResponse()->getStatusCode());
 
         $crawler = $client->followRedirect();
 
@@ -95,7 +95,7 @@ class ReadabilityControllerTest extends WallabagCoreTestCase
         $crawler = $client->request('GET', '/import/readability');
         $form = $crawler->filter('form[name=upload_import_file] > button[type=submit]')->form();
 
-        $file = new UploadedFile(__DIR__.'/../fixtures/readability.json', 'readability.json');
+        $file = new UploadedFile(__DIR__ . '/../fixtures/readability.json', 'readability.json');
 
         $data = [
             'upload_import_file[file]' => $file,
@@ -103,7 +103,7 @@ class ReadabilityControllerTest extends WallabagCoreTestCase
 
         $client->submit($form, $data);
 
-        $this->assertEquals(302, $client->getResponse()->getStatusCode());
+        $this->assertSame(302, $client->getResponse()->getStatusCode());
 
         $crawler = $client->followRedirect();
 
@@ -124,10 +124,10 @@ class ReadabilityControllerTest extends WallabagCoreTestCase
 
         $tags = $content->getTags();
         $this->assertContains('foot', $tags, 'It includes the "foot" tag');
-        $this->assertEquals(1, count($tags));
+        $this->assertSame(1, count($tags));
 
         $this->assertInstanceOf(\DateTime::class, $content->getCreatedAt());
-        $this->assertEquals('2016-09-08', $content->getCreatedAt()->format('Y-m-d'));
+        $this->assertSame('2016-09-08', $content->getCreatedAt()->format('Y-m-d'));
     }
 
     public function testImportReadabilityWithFileAndMarkAllAsRead()
@@ -138,7 +138,7 @@ class ReadabilityControllerTest extends WallabagCoreTestCase
         $crawler = $client->request('GET', '/import/readability');
         $form = $crawler->filter('form[name=upload_import_file] > button[type=submit]')->form();
 
-        $file = new UploadedFile(__DIR__.'/../fixtures/readability-read.json', 'readability-read.json');
+        $file = new UploadedFile(__DIR__ . '/../fixtures/readability-read.json', 'readability-read.json');
 
         $data = [
             'upload_import_file[file]' => $file,
@@ -147,7 +147,7 @@ class ReadabilityControllerTest extends WallabagCoreTestCase
 
         $client->submit($form, $data);
 
-        $this->assertEquals(302, $client->getResponse()->getStatusCode());
+        $this->assertSame(302, $client->getResponse()->getStatusCode());
 
         $crawler = $client->followRedirect();
 
@@ -183,7 +183,7 @@ class ReadabilityControllerTest extends WallabagCoreTestCase
         $crawler = $client->request('GET', '/import/readability');
         $form = $crawler->filter('form[name=upload_import_file] > button[type=submit]')->form();
 
-        $file = new UploadedFile(__DIR__.'/../fixtures/test.txt', 'test.txt');
+        $file = new UploadedFile(__DIR__ . '/../fixtures/test.txt', 'test.txt');
 
         $data = [
             'upload_import_file[file]' => $file,
@@ -191,7 +191,7 @@ class ReadabilityControllerTest extends WallabagCoreTestCase
 
         $client->submit($form, $data);
 
-        $this->assertEquals(302, $client->getResponse()->getStatusCode());
+        $this->assertSame(302, $client->getResponse()->getStatusCode());
 
         $crawler = $client->followRedirect();
 

--- a/tests/Wallabag/ImportBundle/Controller/WallabagV1ControllerTest.php
+++ b/tests/Wallabag/ImportBundle/Controller/WallabagV1ControllerTest.php
@@ -2,8 +2,8 @@
 
 namespace Tests\Wallabag\ImportBundle\Controller;
 
-use Tests\Wallabag\CoreBundle\WallabagCoreTestCase;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
+use Tests\Wallabag\CoreBundle\WallabagCoreTestCase;
 
 class WallabagV1ControllerTest extends WallabagCoreTestCase
 {
@@ -14,9 +14,9 @@ class WallabagV1ControllerTest extends WallabagCoreTestCase
 
         $crawler = $client->request('GET', '/import/wallabag-v1');
 
-        $this->assertEquals(200, $client->getResponse()->getStatusCode());
-        $this->assertEquals(1, $crawler->filter('form[name=upload_import_file] > button[type=submit]')->count());
-        $this->assertEquals(1, $crawler->filter('input[type=file]')->count());
+        $this->assertSame(200, $client->getResponse()->getStatusCode());
+        $this->assertSame(1, $crawler->filter('form[name=upload_import_file] > button[type=submit]')->count());
+        $this->assertSame(1, $crawler->filter('input[type=file]')->count());
     }
 
     public function testImportWallabagWithRabbitEnabled()
@@ -28,9 +28,9 @@ class WallabagV1ControllerTest extends WallabagCoreTestCase
 
         $crawler = $client->request('GET', '/import/wallabag-v1');
 
-        $this->assertEquals(200, $client->getResponse()->getStatusCode());
-        $this->assertEquals(1, $crawler->filter('form[name=upload_import_file] > button[type=submit]')->count());
-        $this->assertEquals(1, $crawler->filter('input[type=file]')->count());
+        $this->assertSame(200, $client->getResponse()->getStatusCode());
+        $this->assertSame(1, $crawler->filter('form[name=upload_import_file] > button[type=submit]')->count());
+        $this->assertSame(1, $crawler->filter('input[type=file]')->count());
 
         $client->getContainer()->get('craue_config')->set('import_with_rabbitmq', 0);
     }
@@ -49,7 +49,7 @@ class WallabagV1ControllerTest extends WallabagCoreTestCase
 
         $client->submit($form, $data);
 
-        $this->assertEquals(200, $client->getResponse()->getStatusCode());
+        $this->assertSame(200, $client->getResponse()->getStatusCode());
     }
 
     public function testImportWallabagWithRedisEnabled()
@@ -62,13 +62,13 @@ class WallabagV1ControllerTest extends WallabagCoreTestCase
 
         $crawler = $client->request('GET', '/import/wallabag-v1');
 
-        $this->assertEquals(200, $client->getResponse()->getStatusCode());
-        $this->assertEquals(1, $crawler->filter('form[name=upload_import_file] > button[type=submit]')->count());
-        $this->assertEquals(1, $crawler->filter('input[type=file]')->count());
+        $this->assertSame(200, $client->getResponse()->getStatusCode());
+        $this->assertSame(1, $crawler->filter('form[name=upload_import_file] > button[type=submit]')->count());
+        $this->assertSame(1, $crawler->filter('input[type=file]')->count());
 
         $form = $crawler->filter('form[name=upload_import_file] > button[type=submit]')->form();
 
-        $file = new UploadedFile(__DIR__.'/../fixtures/wallabag-v1.json', 'wallabag-v1.json');
+        $file = new UploadedFile(__DIR__ . '/../fixtures/wallabag-v1.json', 'wallabag-v1.json');
 
         $data = [
             'upload_import_file[file]' => $file,
@@ -76,7 +76,7 @@ class WallabagV1ControllerTest extends WallabagCoreTestCase
 
         $client->submit($form, $data);
 
-        $this->assertEquals(302, $client->getResponse()->getStatusCode());
+        $this->assertSame(302, $client->getResponse()->getStatusCode());
 
         $crawler = $client->followRedirect();
 
@@ -96,7 +96,7 @@ class WallabagV1ControllerTest extends WallabagCoreTestCase
         $crawler = $client->request('GET', '/import/wallabag-v1');
         $form = $crawler->filter('form[name=upload_import_file] > button[type=submit]')->form();
 
-        $file = new UploadedFile(__DIR__.'/../fixtures/wallabag-v1.json', 'wallabag-v1.json');
+        $file = new UploadedFile(__DIR__ . '/../fixtures/wallabag-v1.json', 'wallabag-v1.json');
 
         $data = [
             'upload_import_file[file]' => $file,
@@ -104,7 +104,7 @@ class WallabagV1ControllerTest extends WallabagCoreTestCase
 
         $client->submit($form, $data);
 
-        $this->assertEquals(302, $client->getResponse()->getStatusCode());
+        $this->assertSame(302, $client->getResponse()->getStatusCode());
 
         $crawler = $client->followRedirect();
 
@@ -126,7 +126,7 @@ class WallabagV1ControllerTest extends WallabagCoreTestCase
         $tags = $content->getTags();
         $this->assertContains('foot', $tags, 'It includes the "foot" tag');
         $this->assertContains('Framabag', $tags, 'It includes the "Framabag" tag');
-        $this->assertEquals(2, count($tags));
+        $this->assertSame(2, count($tags));
 
         $this->assertInstanceOf(\DateTime::class, $content->getCreatedAt());
     }
@@ -139,7 +139,7 @@ class WallabagV1ControllerTest extends WallabagCoreTestCase
         $crawler = $client->request('GET', '/import/wallabag-v1');
         $form = $crawler->filter('form[name=upload_import_file] > button[type=submit]')->form();
 
-        $file = new UploadedFile(__DIR__.'/../fixtures/wallabag-v1-read.json', 'wallabag-v1-read.json');
+        $file = new UploadedFile(__DIR__ . '/../fixtures/wallabag-v1-read.json', 'wallabag-v1-read.json');
 
         $data = [
             'upload_import_file[file]' => $file,
@@ -148,7 +148,7 @@ class WallabagV1ControllerTest extends WallabagCoreTestCase
 
         $client->submit($form, $data);
 
-        $this->assertEquals(302, $client->getResponse()->getStatusCode());
+        $this->assertSame(302, $client->getResponse()->getStatusCode());
 
         $crawler = $client->followRedirect();
 
@@ -184,7 +184,7 @@ class WallabagV1ControllerTest extends WallabagCoreTestCase
         $crawler = $client->request('GET', '/import/wallabag-v1');
         $form = $crawler->filter('form[name=upload_import_file] > button[type=submit]')->form();
 
-        $file = new UploadedFile(__DIR__.'/../fixtures/test.txt', 'test.txt');
+        $file = new UploadedFile(__DIR__ . '/../fixtures/test.txt', 'test.txt');
 
         $data = [
             'upload_import_file[file]' => $file,
@@ -192,7 +192,7 @@ class WallabagV1ControllerTest extends WallabagCoreTestCase
 
         $client->submit($form, $data);
 
-        $this->assertEquals(302, $client->getResponse()->getStatusCode());
+        $this->assertSame(302, $client->getResponse()->getStatusCode());
 
         $crawler = $client->followRedirect();
 

--- a/tests/Wallabag/ImportBundle/Controller/WallabagV2ControllerTest.php
+++ b/tests/Wallabag/ImportBundle/Controller/WallabagV2ControllerTest.php
@@ -2,8 +2,8 @@
 
 namespace Tests\Wallabag\ImportBundle\Controller;
 
-use Tests\Wallabag\CoreBundle\WallabagCoreTestCase;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
+use Tests\Wallabag\CoreBundle\WallabagCoreTestCase;
 
 class WallabagV2ControllerTest extends WallabagCoreTestCase
 {
@@ -14,9 +14,9 @@ class WallabagV2ControllerTest extends WallabagCoreTestCase
 
         $crawler = $client->request('GET', '/import/wallabag-v2');
 
-        $this->assertEquals(200, $client->getResponse()->getStatusCode());
-        $this->assertEquals(1, $crawler->filter('form[name=upload_import_file] > button[type=submit]')->count());
-        $this->assertEquals(1, $crawler->filter('input[type=file]')->count());
+        $this->assertSame(200, $client->getResponse()->getStatusCode());
+        $this->assertSame(1, $crawler->filter('form[name=upload_import_file] > button[type=submit]')->count());
+        $this->assertSame(1, $crawler->filter('input[type=file]')->count());
     }
 
     public function testImportWallabagWithRabbitEnabled()
@@ -28,9 +28,9 @@ class WallabagV2ControllerTest extends WallabagCoreTestCase
 
         $crawler = $client->request('GET', '/import/wallabag-v2');
 
-        $this->assertEquals(200, $client->getResponse()->getStatusCode());
-        $this->assertEquals(1, $crawler->filter('form[name=upload_import_file] > button[type=submit]')->count());
-        $this->assertEquals(1, $crawler->filter('input[type=file]')->count());
+        $this->assertSame(200, $client->getResponse()->getStatusCode());
+        $this->assertSame(1, $crawler->filter('form[name=upload_import_file] > button[type=submit]')->count());
+        $this->assertSame(1, $crawler->filter('input[type=file]')->count());
 
         $client->getContainer()->get('craue_config')->set('import_with_rabbitmq', 0);
     }
@@ -49,7 +49,7 @@ class WallabagV2ControllerTest extends WallabagCoreTestCase
 
         $client->submit($form, $data);
 
-        $this->assertEquals(200, $client->getResponse()->getStatusCode());
+        $this->assertSame(200, $client->getResponse()->getStatusCode());
     }
 
     public function testImportWallabagWithRedisEnabled()
@@ -62,13 +62,13 @@ class WallabagV2ControllerTest extends WallabagCoreTestCase
 
         $crawler = $client->request('GET', '/import/wallabag-v2');
 
-        $this->assertEquals(200, $client->getResponse()->getStatusCode());
-        $this->assertEquals(1, $crawler->filter('form[name=upload_import_file] > button[type=submit]')->count());
-        $this->assertEquals(1, $crawler->filter('input[type=file]')->count());
+        $this->assertSame(200, $client->getResponse()->getStatusCode());
+        $this->assertSame(1, $crawler->filter('form[name=upload_import_file] > button[type=submit]')->count());
+        $this->assertSame(1, $crawler->filter('input[type=file]')->count());
 
         $form = $crawler->filter('form[name=upload_import_file] > button[type=submit]')->form();
 
-        $file = new UploadedFile(__DIR__.'/../fixtures/wallabag-v2.json', 'wallabag-v2.json');
+        $file = new UploadedFile(__DIR__ . '/../fixtures/wallabag-v2.json', 'wallabag-v2.json');
 
         $data = [
             'upload_import_file[file]' => $file,
@@ -76,7 +76,7 @@ class WallabagV2ControllerTest extends WallabagCoreTestCase
 
         $client->submit($form, $data);
 
-        $this->assertEquals(302, $client->getResponse()->getStatusCode());
+        $this->assertSame(302, $client->getResponse()->getStatusCode());
 
         $crawler = $client->followRedirect();
 
@@ -96,7 +96,7 @@ class WallabagV2ControllerTest extends WallabagCoreTestCase
         $crawler = $client->request('GET', '/import/wallabag-v2');
         $form = $crawler->filter('form[name=upload_import_file] > button[type=submit]')->form();
 
-        $file = new UploadedFile(__DIR__.'/../fixtures/wallabag-v2.json', 'wallabag-v2.json');
+        $file = new UploadedFile(__DIR__ . '/../fixtures/wallabag-v2.json', 'wallabag-v2.json');
 
         $data = [
             'upload_import_file[file]' => $file,
@@ -104,7 +104,7 @@ class WallabagV2ControllerTest extends WallabagCoreTestCase
 
         $client->submit($form, $data);
 
-        $this->assertEquals(302, $client->getResponse()->getStatusCode());
+        $this->assertSame(302, $client->getResponse()->getStatusCode());
 
         $crawler = $client->followRedirect();
 
@@ -126,7 +126,7 @@ class WallabagV2ControllerTest extends WallabagCoreTestCase
 
         $tags = $content->getTags();
         $this->assertContains('foot', $tags, 'It includes the "foot" tag');
-        $this->assertEquals(1, count($tags));
+        $this->assertSame(1, count($tags));
 
         $content = $client->getContainer()
             ->get('doctrine.orm.entity_manager')
@@ -144,10 +144,10 @@ class WallabagV2ControllerTest extends WallabagCoreTestCase
         $this->assertContains('foot', $tags, 'It includes the "foot" tag');
         $this->assertContains('mediapart', $tags, 'It includes the "mediapart" tag');
         $this->assertContains('blog', $tags, 'It includes the "blog" tag');
-        $this->assertEquals(3, count($tags));
+        $this->assertSame(3, count($tags));
 
         $this->assertInstanceOf(\DateTime::class, $content->getCreatedAt());
-        $this->assertEquals('2016-09-08', $content->getCreatedAt()->format('Y-m-d'));
+        $this->assertSame('2016-09-08', $content->getCreatedAt()->format('Y-m-d'));
         $this->assertTrue($content->isStarred(), 'Entry is starred');
     }
 
@@ -159,7 +159,7 @@ class WallabagV2ControllerTest extends WallabagCoreTestCase
         $crawler = $client->request('GET', '/import/wallabag-v2');
         $form = $crawler->filter('form[name=upload_import_file] > button[type=submit]')->form();
 
-        $file = new UploadedFile(__DIR__.'/../fixtures/test.txt', 'test.txt');
+        $file = new UploadedFile(__DIR__ . '/../fixtures/test.txt', 'test.txt');
 
         $data = [
             'upload_import_file[file]' => $file,
@@ -167,7 +167,7 @@ class WallabagV2ControllerTest extends WallabagCoreTestCase
 
         $client->submit($form, $data);
 
-        $this->assertEquals(302, $client->getResponse()->getStatusCode());
+        $this->assertSame(302, $client->getResponse()->getStatusCode());
 
         $crawler = $client->followRedirect();
 

--- a/tests/Wallabag/ImportBundle/Import/ChromeImportTest.php
+++ b/tests/Wallabag/ImportBundle/Import/ChromeImportTest.php
@@ -2,14 +2,14 @@
 
 namespace Tests\Wallabag\ImportBundle\Import;
 
-use Wallabag\ImportBundle\Import\ChromeImport;
-use Wallabag\UserBundle\Entity\User;
-use Wallabag\CoreBundle\Entity\Entry;
-use Wallabag\ImportBundle\Redis\Producer;
-use Monolog\Logger;
-use Monolog\Handler\TestHandler;
-use Simpleue\Queue\RedisQueue;
 use M6Web\Component\RedisMock\RedisMockFactory;
+use Monolog\Handler\TestHandler;
+use Monolog\Logger;
+use Simpleue\Queue\RedisQueue;
+use Wallabag\CoreBundle\Entity\Entry;
+use Wallabag\ImportBundle\Import\ChromeImport;
+use Wallabag\ImportBundle\Redis\Producer;
+use Wallabag\UserBundle\Entity\User;
 
 class ChromeImportTest extends \PHPUnit_Framework_TestCase
 {
@@ -18,6 +18,194 @@ class ChromeImportTest extends \PHPUnit_Framework_TestCase
     protected $logHandler;
     protected $contentProxy;
     protected $tagsAssigner;
+
+    public function testInit()
+    {
+        $chromeImport = $this->getChromeImport();
+
+        $this->assertSame('Chrome', $chromeImport->getName());
+        $this->assertNotEmpty($chromeImport->getUrl());
+        $this->assertSame('import.chrome.description', $chromeImport->getDescription());
+    }
+
+    public function testImport()
+    {
+        $chromeImport = $this->getChromeImport(false, 1);
+        $chromeImport->setFilepath(__DIR__ . '/../fixtures/chrome-bookmarks');
+
+        $entryRepo = $this->getMockBuilder('Wallabag\CoreBundle\Repository\EntryRepository')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $entryRepo->expects($this->exactly(1))
+            ->method('findByUrlAndUserId')
+            ->willReturn(false);
+
+        $this->em
+            ->expects($this->any())
+            ->method('getRepository')
+            ->willReturn($entryRepo);
+
+        $entry = $this->getMockBuilder('Wallabag\CoreBundle\Entity\Entry')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $this->contentProxy
+            ->expects($this->exactly(1))
+            ->method('updateEntry')
+            ->willReturn($entry);
+
+        $res = $chromeImport->import();
+
+        $this->assertTrue($res);
+        $this->assertSame(['skipped' => 0, 'imported' => 1, 'queued' => 0], $chromeImport->getSummary());
+    }
+
+    public function testImportAndMarkAllAsRead()
+    {
+        $chromeImport = $this->getChromeImport(false, 1);
+        $chromeImport->setFilepath(__DIR__ . '/../fixtures/chrome-bookmarks');
+
+        $entryRepo = $this->getMockBuilder('Wallabag\CoreBundle\Repository\EntryRepository')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $entryRepo->expects($this->exactly(1))
+            ->method('findByUrlAndUserId')
+            ->will($this->onConsecutiveCalls(false, true));
+
+        $this->em
+            ->expects($this->any())
+            ->method('getRepository')
+            ->willReturn($entryRepo);
+
+        $this->contentProxy
+            ->expects($this->exactly(1))
+            ->method('updateEntry')
+            ->willReturn(new Entry($this->user));
+
+        // check that every entry persisted are archived
+        $this->em
+            ->expects($this->any())
+            ->method('persist')
+            ->with($this->callback(function ($persistedEntry) {
+                return $persistedEntry->isArchived();
+            }));
+
+        $res = $chromeImport->setMarkAsRead(true)->import();
+
+        $this->assertTrue($res);
+
+        $this->assertSame(['skipped' => 0, 'imported' => 1, 'queued' => 0], $chromeImport->getSummary());
+    }
+
+    public function testImportWithRabbit()
+    {
+        $chromeImport = $this->getChromeImport();
+        $chromeImport->setFilepath(__DIR__ . '/../fixtures/chrome-bookmarks');
+
+        $entryRepo = $this->getMockBuilder('Wallabag\CoreBundle\Repository\EntryRepository')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $entryRepo->expects($this->never())
+            ->method('findByUrlAndUserId');
+
+        $this->em
+            ->expects($this->never())
+            ->method('getRepository');
+
+        $entry = $this->getMockBuilder('Wallabag\CoreBundle\Entity\Entry')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $this->contentProxy
+            ->expects($this->never())
+            ->method('updateEntry');
+
+        $producer = $this->getMockBuilder('OldSound\RabbitMqBundle\RabbitMq\Producer')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $producer
+            ->expects($this->exactly(1))
+            ->method('publish');
+
+        $chromeImport->setProducer($producer);
+
+        $res = $chromeImport->setMarkAsRead(true)->import();
+
+        $this->assertTrue($res);
+        $this->assertSame(['skipped' => 0, 'imported' => 0, 'queued' => 1], $chromeImport->getSummary());
+    }
+
+    public function testImportWithRedis()
+    {
+        $chromeImport = $this->getChromeImport();
+        $chromeImport->setFilepath(__DIR__ . '/../fixtures/chrome-bookmarks');
+
+        $entryRepo = $this->getMockBuilder('Wallabag\CoreBundle\Repository\EntryRepository')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $entryRepo->expects($this->never())
+            ->method('findByUrlAndUserId');
+
+        $this->em
+            ->expects($this->never())
+            ->method('getRepository');
+
+        $entry = $this->getMockBuilder('Wallabag\CoreBundle\Entity\Entry')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $this->contentProxy
+            ->expects($this->never())
+            ->method('updateEntry');
+
+        $factory = new RedisMockFactory();
+        $redisMock = $factory->getAdapter('Predis\Client', true);
+
+        $queue = new RedisQueue($redisMock, 'chrome');
+        $producer = new Producer($queue);
+
+        $chromeImport->setProducer($producer);
+
+        $res = $chromeImport->setMarkAsRead(true)->import();
+
+        $this->assertTrue($res);
+        $this->assertSame(['skipped' => 0, 'imported' => 0, 'queued' => 1], $chromeImport->getSummary());
+
+        $this->assertNotEmpty($redisMock->lpop('chrome'));
+    }
+
+    public function testImportBadFile()
+    {
+        $chromeImport = $this->getChromeImport();
+        $chromeImport->setFilepath(__DIR__ . '/../fixtures/wallabag-v1.jsonx');
+
+        $res = $chromeImport->import();
+
+        $this->assertFalse($res);
+
+        $records = $this->logHandler->getRecords();
+        $this->assertContains('Wallabag Browser Import: unable to read file', $records[0]['message']);
+        $this->assertSame('ERROR', $records[0]['level_name']);
+    }
+
+    public function testImportUserNotDefined()
+    {
+        $chromeImport = $this->getChromeImport(true);
+        $chromeImport->setFilepath(__DIR__ . '/../fixtures/chrome-bookmarks');
+
+        $res = $chromeImport->import();
+
+        $this->assertFalse($res);
+
+        $records = $this->logHandler->getRecords();
+        $this->assertContains('Wallabag Browser Import: user is not defined', $records[0]['message']);
+        $this->assertSame('ERROR', $records[0]['level_name']);
+    }
 
     private function getChromeImport($unsetUser = false, $dispatched = 0)
     {
@@ -54,193 +242,5 @@ class ChromeImportTest extends \PHPUnit_Framework_TestCase
         }
 
         return $wallabag;
-    }
-
-    public function testInit()
-    {
-        $chromeImport = $this->getChromeImport();
-
-        $this->assertEquals('Chrome', $chromeImport->getName());
-        $this->assertNotEmpty($chromeImport->getUrl());
-        $this->assertEquals('import.chrome.description', $chromeImport->getDescription());
-    }
-
-    public function testImport()
-    {
-        $chromeImport = $this->getChromeImport(false, 1);
-        $chromeImport->setFilepath(__DIR__.'/../fixtures/chrome-bookmarks');
-
-        $entryRepo = $this->getMockBuilder('Wallabag\CoreBundle\Repository\EntryRepository')
-            ->disableOriginalConstructor()
-            ->getMock();
-
-        $entryRepo->expects($this->exactly(1))
-            ->method('findByUrlAndUserId')
-            ->willReturn(false);
-
-        $this->em
-            ->expects($this->any())
-            ->method('getRepository')
-            ->willReturn($entryRepo);
-
-        $entry = $this->getMockBuilder('Wallabag\CoreBundle\Entity\Entry')
-            ->disableOriginalConstructor()
-            ->getMock();
-
-        $this->contentProxy
-            ->expects($this->exactly(1))
-            ->method('updateEntry')
-            ->willReturn($entry);
-
-        $res = $chromeImport->import();
-
-        $this->assertTrue($res);
-        $this->assertEquals(['skipped' => 0, 'imported' => 1, 'queued' => 0], $chromeImport->getSummary());
-    }
-
-    public function testImportAndMarkAllAsRead()
-    {
-        $chromeImport = $this->getChromeImport(false, 1);
-        $chromeImport->setFilepath(__DIR__.'/../fixtures/chrome-bookmarks');
-
-        $entryRepo = $this->getMockBuilder('Wallabag\CoreBundle\Repository\EntryRepository')
-            ->disableOriginalConstructor()
-            ->getMock();
-
-        $entryRepo->expects($this->exactly(1))
-            ->method('findByUrlAndUserId')
-            ->will($this->onConsecutiveCalls(false, true));
-
-        $this->em
-            ->expects($this->any())
-            ->method('getRepository')
-            ->willReturn($entryRepo);
-
-        $this->contentProxy
-            ->expects($this->exactly(1))
-            ->method('updateEntry')
-            ->willReturn(new Entry($this->user));
-
-        // check that every entry persisted are archived
-        $this->em
-            ->expects($this->any())
-            ->method('persist')
-            ->with($this->callback(function ($persistedEntry) {
-                return $persistedEntry->isArchived();
-            }));
-
-        $res = $chromeImport->setMarkAsRead(true)->import();
-
-        $this->assertTrue($res);
-
-        $this->assertEquals(['skipped' => 0, 'imported' => 1, 'queued' => 0], $chromeImport->getSummary());
-    }
-
-    public function testImportWithRabbit()
-    {
-        $chromeImport = $this->getChromeImport();
-        $chromeImport->setFilepath(__DIR__.'/../fixtures/chrome-bookmarks');
-
-        $entryRepo = $this->getMockBuilder('Wallabag\CoreBundle\Repository\EntryRepository')
-            ->disableOriginalConstructor()
-            ->getMock();
-
-        $entryRepo->expects($this->never())
-            ->method('findByUrlAndUserId');
-
-        $this->em
-            ->expects($this->never())
-            ->method('getRepository');
-
-        $entry = $this->getMockBuilder('Wallabag\CoreBundle\Entity\Entry')
-            ->disableOriginalConstructor()
-            ->getMock();
-
-        $this->contentProxy
-            ->expects($this->never())
-            ->method('updateEntry');
-
-        $producer = $this->getMockBuilder('OldSound\RabbitMqBundle\RabbitMq\Producer')
-            ->disableOriginalConstructor()
-            ->getMock();
-
-        $producer
-            ->expects($this->exactly(1))
-            ->method('publish');
-
-        $chromeImport->setProducer($producer);
-
-        $res = $chromeImport->setMarkAsRead(true)->import();
-
-        $this->assertTrue($res);
-        $this->assertEquals(['skipped' => 0, 'imported' => 0, 'queued' => 1], $chromeImport->getSummary());
-    }
-
-    public function testImportWithRedis()
-    {
-        $chromeImport = $this->getChromeImport();
-        $chromeImport->setFilepath(__DIR__.'/../fixtures/chrome-bookmarks');
-
-        $entryRepo = $this->getMockBuilder('Wallabag\CoreBundle\Repository\EntryRepository')
-            ->disableOriginalConstructor()
-            ->getMock();
-
-        $entryRepo->expects($this->never())
-            ->method('findByUrlAndUserId');
-
-        $this->em
-            ->expects($this->never())
-            ->method('getRepository');
-
-        $entry = $this->getMockBuilder('Wallabag\CoreBundle\Entity\Entry')
-            ->disableOriginalConstructor()
-            ->getMock();
-
-        $this->contentProxy
-            ->expects($this->never())
-            ->method('updateEntry');
-
-        $factory = new RedisMockFactory();
-        $redisMock = $factory->getAdapter('Predis\Client', true);
-
-        $queue = new RedisQueue($redisMock, 'chrome');
-        $producer = new Producer($queue);
-
-        $chromeImport->setProducer($producer);
-
-        $res = $chromeImport->setMarkAsRead(true)->import();
-
-        $this->assertTrue($res);
-        $this->assertEquals(['skipped' => 0, 'imported' => 0, 'queued' => 1], $chromeImport->getSummary());
-
-        $this->assertNotEmpty($redisMock->lpop('chrome'));
-    }
-
-    public function testImportBadFile()
-    {
-        $chromeImport = $this->getChromeImport();
-        $chromeImport->setFilepath(__DIR__.'/../fixtures/wallabag-v1.jsonx');
-
-        $res = $chromeImport->import();
-
-        $this->assertFalse($res);
-
-        $records = $this->logHandler->getRecords();
-        $this->assertContains('Wallabag Browser Import: unable to read file', $records[0]['message']);
-        $this->assertEquals('ERROR', $records[0]['level_name']);
-    }
-
-    public function testImportUserNotDefined()
-    {
-        $chromeImport = $this->getChromeImport(true);
-        $chromeImport->setFilepath(__DIR__.'/../fixtures/chrome-bookmarks');
-
-        $res = $chromeImport->import();
-
-        $this->assertFalse($res);
-
-        $records = $this->logHandler->getRecords();
-        $this->assertContains('Wallabag Browser Import: user is not defined', $records[0]['message']);
-        $this->assertEquals('ERROR', $records[0]['level_name']);
     }
 }

--- a/tests/Wallabag/ImportBundle/Import/FirefoxImportTest.php
+++ b/tests/Wallabag/ImportBundle/Import/FirefoxImportTest.php
@@ -2,14 +2,14 @@
 
 namespace Tests\Wallabag\ImportBundle\Import;
 
-use Wallabag\ImportBundle\Import\FirefoxImport;
-use Wallabag\UserBundle\Entity\User;
-use Wallabag\CoreBundle\Entity\Entry;
-use Wallabag\ImportBundle\Redis\Producer;
-use Monolog\Logger;
-use Monolog\Handler\TestHandler;
-use Simpleue\Queue\RedisQueue;
 use M6Web\Component\RedisMock\RedisMockFactory;
+use Monolog\Handler\TestHandler;
+use Monolog\Logger;
+use Simpleue\Queue\RedisQueue;
+use Wallabag\CoreBundle\Entity\Entry;
+use Wallabag\ImportBundle\Import\FirefoxImport;
+use Wallabag\ImportBundle\Redis\Producer;
+use Wallabag\UserBundle\Entity\User;
 
 class FirefoxImportTest extends \PHPUnit_Framework_TestCase
 {
@@ -18,6 +18,194 @@ class FirefoxImportTest extends \PHPUnit_Framework_TestCase
     protected $logHandler;
     protected $contentProxy;
     protected $tagsAssigner;
+
+    public function testInit()
+    {
+        $firefoxImport = $this->getFirefoxImport();
+
+        $this->assertSame('Firefox', $firefoxImport->getName());
+        $this->assertNotEmpty($firefoxImport->getUrl());
+        $this->assertSame('import.firefox.description', $firefoxImport->getDescription());
+    }
+
+    public function testImport()
+    {
+        $firefoxImport = $this->getFirefoxImport(false, 2);
+        $firefoxImport->setFilepath(__DIR__ . '/../fixtures/firefox-bookmarks.json');
+
+        $entryRepo = $this->getMockBuilder('Wallabag\CoreBundle\Repository\EntryRepository')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $entryRepo->expects($this->exactly(2))
+            ->method('findByUrlAndUserId')
+            ->willReturn(false);
+
+        $this->em
+            ->expects($this->any())
+            ->method('getRepository')
+            ->willReturn($entryRepo);
+
+        $entry = $this->getMockBuilder('Wallabag\CoreBundle\Entity\Entry')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $this->contentProxy
+            ->expects($this->exactly(2))
+            ->method('updateEntry')
+            ->willReturn($entry);
+
+        $res = $firefoxImport->import();
+
+        $this->assertTrue($res);
+        $this->assertSame(['skipped' => 0, 'imported' => 2, 'queued' => 0], $firefoxImport->getSummary());
+    }
+
+    public function testImportAndMarkAllAsRead()
+    {
+        $firefoxImport = $this->getFirefoxImport(false, 1);
+        $firefoxImport->setFilepath(__DIR__ . '/../fixtures/firefox-bookmarks.json');
+
+        $entryRepo = $this->getMockBuilder('Wallabag\CoreBundle\Repository\EntryRepository')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $entryRepo->expects($this->exactly(2))
+            ->method('findByUrlAndUserId')
+            ->will($this->onConsecutiveCalls(false, true));
+
+        $this->em
+            ->expects($this->any())
+            ->method('getRepository')
+            ->willReturn($entryRepo);
+
+        $this->contentProxy
+            ->expects($this->exactly(1))
+            ->method('updateEntry')
+            ->willReturn(new Entry($this->user));
+
+        // check that every entry persisted are archived
+        $this->em
+            ->expects($this->any())
+            ->method('persist')
+            ->with($this->callback(function ($persistedEntry) {
+                return $persistedEntry->isArchived();
+            }));
+
+        $res = $firefoxImport->setMarkAsRead(true)->import();
+
+        $this->assertTrue($res);
+
+        $this->assertSame(['skipped' => 1, 'imported' => 1, 'queued' => 0], $firefoxImport->getSummary());
+    }
+
+    public function testImportWithRabbit()
+    {
+        $firefoxImport = $this->getFirefoxImport();
+        $firefoxImport->setFilepath(__DIR__ . '/../fixtures/firefox-bookmarks.json');
+
+        $entryRepo = $this->getMockBuilder('Wallabag\CoreBundle\Repository\EntryRepository')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $entryRepo->expects($this->never())
+            ->method('findByUrlAndUserId');
+
+        $this->em
+            ->expects($this->never())
+            ->method('getRepository');
+
+        $entry = $this->getMockBuilder('Wallabag\CoreBundle\Entity\Entry')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $this->contentProxy
+            ->expects($this->never())
+            ->method('updateEntry');
+
+        $producer = $this->getMockBuilder('OldSound\RabbitMqBundle\RabbitMq\Producer')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $producer
+            ->expects($this->exactly(1))
+            ->method('publish');
+
+        $firefoxImport->setProducer($producer);
+
+        $res = $firefoxImport->setMarkAsRead(true)->import();
+
+        $this->assertTrue($res);
+        $this->assertSame(['skipped' => 0, 'imported' => 0, 'queued' => 1], $firefoxImport->getSummary());
+    }
+
+    public function testImportWithRedis()
+    {
+        $firefoxImport = $this->getFirefoxImport();
+        $firefoxImport->setFilepath(__DIR__ . '/../fixtures/firefox-bookmarks.json');
+
+        $entryRepo = $this->getMockBuilder('Wallabag\CoreBundle\Repository\EntryRepository')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $entryRepo->expects($this->never())
+            ->method('findByUrlAndUserId');
+
+        $this->em
+            ->expects($this->never())
+            ->method('getRepository');
+
+        $entry = $this->getMockBuilder('Wallabag\CoreBundle\Entity\Entry')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $this->contentProxy
+            ->expects($this->never())
+            ->method('updateEntry');
+
+        $factory = new RedisMockFactory();
+        $redisMock = $factory->getAdapter('Predis\Client', true);
+
+        $queue = new RedisQueue($redisMock, 'firefox');
+        $producer = new Producer($queue);
+
+        $firefoxImport->setProducer($producer);
+
+        $res = $firefoxImport->setMarkAsRead(true)->import();
+
+        $this->assertTrue($res);
+        $this->assertSame(['skipped' => 0, 'imported' => 0, 'queued' => 1], $firefoxImport->getSummary());
+
+        $this->assertNotEmpty($redisMock->lpop('firefox'));
+    }
+
+    public function testImportBadFile()
+    {
+        $firefoxImport = $this->getFirefoxImport();
+        $firefoxImport->setFilepath(__DIR__ . '/../fixtures/wallabag-v1.jsonx');
+
+        $res = $firefoxImport->import();
+
+        $this->assertFalse($res);
+
+        $records = $this->logHandler->getRecords();
+        $this->assertContains('Wallabag Browser Import: unable to read file', $records[0]['message']);
+        $this->assertSame('ERROR', $records[0]['level_name']);
+    }
+
+    public function testImportUserNotDefined()
+    {
+        $firefoxImport = $this->getFirefoxImport(true);
+        $firefoxImport->setFilepath(__DIR__ . '/../fixtures/firefox-bookmarks.json');
+
+        $res = $firefoxImport->import();
+
+        $this->assertFalse($res);
+
+        $records = $this->logHandler->getRecords();
+        $this->assertContains('Wallabag Browser Import: user is not defined', $records[0]['message']);
+        $this->assertSame('ERROR', $records[0]['level_name']);
+    }
 
     private function getFirefoxImport($unsetUser = false, $dispatched = 0)
     {
@@ -54,193 +242,5 @@ class FirefoxImportTest extends \PHPUnit_Framework_TestCase
         }
 
         return $wallabag;
-    }
-
-    public function testInit()
-    {
-        $firefoxImport = $this->getFirefoxImport();
-
-        $this->assertEquals('Firefox', $firefoxImport->getName());
-        $this->assertNotEmpty($firefoxImport->getUrl());
-        $this->assertEquals('import.firefox.description', $firefoxImport->getDescription());
-    }
-
-    public function testImport()
-    {
-        $firefoxImport = $this->getFirefoxImport(false, 2);
-        $firefoxImport->setFilepath(__DIR__.'/../fixtures/firefox-bookmarks.json');
-
-        $entryRepo = $this->getMockBuilder('Wallabag\CoreBundle\Repository\EntryRepository')
-            ->disableOriginalConstructor()
-            ->getMock();
-
-        $entryRepo->expects($this->exactly(2))
-            ->method('findByUrlAndUserId')
-            ->willReturn(false);
-
-        $this->em
-            ->expects($this->any())
-            ->method('getRepository')
-            ->willReturn($entryRepo);
-
-        $entry = $this->getMockBuilder('Wallabag\CoreBundle\Entity\Entry')
-            ->disableOriginalConstructor()
-            ->getMock();
-
-        $this->contentProxy
-            ->expects($this->exactly(2))
-            ->method('updateEntry')
-            ->willReturn($entry);
-
-        $res = $firefoxImport->import();
-
-        $this->assertTrue($res);
-        $this->assertEquals(['skipped' => 0, 'imported' => 2, 'queued' => 0], $firefoxImport->getSummary());
-    }
-
-    public function testImportAndMarkAllAsRead()
-    {
-        $firefoxImport = $this->getFirefoxImport(false, 1);
-        $firefoxImport->setFilepath(__DIR__.'/../fixtures/firefox-bookmarks.json');
-
-        $entryRepo = $this->getMockBuilder('Wallabag\CoreBundle\Repository\EntryRepository')
-            ->disableOriginalConstructor()
-            ->getMock();
-
-        $entryRepo->expects($this->exactly(2))
-            ->method('findByUrlAndUserId')
-            ->will($this->onConsecutiveCalls(false, true));
-
-        $this->em
-            ->expects($this->any())
-            ->method('getRepository')
-            ->willReturn($entryRepo);
-
-        $this->contentProxy
-            ->expects($this->exactly(1))
-            ->method('updateEntry')
-            ->willReturn(new Entry($this->user));
-
-        // check that every entry persisted are archived
-        $this->em
-            ->expects($this->any())
-            ->method('persist')
-            ->with($this->callback(function ($persistedEntry) {
-                return $persistedEntry->isArchived();
-            }));
-
-        $res = $firefoxImport->setMarkAsRead(true)->import();
-
-        $this->assertTrue($res);
-
-        $this->assertEquals(['skipped' => 1, 'imported' => 1, 'queued' => 0], $firefoxImport->getSummary());
-    }
-
-    public function testImportWithRabbit()
-    {
-        $firefoxImport = $this->getFirefoxImport();
-        $firefoxImport->setFilepath(__DIR__.'/../fixtures/firefox-bookmarks.json');
-
-        $entryRepo = $this->getMockBuilder('Wallabag\CoreBundle\Repository\EntryRepository')
-            ->disableOriginalConstructor()
-            ->getMock();
-
-        $entryRepo->expects($this->never())
-            ->method('findByUrlAndUserId');
-
-        $this->em
-            ->expects($this->never())
-            ->method('getRepository');
-
-        $entry = $this->getMockBuilder('Wallabag\CoreBundle\Entity\Entry')
-            ->disableOriginalConstructor()
-            ->getMock();
-
-        $this->contentProxy
-            ->expects($this->never())
-            ->method('updateEntry');
-
-        $producer = $this->getMockBuilder('OldSound\RabbitMqBundle\RabbitMq\Producer')
-            ->disableOriginalConstructor()
-            ->getMock();
-
-        $producer
-            ->expects($this->exactly(1))
-            ->method('publish');
-
-        $firefoxImport->setProducer($producer);
-
-        $res = $firefoxImport->setMarkAsRead(true)->import();
-
-        $this->assertTrue($res);
-        $this->assertEquals(['skipped' => 0, 'imported' => 0, 'queued' => 1], $firefoxImport->getSummary());
-    }
-
-    public function testImportWithRedis()
-    {
-        $firefoxImport = $this->getFirefoxImport();
-        $firefoxImport->setFilepath(__DIR__.'/../fixtures/firefox-bookmarks.json');
-
-        $entryRepo = $this->getMockBuilder('Wallabag\CoreBundle\Repository\EntryRepository')
-            ->disableOriginalConstructor()
-            ->getMock();
-
-        $entryRepo->expects($this->never())
-            ->method('findByUrlAndUserId');
-
-        $this->em
-            ->expects($this->never())
-            ->method('getRepository');
-
-        $entry = $this->getMockBuilder('Wallabag\CoreBundle\Entity\Entry')
-            ->disableOriginalConstructor()
-            ->getMock();
-
-        $this->contentProxy
-            ->expects($this->never())
-            ->method('updateEntry');
-
-        $factory = new RedisMockFactory();
-        $redisMock = $factory->getAdapter('Predis\Client', true);
-
-        $queue = new RedisQueue($redisMock, 'firefox');
-        $producer = new Producer($queue);
-
-        $firefoxImport->setProducer($producer);
-
-        $res = $firefoxImport->setMarkAsRead(true)->import();
-
-        $this->assertTrue($res);
-        $this->assertEquals(['skipped' => 0, 'imported' => 0, 'queued' => 1], $firefoxImport->getSummary());
-
-        $this->assertNotEmpty($redisMock->lpop('firefox'));
-    }
-
-    public function testImportBadFile()
-    {
-        $firefoxImport = $this->getFirefoxImport();
-        $firefoxImport->setFilepath(__DIR__.'/../fixtures/wallabag-v1.jsonx');
-
-        $res = $firefoxImport->import();
-
-        $this->assertFalse($res);
-
-        $records = $this->logHandler->getRecords();
-        $this->assertContains('Wallabag Browser Import: unable to read file', $records[0]['message']);
-        $this->assertEquals('ERROR', $records[0]['level_name']);
-    }
-
-    public function testImportUserNotDefined()
-    {
-        $firefoxImport = $this->getFirefoxImport(true);
-        $firefoxImport->setFilepath(__DIR__.'/../fixtures/firefox-bookmarks.json');
-
-        $res = $firefoxImport->import();
-
-        $this->assertFalse($res);
-
-        $records = $this->logHandler->getRecords();
-        $this->assertContains('Wallabag Browser Import: user is not defined', $records[0]['message']);
-        $this->assertEquals('ERROR', $records[0]['level_name']);
     }
 }

--- a/tests/Wallabag/ImportBundle/Import/ImportChainTest.php
+++ b/tests/Wallabag/ImportBundle/Import/ImportChainTest.php
@@ -16,6 +16,6 @@ class ImportChainTest extends \PHPUnit_Framework_TestCase
         $importChain->addImport($import, 'alias');
 
         $this->assertCount(1, $importChain->getAll());
-        $this->assertEquals($import, $importChain->getAll()['alias']);
+        $this->assertSame($import, $importChain->getAll()['alias']);
     }
 }

--- a/tests/Wallabag/ImportBundle/Import/ImportCompilerPassTest.php
+++ b/tests/Wallabag/ImportBundle/Import/ImportCompilerPassTest.php
@@ -36,7 +36,7 @@ class ImportCompilerPassTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue($definition->hasMethodCall('addImport'));
 
         $calls = $definition->getMethodCalls();
-        $this->assertEquals('pocket', $calls[0][1][1]);
+        $this->assertSame('pocket', $calls[0][1][1]);
     }
 
     protected function process(ContainerBuilder $container)

--- a/tests/Wallabag/ImportBundle/Import/InstapaperImportTest.php
+++ b/tests/Wallabag/ImportBundle/Import/InstapaperImportTest.php
@@ -2,14 +2,14 @@
 
 namespace Tests\Wallabag\ImportBundle\Import;
 
-use Wallabag\ImportBundle\Import\InstapaperImport;
-use Wallabag\UserBundle\Entity\User;
-use Wallabag\CoreBundle\Entity\Entry;
-use Wallabag\ImportBundle\Redis\Producer;
-use Monolog\Logger;
-use Monolog\Handler\TestHandler;
-use Simpleue\Queue\RedisQueue;
 use M6Web\Component\RedisMock\RedisMockFactory;
+use Monolog\Handler\TestHandler;
+use Monolog\Logger;
+use Simpleue\Queue\RedisQueue;
+use Wallabag\CoreBundle\Entity\Entry;
+use Wallabag\ImportBundle\Import\InstapaperImport;
+use Wallabag\ImportBundle\Redis\Producer;
+use Wallabag\UserBundle\Entity\User;
 
 class InstapaperImportTest extends \PHPUnit_Framework_TestCase
 {
@@ -19,6 +19,194 @@ class InstapaperImportTest extends \PHPUnit_Framework_TestCase
     protected $contentProxy;
     protected $tagsAssigner;
     protected $uow;
+
+    public function testInit()
+    {
+        $instapaperImport = $this->getInstapaperImport();
+
+        $this->assertSame('Instapaper', $instapaperImport->getName());
+        $this->assertNotEmpty($instapaperImport->getUrl());
+        $this->assertSame('import.instapaper.description', $instapaperImport->getDescription());
+    }
+
+    public function testImport()
+    {
+        $instapaperImport = $this->getInstapaperImport(false, 4);
+        $instapaperImport->setFilepath(__DIR__ . '/../fixtures/instapaper-export.csv');
+
+        $entryRepo = $this->getMockBuilder('Wallabag\CoreBundle\Repository\EntryRepository')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $entryRepo->expects($this->exactly(4))
+            ->method('findByUrlAndUserId')
+            ->willReturn(false);
+
+        $this->em
+            ->expects($this->any())
+            ->method('getRepository')
+            ->willReturn($entryRepo);
+
+        $entry = $this->getMockBuilder('Wallabag\CoreBundle\Entity\Entry')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $this->contentProxy
+            ->expects($this->exactly(4))
+            ->method('updateEntry')
+            ->willReturn($entry);
+
+        $res = $instapaperImport->import();
+
+        $this->assertTrue($res);
+        $this->assertSame(['skipped' => 0, 'imported' => 4, 'queued' => 0], $instapaperImport->getSummary());
+    }
+
+    public function testImportAndMarkAllAsRead()
+    {
+        $instapaperImport = $this->getInstapaperImport(false, 1);
+        $instapaperImport->setFilepath(__DIR__ . '/../fixtures/instapaper-export.csv');
+
+        $entryRepo = $this->getMockBuilder('Wallabag\CoreBundle\Repository\EntryRepository')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $entryRepo->expects($this->exactly(4))
+            ->method('findByUrlAndUserId')
+            ->will($this->onConsecutiveCalls(false, true, true, true));
+
+        $this->em
+            ->expects($this->any())
+            ->method('getRepository')
+            ->willReturn($entryRepo);
+
+        $this->contentProxy
+            ->expects($this->once())
+            ->method('updateEntry')
+            ->willReturn(new Entry($this->user));
+
+        // check that every entry persisted are archived
+        $this->em
+            ->expects($this->once())
+            ->method('persist')
+            ->with($this->callback(function ($persistedEntry) {
+                return $persistedEntry->isArchived();
+            }));
+
+        $res = $instapaperImport->setMarkAsRead(true)->import();
+
+        $this->assertTrue($res);
+
+        $this->assertSame(['skipped' => 3, 'imported' => 1, 'queued' => 0], $instapaperImport->getSummary());
+    }
+
+    public function testImportWithRabbit()
+    {
+        $instapaperImport = $this->getInstapaperImport();
+        $instapaperImport->setFilepath(__DIR__ . '/../fixtures/instapaper-export.csv');
+
+        $entryRepo = $this->getMockBuilder('Wallabag\CoreBundle\Repository\EntryRepository')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $entryRepo->expects($this->never())
+            ->method('findByUrlAndUserId');
+
+        $this->em
+            ->expects($this->never())
+            ->method('getRepository');
+
+        $entry = $this->getMockBuilder('Wallabag\CoreBundle\Entity\Entry')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $this->contentProxy
+            ->expects($this->never())
+            ->method('updateEntry');
+
+        $producer = $this->getMockBuilder('OldSound\RabbitMqBundle\RabbitMq\Producer')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $producer
+            ->expects($this->exactly(4))
+            ->method('publish');
+
+        $instapaperImport->setProducer($producer);
+
+        $res = $instapaperImport->setMarkAsRead(true)->import();
+
+        $this->assertTrue($res);
+        $this->assertSame(['skipped' => 0, 'imported' => 0, 'queued' => 4], $instapaperImport->getSummary());
+    }
+
+    public function testImportWithRedis()
+    {
+        $instapaperImport = $this->getInstapaperImport();
+        $instapaperImport->setFilepath(__DIR__ . '/../fixtures/instapaper-export.csv');
+
+        $entryRepo = $this->getMockBuilder('Wallabag\CoreBundle\Repository\EntryRepository')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $entryRepo->expects($this->never())
+            ->method('findByUrlAndUserId');
+
+        $this->em
+            ->expects($this->never())
+            ->method('getRepository');
+
+        $entry = $this->getMockBuilder('Wallabag\CoreBundle\Entity\Entry')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $this->contentProxy
+            ->expects($this->never())
+            ->method('updateEntry');
+
+        $factory = new RedisMockFactory();
+        $redisMock = $factory->getAdapter('Predis\Client', true);
+
+        $queue = new RedisQueue($redisMock, 'instapaper');
+        $producer = new Producer($queue);
+
+        $instapaperImport->setProducer($producer);
+
+        $res = $instapaperImport->setMarkAsRead(true)->import();
+
+        $this->assertTrue($res);
+        $this->assertSame(['skipped' => 0, 'imported' => 0, 'queued' => 4], $instapaperImport->getSummary());
+
+        $this->assertNotEmpty($redisMock->lpop('instapaper'));
+    }
+
+    public function testImportBadFile()
+    {
+        $instapaperImport = $this->getInstapaperImport();
+        $instapaperImport->setFilepath(__DIR__ . '/../fixtures/wallabag-v1.jsonx');
+
+        $res = $instapaperImport->import();
+
+        $this->assertFalse($res);
+
+        $records = $this->logHandler->getRecords();
+        $this->assertContains('InstapaperImport: unable to read file', $records[0]['message']);
+        $this->assertSame('ERROR', $records[0]['level_name']);
+    }
+
+    public function testImportUserNotDefined()
+    {
+        $instapaperImport = $this->getInstapaperImport(true);
+        $instapaperImport->setFilepath(__DIR__ . '/../fixtures/instapaper-export.csv');
+
+        $res = $instapaperImport->import();
+
+        $this->assertFalse($res);
+
+        $records = $this->logHandler->getRecords();
+        $this->assertContains('InstapaperImport: user is not defined', $records[0]['message']);
+        $this->assertSame('ERROR', $records[0]['level_name']);
+    }
 
     private function getInstapaperImport($unsetUser = false, $dispatched = 0)
     {
@@ -69,193 +257,5 @@ class InstapaperImportTest extends \PHPUnit_Framework_TestCase
         }
 
         return $import;
-    }
-
-    public function testInit()
-    {
-        $instapaperImport = $this->getInstapaperImport();
-
-        $this->assertEquals('Instapaper', $instapaperImport->getName());
-        $this->assertNotEmpty($instapaperImport->getUrl());
-        $this->assertEquals('import.instapaper.description', $instapaperImport->getDescription());
-    }
-
-    public function testImport()
-    {
-        $instapaperImport = $this->getInstapaperImport(false, 4);
-        $instapaperImport->setFilepath(__DIR__.'/../fixtures/instapaper-export.csv');
-
-        $entryRepo = $this->getMockBuilder('Wallabag\CoreBundle\Repository\EntryRepository')
-            ->disableOriginalConstructor()
-            ->getMock();
-
-        $entryRepo->expects($this->exactly(4))
-            ->method('findByUrlAndUserId')
-            ->willReturn(false);
-
-        $this->em
-            ->expects($this->any())
-            ->method('getRepository')
-            ->willReturn($entryRepo);
-
-        $entry = $this->getMockBuilder('Wallabag\CoreBundle\Entity\Entry')
-            ->disableOriginalConstructor()
-            ->getMock();
-
-        $this->contentProxy
-            ->expects($this->exactly(4))
-            ->method('updateEntry')
-            ->willReturn($entry);
-
-        $res = $instapaperImport->import();
-
-        $this->assertTrue($res);
-        $this->assertEquals(['skipped' => 0, 'imported' => 4, 'queued' => 0], $instapaperImport->getSummary());
-    }
-
-    public function testImportAndMarkAllAsRead()
-    {
-        $instapaperImport = $this->getInstapaperImport(false, 1);
-        $instapaperImport->setFilepath(__DIR__.'/../fixtures/instapaper-export.csv');
-
-        $entryRepo = $this->getMockBuilder('Wallabag\CoreBundle\Repository\EntryRepository')
-            ->disableOriginalConstructor()
-            ->getMock();
-
-        $entryRepo->expects($this->exactly(4))
-            ->method('findByUrlAndUserId')
-            ->will($this->onConsecutiveCalls(false, true, true, true));
-
-        $this->em
-            ->expects($this->any())
-            ->method('getRepository')
-            ->willReturn($entryRepo);
-
-        $this->contentProxy
-            ->expects($this->once())
-            ->method('updateEntry')
-            ->willReturn(new Entry($this->user));
-
-        // check that every entry persisted are archived
-        $this->em
-            ->expects($this->once())
-            ->method('persist')
-            ->with($this->callback(function ($persistedEntry) {
-                return $persistedEntry->isArchived();
-            }));
-
-        $res = $instapaperImport->setMarkAsRead(true)->import();
-
-        $this->assertTrue($res);
-
-        $this->assertEquals(['skipped' => 3, 'imported' => 1, 'queued' => 0], $instapaperImport->getSummary());
-    }
-
-    public function testImportWithRabbit()
-    {
-        $instapaperImport = $this->getInstapaperImport();
-        $instapaperImport->setFilepath(__DIR__.'/../fixtures/instapaper-export.csv');
-
-        $entryRepo = $this->getMockBuilder('Wallabag\CoreBundle\Repository\EntryRepository')
-            ->disableOriginalConstructor()
-            ->getMock();
-
-        $entryRepo->expects($this->never())
-            ->method('findByUrlAndUserId');
-
-        $this->em
-            ->expects($this->never())
-            ->method('getRepository');
-
-        $entry = $this->getMockBuilder('Wallabag\CoreBundle\Entity\Entry')
-            ->disableOriginalConstructor()
-            ->getMock();
-
-        $this->contentProxy
-            ->expects($this->never())
-            ->method('updateEntry');
-
-        $producer = $this->getMockBuilder('OldSound\RabbitMqBundle\RabbitMq\Producer')
-            ->disableOriginalConstructor()
-            ->getMock();
-
-        $producer
-            ->expects($this->exactly(4))
-            ->method('publish');
-
-        $instapaperImport->setProducer($producer);
-
-        $res = $instapaperImport->setMarkAsRead(true)->import();
-
-        $this->assertTrue($res);
-        $this->assertEquals(['skipped' => 0, 'imported' => 0, 'queued' => 4], $instapaperImport->getSummary());
-    }
-
-    public function testImportWithRedis()
-    {
-        $instapaperImport = $this->getInstapaperImport();
-        $instapaperImport->setFilepath(__DIR__.'/../fixtures/instapaper-export.csv');
-
-        $entryRepo = $this->getMockBuilder('Wallabag\CoreBundle\Repository\EntryRepository')
-            ->disableOriginalConstructor()
-            ->getMock();
-
-        $entryRepo->expects($this->never())
-            ->method('findByUrlAndUserId');
-
-        $this->em
-            ->expects($this->never())
-            ->method('getRepository');
-
-        $entry = $this->getMockBuilder('Wallabag\CoreBundle\Entity\Entry')
-            ->disableOriginalConstructor()
-            ->getMock();
-
-        $this->contentProxy
-            ->expects($this->never())
-            ->method('updateEntry');
-
-        $factory = new RedisMockFactory();
-        $redisMock = $factory->getAdapter('Predis\Client', true);
-
-        $queue = new RedisQueue($redisMock, 'instapaper');
-        $producer = new Producer($queue);
-
-        $instapaperImport->setProducer($producer);
-
-        $res = $instapaperImport->setMarkAsRead(true)->import();
-
-        $this->assertTrue($res);
-        $this->assertEquals(['skipped' => 0, 'imported' => 0, 'queued' => 4], $instapaperImport->getSummary());
-
-        $this->assertNotEmpty($redisMock->lpop('instapaper'));
-    }
-
-    public function testImportBadFile()
-    {
-        $instapaperImport = $this->getInstapaperImport();
-        $instapaperImport->setFilepath(__DIR__.'/../fixtures/wallabag-v1.jsonx');
-
-        $res = $instapaperImport->import();
-
-        $this->assertFalse($res);
-
-        $records = $this->logHandler->getRecords();
-        $this->assertContains('InstapaperImport: unable to read file', $records[0]['message']);
-        $this->assertEquals('ERROR', $records[0]['level_name']);
-    }
-
-    public function testImportUserNotDefined()
-    {
-        $instapaperImport = $this->getInstapaperImport(true);
-        $instapaperImport->setFilepath(__DIR__.'/../fixtures/instapaper-export.csv');
-
-        $res = $instapaperImport->import();
-
-        $this->assertFalse($res);
-
-        $records = $this->logHandler->getRecords();
-        $this->assertContains('InstapaperImport: user is not defined', $records[0]['message']);
-        $this->assertEquals('ERROR', $records[0]['level_name']);
     }
 }

--- a/tests/Wallabag/ImportBundle/Import/ReadabilityImportTest.php
+++ b/tests/Wallabag/ImportBundle/Import/ReadabilityImportTest.php
@@ -2,14 +2,14 @@
 
 namespace Tests\Wallabag\ImportBundle\Import;
 
-use Wallabag\ImportBundle\Import\ReadabilityImport;
-use Wallabag\UserBundle\Entity\User;
-use Wallabag\CoreBundle\Entity\Entry;
-use Wallabag\ImportBundle\Redis\Producer;
-use Monolog\Logger;
-use Monolog\Handler\TestHandler;
-use Simpleue\Queue\RedisQueue;
 use M6Web\Component\RedisMock\RedisMockFactory;
+use Monolog\Handler\TestHandler;
+use Monolog\Logger;
+use Simpleue\Queue\RedisQueue;
+use Wallabag\CoreBundle\Entity\Entry;
+use Wallabag\ImportBundle\Import\ReadabilityImport;
+use Wallabag\ImportBundle\Redis\Producer;
+use Wallabag\UserBundle\Entity\User;
 
 class ReadabilityImportTest extends \PHPUnit_Framework_TestCase
 {
@@ -18,6 +18,194 @@ class ReadabilityImportTest extends \PHPUnit_Framework_TestCase
     protected $logHandler;
     protected $contentProxy;
     protected $tagsAssigner;
+
+    public function testInit()
+    {
+        $readabilityImport = $this->getReadabilityImport();
+
+        $this->assertSame('Readability', $readabilityImport->getName());
+        $this->assertNotEmpty($readabilityImport->getUrl());
+        $this->assertSame('import.readability.description', $readabilityImport->getDescription());
+    }
+
+    public function testImport()
+    {
+        $readabilityImport = $this->getReadabilityImport(false, 3);
+        $readabilityImport->setFilepath(__DIR__ . '/../fixtures/readability.json');
+
+        $entryRepo = $this->getMockBuilder('Wallabag\CoreBundle\Repository\EntryRepository')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $entryRepo->expects($this->exactly(3))
+            ->method('findByUrlAndUserId')
+            ->willReturn(false);
+
+        $this->em
+            ->expects($this->any())
+            ->method('getRepository')
+            ->willReturn($entryRepo);
+
+        $entry = $this->getMockBuilder('Wallabag\CoreBundle\Entity\Entry')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $this->contentProxy
+            ->expects($this->exactly(3))
+            ->method('updateEntry')
+            ->willReturn($entry);
+
+        $res = $readabilityImport->import();
+
+        $this->assertTrue($res);
+        $this->assertSame(['skipped' => 0, 'imported' => 3, 'queued' => 0], $readabilityImport->getSummary());
+    }
+
+    public function testImportAndMarkAllAsRead()
+    {
+        $readabilityImport = $this->getReadabilityImport(false, 1);
+        $readabilityImport->setFilepath(__DIR__ . '/../fixtures/readability-read.json');
+
+        $entryRepo = $this->getMockBuilder('Wallabag\CoreBundle\Repository\EntryRepository')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $entryRepo->expects($this->exactly(2))
+            ->method('findByUrlAndUserId')
+            ->will($this->onConsecutiveCalls(false, true));
+
+        $this->em
+            ->expects($this->any())
+            ->method('getRepository')
+            ->willReturn($entryRepo);
+
+        $this->contentProxy
+            ->expects($this->exactly(1))
+            ->method('updateEntry')
+            ->willReturn(new Entry($this->user));
+
+        // check that every entry persisted are archived
+        $this->em
+            ->expects($this->any())
+            ->method('persist')
+            ->with($this->callback(function ($persistedEntry) {
+                return $persistedEntry->isArchived();
+            }));
+
+        $res = $readabilityImport->setMarkAsRead(true)->import();
+
+        $this->assertTrue($res);
+
+        $this->assertSame(['skipped' => 1, 'imported' => 1, 'queued' => 0], $readabilityImport->getSummary());
+    }
+
+    public function testImportWithRabbit()
+    {
+        $readabilityImport = $this->getReadabilityImport();
+        $readabilityImport->setFilepath(__DIR__ . '/../fixtures/readability.json');
+
+        $entryRepo = $this->getMockBuilder('Wallabag\CoreBundle\Repository\EntryRepository')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $entryRepo->expects($this->never())
+            ->method('findByUrlAndUserId');
+
+        $this->em
+            ->expects($this->never())
+            ->method('getRepository');
+
+        $entry = $this->getMockBuilder('Wallabag\CoreBundle\Entity\Entry')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $this->contentProxy
+            ->expects($this->never())
+            ->method('updateEntry');
+
+        $producer = $this->getMockBuilder('OldSound\RabbitMqBundle\RabbitMq\Producer')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $producer
+            ->expects($this->exactly(3))
+            ->method('publish');
+
+        $readabilityImport->setProducer($producer);
+
+        $res = $readabilityImport->setMarkAsRead(true)->import();
+
+        $this->assertTrue($res);
+        $this->assertSame(['skipped' => 0, 'imported' => 0, 'queued' => 3], $readabilityImport->getSummary());
+    }
+
+    public function testImportWithRedis()
+    {
+        $readabilityImport = $this->getReadabilityImport();
+        $readabilityImport->setFilepath(__DIR__ . '/../fixtures/readability.json');
+
+        $entryRepo = $this->getMockBuilder('Wallabag\CoreBundle\Repository\EntryRepository')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $entryRepo->expects($this->never())
+            ->method('findByUrlAndUserId');
+
+        $this->em
+            ->expects($this->never())
+            ->method('getRepository');
+
+        $entry = $this->getMockBuilder('Wallabag\CoreBundle\Entity\Entry')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $this->contentProxy
+            ->expects($this->never())
+            ->method('updateEntry');
+
+        $factory = new RedisMockFactory();
+        $redisMock = $factory->getAdapter('Predis\Client', true);
+
+        $queue = new RedisQueue($redisMock, 'readability');
+        $producer = new Producer($queue);
+
+        $readabilityImport->setProducer($producer);
+
+        $res = $readabilityImport->setMarkAsRead(true)->import();
+
+        $this->assertTrue($res);
+        $this->assertSame(['skipped' => 0, 'imported' => 0, 'queued' => 3], $readabilityImport->getSummary());
+
+        $this->assertNotEmpty($redisMock->lpop('readability'));
+    }
+
+    public function testImportBadFile()
+    {
+        $readabilityImport = $this->getReadabilityImport();
+        $readabilityImport->setFilepath(__DIR__ . '/../fixtures/wallabag-v1.jsonx');
+
+        $res = $readabilityImport->import();
+
+        $this->assertFalse($res);
+
+        $records = $this->logHandler->getRecords();
+        $this->assertContains('ReadabilityImport: unable to read file', $records[0]['message']);
+        $this->assertSame('ERROR', $records[0]['level_name']);
+    }
+
+    public function testImportUserNotDefined()
+    {
+        $readabilityImport = $this->getReadabilityImport(true);
+        $readabilityImport->setFilepath(__DIR__ . '/../fixtures/readability.json');
+
+        $res = $readabilityImport->import();
+
+        $this->assertFalse($res);
+
+        $records = $this->logHandler->getRecords();
+        $this->assertContains('ReadabilityImport: user is not defined', $records[0]['message']);
+        $this->assertSame('ERROR', $records[0]['level_name']);
+    }
 
     private function getReadabilityImport($unsetUser = false, $dispatched = 0)
     {
@@ -54,193 +242,5 @@ class ReadabilityImportTest extends \PHPUnit_Framework_TestCase
         }
 
         return $wallabag;
-    }
-
-    public function testInit()
-    {
-        $readabilityImport = $this->getReadabilityImport();
-
-        $this->assertEquals('Readability', $readabilityImport->getName());
-        $this->assertNotEmpty($readabilityImport->getUrl());
-        $this->assertEquals('import.readability.description', $readabilityImport->getDescription());
-    }
-
-    public function testImport()
-    {
-        $readabilityImport = $this->getReadabilityImport(false, 3);
-        $readabilityImport->setFilepath(__DIR__.'/../fixtures/readability.json');
-
-        $entryRepo = $this->getMockBuilder('Wallabag\CoreBundle\Repository\EntryRepository')
-            ->disableOriginalConstructor()
-            ->getMock();
-
-        $entryRepo->expects($this->exactly(3))
-            ->method('findByUrlAndUserId')
-            ->willReturn(false);
-
-        $this->em
-            ->expects($this->any())
-            ->method('getRepository')
-            ->willReturn($entryRepo);
-
-        $entry = $this->getMockBuilder('Wallabag\CoreBundle\Entity\Entry')
-            ->disableOriginalConstructor()
-            ->getMock();
-
-        $this->contentProxy
-            ->expects($this->exactly(3))
-            ->method('updateEntry')
-            ->willReturn($entry);
-
-        $res = $readabilityImport->import();
-
-        $this->assertTrue($res);
-        $this->assertEquals(['skipped' => 0, 'imported' => 3, 'queued' => 0], $readabilityImport->getSummary());
-    }
-
-    public function testImportAndMarkAllAsRead()
-    {
-        $readabilityImport = $this->getReadabilityImport(false, 1);
-        $readabilityImport->setFilepath(__DIR__.'/../fixtures/readability-read.json');
-
-        $entryRepo = $this->getMockBuilder('Wallabag\CoreBundle\Repository\EntryRepository')
-            ->disableOriginalConstructor()
-            ->getMock();
-
-        $entryRepo->expects($this->exactly(2))
-            ->method('findByUrlAndUserId')
-            ->will($this->onConsecutiveCalls(false, true));
-
-        $this->em
-            ->expects($this->any())
-            ->method('getRepository')
-            ->willReturn($entryRepo);
-
-        $this->contentProxy
-            ->expects($this->exactly(1))
-            ->method('updateEntry')
-            ->willReturn(new Entry($this->user));
-
-        // check that every entry persisted are archived
-        $this->em
-            ->expects($this->any())
-            ->method('persist')
-            ->with($this->callback(function ($persistedEntry) {
-                return $persistedEntry->isArchived();
-            }));
-
-        $res = $readabilityImport->setMarkAsRead(true)->import();
-
-        $this->assertTrue($res);
-
-        $this->assertEquals(['skipped' => 1, 'imported' => 1, 'queued' => 0], $readabilityImport->getSummary());
-    }
-
-    public function testImportWithRabbit()
-    {
-        $readabilityImport = $this->getReadabilityImport();
-        $readabilityImport->setFilepath(__DIR__.'/../fixtures/readability.json');
-
-        $entryRepo = $this->getMockBuilder('Wallabag\CoreBundle\Repository\EntryRepository')
-            ->disableOriginalConstructor()
-            ->getMock();
-
-        $entryRepo->expects($this->never())
-            ->method('findByUrlAndUserId');
-
-        $this->em
-            ->expects($this->never())
-            ->method('getRepository');
-
-        $entry = $this->getMockBuilder('Wallabag\CoreBundle\Entity\Entry')
-            ->disableOriginalConstructor()
-            ->getMock();
-
-        $this->contentProxy
-            ->expects($this->never())
-            ->method('updateEntry');
-
-        $producer = $this->getMockBuilder('OldSound\RabbitMqBundle\RabbitMq\Producer')
-            ->disableOriginalConstructor()
-            ->getMock();
-
-        $producer
-            ->expects($this->exactly(3))
-            ->method('publish');
-
-        $readabilityImport->setProducer($producer);
-
-        $res = $readabilityImport->setMarkAsRead(true)->import();
-
-        $this->assertTrue($res);
-        $this->assertEquals(['skipped' => 0, 'imported' => 0, 'queued' => 3], $readabilityImport->getSummary());
-    }
-
-    public function testImportWithRedis()
-    {
-        $readabilityImport = $this->getReadabilityImport();
-        $readabilityImport->setFilepath(__DIR__.'/../fixtures/readability.json');
-
-        $entryRepo = $this->getMockBuilder('Wallabag\CoreBundle\Repository\EntryRepository')
-            ->disableOriginalConstructor()
-            ->getMock();
-
-        $entryRepo->expects($this->never())
-            ->method('findByUrlAndUserId');
-
-        $this->em
-            ->expects($this->never())
-            ->method('getRepository');
-
-        $entry = $this->getMockBuilder('Wallabag\CoreBundle\Entity\Entry')
-            ->disableOriginalConstructor()
-            ->getMock();
-
-        $this->contentProxy
-            ->expects($this->never())
-            ->method('updateEntry');
-
-        $factory = new RedisMockFactory();
-        $redisMock = $factory->getAdapter('Predis\Client', true);
-
-        $queue = new RedisQueue($redisMock, 'readability');
-        $producer = new Producer($queue);
-
-        $readabilityImport->setProducer($producer);
-
-        $res = $readabilityImport->setMarkAsRead(true)->import();
-
-        $this->assertTrue($res);
-        $this->assertEquals(['skipped' => 0, 'imported' => 0, 'queued' => 3], $readabilityImport->getSummary());
-
-        $this->assertNotEmpty($redisMock->lpop('readability'));
-    }
-
-    public function testImportBadFile()
-    {
-        $readabilityImport = $this->getReadabilityImport();
-        $readabilityImport->setFilepath(__DIR__.'/../fixtures/wallabag-v1.jsonx');
-
-        $res = $readabilityImport->import();
-
-        $this->assertFalse($res);
-
-        $records = $this->logHandler->getRecords();
-        $this->assertContains('ReadabilityImport: unable to read file', $records[0]['message']);
-        $this->assertEquals('ERROR', $records[0]['level_name']);
-    }
-
-    public function testImportUserNotDefined()
-    {
-        $readabilityImport = $this->getReadabilityImport(true);
-        $readabilityImport->setFilepath(__DIR__.'/../fixtures/readability.json');
-
-        $res = $readabilityImport->import();
-
-        $this->assertFalse($res);
-
-        $records = $this->logHandler->getRecords();
-        $this->assertContains('ReadabilityImport: user is not defined', $records[0]['message']);
-        $this->assertEquals('ERROR', $records[0]['level_name']);
     }
 }

--- a/tests/Wallabag/ImportBundle/Import/WallabagV1ImportTest.php
+++ b/tests/Wallabag/ImportBundle/Import/WallabagV1ImportTest.php
@@ -2,14 +2,14 @@
 
 namespace Tests\Wallabag\ImportBundle\Import;
 
-use Wallabag\ImportBundle\Import\WallabagV1Import;
-use Wallabag\UserBundle\Entity\User;
-use Wallabag\CoreBundle\Entity\Entry;
-use Wallabag\ImportBundle\Redis\Producer;
-use Monolog\Logger;
-use Monolog\Handler\TestHandler;
-use Simpleue\Queue\RedisQueue;
 use M6Web\Component\RedisMock\RedisMockFactory;
+use Monolog\Handler\TestHandler;
+use Monolog\Logger;
+use Simpleue\Queue\RedisQueue;
+use Wallabag\CoreBundle\Entity\Entry;
+use Wallabag\ImportBundle\Import\WallabagV1Import;
+use Wallabag\ImportBundle\Redis\Producer;
+use Wallabag\UserBundle\Entity\User;
 
 class WallabagV1ImportTest extends \PHPUnit_Framework_TestCase
 {
@@ -21,6 +21,194 @@ class WallabagV1ImportTest extends \PHPUnit_Framework_TestCase
     protected $uow;
     protected $fetchingErrorMessageTitle = 'No title found';
     protected $fetchingErrorMessage = 'wallabag can\'t retrieve contents for this article. Please <a href="http://doc.wallabag.org/en/master/user/errors_during_fetching.html#how-can-i-help-to-fix-that">troubleshoot this issue</a>.';
+
+    public function testInit()
+    {
+        $wallabagV1Import = $this->getWallabagV1Import();
+
+        $this->assertSame('wallabag v1', $wallabagV1Import->getName());
+        $this->assertNotEmpty($wallabagV1Import->getUrl());
+        $this->assertSame('import.wallabag_v1.description', $wallabagV1Import->getDescription());
+    }
+
+    public function testImport()
+    {
+        $wallabagV1Import = $this->getWallabagV1Import(false, 1);
+        $wallabagV1Import->setFilepath(__DIR__ . '/../fixtures/wallabag-v1.json');
+
+        $entryRepo = $this->getMockBuilder('Wallabag\CoreBundle\Repository\EntryRepository')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $entryRepo->expects($this->exactly(2))
+            ->method('findByUrlAndUserId')
+            ->will($this->onConsecutiveCalls(false, true, false, false));
+
+        $this->em
+            ->expects($this->any())
+            ->method('getRepository')
+            ->willReturn($entryRepo);
+
+        $entry = $this->getMockBuilder('Wallabag\CoreBundle\Entity\Entry')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $this->contentProxy
+            ->expects($this->exactly(1))
+            ->method('updateEntry')
+            ->willReturn($entry);
+
+        $res = $wallabagV1Import->import();
+
+        $this->assertTrue($res);
+        $this->assertSame(['skipped' => 1, 'imported' => 1, 'queued' => 0], $wallabagV1Import->getSummary());
+    }
+
+    public function testImportAndMarkAllAsRead()
+    {
+        $wallabagV1Import = $this->getWallabagV1Import(false, 3);
+        $wallabagV1Import->setFilepath(__DIR__ . '/../fixtures/wallabag-v1-read.json');
+
+        $entryRepo = $this->getMockBuilder('Wallabag\CoreBundle\Repository\EntryRepository')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $entryRepo->expects($this->exactly(3))
+            ->method('findByUrlAndUserId')
+            ->will($this->onConsecutiveCalls(false, false, false));
+
+        $this->em
+            ->expects($this->any())
+            ->method('getRepository')
+            ->willReturn($entryRepo);
+
+        $this->contentProxy
+            ->expects($this->exactly(3))
+            ->method('updateEntry')
+            ->willReturn(new Entry($this->user));
+
+        // check that every entry persisted are archived
+        $this->em
+            ->expects($this->any())
+            ->method('persist')
+            ->with($this->callback(function ($persistedEntry) {
+                return $persistedEntry->isArchived();
+            }));
+
+        $res = $wallabagV1Import->setMarkAsRead(true)->import();
+
+        $this->assertTrue($res);
+
+        $this->assertSame(['skipped' => 0, 'imported' => 3, 'queued' => 0], $wallabagV1Import->getSummary());
+    }
+
+    public function testImportWithRabbit()
+    {
+        $wallabagV1Import = $this->getWallabagV1Import();
+        $wallabagV1Import->setFilepath(__DIR__ . '/../fixtures/wallabag-v1.json');
+
+        $entryRepo = $this->getMockBuilder('Wallabag\CoreBundle\Repository\EntryRepository')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $entryRepo->expects($this->never())
+            ->method('findByUrlAndUserId');
+
+        $this->em
+            ->expects($this->never())
+            ->method('getRepository');
+
+        $entry = $this->getMockBuilder('Wallabag\CoreBundle\Entity\Entry')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $this->contentProxy
+            ->expects($this->never())
+            ->method('updateEntry');
+
+        $producer = $this->getMockBuilder('OldSound\RabbitMqBundle\RabbitMq\Producer')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $producer
+            ->expects($this->exactly(2))
+            ->method('publish');
+
+        $wallabagV1Import->setProducer($producer);
+
+        $res = $wallabagV1Import->setMarkAsRead(true)->import();
+
+        $this->assertTrue($res);
+        $this->assertSame(['skipped' => 0, 'imported' => 0, 'queued' => 2], $wallabagV1Import->getSummary());
+    }
+
+    public function testImportWithRedis()
+    {
+        $wallabagV1Import = $this->getWallabagV1Import();
+        $wallabagV1Import->setFilepath(__DIR__ . '/../fixtures/wallabag-v1.json');
+
+        $entryRepo = $this->getMockBuilder('Wallabag\CoreBundle\Repository\EntryRepository')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $entryRepo->expects($this->never())
+            ->method('findByUrlAndUserId');
+
+        $this->em
+            ->expects($this->never())
+            ->method('getRepository');
+
+        $entry = $this->getMockBuilder('Wallabag\CoreBundle\Entity\Entry')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $this->contentProxy
+            ->expects($this->never())
+            ->method('updateEntry');
+
+        $factory = new RedisMockFactory();
+        $redisMock = $factory->getAdapter('Predis\Client', true);
+
+        $queue = new RedisQueue($redisMock, 'wallabag_v1');
+        $producer = new Producer($queue);
+
+        $wallabagV1Import->setProducer($producer);
+
+        $res = $wallabagV1Import->setMarkAsRead(true)->import();
+
+        $this->assertTrue($res);
+        $this->assertSame(['skipped' => 0, 'imported' => 0, 'queued' => 2], $wallabagV1Import->getSummary());
+
+        $this->assertNotEmpty($redisMock->lpop('wallabag_v1'));
+    }
+
+    public function testImportBadFile()
+    {
+        $wallabagV1Import = $this->getWallabagV1Import();
+        $wallabagV1Import->setFilepath(__DIR__ . '/../fixtures/wallabag-v1.jsonx');
+
+        $res = $wallabagV1Import->import();
+
+        $this->assertFalse($res);
+
+        $records = $this->logHandler->getRecords();
+        $this->assertContains('WallabagImport: unable to read file', $records[0]['message']);
+        $this->assertSame('ERROR', $records[0]['level_name']);
+    }
+
+    public function testImportUserNotDefined()
+    {
+        $wallabagV1Import = $this->getWallabagV1Import(true);
+        $wallabagV1Import->setFilepath(__DIR__ . '/../fixtures/wallabag-v1.json');
+
+        $res = $wallabagV1Import->import();
+
+        $this->assertFalse($res);
+
+        $records = $this->logHandler->getRecords();
+        $this->assertContains('WallabagImport: user is not defined', $records[0]['message']);
+        $this->assertSame('ERROR', $records[0]['level_name']);
+    }
 
     private function getWallabagV1Import($unsetUser = false, $dispatched = 0)
     {
@@ -78,193 +266,5 @@ class WallabagV1ImportTest extends \PHPUnit_Framework_TestCase
         }
 
         return $wallabag;
-    }
-
-    public function testInit()
-    {
-        $wallabagV1Import = $this->getWallabagV1Import();
-
-        $this->assertEquals('wallabag v1', $wallabagV1Import->getName());
-        $this->assertNotEmpty($wallabagV1Import->getUrl());
-        $this->assertEquals('import.wallabag_v1.description', $wallabagV1Import->getDescription());
-    }
-
-    public function testImport()
-    {
-        $wallabagV1Import = $this->getWallabagV1Import(false, 1);
-        $wallabagV1Import->setFilepath(__DIR__.'/../fixtures/wallabag-v1.json');
-
-        $entryRepo = $this->getMockBuilder('Wallabag\CoreBundle\Repository\EntryRepository')
-            ->disableOriginalConstructor()
-            ->getMock();
-
-        $entryRepo->expects($this->exactly(2))
-            ->method('findByUrlAndUserId')
-            ->will($this->onConsecutiveCalls(false, true, false, false));
-
-        $this->em
-            ->expects($this->any())
-            ->method('getRepository')
-            ->willReturn($entryRepo);
-
-        $entry = $this->getMockBuilder('Wallabag\CoreBundle\Entity\Entry')
-            ->disableOriginalConstructor()
-            ->getMock();
-
-        $this->contentProxy
-            ->expects($this->exactly(1))
-            ->method('updateEntry')
-            ->willReturn($entry);
-
-        $res = $wallabagV1Import->import();
-
-        $this->assertTrue($res);
-        $this->assertEquals(['skipped' => 1, 'imported' => 1, 'queued' => 0], $wallabagV1Import->getSummary());
-    }
-
-    public function testImportAndMarkAllAsRead()
-    {
-        $wallabagV1Import = $this->getWallabagV1Import(false, 3);
-        $wallabagV1Import->setFilepath(__DIR__.'/../fixtures/wallabag-v1-read.json');
-
-        $entryRepo = $this->getMockBuilder('Wallabag\CoreBundle\Repository\EntryRepository')
-            ->disableOriginalConstructor()
-            ->getMock();
-
-        $entryRepo->expects($this->exactly(3))
-            ->method('findByUrlAndUserId')
-            ->will($this->onConsecutiveCalls(false, false, false));
-
-        $this->em
-            ->expects($this->any())
-            ->method('getRepository')
-            ->willReturn($entryRepo);
-
-        $this->contentProxy
-            ->expects($this->exactly(3))
-            ->method('updateEntry')
-            ->willReturn(new Entry($this->user));
-
-        // check that every entry persisted are archived
-        $this->em
-            ->expects($this->any())
-            ->method('persist')
-            ->with($this->callback(function ($persistedEntry) {
-                return $persistedEntry->isArchived();
-            }));
-
-        $res = $wallabagV1Import->setMarkAsRead(true)->import();
-
-        $this->assertTrue($res);
-
-        $this->assertEquals(['skipped' => 0, 'imported' => 3, 'queued' => 0], $wallabagV1Import->getSummary());
-    }
-
-    public function testImportWithRabbit()
-    {
-        $wallabagV1Import = $this->getWallabagV1Import();
-        $wallabagV1Import->setFilepath(__DIR__.'/../fixtures/wallabag-v1.json');
-
-        $entryRepo = $this->getMockBuilder('Wallabag\CoreBundle\Repository\EntryRepository')
-            ->disableOriginalConstructor()
-            ->getMock();
-
-        $entryRepo->expects($this->never())
-            ->method('findByUrlAndUserId');
-
-        $this->em
-            ->expects($this->never())
-            ->method('getRepository');
-
-        $entry = $this->getMockBuilder('Wallabag\CoreBundle\Entity\Entry')
-            ->disableOriginalConstructor()
-            ->getMock();
-
-        $this->contentProxy
-            ->expects($this->never())
-            ->method('updateEntry');
-
-        $producer = $this->getMockBuilder('OldSound\RabbitMqBundle\RabbitMq\Producer')
-            ->disableOriginalConstructor()
-            ->getMock();
-
-        $producer
-            ->expects($this->exactly(2))
-            ->method('publish');
-
-        $wallabagV1Import->setProducer($producer);
-
-        $res = $wallabagV1Import->setMarkAsRead(true)->import();
-
-        $this->assertTrue($res);
-        $this->assertEquals(['skipped' => 0, 'imported' => 0, 'queued' => 2], $wallabagV1Import->getSummary());
-    }
-
-    public function testImportWithRedis()
-    {
-        $wallabagV1Import = $this->getWallabagV1Import();
-        $wallabagV1Import->setFilepath(__DIR__.'/../fixtures/wallabag-v1.json');
-
-        $entryRepo = $this->getMockBuilder('Wallabag\CoreBundle\Repository\EntryRepository')
-            ->disableOriginalConstructor()
-            ->getMock();
-
-        $entryRepo->expects($this->never())
-            ->method('findByUrlAndUserId');
-
-        $this->em
-            ->expects($this->never())
-            ->method('getRepository');
-
-        $entry = $this->getMockBuilder('Wallabag\CoreBundle\Entity\Entry')
-            ->disableOriginalConstructor()
-            ->getMock();
-
-        $this->contentProxy
-            ->expects($this->never())
-            ->method('updateEntry');
-
-        $factory = new RedisMockFactory();
-        $redisMock = $factory->getAdapter('Predis\Client', true);
-
-        $queue = new RedisQueue($redisMock, 'wallabag_v1');
-        $producer = new Producer($queue);
-
-        $wallabagV1Import->setProducer($producer);
-
-        $res = $wallabagV1Import->setMarkAsRead(true)->import();
-
-        $this->assertTrue($res);
-        $this->assertEquals(['skipped' => 0, 'imported' => 0, 'queued' => 2], $wallabagV1Import->getSummary());
-
-        $this->assertNotEmpty($redisMock->lpop('wallabag_v1'));
-    }
-
-    public function testImportBadFile()
-    {
-        $wallabagV1Import = $this->getWallabagV1Import();
-        $wallabagV1Import->setFilepath(__DIR__.'/../fixtures/wallabag-v1.jsonx');
-
-        $res = $wallabagV1Import->import();
-
-        $this->assertFalse($res);
-
-        $records = $this->logHandler->getRecords();
-        $this->assertContains('WallabagImport: unable to read file', $records[0]['message']);
-        $this->assertEquals('ERROR', $records[0]['level_name']);
-    }
-
-    public function testImportUserNotDefined()
-    {
-        $wallabagV1Import = $this->getWallabagV1Import(true);
-        $wallabagV1Import->setFilepath(__DIR__.'/../fixtures/wallabag-v1.json');
-
-        $res = $wallabagV1Import->import();
-
-        $this->assertFalse($res);
-
-        $records = $this->logHandler->getRecords();
-        $this->assertContains('WallabagImport: user is not defined', $records[0]['message']);
-        $this->assertEquals('ERROR', $records[0]['level_name']);
     }
 }

--- a/tests/Wallabag/ImportBundle/Import/WallabagV2ImportTest.php
+++ b/tests/Wallabag/ImportBundle/Import/WallabagV2ImportTest.php
@@ -2,14 +2,14 @@
 
 namespace Tests\Wallabag\ImportBundle\Import;
 
-use Wallabag\ImportBundle\Import\WallabagV2Import;
-use Wallabag\UserBundle\Entity\User;
-use Wallabag\CoreBundle\Entity\Entry;
-use Wallabag\ImportBundle\Redis\Producer;
-use Monolog\Logger;
-use Monolog\Handler\TestHandler;
-use Simpleue\Queue\RedisQueue;
 use M6Web\Component\RedisMock\RedisMockFactory;
+use Monolog\Handler\TestHandler;
+use Monolog\Logger;
+use Simpleue\Queue\RedisQueue;
+use Wallabag\CoreBundle\Entity\Entry;
+use Wallabag\ImportBundle\Import\WallabagV2Import;
+use Wallabag\ImportBundle\Redis\Producer;
+use Wallabag\UserBundle\Entity\User;
 
 class WallabagV2ImportTest extends \PHPUnit_Framework_TestCase
 {
@@ -19,6 +19,222 @@ class WallabagV2ImportTest extends \PHPUnit_Framework_TestCase
     protected $contentProxy;
     protected $tagsAssigner;
     protected $uow;
+
+    public function testInit()
+    {
+        $wallabagV2Import = $this->getWallabagV2Import();
+
+        $this->assertSame('wallabag v2', $wallabagV2Import->getName());
+        $this->assertNotEmpty($wallabagV2Import->getUrl());
+        $this->assertSame('import.wallabag_v2.description', $wallabagV2Import->getDescription());
+    }
+
+    public function testImport()
+    {
+        $wallabagV2Import = $this->getWallabagV2Import(false, 2);
+        $wallabagV2Import->setFilepath(__DIR__ . '/../fixtures/wallabag-v2.json');
+
+        $entryRepo = $this->getMockBuilder('Wallabag\CoreBundle\Repository\EntryRepository')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $entryRepo->expects($this->exactly(6))
+            ->method('findByUrlAndUserId')
+            ->will($this->onConsecutiveCalls(false, true, false));
+
+        $this->em
+            ->expects($this->any())
+            ->method('getRepository')
+            ->willReturn($entryRepo);
+
+        $this->contentProxy
+            ->expects($this->exactly(2))
+            ->method('updateEntry')
+            ->willReturn(new Entry($this->user));
+
+        $res = $wallabagV2Import->import();
+
+        $this->assertTrue($res);
+        $this->assertSame(['skipped' => 4, 'imported' => 2, 'queued' => 0], $wallabagV2Import->getSummary());
+    }
+
+    public function testImportAndMarkAllAsRead()
+    {
+        $wallabagV2Import = $this->getWallabagV2Import(false, 2);
+        $wallabagV2Import->setFilepath(__DIR__ . '/../fixtures/wallabag-v2-read.json');
+
+        $entryRepo = $this->getMockBuilder('Wallabag\CoreBundle\Repository\EntryRepository')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $entryRepo->expects($this->exactly(2))
+            ->method('findByUrlAndUserId')
+            ->will($this->onConsecutiveCalls(false, false));
+
+        $this->em
+            ->expects($this->any())
+            ->method('getRepository')
+            ->willReturn($entryRepo);
+
+        $this->contentProxy
+            ->expects($this->exactly(2))
+            ->method('updateEntry')
+            ->willReturn(new Entry($this->user));
+
+        // check that every entry persisted are archived
+        $this->em
+            ->expects($this->any())
+            ->method('persist')
+            ->with($this->callback(function ($persistedEntry) {
+                return $persistedEntry->isArchived();
+            }));
+
+        $res = $wallabagV2Import->setMarkAsRead(true)->import();
+
+        $this->assertTrue($res);
+
+        $this->assertSame(['skipped' => 0, 'imported' => 2, 'queued' => 0], $wallabagV2Import->getSummary());
+    }
+
+    public function testImportWithRabbit()
+    {
+        $wallabagV2Import = $this->getWallabagV2Import();
+        $wallabagV2Import->setFilepath(__DIR__ . '/../fixtures/wallabag-v2.json');
+
+        $entryRepo = $this->getMockBuilder('Wallabag\CoreBundle\Repository\EntryRepository')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $entryRepo->expects($this->never())
+            ->method('findByUrlAndUserId');
+
+        $this->em
+            ->expects($this->never())
+            ->method('getRepository');
+
+        $this->contentProxy
+            ->expects($this->never())
+            ->method('updateEntry');
+
+        $producer = $this->getMockBuilder('OldSound\RabbitMqBundle\RabbitMq\Producer')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $producer
+            ->expects($this->exactly(6))
+            ->method('publish');
+
+        $wallabagV2Import->setProducer($producer);
+
+        $res = $wallabagV2Import->setMarkAsRead(true)->import();
+
+        $this->assertTrue($res);
+        $this->assertSame(['skipped' => 0, 'imported' => 0, 'queued' => 6], $wallabagV2Import->getSummary());
+    }
+
+    public function testImportWithRedis()
+    {
+        $wallabagV2Import = $this->getWallabagV2Import();
+        $wallabagV2Import->setFilepath(__DIR__ . '/../fixtures/wallabag-v2.json');
+
+        $entryRepo = $this->getMockBuilder('Wallabag\CoreBundle\Repository\EntryRepository')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $entryRepo->expects($this->never())
+            ->method('findByUrlAndUserId');
+
+        $this->em
+            ->expects($this->never())
+            ->method('getRepository');
+
+        $this->contentProxy
+            ->expects($this->never())
+            ->method('updateEntry');
+
+        $factory = new RedisMockFactory();
+        $redisMock = $factory->getAdapter('Predis\Client', true);
+
+        $queue = new RedisQueue($redisMock, 'wallabag_v2');
+        $producer = new Producer($queue);
+
+        $wallabagV2Import->setProducer($producer);
+
+        $res = $wallabagV2Import->setMarkAsRead(true)->import();
+
+        $this->assertTrue($res);
+        $this->assertSame(['skipped' => 0, 'imported' => 0, 'queued' => 6], $wallabagV2Import->getSummary());
+
+        $this->assertNotEmpty($redisMock->lpop('wallabag_v2'));
+    }
+
+    public function testImportBadFile()
+    {
+        $wallabagV1Import = $this->getWallabagV2Import();
+        $wallabagV1Import->setFilepath(__DIR__ . '/../fixtures/wallabag-v2.jsonx');
+
+        $res = $wallabagV1Import->import();
+
+        $this->assertFalse($res);
+
+        $records = $this->logHandler->getRecords();
+        $this->assertContains('WallabagImport: unable to read file', $records[0]['message']);
+        $this->assertSame('ERROR', $records[0]['level_name']);
+    }
+
+    public function testImportUserNotDefined()
+    {
+        $wallabagV1Import = $this->getWallabagV2Import(true);
+        $wallabagV1Import->setFilepath(__DIR__ . '/../fixtures/wallabag-v2.json');
+
+        $res = $wallabagV1Import->import();
+
+        $this->assertFalse($res);
+
+        $records = $this->logHandler->getRecords();
+        $this->assertContains('WallabagImport: user is not defined', $records[0]['message']);
+        $this->assertSame('ERROR', $records[0]['level_name']);
+    }
+
+    public function testImportEmptyFile()
+    {
+        $wallabagV2Import = $this->getWallabagV2Import();
+        $wallabagV2Import->setFilepath(__DIR__ . '/../fixtures/wallabag-v2-empty.json');
+
+        $res = $wallabagV2Import->import();
+
+        $this->assertFalse($res);
+        $this->assertSame(['skipped' => 0, 'imported' => 0, 'queued' => 0], $wallabagV2Import->getSummary());
+    }
+
+    public function testImportWithExceptionFromGraby()
+    {
+        $wallabagV2Import = $this->getWallabagV2Import(false, 2);
+        $wallabagV2Import->setFilepath(__DIR__ . '/../fixtures/wallabag-v2.json');
+
+        $entryRepo = $this->getMockBuilder('Wallabag\CoreBundle\Repository\EntryRepository')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $entryRepo->expects($this->exactly(6))
+            ->method('findByUrlAndUserId')
+            ->will($this->onConsecutiveCalls(false, true, false));
+
+        $this->em
+            ->expects($this->any())
+            ->method('getRepository')
+            ->willReturn($entryRepo);
+
+        $this->contentProxy
+            ->expects($this->exactly(2))
+            ->method('updateEntry')
+            ->will($this->throwException(new \Exception()));
+
+        $res = $wallabagV2Import->import();
+
+        $this->assertTrue($res);
+        $this->assertSame(['skipped' => 4, 'imported' => 2, 'queued' => 0], $wallabagV2Import->getSummary());
+    }
 
     private function getWallabagV2Import($unsetUser = false, $dispatched = 0)
     {
@@ -69,221 +285,5 @@ class WallabagV2ImportTest extends \PHPUnit_Framework_TestCase
         }
 
         return $wallabag;
-    }
-
-    public function testInit()
-    {
-        $wallabagV2Import = $this->getWallabagV2Import();
-
-        $this->assertEquals('wallabag v2', $wallabagV2Import->getName());
-        $this->assertNotEmpty($wallabagV2Import->getUrl());
-        $this->assertEquals('import.wallabag_v2.description', $wallabagV2Import->getDescription());
-    }
-
-    public function testImport()
-    {
-        $wallabagV2Import = $this->getWallabagV2Import(false, 2);
-        $wallabagV2Import->setFilepath(__DIR__.'/../fixtures/wallabag-v2.json');
-
-        $entryRepo = $this->getMockBuilder('Wallabag\CoreBundle\Repository\EntryRepository')
-            ->disableOriginalConstructor()
-            ->getMock();
-
-        $entryRepo->expects($this->exactly(6))
-            ->method('findByUrlAndUserId')
-            ->will($this->onConsecutiveCalls(false, true, false));
-
-        $this->em
-            ->expects($this->any())
-            ->method('getRepository')
-            ->willReturn($entryRepo);
-
-        $this->contentProxy
-            ->expects($this->exactly(2))
-            ->method('updateEntry')
-            ->willReturn(new Entry($this->user));
-
-        $res = $wallabagV2Import->import();
-
-        $this->assertTrue($res);
-        $this->assertEquals(['skipped' => 4, 'imported' => 2, 'queued' => 0], $wallabagV2Import->getSummary());
-    }
-
-    public function testImportAndMarkAllAsRead()
-    {
-        $wallabagV2Import = $this->getWallabagV2Import(false, 2);
-        $wallabagV2Import->setFilepath(__DIR__.'/../fixtures/wallabag-v2-read.json');
-
-        $entryRepo = $this->getMockBuilder('Wallabag\CoreBundle\Repository\EntryRepository')
-            ->disableOriginalConstructor()
-            ->getMock();
-
-        $entryRepo->expects($this->exactly(2))
-            ->method('findByUrlAndUserId')
-            ->will($this->onConsecutiveCalls(false, false));
-
-        $this->em
-            ->expects($this->any())
-            ->method('getRepository')
-            ->willReturn($entryRepo);
-
-        $this->contentProxy
-            ->expects($this->exactly(2))
-            ->method('updateEntry')
-            ->willReturn(new Entry($this->user));
-
-        // check that every entry persisted are archived
-        $this->em
-            ->expects($this->any())
-            ->method('persist')
-            ->with($this->callback(function ($persistedEntry) {
-                return $persistedEntry->isArchived();
-            }));
-
-        $res = $wallabagV2Import->setMarkAsRead(true)->import();
-
-        $this->assertTrue($res);
-
-        $this->assertEquals(['skipped' => 0, 'imported' => 2, 'queued' => 0], $wallabagV2Import->getSummary());
-    }
-
-    public function testImportWithRabbit()
-    {
-        $wallabagV2Import = $this->getWallabagV2Import();
-        $wallabagV2Import->setFilepath(__DIR__.'/../fixtures/wallabag-v2.json');
-
-        $entryRepo = $this->getMockBuilder('Wallabag\CoreBundle\Repository\EntryRepository')
-            ->disableOriginalConstructor()
-            ->getMock();
-
-        $entryRepo->expects($this->never())
-            ->method('findByUrlAndUserId');
-
-        $this->em
-            ->expects($this->never())
-            ->method('getRepository');
-
-        $this->contentProxy
-            ->expects($this->never())
-            ->method('updateEntry');
-
-        $producer = $this->getMockBuilder('OldSound\RabbitMqBundle\RabbitMq\Producer')
-            ->disableOriginalConstructor()
-            ->getMock();
-
-        $producer
-            ->expects($this->exactly(6))
-            ->method('publish');
-
-        $wallabagV2Import->setProducer($producer);
-
-        $res = $wallabagV2Import->setMarkAsRead(true)->import();
-
-        $this->assertTrue($res);
-        $this->assertEquals(['skipped' => 0, 'imported' => 0, 'queued' => 6], $wallabagV2Import->getSummary());
-    }
-
-    public function testImportWithRedis()
-    {
-        $wallabagV2Import = $this->getWallabagV2Import();
-        $wallabagV2Import->setFilepath(__DIR__.'/../fixtures/wallabag-v2.json');
-
-        $entryRepo = $this->getMockBuilder('Wallabag\CoreBundle\Repository\EntryRepository')
-            ->disableOriginalConstructor()
-            ->getMock();
-
-        $entryRepo->expects($this->never())
-            ->method('findByUrlAndUserId');
-
-        $this->em
-            ->expects($this->never())
-            ->method('getRepository');
-
-        $this->contentProxy
-            ->expects($this->never())
-            ->method('updateEntry');
-
-        $factory = new RedisMockFactory();
-        $redisMock = $factory->getAdapter('Predis\Client', true);
-
-        $queue = new RedisQueue($redisMock, 'wallabag_v2');
-        $producer = new Producer($queue);
-
-        $wallabagV2Import->setProducer($producer);
-
-        $res = $wallabagV2Import->setMarkAsRead(true)->import();
-
-        $this->assertTrue($res);
-        $this->assertEquals(['skipped' => 0, 'imported' => 0, 'queued' => 6], $wallabagV2Import->getSummary());
-
-        $this->assertNotEmpty($redisMock->lpop('wallabag_v2'));
-    }
-
-    public function testImportBadFile()
-    {
-        $wallabagV1Import = $this->getWallabagV2Import();
-        $wallabagV1Import->setFilepath(__DIR__.'/../fixtures/wallabag-v2.jsonx');
-
-        $res = $wallabagV1Import->import();
-
-        $this->assertFalse($res);
-
-        $records = $this->logHandler->getRecords();
-        $this->assertContains('WallabagImport: unable to read file', $records[0]['message']);
-        $this->assertEquals('ERROR', $records[0]['level_name']);
-    }
-
-    public function testImportUserNotDefined()
-    {
-        $wallabagV1Import = $this->getWallabagV2Import(true);
-        $wallabagV1Import->setFilepath(__DIR__.'/../fixtures/wallabag-v2.json');
-
-        $res = $wallabagV1Import->import();
-
-        $this->assertFalse($res);
-
-        $records = $this->logHandler->getRecords();
-        $this->assertContains('WallabagImport: user is not defined', $records[0]['message']);
-        $this->assertEquals('ERROR', $records[0]['level_name']);
-    }
-
-    public function testImportEmptyFile()
-    {
-        $wallabagV2Import = $this->getWallabagV2Import();
-        $wallabagV2Import->setFilepath(__DIR__.'/../fixtures/wallabag-v2-empty.json');
-
-        $res = $wallabagV2Import->import();
-
-        $this->assertFalse($res);
-        $this->assertEquals(['skipped' => 0, 'imported' => 0, 'queued' => 0], $wallabagV2Import->getSummary());
-    }
-
-    public function testImportWithExceptionFromGraby()
-    {
-        $wallabagV2Import = $this->getWallabagV2Import(false, 2);
-        $wallabagV2Import->setFilepath(__DIR__.'/../fixtures/wallabag-v2.json');
-
-        $entryRepo = $this->getMockBuilder('Wallabag\CoreBundle\Repository\EntryRepository')
-            ->disableOriginalConstructor()
-            ->getMock();
-
-        $entryRepo->expects($this->exactly(6))
-            ->method('findByUrlAndUserId')
-            ->will($this->onConsecutiveCalls(false, true, false));
-
-        $this->em
-            ->expects($this->any())
-            ->method('getRepository')
-            ->willReturn($entryRepo);
-
-        $this->contentProxy
-            ->expects($this->exactly(2))
-            ->method('updateEntry')
-            ->will($this->throwException(new \Exception()));
-
-        $res = $wallabagV2Import->import();
-
-        $this->assertTrue($res);
-        $this->assertEquals(['skipped' => 4, 'imported' => 2, 'queued' => 0], $wallabagV2Import->getSummary());
     }
 }

--- a/tests/Wallabag/UserBundle/Controller/ManageControllerTest.php
+++ b/tests/Wallabag/UserBundle/Controller/ManageControllerTest.php
@@ -12,7 +12,7 @@ class ManageControllerTest extends WallabagCoreTestCase
 
         $client->request('GET', '/users/list');
 
-        $this->assertEquals(302, $client->getResponse()->getStatusCode());
+        $this->assertSame(302, $client->getResponse()->getStatusCode());
         $this->assertContains('login', $client->getResponse()->headers->get('location'));
     }
 
@@ -23,16 +23,16 @@ class ManageControllerTest extends WallabagCoreTestCase
 
         // Create a new user in the database
         $crawler = $client->request('GET', '/users/list');
-        $this->assertEquals(200, $client->getResponse()->getStatusCode(), 'Unexpected HTTP status code for GET /users/');
+        $this->assertSame(200, $client->getResponse()->getStatusCode(), 'Unexpected HTTP status code for GET /users/');
         $crawler = $client->click($crawler->selectLink('user.list.create_new_one')->link());
 
         // Fill in the form and submit it
-        $form = $crawler->selectButton('user.form.save')->form(array(
+        $form = $crawler->selectButton('user.form.save')->form([
             'new_user[username]' => 'test_user',
             'new_user[email]' => 'test@test.io',
             'new_user[plainPassword][first]' => 'testtest',
             'new_user[plainPassword][second]' => 'testtest',
-        ));
+        ]);
 
         $client->submit($form);
         $client->followRedirect();
@@ -44,12 +44,12 @@ class ManageControllerTest extends WallabagCoreTestCase
         // Edit the user
         $crawler = $client->click($crawler->selectLink('user.list.edit_action')->last()->link());
 
-        $form = $crawler->selectButton('user.form.save')->form(array(
+        $form = $crawler->selectButton('user.form.save')->form([
             'user[name]' => 'Foo User',
             'user[username]' => 'test_user',
             'user[email]' => 'test@test.io',
             'user[enabled]' => true,
-        ));
+        ]);
 
         $client->submit($form);
         $crawler = $client->followRedirect();
@@ -73,10 +73,10 @@ class ManageControllerTest extends WallabagCoreTestCase
         $this->logInAs('admin');
         $client = $this->getClient();
 
-        $crawler = $client->request('GET', '/users/'.$this->getLoggedInUserId().'/edit');
+        $crawler = $client->request('GET', '/users/' . $this->getLoggedInUserId() . '/edit');
         $disabled = $crawler->selectButton('user.form.delete')->extract('disabled');
 
-        $this->assertEquals('disabled', $disabled[0]);
+        $this->assertSame('disabled', $disabled[0]);
     }
 
     public function testUserSearch()

--- a/tests/Wallabag/UserBundle/EventListener/AuthenticationFailureListenerTest.php
+++ b/tests/Wallabag/UserBundle/EventListener/AuthenticationFailureListenerTest.php
@@ -2,14 +2,14 @@
 
 namespace Tests\Wallabag\UserBundle\EventListener;
 
+use Monolog\Handler\TestHandler;
+use Monolog\Logger;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Component\HttpFoundation\Request;
-use Wallabag\UserBundle\EventListener\AuthenticationFailureListener;
-use Monolog\Logger;
-use Monolog\Handler\TestHandler;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\Security\Core\AuthenticationEvents;
 use Symfony\Component\Security\Core\Event\AuthenticationFailureEvent;
+use Wallabag\UserBundle\EventListener\AuthenticationFailureListener;
 
 class AuthenticationFailureListenerTest extends \PHPUnit_Framework_TestCase
 {

--- a/tests/Wallabag/UserBundle/EventListener/CreateConfigListenerTest.php
+++ b/tests/Wallabag/UserBundle/EventListener/CreateConfigListenerTest.php
@@ -8,8 +8,8 @@ use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Wallabag\CoreBundle\Entity\Config;
-use Wallabag\UserBundle\EventListener\CreateConfigListener;
 use Wallabag\UserBundle\Entity\User;
+use Wallabag\UserBundle\EventListener\CreateConfigListener;
 
 class CreateConfigListenerTest extends \PHPUnit_Framework_TestCase
 {

--- a/tests/Wallabag/UserBundle/Mailer/AuthCodeMailerTest.php
+++ b/tests/Wallabag/UserBundle/Mailer/AuthCodeMailerTest.php
@@ -68,8 +68,8 @@ TWIG;
 
         $msg = $this->spool->getMessages()[0];
         $this->assertArrayHasKey('test@wallabag.io', $msg->getTo());
-        $this->assertEquals(['nobody@test.io' => 'wallabag test'], $msg->getFrom());
-        $this->assertEquals('subject', $msg->getSubject());
+        $this->assertSame(['nobody@test.io' => 'wallabag test'], $msg->getFrom());
+        $this->assertSame('subject', $msg->getSubject());
         $this->assertContains('text body http://0.0.0.0/support', $msg->toString());
         $this->assertContains('html body 666666', $msg->toString());
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | don't know
| Documentation | no
| Translation   | no
| Fixed tickets | #...
| License       | MIT

I added a real configuration for php-cs-fixer (see `.php_cs`). All decisions are not acted we can discuss them.
I haven't launched the test suite but I think it might failed regarding the change from `assertEquals` to `assertSame`.