### PR TITLE
Multiple tag search, which was broken from API

### DIFF
--- a/src/Wallabag/CoreBundle/DataFixtures/ORM/LoadTagData.php
+++ b/src/Wallabag/CoreBundle/DataFixtures/ORM/LoadTagData.php
@@ -19,7 +19,7 @@ class LoadTagData extends AbstractFixture implements OrderedFixtureInterface
 
         $manager->persist($tag1);
 
-        $this->addReference('foo-tag', $tag1);
+        $this->addReference('foo-bar-tag', $tag1);
 
         $tag2 = new Tag();
         $tag2->setLabel('bar');
@@ -34,6 +34,13 @@ class LoadTagData extends AbstractFixture implements OrderedFixtureInterface
         $manager->persist($tag3);
 
         $this->addReference('baz-tag', $tag3);
+
+        $tag4 = new Tag();
+        $tag4->setLabel('foo');
+
+        $manager->persist($tag4);
+
+        $this->addReference('foo-tag', $tag4);
 
         $manager->flush();
     }

--- a/src/Wallabag/CoreBundle/Repository/EntryRepository.php
+++ b/src/Wallabag/CoreBundle/Repository/EntryRepository.php
@@ -156,7 +156,7 @@ class EntryRepository extends EntityRepository
                 $entryAlias = 'e' . $i;
                 $tagAlias = 't' . $i;
 
-                // Complexe queries to ensure multiple tags is associated to an entry
+                // Complexe queries to ensure multiple tags are associated to an entry
                 // https://stackoverflow.com/a/6638146/569101
                 $qb->andWhere($qb->expr()->in(
                     'e.id',

--- a/src/Wallabag/CoreBundle/Repository/EntryRepository.php
+++ b/src/Wallabag/CoreBundle/Repository/EntryRepository.php
@@ -345,26 +345,6 @@ class EntryRepository extends EntityRepository
     }
 
     /**
-     * Count all entries for a tag and a user.
-     *
-     * @param int $userId
-     * @param int $tagId
-     *
-     * @return int
-     */
-    public function countAllEntriesByUserIdAndTagId($userId, $tagId)
-    {
-        $qb = $this->createQueryBuilder('e')
-            ->select('count(e.id)')
-            ->leftJoin('e.tags', 't')
-            ->where('e.user = :userId')->setParameter('userId', $userId)
-            ->andWhere('t.id = :tagId')->setParameter('tagId', $tagId)
-        ;
-
-        return (int) $qb->getQuery()->getSingleScalarResult();
-    }
-
-    /**
      * Remove all entries for a user id.
      * Used when a user want to reset all informations.
      *

--- a/tests/Wallabag/ApiBundle/Controller/EntryRestControllerTest.php
+++ b/tests/Wallabag/ApiBundle/Controller/EntryRestControllerTest.php
@@ -292,6 +292,9 @@ class EntryRestControllerTest extends WallabagApiTestCase
         $this->assertSame(1, $content['page']);
         $this->assertGreaterThanOrEqual(1, $content['pages']);
 
+        $this->assertContains('foo', array_column($content['_embedded']['items'][0]['tags'], 'label'), 'Entries tags should have "foo" tag');
+        $this->assertContains('bar', array_column($content['_embedded']['items'][0]['tags'], 'label'), 'Entries tags should have "bar" tag');
+
         $this->assertArrayHasKey('_links', $content);
         $this->assertArrayHasKey('self', $content['_links']);
         $this->assertArrayHasKey('first', $content['_links']);

--- a/tests/Wallabag/CoreBundle/Controller/ExportControllerTest.php
+++ b/tests/Wallabag/CoreBundle/Controller/ExportControllerTest.php
@@ -239,7 +239,7 @@ class ExportControllerTest extends WallabagCoreTestCase
         $this->assertSame($contentInDB->getLanguage(), $content[0]['language']);
         $this->assertSame($contentInDB->getReadingtime(), $content[0]['reading_time']);
         $this->assertSame($contentInDB->getDomainname(), $content[0]['domain_name']);
-        $this->assertSame(['foo bar', 'baz'], $content[0]['tags']);
+        $this->assertSame(['baz', 'foo'], $content[0]['tags']);
     }
 
     public function testXmlExport()

--- a/tests/Wallabag/CoreBundle/Controller/ExportControllerTest.php
+++ b/tests/Wallabag/CoreBundle/Controller/ExportControllerTest.php
@@ -239,7 +239,8 @@ class ExportControllerTest extends WallabagCoreTestCase
         $this->assertSame($contentInDB->getLanguage(), $content[0]['language']);
         $this->assertSame($contentInDB->getReadingtime(), $content[0]['reading_time']);
         $this->assertSame($contentInDB->getDomainname(), $content[0]['domain_name']);
-        $this->assertSame(['baz', 'foo'], $content[0]['tags']);
+        $this->assertContains('baz', $content[0]['tags']);
+        $this->assertContains('foo', $content[0]['tags']);
     }
 
     public function testXmlExport()

--- a/tests/Wallabag/CoreBundle/Controller/RssControllerTest.php
+++ b/tests/Wallabag/CoreBundle/Controller/RssControllerTest.php
@@ -184,13 +184,13 @@ class RssControllerTest extends WallabagCoreTestCase
         $em->flush();
 
         $client = $this->getClient();
-        $client->request('GET', '/admin/SUPERTOKEN/tags/foo-bar.xml');
+        $client->request('GET', '/admin/SUPERTOKEN/tags/foo.xml');
 
         $this->assertSame(200, $client->getResponse()->getStatusCode());
 
-        $this->validateDom($client->getResponse()->getContent(), 'tag (foo bar)', 'tags/foo-bar');
+        $this->validateDom($client->getResponse()->getContent(), 'tag (foo)', 'tags/foo');
 
-        $client->request('GET', '/admin/SUPERTOKEN/tags/foo-bar.xml?page=3000');
+        $client->request('GET', '/admin/SUPERTOKEN/tags/foo.xml?page=3000');
         $this->assertSame(302, $client->getResponse()->getStatusCode());
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Documentation | no
| Translation   | no
| Fixed tickets | #...
| License       | MIT

First, the `setParameter()` were done on the same parameter which in fact just duplicated the condition in the SQL query (like `where t.label = 'test' and t.label = 'test'`).

Changed the parameter doesn't help because the query was then wrong.

Changing the way to match associated tags for an entry and it worked.

poke @Zlitus