### PR TITLE
Add originUrl property to Entry

### DIFF
--- a/app/DoctrineMigrations/Version20171105202000.php
+++ b/app/DoctrineMigrations/Version20171105202000.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Application\Migrations;
+
+use Doctrine\DBAL\Migrations\AbstractMigration;
+use Doctrine\DBAL\Schema\Schema;
+use Symfony\Component\DependencyInjection\ContainerAwareInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Add origin_url column
+ */
+class Version20171105202000 extends AbstractMigration implements ContainerAwareInterface
+{
+    /**
+     * @var ContainerInterface
+     */
+    private $container;
+
+    public function setContainer(ContainerInterface $container = null)
+    {
+        $this->container = $container;
+    }
+
+    /**
+     * @param Schema $schema
+     */
+    public function up(Schema $schema)
+    {
+        $entryTable = $schema->getTable($this->getTable('entry'));
+
+        $this->skipIf($entryTable->hasColumn('origin_url'), 'It seems that you already played this migration.');
+
+        $entryTable->addColumn('origin_url', 'text', [
+            'notnull' => false,
+        ]);
+    }
+
+    /**
+     * @param Schema $schema
+     */
+    public function down(Schema $schema)
+    {
+        $entryTable = $schema->getTable($this->getTable('entry'));
+
+        $this->skipIf(!$entryTable->hasColumn('origin_url'), 'It seems that you already played this migration.');
+
+        $entryTable->dropColumn('origin_url');
+    }
+
+    private function getTable($tableName)
+    {
+        return $this->container->getParameter('database_table_prefix') . $tableName;
+    }
+}

--- a/app/DoctrineMigrations/Version20171105202000.php
+++ b/app/DoctrineMigrations/Version20171105202000.php
@@ -8,7 +8,7 @@ use Symfony\Component\DependencyInjection\ContainerAwareInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
- * Add origin_url column
+ * Add origin_url column.
  */
 class Version20171105202000 extends AbstractMigration implements ContainerAwareInterface
 {

--- a/src/Wallabag/ApiBundle/Controller/EntryRestController.php
+++ b/src/Wallabag/ApiBundle/Controller/EntryRestController.php
@@ -309,6 +309,7 @@ class EntryRestController extends WallabagRestController
      *          {"name"="published_at", "dataType"="datetime|integer", "format"="YYYY-MM-DDTHH:II:SS+TZ or a timestamp", "required"=false, "description"="Published date of the entry"},
      *          {"name"="authors", "dataType"="string", "format"="Name Firstname,author2,author3", "required"=false, "description"="Authors of the entry"},
      *          {"name"="public", "dataType"="integer", "required"=false, "format"="1 or 0", "description"="will generate a public link for the entry"},
+     *          {"name"="origin_url", "dataType"="string", "required"=false, "format"="http://www.test.com/article.html", "description"="Origin url for the entry."},
      *       }
      * )
      *
@@ -368,6 +369,10 @@ class EntryRestController extends WallabagRestController
             $this->get('wallabag_core.tags_assigner')->assignTagsToEntry($entry, $data['tags']);
         }
 
+        if (!empty($data['origin_url'])) {
+            $entry->setOriginUrl($data['origin_url']);
+        }
+
         if (null !== $data['isPublic']) {
             if (true === (bool) $data['isPublic'] && null === $entry->getUid()) {
                 $entry->generateUid();
@@ -404,6 +409,7 @@ class EntryRestController extends WallabagRestController
      *          {"name"="published_at", "dataType"="datetime|integer", "format"="YYYY-MM-DDTHH:II:SS+TZ or a timestamp", "required"=false, "description"="Published date of the entry"},
      *          {"name"="authors", "dataType"="string", "format"="Name Firstname,author2,author3", "required"=false, "description"="Authors of the entry"},
      *          {"name"="public", "dataType"="integer", "required"=false, "format"="1 or 0", "description"="will generate a public link for the entry"},
+     *          {"name"="origin_url", "dataType"="string", "required"=false, "format"="http://www.test.com/article.html", "description"="Origin url for the entry."},
      *      }
      * )
      *
@@ -478,6 +484,10 @@ class EntryRestController extends WallabagRestController
             } elseif (false === (bool) $data['isPublic']) {
                 $entry->cleanUid();
             }
+        }
+
+        if (!empty($data['origin_url'])) {
+            $entry->setOriginUrl($data['origin_url']);
         }
 
         $em = $this->getDoctrine()->getManager();
@@ -778,6 +788,7 @@ class EntryRestController extends WallabagRestController
             'picture' => $request->request->get('preview_picture'),
             'publishedAt' => $request->request->get('published_at'),
             'authors' => $request->request->get('authors', ''),
+            'origin_url' => $request->request->get('origin_url', ''),
         ];
     }
 

--- a/src/Wallabag/ApiBundle/Controller/EntryRestController.php
+++ b/src/Wallabag/ApiBundle/Controller/EntryRestController.php
@@ -309,7 +309,7 @@ class EntryRestController extends WallabagRestController
      *          {"name"="published_at", "dataType"="datetime|integer", "format"="YYYY-MM-DDTHH:II:SS+TZ or a timestamp", "required"=false, "description"="Published date of the entry"},
      *          {"name"="authors", "dataType"="string", "format"="Name Firstname,author2,author3", "required"=false, "description"="Authors of the entry"},
      *          {"name"="public", "dataType"="integer", "required"=false, "format"="1 or 0", "description"="will generate a public link for the entry"},
-     *          {"name"="origin_url", "dataType"="string", "required"=false, "format"="http://www.test.com/article.html", "description"="Origin url for the entry."},
+     *          {"name"="origin_url", "dataType"="string", "required"=false, "format"="http://www.test.com/article.html", "description"="Origin url for the entry (from where you found it)."},
      *       }
      * )
      *
@@ -409,7 +409,7 @@ class EntryRestController extends WallabagRestController
      *          {"name"="published_at", "dataType"="datetime|integer", "format"="YYYY-MM-DDTHH:II:SS+TZ or a timestamp", "required"=false, "description"="Published date of the entry"},
      *          {"name"="authors", "dataType"="string", "format"="Name Firstname,author2,author3", "required"=false, "description"="Authors of the entry"},
      *          {"name"="public", "dataType"="integer", "required"=false, "format"="1 or 0", "description"="will generate a public link for the entry"},
-     *          {"name"="origin_url", "dataType"="string", "required"=false, "format"="http://www.test.com/article.html", "description"="Origin url for the entry."},
+     *          {"name"="origin_url", "dataType"="string", "required"=false, "format"="http://www.test.com/article.html", "description"="Origin url for the entry (from where you found it)."},
      *      }
      * )
      *

--- a/src/Wallabag/CoreBundle/DataFixtures/ORM/LoadEntryData.php
+++ b/src/Wallabag/CoreBundle/DataFixtures/ORM/LoadEntryData.php
@@ -37,6 +37,7 @@ class LoadEntryData extends AbstractFixture implements OrderedFixtureInterface
         $entry2->setMimetype('text/html');
         $entry2->setTitle('test title entry2');
         $entry2->setContent('This is my content /o/');
+        $entry2->setOriginUrl('ftp://oneftp.tld');
         $entry2->setLanguage('fr');
 
         $manager->persist($entry2);

--- a/src/Wallabag/CoreBundle/Entity/Entry.php
+++ b/src/Wallabag/CoreBundle/Entity/Entry.php
@@ -245,6 +245,15 @@ class Entry
      */
     private $tags;
 
+    /**
+     * @var string
+     *
+     * @ORM\Column(name="origin_url", type="text", nullable=true)
+     *
+     * @Groups({"entries_for_user", "export_all"})
+     */
+    private $originUrl;
+
     /*
      * @param User     $user
      */
@@ -830,5 +839,29 @@ class Entry
         $this->headers = $headers;
 
         return $this;
+    }
+    
+    /**
+     * Set origin url.
+     *
+     * @param string $originUrl
+     *
+     * @return Entry
+     */
+    public function setOriginUrl($originUrl)
+    {
+        $this->originUrl = $originUrl;
+
+        return $this;
+    }
+    
+    /**
+     * Get origin url.
+     *
+     * @return string
+     */
+    public function getOriginUrl()
+    {
+        return $this->originUrl;
     }
 }

--- a/src/Wallabag/CoreBundle/Entity/Entry.php
+++ b/src/Wallabag/CoreBundle/Entity/Entry.php
@@ -840,7 +840,7 @@ class Entry
 
         return $this;
     }
-    
+
     /**
      * Set origin url.
      *
@@ -854,7 +854,7 @@ class Entry
 
         return $this;
     }
-    
+
     /**
      * Get origin url.
      *

--- a/src/Wallabag/CoreBundle/Form/Type/EditEntryType.php
+++ b/src/Wallabag/CoreBundle/Form/Type/EditEntryType.php
@@ -5,6 +5,7 @@ namespace Wallabag\CoreBundle\Form\Type;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\SubmitType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\Form\Extension\Core\Type\UrlType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
@@ -17,12 +18,12 @@ class EditEntryType extends AbstractType
                 'required' => true,
                 'label' => 'entry.edit.title_label',
             ])
-            ->add('url', TextType::class, [
+            ->add('url', UrlType::class, [
                 'disabled' => true,
                 'required' => false,
                 'label' => 'entry.edit.url_label',
             ])
-            ->add('origin_url', TextType::class, [
+            ->add('origin_url', UrlType::class, [
                 'required' => false,
                 'property_path' => 'originUrl',
                 'label' => 'entry.edit.origin_url_label',

--- a/src/Wallabag/CoreBundle/Form/Type/EditEntryType.php
+++ b/src/Wallabag/CoreBundle/Form/Type/EditEntryType.php
@@ -22,6 +22,11 @@ class EditEntryType extends AbstractType
                 'required' => false,
                 'label' => 'entry.edit.url_label',
             ])
+            ->add('origin_url', TextType::class, [
+                'required' => false,
+                'property_path' => 'originUrl',
+                'label' => 'entry.edit.origin_url_label',
+            ])
             ->add('save', SubmitType::class, [
                 'label' => 'entry.edit.save_label',
             ])

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.da.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.da.yml
@@ -244,6 +244,7 @@ entry:
         # page_title: 'Edit an entry'
         # title_label: 'Title'
         url_label: 'Url'
+        # origin_url_label: 'Origin url'
         save_label: 'Gem'
     public:
         # shared_by_wallabag: "This article has been shared by %username% with <a href='%wallabag_instance%'>wallabag</a>"

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.da.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.da.yml
@@ -244,7 +244,7 @@ entry:
         # page_title: 'Edit an entry'
         # title_label: 'Title'
         url_label: 'Url'
-        # origin_url_label: 'Origin url'
+        # origin_url_label: 'Origin url (from where you found that entry)'
         save_label: 'Gem'
     public:
         # shared_by_wallabag: "This article has been shared by %username% with <a href='%wallabag_instance%'>wallabag</a>"

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.da.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.da.yml
@@ -233,6 +233,7 @@ entry:
         created_at: 'Oprettelsesdato'
         # published_at: 'Publication date'
         # published_by: 'Published by'
+        # provided_by: 'Provided by'
     new:
         page_title: 'Gem ny artikel'
         placeholder: 'http://website.com'

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.de.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.de.yml
@@ -244,7 +244,7 @@ entry:
         page_title: 'Eintrag bearbeiten'
         title_label: 'Titel'
         url_label: 'URL'
-        # origin_url_label: 'Origin url'
+        # origin_url_label: 'Origin url (from where you found that entry)'
         save_label: 'Speichern'
     public:
         shared_by_wallabag: 'Dieser Artikel wurde von %username% mittels <a href="%wallabag_instance%">wallabag</a> geteilt'

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.de.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.de.yml
@@ -233,6 +233,7 @@ entry:
         created_at: 'Erstellungsdatum'
         published_at: 'Erscheinungsdatum'
         published_by: 'Veröffentlicht von'
+        # provided_by: 'Provided by'
     new:
         page_title: 'Neuen Artikel speichern'
         placeholder: 'https://website.de'

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.de.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.de.yml
@@ -244,6 +244,7 @@ entry:
         page_title: 'Eintrag bearbeiten'
         title_label: 'Titel'
         url_label: 'URL'
+        # origin_url_label: 'Origin url'
         save_label: 'Speichern'
     public:
         shared_by_wallabag: 'Dieser Artikel wurde von %username% mittels <a href="%wallabag_instance%">wallabag</a> geteilt'

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.en.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.en.yml
@@ -233,6 +233,7 @@ entry:
         created_at: 'Creation date'
         published_at: 'Publication date'
         published_by: 'Published by'
+        provided_by: 'Provided by'
     new:
         page_title: 'Save new entry'
         placeholder: 'http://website.com'

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.en.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.en.yml
@@ -244,6 +244,7 @@ entry:
         page_title: 'Edit an entry'
         title_label: 'Title'
         url_label: 'Url'
+        origin_url_label: 'Origin url'
         save_label: 'Save'
     public:
         shared_by_wallabag: "This article has been shared by %username% with <a href='%wallabag_instance%'>wallabag</a>"

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.en.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.en.yml
@@ -244,7 +244,7 @@ entry:
         page_title: 'Edit an entry'
         title_label: 'Title'
         url_label: 'Url'
-        origin_url_label: 'Origin url'
+        origin_url_label: 'Origin url (from where you found that entry)'
         save_label: 'Save'
     public:
         shared_by_wallabag: "This article has been shared by %username% with <a href='%wallabag_instance%'>wallabag</a>"

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.es.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.es.yml
@@ -233,6 +233,7 @@ entry:
         created_at: 'Fecha de creación'
         # published_at: 'Publication date'
         # published_by: 'Published by'
+        # provided_by: 'Provided by'
     new:
         page_title: 'Guardar un nuevo artículo'
         placeholder: 'http://sitioweb.com'

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.es.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.es.yml
@@ -244,6 +244,7 @@ entry:
         page_title: 'Editar un artículo'
         title_label: 'Título'
         url_label: 'URL'
+        # origin_url_label: 'Origin url'
         save_label: 'Guardar'
     public:
         shared_by_wallabag: "Este artículo se ha compartido con <a href='%wallabag_instance%'>wallabag</a>"

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.es.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.es.yml
@@ -244,7 +244,7 @@ entry:
         page_title: 'Editar un artículo'
         title_label: 'Título'
         url_label: 'URL'
-        # origin_url_label: 'Origin url'
+        # origin_url_label: 'Origin url (from where you found that entry)'
         save_label: 'Guardar'
     public:
         shared_by_wallabag: "Este artículo se ha compartido con <a href='%wallabag_instance%'>wallabag</a>"

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.fa.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.fa.yml
@@ -233,6 +233,7 @@ entry:
         created_at: 'زمان ساخت'
         # published_at: 'Publication date'
         # published_by: 'Published by'
+        # provided_by: 'Provided by'
     new:
         page_title: 'ذخیرهٔ مقالهٔ تازه'
         placeholder: 'http://website.com'

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.fa.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.fa.yml
@@ -244,6 +244,7 @@ entry:
         page_title: 'ویرایش مقاله'
         title_label: 'عنوان'
         url_label: 'نشانی'
+        # origin_url_label: 'Origin url'
         save_label: 'ذخیره'
     public:
         # shared_by_wallabag: "This article has been shared by %username% with <a href='%wallabag_instance%'>wallabag</a>"

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.fa.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.fa.yml
@@ -244,7 +244,7 @@ entry:
         page_title: 'ویرایش مقاله'
         title_label: 'عنوان'
         url_label: 'نشانی'
-        # origin_url_label: 'Origin url'
+        # origin_url_label: 'Origin url (from where you found that entry)'
         save_label: 'ذخیره'
     public:
         # shared_by_wallabag: "This article has been shared by %username% with <a href='%wallabag_instance%'>wallabag</a>"

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.fr.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.fr.yml
@@ -244,6 +244,7 @@ entry:
         page_title: "Éditer un article"
         title_label: "Titre"
         url_label: "Adresse"
+        origin_url_label: "Adresse d'origine"
         save_label: "Enregistrer"
     public:
         shared_by_wallabag: "Cet article a été partagé par %username% avec <a href=\"%wallabag_instance%\">wallabag</a>"

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.fr.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.fr.yml
@@ -244,7 +244,7 @@ entry:
         page_title: "Éditer un article"
         title_label: "Titre"
         url_label: "Adresse"
-        origin_url_label: "Adresse d'origine"
+        origin_url_label: "Adresse d'origine (d'où vous avez trouvé cet article)"
         save_label: "Enregistrer"
     public:
         shared_by_wallabag: "Cet article a été partagé par %username% avec <a href=\"%wallabag_instance%\">wallabag</a>"

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.fr.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.fr.yml
@@ -233,6 +233,7 @@ entry:
         created_at: "Date de création"
         published_at: "Date de publication"
         published_by: "Publié par"
+        provided_by: "Fourni par"
     new:
         page_title: "Sauvegarder un nouvel article"
         placeholder: "http://website.com"

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.it.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.it.yml
@@ -233,6 +233,7 @@ entry:
         created_at: 'Data di creazione'
         published_at: 'Data di pubblicazione'
         published_by: 'Pubblicato da'
+        # provided_by: 'Provided by'
     new:
         page_title: 'Salva un nuovo contenuto'
         placeholder: 'http://website.com'

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.it.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.it.yml
@@ -244,7 +244,7 @@ entry:
         page_title: 'Modifica voce'
         title_label: 'Titolo'
         url_label: 'Url'
-        # origin_url_label: 'Origin url'
+        # origin_url_label: 'Origin url (from where you found that entry)'
         save_label: 'Salva'
     public:
         shared_by_wallabag: "Questo articolo è stato condiviso da %username% con <a href='%wallabag_instance%'>wallabag</a>"

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.it.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.it.yml
@@ -244,6 +244,7 @@ entry:
         page_title: 'Modifica voce'
         title_label: 'Titolo'
         url_label: 'Url'
+        # origin_url_label: 'Origin url'
         save_label: 'Salva'
     public:
         shared_by_wallabag: "Questo articolo è stato condiviso da %username% con <a href='%wallabag_instance%'>wallabag</a>"

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.oc.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.oc.yml
@@ -233,6 +233,7 @@ entry:
         created_at: 'Data de creacion'
         published_at: 'Data de publicacion'
         published_by: 'Publicat per'
+        # provided_by: 'Provided by'
     new:
         page_title: 'Enregistrar un novèl article'
         placeholder: 'http://website.com'

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.oc.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.oc.yml
@@ -244,6 +244,7 @@ entry:
         page_title: 'Modificar un article'
         title_label: 'Títol'
         url_label: 'Url'
+        # origin_url_label: 'Origin url'
         save_label: 'Enregistrar'
     public:
         shared_by_wallabag: "Aqueste article es estat partejat per <a href='%wallabag_instance%'>wallabag</a>"

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.oc.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.oc.yml
@@ -244,7 +244,7 @@ entry:
         page_title: 'Modificar un article'
         title_label: 'Títol'
         url_label: 'Url'
-        # origin_url_label: 'Origin url'
+        # origin_url_label: 'Origin url (from where you found that entry)'
         save_label: 'Enregistrar'
     public:
         shared_by_wallabag: "Aqueste article es estat partejat per <a href='%wallabag_instance%'>wallabag</a>"

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.pl.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.pl.yml
@@ -244,6 +244,7 @@ entry:
         page_title: 'Edytuj wpis'
         title_label: 'Tytuł'
         url_label: 'Adres URL'
+        # origin_url_label: 'Origin url'
         save_label: 'Zapisz'
     public:
         shared_by_wallabag: "Ten artykuł został udostępniony przez <a href='%wallabag_instance%'>wallabag</a>"

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.pl.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.pl.yml
@@ -233,6 +233,7 @@ entry:
         created_at: 'Czas stworzenia'
         published_at: 'Data publikacji'
         published_by: 'Opublikowane przez'
+        # provided_by: 'Provided by'
     new:
         page_title: 'Zapisz nowy wpis'
         placeholder: 'http://website.com'

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.pl.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.pl.yml
@@ -244,7 +244,7 @@ entry:
         page_title: 'Edytuj wpis'
         title_label: 'Tytuł'
         url_label: 'Adres URL'
-        # origin_url_label: 'Origin url'
+        # origin_url_label: 'Origin url (from where you found that entry)'
         save_label: 'Zapisz'
     public:
         shared_by_wallabag: "Ten artykuł został udostępniony przez <a href='%wallabag_instance%'>wallabag</a>"

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.pt.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.pt.yml
@@ -233,6 +233,7 @@ entry:
         created_at: 'Data de criação'
         # published_at: 'Publication date'
         # published_by: 'Published by'
+        # provided_by: 'Provided by'
     new:
         page_title: 'Salvar nova entrada'
         placeholder: 'http://website.com'

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.pt.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.pt.yml
@@ -244,6 +244,7 @@ entry:
         page_title: 'Editar uma entrada'
         title_label: 'Título'
         url_label: 'Url'
+        # origin_url_label: 'Origin url'
         save_label: 'Salvar'
     public:
         shared_by_wallabag: "Este artigo foi compartilhado pelo <a href='%wallabag_instance%'>wallabag</a>"

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.pt.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.pt.yml
@@ -244,7 +244,7 @@ entry:
         page_title: 'Editar uma entrada'
         title_label: 'Título'
         url_label: 'Url'
-        # origin_url_label: 'Origin url'
+        # origin_url_label: 'Origin url (from where you found that entry)'
         save_label: 'Salvar'
     public:
         shared_by_wallabag: "Este artigo foi compartilhado pelo <a href='%wallabag_instance%'>wallabag</a>"

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.ro.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.ro.yml
@@ -244,7 +244,7 @@ entry:
         # page_title: 'Edit an entry'
         # title_label: 'Title'
         url_label: 'Url'
-        # origin_url_label: 'Origin url'
+        # origin_url_label: 'Origin url (from where you found that entry)'
         save_label: 'Salvează'
     public:
         # shared_by_wallabag: "This article has been shared by %username% with <a href='%wallabag_instance%'>wallabag</a>"

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.ro.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.ro.yml
@@ -233,6 +233,7 @@ entry:
         created_at: 'Data creării'
         # published_at: 'Publication date'
         # published_by: 'Published by'
+        # provided_by: 'Provided by'
     new:
         page_title: 'Salvează un nou articol'
         placeholder: 'http://website.com'

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.ro.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.ro.yml
@@ -244,6 +244,7 @@ entry:
         # page_title: 'Edit an entry'
         # title_label: 'Title'
         url_label: 'Url'
+        # origin_url_label: 'Origin url'
         save_label: 'Salvează'
     public:
         # shared_by_wallabag: "This article has been shared by %username% with <a href='%wallabag_instance%'>wallabag</a>"

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.ru.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.ru.yml
@@ -234,6 +234,7 @@ entry:
         page_title: 'Изменить запись'
         title_label: 'Название'
         url_label: 'Ссылка'
+        # origin_url_label: 'Origin url (from where you found that entry)'
         is_public_label: 'Публичная'
         save_label: 'Сохранить'
     public:

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.ru.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.ru.yml
@@ -223,6 +223,7 @@ entry:
         original_article: 'оригинал'
         annotations_on_the_entry: '{0} Нет аннотации|{1} Одна аннотация|]1,Inf[ %count% аннотаций'
         created_at: 'Дата создания'
+        # provided_by: 'Provided by'
     new:
         page_title: 'Сохранить новую запись'
         placeholder: 'http://website.com'

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.tr.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.tr.yml
@@ -242,7 +242,7 @@ entry:
         page_title: 'Makaleyi düzenle'
         title_label: 'Başlık'
         url_label: 'Url'
-        # origin_url_label: 'Origin url'
+        # origin_url_label: 'Origin url (from where you found that entry)'
         save_label: 'Kaydet'
     public:
         # shared_by_wallabag: "This article has been shared by %username% with <a href='%wallabag_instance%'>wallabag</a>"

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.tr.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.tr.yml
@@ -231,6 +231,7 @@ entry:
         created_at: 'Oluşturulma tarihi'
         # published_at: 'Publication date'
         # published_by: 'Published by'
+        # provided_by: 'Provided by'
     new:
         page_title: 'Yeni makaleyi kaydet'
         placeholder: 'http://website.com'

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.tr.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.tr.yml
@@ -242,6 +242,7 @@ entry:
         page_title: 'Makaleyi düzenle'
         title_label: 'Başlık'
         url_label: 'Url'
+        # origin_url_label: 'Origin url'
         save_label: 'Kaydet'
     public:
         # shared_by_wallabag: "This article has been shared by %username% with <a href='%wallabag_instance%'>wallabag</a>"

--- a/src/Wallabag/CoreBundle/Resources/views/themes/baggy/Entry/entry.html.twig
+++ b/src/Wallabag/CoreBundle/Resources/views/themes/baggy/Entry/entry.html.twig
@@ -71,6 +71,14 @@
             </i>
 
             <span class="tool link"><i class="material-icons link">comment</i> {{ 'entry.view.annotations_on_the_entry'|transchoice(entry.annotations | length) }}</span>
+
+            {% if entry.originUrl is not empty %}
+                <i class="material-icons" title="Provided by">launch</i>
+                <a href="{{ entry.originUrl|e }}" target="_blank" class="tool">
+                    {{ entry.originUrl|striptags|removeSchemeAndWww|truncate(32) }}
+                </a>
+            {% endif %}
+
             <aside class="tags">
                 <div class="card-entry-tags">
                 {% for tag in entry.tags %}

--- a/src/Wallabag/CoreBundle/Resources/views/themes/baggy/Entry/entry.html.twig
+++ b/src/Wallabag/CoreBundle/Resources/views/themes/baggy/Entry/entry.html.twig
@@ -73,7 +73,7 @@
             <span class="tool link"><i class="material-icons link">comment</i> {{ 'entry.view.annotations_on_the_entry'|transchoice(entry.annotations | length) }}</span>
 
             {% if entry.originUrl is not empty %}
-                <i class="material-icons" title="Provided by">launch</i>
+                <i class="material-icons" title="{{ 'entry.view.provided_by'|trans }}">launch</i>
                 <a href="{{ entry.originUrl|e }}" target="_blank" class="tool">
                     {{ entry.originUrl|striptags|removeSchemeAndWww|truncate(32) }}
                 </a>

--- a/src/Wallabag/CoreBundle/Resources/views/themes/material/Entry/edit.html.twig
+++ b/src/Wallabag/CoreBundle/Resources/views/themes/material/Entry/edit.html.twig
@@ -27,6 +27,11 @@
                             {{ form_label(form.url) }}
                             {{ form_widget(form.url) }}
                         </div>
+
+                        <div class="input-field s12">
+                            {{ form_label(form.origin_url) }}
+                            {{ form_widget(form.origin_url) }}
+                        </div>
                         <br>
 
                         {{ form_widget(form.save, {'attr': {'class': 'btn waves-effect waves-light'}}) }}

--- a/src/Wallabag/CoreBundle/Resources/views/themes/material/Entry/entry.html.twig
+++ b/src/Wallabag/CoreBundle/Resources/views/themes/material/Entry/entry.html.twig
@@ -251,7 +251,7 @@
                     </li>
                     {% if entry.originUrl is not empty %}
                         <li>
-                            <i class="material-icons" title="Provided by">launch</i>
+                            <i class="material-icons" title="{{ 'entry.view.provided_by'|trans }}">launch</i>
                             <a href="{{ entry.originUrl|e }}" target="_blank" class="tool">
                                 {{ entry.originUrl|striptags|removeSchemeAndWww|truncate(32) }}
                             </a>

--- a/src/Wallabag/CoreBundle/Resources/views/themes/material/Entry/entry.html.twig
+++ b/src/Wallabag/CoreBundle/Resources/views/themes/material/Entry/entry.html.twig
@@ -125,7 +125,7 @@
                     {% endif %}
                     {% if craue_setting('share_shaarli') %}
                         <li>
-                        <a href="{{ craue_setting('shaarli_url') }}/index.php?post={{ entry.url|url_encode }}&amp;title={{ entry.title|striptags|url_encode }}&amp;tags={{ entry.tags|join(',')|striptags|url_encode }}" target="_blank" title="shaarli" class="tool icon-image shaarli">
+                        <a href="{{ craue_setting('shaarli_url') }}/index.php?post={{ entry.url|url_encode }}&amp;title={{ entry.title|striptags|url_encode }}&amp;tags={{ entry.tags|join(',')|striptags|url_encode }}&amp;lf_original_url={{ entry.originUrl|url_encode }}" target="_blank" title="shaarli" class="tool icon-image shaarli">
                                 <span>shaarli</span>
                             </a>
                         </li>

--- a/src/Wallabag/CoreBundle/Resources/views/themes/material/Entry/entry.html.twig
+++ b/src/Wallabag/CoreBundle/Resources/views/themes/material/Entry/entry.html.twig
@@ -249,6 +249,14 @@
                         <i class="material-icons link">comment</i>
                         {{ 'entry.view.annotations_on_the_entry'|transchoice(entry.annotations | length) }}
                     </li>
+                    {% if entry.originUrl is not empty %}
+                        <li>
+                            <i class="material-icons" title="Provided by">launch</i>
+                            <a href="{{ entry.originUrl|e }}" target="_blank" class="tool">
+                                {{ entry.originUrl|striptags|removeSchemeAndWww|truncate(32) }}
+                            </a>
+                        </li>
+                    {% endif %}
                 </ul>
                 <ul class="tags">
                     {% for tag in entry.tags %}

--- a/src/Wallabag/CoreBundle/Twig/WallabagExtension.php
+++ b/src/Wallabag/CoreBundle/Twig/WallabagExtension.php
@@ -28,6 +28,7 @@ class WallabagExtension extends \Twig_Extension implements \Twig_Extension_Globa
     {
         return [
             new \Twig_SimpleFilter('removeWww', [$this, 'removeWww']),
+            new \Twig_SimpleFilter('removeSchemeAndWww', [$this, 'removeSchemeAndWww']),
         ];
     }
 
@@ -43,6 +44,13 @@ class WallabagExtension extends \Twig_Extension implements \Twig_Extension_Globa
     public function removeWww($url)
     {
         return preg_replace('/^www\./i', '', $url);
+    }
+
+    public function removeSchemeAndWww($url)
+    {
+        return $this->removeWww(
+            preg_replace('@^https?://@i', '', $url)
+        );
     }
 
     /**

--- a/tests/Wallabag/ApiBundle/Controller/EntryRestControllerTest.php
+++ b/tests/Wallabag/ApiBundle/Controller/EntryRestControllerTest.php
@@ -712,28 +712,28 @@ class EntryRestControllerTest extends WallabagApiTestCase
         $this->assertSame($previousLanguage, $content['language'], 'Ensure language has not moved');
         $this->assertSame($previousTitle, $content['title'], 'Ensure title has not moved');
     }
-    
-        public function testPatchEntryNullOriginUrl()
-        {
-            $entry = $this->client->getContainer()
+
+    public function testPatchEntryNullOriginUrl()
+    {
+        $entry = $this->client->getContainer()
             ->get('doctrine.orm.entity_manager')
             ->getRepository('WallabagCoreBundle:Entry')
             ->findOneByUser(1);
-    
-            if (!$entry) {
-                $this->markTestSkipped('No content found in db.');
-            }
-    
-            $this->client->request('PATCH', '/api/entries/' . $entry->getId() . '.json', [
+
+        if (!$entry) {
+            $this->markTestSkipped('No content found in db.');
+        }
+
+        $this->client->request('PATCH', '/api/entries/' . $entry->getId() . '.json', [
                 'origin_url' => null,
             ]);
-    
-            $this->assertSame(200, $this->client->getResponse()->getStatusCode());
-    
-            $content = json_decode($this->client->getResponse()->getContent(), true);
-    
-            $this->assertNull($content['origin_url']);
-        }
+
+        $this->assertSame(200, $this->client->getResponse()->getStatusCode());
+
+        $content = json_decode($this->client->getResponse()->getContent(), true);
+
+        $this->assertNull($content['origin_url']);
+    }
 
     public function testGetTagsEntry()
     {

--- a/tests/Wallabag/CoreBundle/Controller/EntryControllerTest.php
+++ b/tests/Wallabag/CoreBundle/Controller/EntryControllerTest.php
@@ -519,7 +519,7 @@ class EntryControllerTest extends WallabagCoreTestCase
 
         $this->assertGreaterThan(1, $title = $crawler->filter('div[id=article] h1')->extract(['_text']));
         $this->assertContains('My updated title hehe :)', $title[0]);
-        $this->assertSame(1, sizeof($stats = $crawler->filter('div[class=tools] ul[class=stats] li a[class=tool]')->extract(['_text'])));
+        $this->assertSame(1, count($stats = $crawler->filter('div[class=tools] ul[class=stats] li a[class=tool]')->extract(['_text'])));
         $this->assertNotContains('example.io', trim($stats[0]));
     }
 

--- a/tests/Wallabag/CoreBundle/Controller/EntryControllerTest.php
+++ b/tests/Wallabag/CoreBundle/Controller/EntryControllerTest.php
@@ -475,6 +475,7 @@ class EntryControllerTest extends WallabagCoreTestCase
 
         $data = [
             'entry[title]' => 'My updated title hehe :)',
+            'entry[origin_url]' => 'https://example.io',
         ];
 
         $client->submit($form, $data);
@@ -483,8 +484,43 @@ class EntryControllerTest extends WallabagCoreTestCase
 
         $crawler = $client->followRedirect();
 
-        $this->assertGreaterThan(1, $alert = $crawler->filter('div[id=article] h1')->extract(['_text']));
-        $this->assertContains('My updated title hehe :)', $alert[0]);
+        $this->assertGreaterThan(1, $title = $crawler->filter('div[id=article] h1')->extract(['_text']));
+        $this->assertContains('My updated title hehe :)', $title[0]);
+        $this->assertGreaterThan(1, $stats = $crawler->filter('div[class=tools] ul[class=stats] li a[class=tool]')->extract(['_text']));
+        $this->assertContains('example.io', trim($stats[1]));
+    }
+
+    public function testEditRemoveOriginUrl()
+    {
+        $this->logInAs('admin');
+        $client = $this->getClient();
+
+        $entry = new Entry($this->getLoggedInUser());
+        $entry->setUrl($this->url);
+        $this->getEntityManager()->persist($entry);
+        $this->getEntityManager()->flush();
+
+        $crawler = $client->request('GET', '/edit/' . $entry->getId());
+
+        $this->assertSame(200, $client->getResponse()->getStatusCode());
+
+        $form = $crawler->filter('button[type=submit]')->form();
+
+        $data = [
+            'entry[title]' => 'My updated title hehe :)',
+            'entry[origin_url]' => '',
+        ];
+
+        $client->submit($form, $data);
+
+        $this->assertSame(302, $client->getResponse()->getStatusCode());
+
+        $crawler = $client->followRedirect();
+
+        $this->assertGreaterThan(1, $title = $crawler->filter('div[id=article] h1')->extract(['_text']));
+        $this->assertContains('My updated title hehe :)', $title[0]);
+        $this->assertSame(1, sizeof($stats = $crawler->filter('div[class=tools] ul[class=stats] li a[class=tool]')->extract(['_text'])));
+        $this->assertNotContains('example.io', trim($stats[0]));
     }
 
     public function testToggleArchive()

--- a/tests/Wallabag/CoreBundle/Twig/WallabagExtensionTest.php
+++ b/tests/Wallabag/CoreBundle/Twig/WallabagExtensionTest.php
@@ -50,7 +50,7 @@ class WallabagExtensionTest extends \PHPUnit_Framework_TestCase
             ->getMock();
 
         $extension = new WallabagExtension($entryRepository, $tagRepository, $tokenStorage, 0, $translator);
-        
+
         $this->assertSame('lemonde.fr', $extension->removeSchemeAndWww('www.lemonde.fr'));
         $this->assertSame('lemonde.fr', $extension->removeSchemeAndWww('http://lemonde.fr'));
         $this->assertSame('lemonde.fr', $extension->removeSchemeAndWww('https://www.lemonde.fr'));

--- a/tests/Wallabag/CoreBundle/Twig/WallabagExtensionTest.php
+++ b/tests/Wallabag/CoreBundle/Twig/WallabagExtensionTest.php
@@ -30,4 +30,31 @@ class WallabagExtensionTest extends \PHPUnit_Framework_TestCase
         $this->assertSame('lemonde.fr', $extension->removeWww('lemonde.fr'));
         $this->assertSame('gist.github.com', $extension->removeWww('gist.github.com'));
     }
+
+    public function testRemoveSchemeAndWww()
+    {
+        $entryRepository = $this->getMockBuilder('Wallabag\CoreBundle\Repository\EntryRepository')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $tagRepository = $this->getMockBuilder('Wallabag\CoreBundle\Repository\TagRepository')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $tokenStorage = $this->getMockBuilder('Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $translator = $this->getMockBuilder('Symfony\Component\Translation\TranslatorInterface')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $extension = new WallabagExtension($entryRepository, $tagRepository, $tokenStorage, 0, $translator);
+        
+        $this->assertSame('lemonde.fr', $extension->removeSchemeAndWww('www.lemonde.fr'));
+        $this->assertSame('lemonde.fr', $extension->removeSchemeAndWww('http://lemonde.fr'));
+        $this->assertSame('lemonde.fr', $extension->removeSchemeAndWww('https://www.lemonde.fr'));
+        $this->assertSame('gist.github.com', $extension->removeSchemeAndWww('https://gist.github.com'));
+        $this->assertSame('ftp://gist.github.com', $extension->removeSchemeAndWww('ftp://gist.github.com'));
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | -
| Documentation | -
| Translation   | yes
| Fixed tickets | #2106
| License       | MIT

Fixes #2106

This PR adds a new property (`originUrl`) to Entry. It lets the user to specify an origin url from which she retrieved/found an entry.

- [x] Update Entry entity / form / API / view
- [x] Tests
- [x] Documentation