### PR TITLE
Disable controller access if feature disabled

### DIFF
--- a/src/Wallabag/CoreBundle/Controller/SiteCredentialController.php
+++ b/src/Wallabag/CoreBundle/Controller/SiteCredentialController.php
@@ -24,6 +24,8 @@ class SiteCredentialController extends Controller
      */
     public function indexAction()
     {
+        $this->isSiteCredentialsEnabled();
+
         $credentials = $this->get('wallabag_core.site_credential_repository')->findByUser($this->getUser());
 
         return $this->render('WallabagCoreBundle:SiteCredential:index.html.twig', [
@@ -43,6 +45,8 @@ class SiteCredentialController extends Controller
      */
     public function newAction(Request $request)
     {
+        $this->isSiteCredentialsEnabled();
+
         $credential = new SiteCredential($this->getUser());
 
         $form = $this->createForm('Wallabag\CoreBundle\Form\Type\SiteCredentialType', $credential);
@@ -83,6 +87,8 @@ class SiteCredentialController extends Controller
      */
     public function editAction(Request $request, SiteCredential $siteCredential)
     {
+        $this->isSiteCredentialsEnabled();
+
         $this->checkUserAction($siteCredential);
 
         $deleteForm = $this->createDeleteForm($siteCredential);
@@ -125,6 +131,8 @@ class SiteCredentialController extends Controller
      */
     public function deleteAction(Request $request, SiteCredential $siteCredential)
     {
+        $this->isSiteCredentialsEnabled();
+
         $this->checkUserAction($siteCredential);
 
         $form = $this->createDeleteForm($siteCredential);
@@ -142,6 +150,16 @@ class SiteCredentialController extends Controller
         }
 
         return $this->redirectToRoute('site_credentials_index');
+    }
+
+    /**
+     * Throw a 404 if the feature is disabled.
+     */
+    private function isSiteCredentialsEnabled()
+    {
+        if (!$this->get('craue_config')->get('restricted_access')) {
+            throw $this->createNotFoundException('Feature "restricted_access" is disabled, controllers too.');
+        }
     }
 
     /**

--- a/tests/Wallabag/CoreBundle/Controller/SiteCredentialControllerTest.php
+++ b/tests/Wallabag/CoreBundle/Controller/SiteCredentialControllerTest.php
@@ -8,6 +8,20 @@ use Wallabag\CoreBundle\Entity\SiteCredential;
 
 class SiteCredentialControllerTest extends WallabagCoreTestCase
 {
+    public function testAccessDeniedBecauseFeatureDisabled()
+    {
+        $this->logInAs('admin');
+        $client = $this->getClient();
+
+        $client->getContainer()->get('craue_config')->set('restricted_access', 0);
+
+        $client->request('GET', '/site-credentials/');
+
+        $this->assertSame(404, $client->getResponse()->getStatusCode());
+
+        $client->getContainer()->get('craue_config')->set('restricted_access', 1);
+    }
+
     public function testListSiteCredential()
     {
         $this->logInAs('admin');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Documentation | no
| Translation   | no
| Fixed tickets | fixes #3429
| License       | MIT

If `restricted_access` is disabled, accessing `/site-credentials/` must be disabled.