### PR TITLE
Use the article publisher as author for exported files

### DIFF
--- a/src/Wallabag/ApiBundle/Controller/EntryRestController.php
+++ b/src/Wallabag/ApiBundle/Controller/EntryRestController.php
@@ -180,6 +180,7 @@ class EntryRestController extends WallabagRestController
         return $this->get('wallabag_core.helper.entries_export')
             ->setEntries($entry)
             ->updateTitle('entry')
+            ->updateAuthor('entry')
             ->exportAs($request->attributes->get('_format'));
     }
 

--- a/src/Wallabag/CoreBundle/Command/ExportCommand.php
+++ b/src/Wallabag/CoreBundle/Command/ExportCommand.php
@@ -56,6 +56,7 @@ class ExportCommand extends ContainerAwareCommand
             $data = $this->getContainer()->get('wallabag_core.helper.entries_export')
                 ->setEntries($entries)
                 ->updateTitle('All')
+                ->updateAuthor('All')
                 ->exportJsonData();
             file_put_contents($filePath, $data);
         } catch (\InvalidArgumentException $e) {

--- a/src/Wallabag/CoreBundle/Controller/ExportController.php
+++ b/src/Wallabag/CoreBundle/Controller/ExportController.php
@@ -33,6 +33,7 @@ class ExportController extends Controller
             return $this->get('wallabag_core.helper.entries_export')
                 ->setEntries($entry)
                 ->updateTitle('entry')
+                ->updateAuthor('entry')
                 ->exportAs($format);
         } catch (\InvalidArgumentException $e) {
             throw new NotFoundHttpException($e->getMessage());
@@ -76,6 +77,7 @@ class ExportController extends Controller
             return $this->get('wallabag_core.helper.entries_export')
                 ->setEntries($entries)
                 ->updateTitle($method)
+                ->updateAuthor($method)
                 ->exportAs($format);
         } catch (\InvalidArgumentException $e) {
             throw new NotFoundHttpException($e->getMessage());

--- a/src/Wallabag/CoreBundle/Helper/EntriesExport.php
+++ b/src/Wallabag/CoreBundle/Helper/EntriesExport.php
@@ -18,7 +18,7 @@ class EntriesExport
     private $logoPath;
     private $title = '';
     private $entries = [];
-    private $authors = ['wallabag'];
+    private $author = 'wallabag';
     private $language = '';
     private $footerTemplate = '<div style="text-align:center;">
         <p>Produced by wallabag with %EXPORT_METHOD%</p>
@@ -67,6 +67,24 @@ class EntriesExport
 
         if ('entry' === $method) {
             $this->title = $this->entries[0]->getTitle();
+        }
+
+        return $this;
+    }
+
+    /**
+     * Sets the author for just one entry.
+     *
+     * @param string $method Method to get articles
+     *
+     * @return EntriesExport
+     */
+    public function updateAuthor($method)
+    {
+        $this->author = $method.' authors';
+
+        if ('entry' === $method) {
+            $this->author = $this->entries[0]->getDomainName();
         }
 
         return $this;
@@ -128,9 +146,7 @@ class EntriesExport
         $book->setLanguage($this->language);
         $book->setDescription('Some articles saved on my wallabag');
 
-        foreach ($this->authors as $author) {
-            $book->setAuthor($author, $author);
-        }
+        $book->setAuthor($this->author, $this->author);
 
         // I hope this is a non existant address :)
         $book->setPublisher('wallabag', 'wallabag');
@@ -196,7 +212,7 @@ class EntriesExport
          * Book metadata
          */
         $content->set('title', $this->title);
-        $content->set('author', implode($this->authors));
+        $content->set('author', $this->author);
         $content->set('subject', $this->title);
 
         /*
@@ -247,7 +263,7 @@ class EntriesExport
          * Book metadata
          */
         $pdf->SetCreator(PDF_CREATOR);
-        $pdf->SetAuthor('wallabag');
+        $pdf->SetAuthor($this->author);
         $pdf->SetTitle($this->title);
         $pdf->SetSubject('Articles via wallabag');
         $pdf->SetKeywords('wallabag');

--- a/src/Wallabag/CoreBundle/Helper/EntriesExport.php
+++ b/src/Wallabag/CoreBundle/Helper/EntriesExport.php
@@ -73,7 +73,9 @@ class EntriesExport
     }
 
     /**
-     * Sets the author for just one entry.
+     * Sets the author for one entry or category.
+     *
+     * The publishers are used, or the domain name if empty.
      *
      * @param string $method Method to get articles
      *
@@ -84,7 +86,12 @@ class EntriesExport
         $this->author = $method.' authors';
 
         if ('entry' === $method) {
-            $this->author = $this->entries[0]->getDomainName();
+            $publishedBy = $this->entries[0]->getPublishedBy();
+            if (!empty($publishedBy)) {
+                $this->author = implode(', ', $this->entries[0]->getPublishedBy());
+            } else {
+                $this->author = $this->entries[0]->getDomainName();
+            }
         }
 
         return $this;

--- a/src/Wallabag/CoreBundle/Helper/EntriesExport.php
+++ b/src/Wallabag/CoreBundle/Helper/EntriesExport.php
@@ -83,15 +83,17 @@ class EntriesExport
      */
     public function updateAuthor($method)
     {
-        $this->author = $method.' authors';
+        if ('entry' !== $method) {
+            $this->author = $method . ' authors';
 
-        if ('entry' === $method) {
-            $publishedBy = $this->entries[0]->getPublishedBy();
-            if (!empty($publishedBy)) {
-                $this->author = implode(', ', $this->entries[0]->getPublishedBy());
-            } else {
-                $this->author = $this->entries[0]->getDomainName();
-            }
+            return $this;
+        }
+
+        $this->author = $this->entries[0]->getDomainName();
+
+        $publishedBy = $this->entries[0]->getPublishedBy();
+        if (!empty($publishedBy)) {
+            $this->author = implode(', ', $publishedBy);
         }
 
         return $this;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | maybe
| Documentation | no
| Translation   | no
| License       | MIT

As mentioned in #2821, the author of an epub file is always "wallabag".

This PR introduces another author:
- When exporting a single article to epub, mobi, and pdf, use the article domain for the "author" metadata
- When exporting multiple articles in one file (all or category), the author is set to "_All authors_" or "_&lt;category> authors_", similar to the title ("_All articles_" or "_&lt;category> articles_"). Please tell me if you would rather display a list of all the authors of the exported articles; I can do that instead.

N.B.: I changed the author from array to string, because for now, there is always only one author.