### PR TITLE
Translate missing strings, add quotation marks

### DIFF
--- a/app/Resources/CraueConfigBundle/translations/CraueConfigBundle.de.yml
+++ b/app/Resources/CraueConfigBundle/translations/CraueConfigBundle.de.yml
@@ -1,36 +1,36 @@
-# settings_changed: Configuration updated
-download_pictures: Bilder auf den Server herunterladen
-carrot: Teilen zu Carrot aktivieren
-diaspora_url: Diaspora-URL, sofern der Service aktiviert ist
-export_epub: ePUB-Export aktivieren
-export_mobi: mobi-Export aktivieren
-export_pdf: PDF-Export aktivieren
-export_csv: CSV-Export aktivieren
-export_json: JSON-Export aktivieren
-export_txt: TXT-Export aktivieren
-export_xml: XML-Export aktivieren
-import_with_rabbitmq: Aktiviere RabbitMQ, um Artikel asynchron zu importieren
-import_with_redis: Aktiviere Redis, um Artikel asynchron zu importieren
-shaarli_url: Shaarli-URL, sofern der Service aktiviert ist
-share_diaspora: Teilen zu Diaspora aktiveren
-share_mail: Teilen via E-Mail aktiveren
-share_shaarli: Teilen zu Shaarli aktiveren
-share_scuttle: Teilen zu Scuttle aktiveren
-share_twitter: Teilen zu Twitter aktiveren
-share_unmark: Teilen zu Unmark.it aktiveren
-show_printlink: Link anzeigen, um den Inhalt auszudrucken
-wallabag_support_url: Support-URL für wallabag
-entry: "Artikel"
-export: "Export"
-import: "Import"
-misc: "Verschiedenes"
-modify_settings: "Übernehmen"
-piwik_host: Host deiner Webseite in Piwik (ohne http:// oder https://)
-piwik_site_id: ID deiner Webseite in Piwik
-piwik_enabled: Piwik aktivieren
-demo_mode_enabled: "Test-Modus aktivieren? (nur für die öffentliche wallabag-Demo genutzt)"
-demo_mode_username: "Test-Benutzer"
-share_public: Erlaube eine öffentliche URL für Einträge
-# download_images_enabled: Download images locally
-# restricted_access: Enable authentication for websites with paywall
-# api_user_registration: Enable user to be registered using the API
+settings_changed: 'Konfiguration aktualisiert'
+download_pictures: 'Bilder auf den Server herunterladen'
+carrot: 'Teilen zu Carrot aktivieren'
+diaspora_url: 'Diaspora-URL, sofern der Service aktiviert ist'
+export_epub: 'ePUB-Export aktivieren'
+export_mobi: 'mobi-Export aktivieren'
+export_pdf: 'PDF-Export aktivieren'
+export_csv: 'CSV-Export aktivieren'
+export_json: 'JSON-Export aktivieren'
+export_txt: 'TXT-Export aktivieren'
+export_xml: 'XML-Export aktivieren'
+import_with_rabbitmq: 'Aktiviere RabbitMQ, um Artikel asynchron zu importieren'
+import_with_redis: 'Aktiviere Redis, um Artikel asynchron zu importieren'
+shaarli_url: 'Shaarli-URL, sofern der Service aktiviert ist'
+share_diaspora: 'Teilen zu Diaspora aktiveren'
+share_mail: 'Teilen via E-Mail aktiveren'
+share_shaarli: 'Teilen zu Shaarli aktiveren'
+share_twitter: 'Teilen zu Twitter aktiveren'
+share_unmark: 'Teilen zu Unmark.it aktiveren'
+show_printlink: 'Link anzeigen, um den Inhalt auszudrucken'
+wallabag_support_url: 'Support-URL für wallabag'
+wallabag_url: 'URL von *deiner* wallabag-Instanz'
+entry: 'Artikel'
+export: 'Export'
+import: 'Import'
+misc: 'Verschiedenes'
+modify_settings: 'Übernehmen'
+piwik_host: 'Host deiner Webseite in Piwik (ohne http:// oder https://)'
+piwik_site_id: 'ID deiner Webseite in Piwik'
+piwik_enabled: 'Piwik aktivieren'
+demo_mode_enabled: 'Test-Modus aktivieren? (nur für die öffentliche wallabag-Demo genutzt)'
+demo_mode_username: 'Test-Benutzer'
+share_public: 'Erlaube eine öffentliche URL für Einträge'
+download_images_enabled: 'Bilder lokal herunterladen'
+restricted_access: 'Authentifizierung für Webseiten mit Paywall aktivieren'
+api_user_registration: 'Registrierung eines Benutzers über die API ermöglichen'


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Documentation | no
| Translation   | yes
| Fixed tickets | #...
| License       | MIT

Translate commented out strings and add missing quotation marks.
This time for wallabag branch 2.3 instead of master.

(Avoiding same merge conflict like with #3336 )