### PR TITLE
Reduce number of queries on tag list

### DIFF
--- a/src/Wallabag/CoreBundle/Controller/TagController.php
+++ b/src/Wallabag/CoreBundle/Controller/TagController.php
@@ -84,28 +84,11 @@ class TagController extends Controller
      */
     public function showTagAction()
     {
-        $repository = $this->get('wallabag_core.entry_repository');
         $tags = $this->get('wallabag_core.tag_repository')
-            ->findAllTags($this->getUser()->getId());
-
-        $flatTags = [];
-
-        foreach ($tags as $tag) {
-            $nbEntries = $repository->countAllEntriesByUserIdAndTagId(
-                $this->getUser()->getId(),
-                $tag->getId()
-            );
-
-            $flatTags[] = [
-                'id' => $tag->getId(),
-                'label' => $tag->getLabel(),
-                'slug' => $tag->getSlug(),
-                'nbEntries' => $nbEntries,
-            ];
-        }
+            ->findAllFlatTagsWithNbEntries($this->getUser()->getId());
 
         return $this->render('WallabagCoreBundle:Tag:tags.html.twig', [
-            'tags' => $flatTags,
+            'tags' => $tags,
         ]);
     }
 

--- a/src/Wallabag/CoreBundle/Repository/EntryRepository.php
+++ b/src/Wallabag/CoreBundle/Repository/EntryRepository.php
@@ -330,26 +330,6 @@ class EntryRepository extends EntityRepository
     }
 
     /**
-     * Count all entries for a tag and a user.
-     *
-     * @param int $userId
-     * @param int $tagId
-     *
-     * @return int
-     */
-    public function countAllEntriesByUserIdAndTagId($userId, $tagId)
-    {
-        $qb = $this->createQueryBuilder('e')
-            ->select('count(e.id)')
-            ->leftJoin('e.tags', 't')
-            ->where('e.user=:userId')->setParameter('userId', $userId)
-            ->andWhere('t.id=:tagId')->setParameter('tagId', $tagId)
-        ;
-
-        return (int) $qb->getQuery()->getSingleScalarResult();
-    }
-
-    /**
      * Remove all entries for a user id.
      * Used when a user want to reset all informations.
      *

--- a/src/Wallabag/CoreBundle/Repository/TagRepository.php
+++ b/src/Wallabag/CoreBundle/Repository/TagRepository.php
@@ -63,6 +63,27 @@ class TagRepository extends EntityRepository
     }
 
     /**
+     * Find all tags (flat) per user with nb entries.
+     *
+     * @param int $userId
+     *
+     * @return array
+     */
+    public function findAllFlatTagsWithNbEntries($userId)
+    {
+        return $this->createQueryBuilder('t')
+            ->select('t.id, t.label, t.slug, count(e.id) as nbEntries')
+            ->distinct(true)
+            ->leftJoin('t.entries', 'e')
+            ->where('e.user = :userId')
+            ->groupBy('t.id')
+            ->orderBy('t.slug')
+            ->setParameter('userId', $userId)
+            ->getQuery()
+            ->getArrayResult();
+    }
+
+    /**
      * Used only in test case to get a tag for our entry.
      *
      * @return Tag


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Documentation | no
| Translation   | no
| Fixed tickets | #3313 
| License       | MIT

Previously, two queries were executed by tag.
Now there is only one query executed for the complete tag list.