### PR TITLE
Fix MySQL issue on mig from #3373

### DIFF
--- a/app/DoctrineMigrations/Version20171008195606.php
+++ b/app/DoctrineMigrations/Version20171008195606.php
@@ -31,6 +31,7 @@ class Version20171008195606 extends AbstractMigration implements ContainerAwareI
 
         switch ($this->connection->getDatabasePlatform()->getName()) {
             case 'mysql':
+                $this->addSql('UPDATE ' . $this->getTable('entry') . ' SET reading_time = 0 WHERE reading_time IS NULL;');
                 $this->addSql('ALTER TABLE ' . $this->getTable('entry') . ' CHANGE reading_time reading_time INT(11) NOT NULL;');
                 break;
             case 'postgresql':

--- a/tests/Wallabag/ApiBundle/Controller/EntryRestControllerTest.php
+++ b/tests/Wallabag/ApiBundle/Controller/EntryRestControllerTest.php
@@ -983,7 +983,7 @@ class EntryRestControllerTest extends WallabagApiTestCase
 
         $content = json_decode($this->client->getResponse()->getContent(), true);
 
-        $this->assertSame(false, $content['exists']);
+        $this->assertFalse($content['exists']);
     }
 
     public function testGetEntriesExistsWithNoUrl()

--- a/tests/Wallabag/CoreBundle/GuzzleSiteAuthenticator/GrabySiteConfigBuilderTest.php
+++ b/tests/Wallabag/CoreBundle/GuzzleSiteAuthenticator/GrabySiteConfigBuilderTest.php
@@ -68,7 +68,7 @@ class GrabySiteConfigBuilderTest extends \PHPUnit_Framework_TestCase
         $config = $this->builder->buildForHost('www.example.com');
 
         $this->assertSame('example.com', $config->getHost());
-        $this->assertSame(true, $config->requiresLogin());
+        $this->assertTrue($config->requiresLogin());
         $this->assertSame('http://www.example.com/login', $config->getLoginUri());
         $this->assertSame('login', $config->getUsernameField());
         $this->assertSame('password', $config->getPasswordField());

--- a/tests/Wallabag/CoreBundle/Helper/ContentProxyTest.php
+++ b/tests/Wallabag/CoreBundle/Helper/ContentProxyTest.php
@@ -51,7 +51,7 @@ class ContentProxyTest extends \PHPUnit_Framework_TestCase
         $this->assertEmpty($entry->getMimetype());
         $this->assertEmpty($entry->getLanguage());
         $this->assertSame(0.0, $entry->getReadingTime());
-        $this->assertSame(null, $entry->getDomainName());
+        $this->assertNull($entry->getDomainName());
     }
 
     public function testWithEmptyContent()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | -
| Documentation | -
| Translation   | -
| Fixed tickets | -
| License       | MIT

This PR fixes migration from PR #3373 for MySQL databases.