### PR TITLE
Fix empty title and domain_name when exception is thrown during fetch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 # Changelog
 
-##  [2.3.0](https://github.com/wallabag/wallabag/tree/2.3.0) (2017-10-21)
+## [unreleased](https://github.com/wallabag/wallabag/tree/master)
+   [Full Changelog](https://github.com/wallabag/wallabag/compare/2.3.0...master)
+
+### Fixes
+
+ - Fix empty title and domain_name when exception is thrown during fetch [#3442](https://github.com/wallabag/wallabag/pull/3442)
+
+##  [2.3.0](https://github.com/wallabag/wallabag/tree/2.3.0) (2017-12-11)
    [Full Changelog](https://github.com/wallabag/wallabag/compare/2.2.3...2.3.0)
 
 ### API

--- a/src/Wallabag/ApiBundle/Controller/EntryRestController.php
+++ b/src/Wallabag/ApiBundle/Controller/EntryRestController.php
@@ -381,6 +381,14 @@ class EntryRestController extends WallabagRestController
             }
         }
 
+        if (empty($entry->getDomainName())) {
+            $this->get('wallabag_core.content_proxy')->setEntryDomainName($entry);
+        }
+
+        if (empty($entry->getTitle())) {
+            $this->get('wallabag_core.content_proxy')->setDefaultEntryTitle($entry);
+        }
+
         $em = $this->getDoctrine()->getManager();
         $em->persist($entry);
         $em->flush();
@@ -488,6 +496,14 @@ class EntryRestController extends WallabagRestController
 
         if (!empty($data['origin_url'])) {
             $entry->setOriginUrl($data['origin_url']);
+        }
+
+        if (empty($entry->getDomainName())) {
+            $this->get('wallabag_core.content_proxy')->setEntryDomainName($entry);
+        }
+
+        if (empty($entry->getTitle())) {
+            $this->get('wallabag_core.content_proxy')->setDefaultEntryTitle($entry);
         }
 
         $em = $this->getDoctrine()->getManager();

--- a/src/Wallabag/CoreBundle/Controller/EntryController.php
+++ b/src/Wallabag/CoreBundle/Controller/EntryController.php
@@ -502,6 +502,14 @@ class EntryController extends Controller
             $message = 'flashes.entry.notice.' . $prefixMessage . '_failed';
         }
 
+        if (empty($entry->getDomainName())) {
+            $this->get('wallabag_core.content_proxy')->setEntryDomainName($entry);
+        }
+
+        if (empty($entry->getTitle())) {
+            $this->get('wallabag_core.content_proxy')->setDefaultEntryTitle($entry);
+        }
+
         $this->get('session')->getFlashBag()->add('notice', $message);
     }
 

--- a/src/Wallabag/CoreBundle/Helper/ContentProxy.php
+++ b/src/Wallabag/CoreBundle/Helper/ContentProxy.php
@@ -145,6 +145,38 @@ class ContentProxy
     }
 
     /**
+     * Helper to extract and save host from entry url.
+     *
+     * @param Entry $entry
+     */
+    public function setEntryDomainName(Entry $entry)
+    {
+        $domainName = parse_url($entry->getUrl(), PHP_URL_HOST);
+        if (false !== $domainName) {
+            $entry->setDomainName($domainName);
+        }
+    }
+
+    /**
+     * Helper to set a default title using:
+     * - url basename, if applicable
+     * - hostname.
+     *
+     * @param Entry $entry
+     */
+    public function setDefaultEntryTitle(Entry $entry)
+    {
+        $url = parse_url($entry->getUrl());
+        $path = pathinfo($url['path'], PATHINFO_BASENAME);
+
+        if (empty($path)) {
+            $path = $url['host'];
+        }
+
+        $entry->setTitle($path);
+    }
+
+    /**
      * Stock entry with fetched or imported content.
      * Will fall back to OpenGraph data if available.
      *
@@ -155,10 +187,7 @@ class ContentProxy
     {
         $entry->setUrl($content['url']);
 
-        $domainName = parse_url($entry->getUrl(), PHP_URL_HOST);
-        if (false !== $domainName) {
-            $entry->setDomainName($domainName);
-        }
+        $this->setEntryDomainName($entry);
 
         if (!empty($content['title'])) {
             $entry->setTitle($content['title']);

--- a/tests/Wallabag/ApiBundle/Controller/EntryRestControllerTest.php
+++ b/tests/Wallabag/ApiBundle/Controller/EntryRestControllerTest.php
@@ -501,6 +501,8 @@ class EntryRestControllerTest extends WallabagApiTestCase
             $content = json_decode($this->client->getResponse()->getContent(), true);
             $this->assertGreaterThan(0, $content['id']);
             $this->assertSame('http://www.example.com/', $content['url']);
+            $this->assertSame('www.example.com', $content['domain_name']);
+            $this->assertSame('www.example.com', $content['title']);
         } finally {
             // Remove the created entry to avoid side effects on other tests
             if (isset($content['id'])) {

--- a/tests/Wallabag/CoreBundle/WallabagCoreTestCase.php
+++ b/tests/Wallabag/CoreBundle/WallabagCoreTestCase.php
@@ -25,6 +25,11 @@ abstract class WallabagCoreTestCase extends WebTestCase
         $this->client = static::createClient();
     }
 
+    public function getNewClient()
+    {
+        return $this->client = static::createClient();
+    }
+
     public function getClient()
     {
         return $this->client;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | -
| Documentation | no
| Translation   | no
| Fixed tickets | #2053 
| License       | MIT

Entries will now have a default title when it's empty (*because of an exception during the fetch*):

- basename part of entry's path, if any
- or domain name

This default title does not replace the "No title found" of Graby when it fails to extract a title.

This PR still needs a test on `EntryControllerTest` using a mock.