### PR TITLE
 Replace kernel.root_dir by kernel.project_dir

### DIFF
--- a/app/AppKernel.php
+++ b/app/AppKernel.php
@@ -57,11 +57,6 @@ class AppKernel extends Kernel
         return $bundles;
     }
 
-    public function getRootDir()
-    {
-        return __DIR__;
-    }
-
     public function getCacheDir()
     {
         return dirname(__DIR__) . '/var/cache/' . $this->getEnvironment();
@@ -74,7 +69,7 @@ class AppKernel extends Kernel
 
     public function registerContainerConfiguration(LoaderInterface $loader)
     {
-        $loader->load($this->getRootDir() . '/config/config_' . $this->getEnvironment() . '.yml');
+        $loader->load($this->getProjectDir() . '/app/config/config_' . $this->getEnvironment() . '.yml');
         $loader->load(function ($container) {
             if ($container->getParameter('use_webpack_dev_server')) {
                 $container->loadFromExtension('framework', [

--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -16,7 +16,7 @@ framework:
         fallback: "%locale%"
     secret: "%secret%"
     router:
-        resource: "%kernel.root_dir%/config/routing.yml"
+        resource: "%kernel.project_dir%/app/config/routing.yml"
         strict_requirements: ~
     form: ~
     csrf_protection: ~
@@ -30,7 +30,7 @@ framework:
     session:
         # handler_id set to null will use default session handler from php.ini
         handler_id: session.handler.native_file
-        save_path: "%kernel.root_dir%/../var/sessions/%kernel.environment%"
+        save_path: "%kernel.project_dir%/var/sessions/%kernel.environment%"
     fragments: ~
     http_method_override: true
     assets: ~
@@ -72,7 +72,7 @@ stof_doctrine_extensions:
             sluggable: true
 
 doctrine_migrations:
-    dir_name: "%kernel.root_dir%/DoctrineMigrations"
+    dir_name: "%kernel.project_dir%/app/DoctrineMigrations"
     namespace: Application\Migrations
     table_name: migration_versions
     name: Application Migrations

--- a/app/config/config_dev.yml
+++ b/app/config/config_dev.yml
@@ -3,7 +3,7 @@ imports:
 
 framework:
     router:
-        resource: "%kernel.root_dir%/config/routing_dev.yml"
+        resource: "%kernel.project_dir%/app/config/routing_dev.yml"
         strict_requirements: true
     profiler:
         only_exceptions: false

--- a/app/config/config_prod.yml
+++ b/app/config/config_prod.yml
@@ -3,7 +3,7 @@ imports:
 
 framework:
     assets:
-        # json_manifest_path: '%kernel.root_dir%/../web/bundles/wallabagcore/manifest.json'
+        # json_manifest_path: '%kernel.project_dir%/web/bundles/wallabagcore/manifest.json'
 
 #doctrine:
 #    orm:

--- a/app/config/parameters.yml.dist
+++ b/app/config/parameters.yml.dist
@@ -16,7 +16,7 @@ parameters:
     database_name: wallabag
     database_user: root
     database_password: ~
-    # For SQLite, database_path should be "%kernel.root_dir%/../data/db/wallabag.sqlite"
+    # For SQLite, database_path should be "%kernel.project_dir%/data/db/wallabag.sqlite"
     database_path: null
     database_table_prefix: wallabag_
     database_socket: null

--- a/app/config/parameters_test.yml
+++ b/app/config/parameters_test.yml
@@ -6,5 +6,5 @@ parameters:
     test_database_user: null
     test_database_password: null
     test_database_path: "%env(TEST_DATABASE_PATH)%"
-    env(TEST_DATABASE_PATH): "%kernel.root_dir%/../data/db/wallabag_test.sqlite"
+    env(TEST_DATABASE_PATH): "%kernel.project_dir%/data/db/wallabag_test.sqlite"
     test_database_charset: utf8

--- a/app/config/tests/parameters_test.sqlite.yml
+++ b/app/config/tests/parameters_test.sqlite.yml
@@ -8,5 +8,5 @@ parameters:
     # Using an environnement variable in order to avoid the error "attempt to write a readonly database"
     # when the schema is dropped then recreate
     test_database_path: "%env(TEST_DATABASE_PATH)%"
-    env(TEST_DATABASE_PATH): "%kernel.root_dir%/../data/db/wallabag_test.sqlite"
+    env(TEST_DATABASE_PATH): "%kernel.project_dir%/data/db/wallabag_test.sqlite"
     test_database_charset: utf8

--- a/app/config/wallabag.yml
+++ b/app/config/wallabag.yml
@@ -27,7 +27,7 @@ wallabag_core:
     fetching_error_message: |
         wallabag can't retrieve contents for this article. Please <a href="http://doc.wallabag.org/en/user/errors_during_fetching.html#how-can-i-help-to-fix-that">troubleshoot this issue</a>.
     api_limit_mass_actions: 10
-    encryption_key_path: "%kernel.root_dir%/../data/site-credentials-secret-key.txt"
+    encryption_key_path: "%kernel.project_dir%/data/site-credentials-secret-key.txt"
     default_internal_settings:
         -
             name: share_public
@@ -159,4 +159,4 @@ wallabag_user:
 
 wallabag_import:
     allow_mimetypes: ['application/octet-stream', 'application/json', 'text/plain', 'text/csv']
-    resource_dir: "%kernel.root_dir%/../web/uploads/import"
+    resource_dir: "%kernel.project_dir%/web/uploads/import"

--- a/src/Wallabag/CoreBundle/Command/ExportCommand.php
+++ b/src/Wallabag/CoreBundle/Command/ExportCommand.php
@@ -52,7 +52,7 @@ class ExportCommand extends ContainerAwareCommand
         $filePath = $input->getArgument('filepath');
 
         if (!$filePath) {
-            $filePath = $this->getContainer()->getParameter('kernel.root_dir') . '/../' . sprintf('%s-export.json', $user->getUsername());
+            $filePath = $this->getContainer()->getParameter('kernel.project_dir') . '/' . sprintf('%s-export.json', $user->getUsername());
         }
 
         try {

--- a/src/Wallabag/CoreBundle/Resources/config/services.yml
+++ b/src/Wallabag/CoreBundle/Resources/config/services.yml
@@ -205,7 +205,7 @@ services:
         class: Wallabag\CoreBundle\Helper\DownloadImages
         arguments:
             - "@wallabag_core.entry.download_images.client"
-            - "%kernel.root_dir%/../web/assets/images"
+            - "%kernel.project_dir%/web/assets/images"
             - '%domain_name%'
             - "@logger"
 

--- a/tests/Wallabag/ImportBundle/Command/ImportCommandTest.php
+++ b/tests/Wallabag/ImportBundle/Command/ImportCommandTest.php
@@ -74,7 +74,7 @@ class ImportCommandTest extends WallabagCoreTestCase
         $tester->execute([
             'command' => $command->getName(),
             'username' => 'admin',
-            'filepath' => $application->getKernel()->getContainer()->getParameter('kernel.root_dir') . '/../tests/Wallabag/ImportBundle/fixtures/wallabag-v2-read.json',
+            'filepath' => $application->getKernel()->getContainer()->getParameter('kernel.project_dir') . '/tests/Wallabag/ImportBundle/fixtures/wallabag-v2-read.json',
             '--importer' => 'v2',
         ]);
 
@@ -93,7 +93,7 @@ class ImportCommandTest extends WallabagCoreTestCase
         $tester->execute([
             'command' => $command->getName(),
             'username' => 1,
-            'filepath' => $application->getKernel()->getContainer()->getParameter('kernel.root_dir') . '/../tests/Wallabag/ImportBundle/fixtures/wallabag-v2-read.json',
+            'filepath' => $application->getKernel()->getContainer()->getParameter('kernel.project_dir') . '/tests/Wallabag/ImportBundle/fixtures/wallabag-v2-read.json',
             '--useUserId' => true,
             '--importer' => 'v2',
         ]);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Documentation | no
| Translation   | no
| Fixed tickets | #...
| License       | MIT


Replace `kernel.root_dir` by `kernel.project_dir` and `Kernel::getRootDir()` by `Kernel::getProjectDir()`.
`kernel.root_dir` and `Kernel::getProjectDir()` are deprecated since Symfony 3.3.

See https://symfony.com/blog/new-in-symfony-3-3-a-simpler-way-to-get-the-project-root-directory and https://github.com/symfony/symfony/blob/3.3/UPGRADE-3.3.md#httpkernel for more information.