### PR TITLE
Fix #3361 check type for tags in entry repository

### DIFF
--- a/src/Wallabag/ApiBundle/Controller/EntryRestController.php
+++ b/src/Wallabag/ApiBundle/Controller/EntryRestController.php
@@ -102,7 +102,7 @@ class EntryRestController extends WallabagRestController
         $order = $request->query->get('order', 'desc');
         $page = (int) $request->query->get('page', 1);
         $perPage = (int) $request->query->get('perPage', 30);
-        $tags = $request->query->get('tags', '');
+        $tags = is_array($request->query->get('tags')) ? '' : (string) $request->query->get('tags', '');
         $since = $request->query->get('since', 0);
 
         /** @var \Pagerfanta\Pagerfanta $pager */

--- a/src/Wallabag/CoreBundle/Repository/EntryRepository.php
+++ b/src/Wallabag/CoreBundle/Repository/EntryRepository.php
@@ -151,7 +151,7 @@ class EntryRepository extends EntityRepository
             $qb->andWhere('e.updatedAt > :since')->setParameter('since', new \DateTime(date('Y-m-d H:i:s', $since)));
         }
 
-        if ('' !== $tags) {
+        if (is_string($tags) && '' !== $tags) {
             foreach (explode(',', $tags) as $i => $tag) {
                 $entryAlias = 'e' . $i;
                 $tagAlias = 't' . $i;

--- a/tests/Wallabag/ApiBundle/Controller/EntryRestControllerTest.php
+++ b/tests/Wallabag/ApiBundle/Controller/EntryRestControllerTest.php
@@ -308,6 +308,13 @@ class EntryRestControllerTest extends WallabagApiTestCase
         $this->assertSame('application/json', $this->client->getResponse()->headers->get('Content-Type'));
     }
 
+    public function testGetTaggedEntriesWithBadParams()
+    {
+        $this->client->request('GET', '/api/entries', ['tags' => ['foo','bar']]);
+
+        $this->assertSame(200, $this->client->getResponse()->getStatusCode());
+    }
+
     public function testGetDatedEntries()
     {
         $this->client->request('GET', '/api/entries', ['since' => 1443274283]);

--- a/tests/Wallabag/ApiBundle/Controller/EntryRestControllerTest.php
+++ b/tests/Wallabag/ApiBundle/Controller/EntryRestControllerTest.php
@@ -310,7 +310,7 @@ class EntryRestControllerTest extends WallabagApiTestCase
 
     public function testGetTaggedEntriesWithBadParams()
     {
-        $this->client->request('GET', '/api/entries', ['tags' => ['foo','bar']]);
+        $this->client->request('GET', '/api/entries', ['tags' => ['foo', 'bar']]);
 
         $this->assertSame(200, $this->client->getResponse()->getStatusCode());
     }


### PR DESCRIPTION
Check is $tags is a string before explode

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Documentation | no
| Translation   | no
| Fixed tickets | #3361 
| License       | MIT

<!--
- Please fill in this template according to the PR you're about to submit.
- Replace this comment by a description of what your PR is solving.
-->
