### PR TITLE
Fix make build by replacing grunt with webpack

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,8 +23,8 @@ dev: ## Install the latest dev version
 run: ## Run the wallabag built-in server
 	@php bin/console server:run --env=$(ENV)
 
-build: ## Run grunt
-	@grunt
+build: ## Run webpack
+	@npm run build:$(ENV)
 
 test: ## Launch wallabag testsuite
 	@ant prepare && bin/simple-phpunit -v


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Documentation | no
| Translation   | no
| Fixed tickets | no
| License       | MIT

Make build command was still using grunt.
