### PR TITLE
Update doctrine annotation usage to avoid memory leaks

### DIFF
--- a/app/autoload.php
+++ b/app/autoload.php
@@ -8,6 +8,6 @@ use Doctrine\Common\Annotations\AnnotationRegistry;
  */
 $loader = require __DIR__ . '/../vendor/autoload.php';
 
-AnnotationRegistry::registerLoader([$loader, 'loadClass']);
+AnnotationRegistry::registerUniqueLoader([$loader, 'loadClass']);
 
 return $loader;

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
         "issues": "https://github.com/wallabag/wallabag/issues"
     },
     "require": {
-        "php": ">=5.6.0",
+        "php": "^7.1",
         "ext-pcre": "*",
         "ext-dom": "*",
         "ext-curl": "*",
@@ -47,6 +47,7 @@
         "doctrine/orm": "^2.5.12",
         "doctrine/doctrine-bundle": "^1.8.0",
         "doctrine/doctrine-cache-bundle": "^1.3.2",
+        "doctrine/annotations": "^1.6",
         "twig/extensions": "^1.5.1",
         "symfony/swiftmailer-bundle": "^2.6.7",
         "symfony/monolog-bundle": "^3.1.2",
@@ -132,7 +133,7 @@
     "config": {
         "bin-dir": "bin",
         "platform": {
-            "php": "5.6.0"
+            "php": "7.1.0"
         }
     },
     "minimum-stability": "dev",


### PR DESCRIPTION
https://github.com/doctrine/annotations/pull/162

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Documentation | no
| Translation   | no
| Fixed tickets | 
| License       | MIT

This use the new endpoint for doctrine annotations so as to make sure that you can't shoot yourself in the foot by calling the loader multiple times.
