### PR TITLE
Change the way to check for initial migration

### DIFF
--- a/app/DoctrineMigrations/Version20160401000000.php
+++ b/app/DoctrineMigrations/Version20160401000000.php
@@ -4,7 +4,6 @@ namespace Application\Migrations;
 
 use Doctrine\DBAL\Migrations\AbstractMigration;
 use Doctrine\DBAL\Schema\Schema;
-use Doctrine\DBAL\Schema\SchemaException;
 use Symfony\Component\DependencyInjection\ContainerAwareInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 

--- a/app/DoctrineMigrations/Version20160401000000.php
+++ b/app/DoctrineMigrations/Version20160401000000.php
@@ -28,13 +28,7 @@ class Version20160401000000 extends AbstractMigration implements ContainerAwareI
      */
     public function up(Schema $schema)
     {
-        try {
-            $schema->getTable($this->getTable('entry'));
-
-            $this->skipIf(true, 'Database already initialized');
-        } catch (SchemaException $e) {
-            // it's ok, the table does not exist we can proceed to the initial migration
-        }
+        $this->skipIf($schema->hasTable($this->getTable('entry')), 'Database already initialized');
 
         switch ($this->connection->getDatabasePlatform()->getName()) {
             case 'sqlite':


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Documentation | no
| Translation   | no
| CHANGELOG.md  | :confused: 
| Fixed tickets | #3480
| License       | MIT

Instead of checking if some migrations were run we just check if the main table exist.
- if it exists, we can skip the initial migration
- if not, run the initial migration

Poke @aaa2000 