### PR TITLE
Freeze phpunit-bridge to 3.3 branch to fix phpunit issue

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -91,7 +91,7 @@
         "doctrine/doctrine-fixtures-bundle": "~2.2",
         "doctrine/data-fixtures": "~1.1",
         "sensio/generator-bundle": "^3.0",
-        "symfony/phpunit-bridge": "^3.3",
+        "symfony/phpunit-bridge": "~3.3.13",
         "friendsofphp/php-cs-fixer": "~2.0",
         "m6web/redis-mock": "^2.0",
         "dama/doctrine-test-bundle": "^3.0"


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | _probably better than before :D_
| Documentation | no
| Translation   | no
| Fixed tickets | -
| License       | MIT

Workaround for waiting https://github.com/symfony/phpunit-bridge/commit/a558e6a6a754297c8aacd2f179cec54fe343ca4d to be released, fixing phpunit issue on phpunit-bridge>=3.4.0
