### PR TITLE
Replaced env by dev for make run

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ dev: ## Install the latest dev version
 	@sh scripts/dev.sh
 
 run: ## Run the wallabag built-in server
-	@php bin/console server:run --env=$(ENV)
+	@php bin/console server:run --env=dev
 
 build: ## Run webpack
 	@npm run build:$(ENV)


### PR DESCRIPTION
The symfony server:run command can only be used in dev environment

| Q             | A
| ------------- | ---
| Bug fix?      | yes, kind of
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Documentation | no
| Translation   | no
| CHANGELOG.md  | no
| Fixed tickets | N/A
| License       | MIT

The symfony `server:run` command can only be used in dev environment.