### PR TITLE
Empty currentTag should be null

### DIFF
--- a/src/Wallabag/CoreBundle/Resources/views/themes/baggy/Entry/entries.html.twig
+++ b/src/Wallabag/CoreBundle/Resources/views/themes/baggy/Entry/entries.html.twig
@@ -86,7 +86,7 @@
 
     <!-- Export -->
     <aside id="download-form">
-    {% set currentTag = '' %}
+    {% set currentTag = null %}
     {% if tag is defined %}
         {% set currentTag = tag %}
     {% endif %}

--- a/src/Wallabag/CoreBundle/Resources/views/themes/material/Entry/entries.html.twig
+++ b/src/Wallabag/CoreBundle/Resources/views/themes/material/Entry/entries.html.twig
@@ -57,7 +57,7 @@
 
     <!-- Export -->
     <div id="export" class="side-nav right-aligned">
-    {% set currentTag = '' %}
+    {% set currentTag = null %}
     {% if tag is defined %}
         {% set currentTag = tag.slug %}
     {% endif %}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Documentation | no
| Translation   | yes
| Fixed tickets | #3019 (second part)
| License       | MIT

And when a parameter is null, it won't appear in the url like `?tag=`.