### PR TITLE
Entry view: update .stats margins and color

### DIFF
--- a/app/Resources/static/themes/material/css/article.scss
+++ b/app/Resources/static/themes/material/css/article.scss
@@ -108,12 +108,17 @@
 
       .stats {
         font-size: 0.8em;
-        margin: 8px 15px 5px;
+        margin: 8px 5px 5px;
 
         li {
           display: inline-flex;
           vertical-align: middle;
-          margin: 0 5px;
+          margin: 3px 5px;
+
+          i.material-icons {
+            color: #3e3e3e;
+            margin-right: 3px;
+          }
         }
 
         a {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | -
| Documentation | -
| Translation   | -
| Fixed tickets | -
| License       | MIT

Decreasing margin of .stats, increasing vertical margin of .stats li,
increasing right margin of material icons and reducing contrast of
material icons.

Here is a screenshot of current style:

![2017-09-09-185458_1920x1080](https://user-images.githubusercontent.com/226063/30243350-8bfefc48-95a7-11e7-99e0-87cf8a8a030e.png)

And the updated style:

![2017-09-09-191719_1920x1080](https://user-images.githubusercontent.com/226063/30243351-90c7e4ec-95a7-11e7-8d8b-4d8aa222288d.png)

Can someone push the updated compiled assets please?