### PR TITLE
Add reload entry command

### DIFF
--- a/src/Wallabag/CoreBundle/Command/CleanDuplicatesCommand.php
+++ b/src/Wallabag/CoreBundle/Command/CleanDuplicatesCommand.php
@@ -71,7 +71,7 @@ class CleanDuplicatesCommand extends ContainerAwareCommand
         $em = $this->getContainer()->get('doctrine.orm.entity_manager');
         $repo = $this->getContainer()->get('wallabag_core.entry_repository');
 
-        $entries = $repo->getAllEntriesIdAndUrl($user->getId());
+        $entries = $repo->findAllEntriesIdAndUrlByUserId($user->getId());
 
         $duplicatesCount = 0;
         $urls = [];

--- a/src/Wallabag/CoreBundle/Command/ReloadEntryCommand.php
+++ b/src/Wallabag/CoreBundle/Command/ReloadEntryCommand.php
@@ -41,7 +41,7 @@ class ReloadEntryCommand extends ContainerAwareCommand
         }
 
         $entryRepository = $this->getContainer()->get('wallabag_core.entry_repository');
-        $entryIds = $entryRepository->getAllEntriesId($userId);
+        $entryIds = $entryRepository->findAllEntriesIdByUserId($userId);
 
         $nbEntries = count($entryIds);
         if (!$nbEntries) {

--- a/src/Wallabag/CoreBundle/Command/ReloadEntryCommand.php
+++ b/src/Wallabag/CoreBundle/Command/ReloadEntryCommand.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace Wallabag\CoreBundle\Command;
+
+use Doctrine\ORM\NoResultException;
+use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+use Wallabag\CoreBundle\Event\EntrySavedEvent;
+
+class ReloadEntryCommand extends ContainerAwareCommand
+{
+    protected function configure()
+    {
+        $this
+            ->setName('wallabag:entry:reload')
+            ->setDescription('Reload entries')
+            ->setHelp('This command reload entries')
+            ->addArgument('username', InputArgument::OPTIONAL, 'Reload entries only for the given user')
+        ;
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $io = new SymfonyStyle($input, $output);
+
+        $userId = null;
+        if ($username = $input->getArgument('username')) {
+            try {
+                $userId = $this->getContainer()
+                    ->get('wallabag_user.user_repository')
+                    ->findOneByUserName($username)
+                    ->getId();
+            } catch (NoResultException $e) {
+                $io->error(sprintf('User "%s" not found.', $username));
+
+                return 1;
+            }
+        }
+
+        $entryRepository = $this->getContainer()->get('wallabag_core.entry_repository');
+        $entryIds = $entryRepository->getAllEntriesId($userId);
+
+        $nbEntries = count($entryIds);
+        if (!$nbEntries) {
+            $io->success('No entry to reload.');
+
+            return 0;
+        }
+
+        $io->note(
+            sprintf(
+                "You're going to reload %s entries. Depending on the number of entry to reload, this could be a very long process.",
+                $nbEntries
+            )
+        );
+
+        if (!$io->confirm('Are you sure you want to proceed?')) {
+            return 0;
+        }
+
+        $progressBar = $io->createProgressBar($nbEntries);
+
+        $contentProxy = $this->getContainer()->get('wallabag_core.content_proxy');
+        $em = $this->getContainer()->get('doctrine')->getManager();
+        $dispatcher = $this->getContainer()->get('event_dispatcher');
+
+        $progressBar->start();
+        foreach ($entryIds as $entryId) {
+            $entry = $entryRepository->find($entryId);
+
+            $contentProxy->updateEntry($entry, $entry->getUrl());
+            $em->persist($entry);
+            $em->flush();
+
+            $dispatcher->dispatch(EntrySavedEvent::NAME, new EntrySavedEvent($entry));
+            $progressBar->advance();
+
+            $em->detach($entry);
+        }
+        $progressBar->finish();
+
+        $io->newLine(2);
+        $io->success('Done.');
+
+        return 0;
+    }
+}

--- a/src/Wallabag/CoreBundle/Repository/EntryRepository.php
+++ b/src/Wallabag/CoreBundle/Repository/EntryRepository.php
@@ -369,7 +369,7 @@ class EntryRepository extends EntityRepository
      *
      * @return array
      */
-    public function getAllEntriesId($userId = null)
+    public function findAllEntriesIdByUserId($userId = null)
     {
         $qb = $this->createQueryBuilder('e')
             ->select('e.id');

--- a/src/Wallabag/CoreBundle/Repository/EntryRepository.php
+++ b/src/Wallabag/CoreBundle/Repository/EntryRepository.php
@@ -365,6 +365,23 @@ class EntryRepository extends EntityRepository
     }
 
     /**
+     * @param int $userId
+     *
+     * @return array
+     */
+    public function getAllEntriesId($userId = null)
+    {
+        $qb = $this->createQueryBuilder('e')
+            ->select('e.id');
+
+        if (null !== $userId) {
+            $qb->where('e.user = :userid')->setParameter(':userid', $userId);
+        }
+
+        return $qb->getQuery()->getArrayResult();
+    }
+
+    /**
      * Find all entries by url and owner.
      *
      * @param $url

--- a/src/Wallabag/CoreBundle/Repository/EntryRepository.php
+++ b/src/Wallabag/CoreBundle/Repository/EntryRepository.php
@@ -355,7 +355,7 @@ class EntryRepository extends EntityRepository
      * Get id and url from all entries
      * Used for the clean-duplicates command.
      */
-    public function getAllEntriesIdAndUrl($userId)
+    public function findAllEntriesIdAndUrlByUserId($userId)
     {
         $qb = $this->createQueryBuilder('e')
             ->select('e.id, e.url')

--- a/tests/Wallabag/CoreBundle/Command/ReloadEntryCommandTest.php
+++ b/tests/Wallabag/CoreBundle/Command/ReloadEntryCommandTest.php
@@ -1,0 +1,115 @@
+<?php
+
+namespace Tests\Wallabag\CoreBundle\Command;
+
+use Symfony\Bundle\FrameworkBundle\Console\Application;
+use Symfony\Component\Console\Tester\CommandTester;
+use Tests\Wallabag\CoreBundle\WallabagCoreTestCase;
+use Wallabag\CoreBundle\Command\ReloadEntryCommand;
+use Wallabag\CoreBundle\Entity\Entry;
+
+class ReloadEntryCommandTest extends WallabagCoreTestCase
+{
+    public $url = 'http://www.lemonde.fr/pixels/article/2015/03/28/plongee-dans-l-univers-d-ingress-le-jeu-de-google-aux-frontieres-du-reel_4601155_4408996.html';
+
+    /**
+     * @var entry
+     */
+    public $adminEntry;
+
+    /**
+     * @var Entry
+     */
+    public $bobEntry;
+
+    public function setUp()
+    {
+        parent::setUp();
+
+        $userRepository = $this->getClient()->getContainer()->get('wallabag_user.user_repository');
+
+        $user = $userRepository->findOneByUserName('admin');
+        $this->adminEntry = new Entry($user);
+        $this->adminEntry->setUrl($this->url);
+        $this->adminEntry->setTitle('title foo');
+        $this->adminEntry->setContent('');
+        $this->getEntityManager()->persist($this->adminEntry);
+
+        $user = $userRepository->findOneByUserName('bob');
+        $this->bobEntry = new Entry($user);
+        $this->bobEntry->setUrl($this->url);
+        $this->bobEntry->setTitle('title foo');
+        $this->bobEntry->setContent('');
+        $this->getEntityManager()->persist($this->bobEntry);
+
+        $this->getEntityManager()->flush();
+    }
+
+    public function testRunReloadEntryCommand()
+    {
+        $application = new Application($this->getClient()->getKernel());
+        $application->add(new ReloadEntryCommand());
+
+        $command = $application->find('wallabag:entry:reload');
+        $tester = new CommandTester($command);
+        $tester->execute([
+            'command' => $command->getName(),
+        ], [
+            'interactive' => false,
+        ]);
+
+        $reloadedEntries = $this->getClient()
+            ->getContainer()
+            ->get('wallabag_core.entry_repository')
+            ->findById([$this->adminEntry->getId(), $this->bobEntry->getId()]);
+
+        foreach ($reloadedEntries as $reloadedEntry) {
+            $this->assertNotEmpty($reloadedEntry->getContent());
+        }
+
+        $this->assertContains('Done', $tester->getDisplay());
+    }
+
+    public function testRunReloadEntryWithUsernameCommand()
+    {
+        $application = new Application($this->getClient()->getKernel());
+        $application->add(new ReloadEntryCommand());
+
+        $command = $application->find('wallabag:entry:reload');
+        $tester = new CommandTester($command);
+        $tester->execute([
+            'command' => $command->getName(),
+            'username' => 'admin',
+        ], [
+            'interactive' => false,
+        ]);
+
+        $entryRepository = $this->getClient()->getContainer()->get('wallabag_core.entry_repository');
+
+        $reloadedAdminEntry = $entryRepository->find($this->adminEntry->getId());
+        $this->assertNotEmpty($reloadedAdminEntry->getContent());
+
+        $reloadedBobEntry = $entryRepository->find($this->bobEntry->getId());
+        $this->assertEmpty($reloadedBobEntry->getContent());
+
+        $this->assertContains('Done', $tester->getDisplay());
+    }
+
+    public function testRunReloadEntryWithoutEntryCommand()
+    {
+        $application = new Application($this->getClient()->getKernel());
+        $application->add(new ReloadEntryCommand());
+
+        $command = $application->find('wallabag:entry:reload');
+        $tester = new CommandTester($command);
+        $tester->execute([
+            'command' => $command->getName(),
+            'username' => 'empty',
+        ], [
+            'interactive' => false,
+        ]);
+
+        $this->assertContains('No entry to reload', $tester->getDisplay());
+        $this->assertNotContains('Done', $tester->getDisplay());
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Documentation | yes
| Translation   | no
| Fixed tickets | #3247 
| License       | MIT

![reload-entry](https://user-images.githubusercontent.com/833625/29511227-c7b9b1ae-865e-11e7-8f3b-0bb8f72642a9.png)

I did not implement the `article` option described in the original issue because it seems easier to use the UI for this use case. Let me know if you want me to add it.

I have some ideas of relevant options for later like : 

* `wallabag:entry:reload --unread`
* `wallabag:entry:reload --starred`
* `wallabag:entry:reload --filter="insert rule here"`
* ...