### PR TITLE
Disallow html for API templating formats

### DIFF
--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -110,7 +110,7 @@ fos_rest:
             epub: true
             mobi: true
         templating_formats:
-            html: true
+            html: false
         force_redirects:
             html: true
         failed_validation: HTTP_BAD_REQUEST


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Documentation | no
| Translation   | no
| Fixed tickets | https://github.com/wallabag/wallabag/issues/3268
| License       | MIT

Using html template format will then put the html format in the allowed list for the api doc which we don’t want since the api doesn’t response for html format.
