### PR TITLE
Spelling: Two-factor for wallabag connection

### DIFF
--- a/src/Wallabag/UserBundle/Resources/translations/wallabag_user.en.yml
+++ b/src/Wallabag/UserBundle/Resources/translations/wallabag_user.en.yml
@@ -5,7 +5,7 @@ auth_code:
         subject: 'wallabag authentication code'
         body:
             hello: "Hi %user%,"
-            first_para: "Since you enable two factor authentication on your wallabag account and you just logged in from a new device (computer, phone, etc.), we send you a code to validate your connection."
+            first_para: "Since you require two factor authentication to log in on your wallabag account, and a new device just used it, we send you a code to validate its connection."
             second_para: "Here is the code:"
             support: "Please don't hesitate to contact us if you have any problems:"
             signature: "The wallabag team"


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes/no
| New feature?  | yes/no
| BC breaks?    | yes/no
| Deprecations? | yes/no
| Tests pass?   | yes/no
| Documentation | /no
| Translation   | yes/
| Fixed tickets | #...
| License       | MIT

<!--
Does away with "Since you enable" (without the d that should have been there), and instead of assuming all connections are valid, instead makes the distinction between possibly malicious ones, and ones made by the user.
-->
