### PR TITLE
Put the final URL in data test

### DIFF
--- a/src/Wallabag/ImportBundle/Controller/BrowserController.php
+++ b/src/Wallabag/ImportBundle/Controller/BrowserController.php
@@ -80,10 +80,10 @@ abstract class BrowserController extends Controller
      */
     abstract protected function getImportService();
 
-     /**
-      * Return the template used for the form.
-      *
-      * @return string
-      */
-     abstract protected function getImportTemplate();
+    /**
+     * Return the template used for the form.
+     *
+     * @return string
+     */
+    abstract protected function getImportTemplate();
 }

--- a/tests/Wallabag/CoreBundle/Controller/EntryControllerTest.php
+++ b/tests/Wallabag/CoreBundle/Controller/EntryControllerTest.php
@@ -1300,7 +1300,7 @@ class EntryControllerTest extends WallabagCoreTestCase
                 null,
             ],
             'es-ES' => [
-                'http://www.muylinux.com/2015/04/17/odf-reino-unido-microsoft-google',
+                'http://www.muylinux.com/2015/04/17/odf-reino-unido-microsoft-google/',
                 'es_ES',
             ],
         ];


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Documentation | no
| Translation   | no
| Fixed tickets | #...
| License       | MIT

The previous url was redirected.
So while looking for that initial url in the database we couln't find it because it got and ending `/` at the end. Updating the initial url fix the problem.