### PR TITLE
Fix All RSS not accessible if not logged in + Tests

### DIFF
--- a/app/config/security.yml
+++ b/app/config/security.yml
@@ -60,7 +60,7 @@ security:
         - { path: ^/login, roles: IS_AUTHENTICATED_ANONYMOUSLY }
         - { path: ^/register, role: IS_AUTHENTICATED_ANONYMOUSLY }
         - { path: ^/resetting, role: IS_AUTHENTICATED_ANONYMOUSLY }
-        - { path: /(unread|starred|archive).xml$, roles: IS_AUTHENTICATED_ANONYMOUSLY }
+        - { path: /(unread|starred|archive|all).xml$, roles: IS_AUTHENTICATED_ANONYMOUSLY }
         - { path: /tags/(.*).xml$, roles: IS_AUTHENTICATED_ANONYMOUSLY }
         - { path: ^/share, roles: IS_AUTHENTICATED_ANONYMOUSLY }
         - { path: ^/settings, roles: ROLE_SUPER_ADMIN }

--- a/tests/Wallabag/CoreBundle/Controller/RssControllerTest.php
+++ b/tests/Wallabag/CoreBundle/Controller/RssControllerTest.php
@@ -61,6 +61,9 @@ class RssControllerTest extends WallabagCoreTestCase
             [
                 '/wallace/YZIOAUZIAO/archives.xml',
             ],
+            [
+                '/wallace/YZIOAUZIAO/all.xml',
+            ],
         ];
     }
 
@@ -139,6 +142,28 @@ class RssControllerTest extends WallabagCoreTestCase
         $this->assertSame(200, $client->getResponse()->getStatusCode());
 
         $this->validateDom($client->getResponse()->getContent(), 'archive', 'archive');
+    }
+
+    public function testAll()
+    {
+        $client = $this->getClient();
+        $em = $client->getContainer()->get('doctrine.orm.entity_manager');
+        $user = $em
+            ->getRepository('WallabagUserBundle:User')
+            ->findOneByUsername('admin');
+
+        $config = $user->getConfig();
+        $config->setRssToken('SUPERTOKEN');
+        $config->setRssLimit(null);
+        $em->persist($config);
+        $em->flush();
+
+        $client = $this->getClient();
+        $client->request('GET', '/admin/SUPERTOKEN/all.xml');
+
+        $this->assertSame(200, $client->getResponse()->getStatusCode());
+
+        $this->validateDom($client->getResponse()->getContent(), 'all', 'all');
     }
 
     public function testPagination()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Documentation | -
| Translation   | -
| Fixed tickets | -
| License       | MIT

When fixing `pubDate` format on RSS feeds, I realized the "all.xml" feed was not accessible if you were not previously logged in to the UI _(this is what token is supposed to avoid)_.
I also added test method "All" feed and all.xml bad url.
