### PR TITLE
Add custom driver & schema manager for PostgreSQL 10

### DIFF
--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -47,6 +47,7 @@ twig:
 doctrine:
     dbal:
         driver: "%database_driver%"
+        driver_class: "%database_driver_class%"
         host: "%database_host%"
         port: "%database_port%"
         dbname: "%database_name%"

--- a/app/config/config_test.yml
+++ b/app/config/config_test.yml
@@ -23,6 +23,7 @@ swiftmailer:
 doctrine:
     dbal:
         driver: "%test_database_driver%"
+        driver_class: "%test_database_driver_class%"
         host: "%test_database_host%"
         port: "%test_database_port%"
         dbname: "%test_database_name%"

--- a/app/config/parameters.yml.dist
+++ b/app/config/parameters.yml.dist
@@ -11,6 +11,8 @@ parameters:
     # database_password: %env.database_password%
 
     database_driver: pdo_mysql
+    database_driver_class: ~
+    # database_driver_class: Wallabag\CoreBundle\Doctrine\DBAL\Driver\CustomPostgreSQLDriver
     database_host: 127.0.0.1
     database_port: ~
     database_name: wallabag

--- a/app/config/tests/parameters_test.mysql.yml
+++ b/app/config/tests/parameters_test.mysql.yml
@@ -1,5 +1,6 @@
 parameters:
     test_database_driver: pdo_mysql
+    test_database_driver_class: ~
     test_database_host: localhost
     test_database_port: 3306
     test_database_name: wallabag_test

--- a/app/config/tests/parameters_test.pgsql.yml
+++ b/app/config/tests/parameters_test.pgsql.yml
@@ -1,5 +1,6 @@
 parameters:
     test_database_driver: pdo_pgsql
+    test_database_driver_class: Wallabag\CoreBundle\Doctrine\DBAL\Driver\CustomPostgreSQLDriver
     test_database_host: localhost
     test_database_port:
     test_database_name: wallabag_test

--- a/app/config/tests/parameters_test.sqlite.yml
+++ b/app/config/tests/parameters_test.sqlite.yml
@@ -1,5 +1,6 @@
 parameters:
     test_database_driver: pdo_sqlite
+    test_database_driver_class: ~
     test_database_host: localhost
     test_database_port:
     test_database_name: ~

--- a/src/Wallabag/CoreBundle/Doctrine/DBAL/Driver/CustomPostgreSQLDriver.php
+++ b/src/Wallabag/CoreBundle/Doctrine/DBAL/Driver/CustomPostgreSQLDriver.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Wallabag\CoreBundle\Doctrine\DBAL\Driver;
+
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Driver\PDOPgSql\Driver;
+use Wallabag\CoreBundle\Doctrine\DBAL\Schema\CustomPostgreSqlSchemaManager;
+
+/**
+ * This custom driver allow to use a different schema manager
+ * So we can fix the PostgreSQL 10 problem.
+ *
+ * @see https://github.com/wallabag/wallabag/issues/3479
+ * @see https://github.com/doctrine/dbal/issues/2868
+ */
+class CustomPostgreSQLDriver extends Driver
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function getSchemaManager(Connection $conn)
+    {
+        return new CustomPostgreSqlSchemaManager($conn);
+    }
+}

--- a/src/Wallabag/CoreBundle/Doctrine/DBAL/Schema/CustomPostgreSqlSchemaManager.php
+++ b/src/Wallabag/CoreBundle/Doctrine/DBAL/Schema/CustomPostgreSqlSchemaManager.php
@@ -18,16 +18,16 @@ class CustomPostgreSqlSchemaManager extends PostgreSqlSchemaManager
      */
     protected function _getPortableSequenceDefinition($sequence)
     {
+        $sequenceName = $sequence['relname'];
         if ('public' !== $sequence['schemaname']) {
             $sequenceName = $sequence['schemaname'] . '.' . $sequence['relname'];
-        } else {
-            $sequenceName = $sequence['relname'];
         }
 
         $query = 'SELECT min_value, increment_by FROM ' . $this->_platform->quoteIdentifier($sequenceName);
 
-        // patch for PostgreSql >= 10
-        if ((float) ($this->_conn->getWrappedConnection()->getServerVersion()) >= 10) {
+        // the `method_exists` is only to avoid test to fail:
+        // DAMA\DoctrineTestBundle\Doctrine\DBAL\StaticConnection doesn't support the `getServerVersion`
+        if (method_exists($this->_conn->getWrappedConnection(), 'getServerVersion') && (float) ($this->_conn->getWrappedConnection()->getServerVersion()) >= 10) {
             $query = "SELECT min_value, increment_by FROM pg_sequences WHERE schemaname = 'public' AND sequencename = " . $this->_conn->quote($sequenceName);
         }
 

--- a/src/Wallabag/CoreBundle/Doctrine/DBAL/Schema/CustomPostgreSqlSchemaManager.php
+++ b/src/Wallabag/CoreBundle/Doctrine/DBAL/Schema/CustomPostgreSqlSchemaManager.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Wallabag\CoreBundle\Doctrine\DBAL\Schema;
+
+use Doctrine\DBAL\Schema\PostgreSqlSchemaManager;
+use Doctrine\DBAL\Schema\Sequence;
+
+/**
+ * This custom schema manager fix the PostgreSQL 10 problem.
+ *
+ * @see https://github.com/wallabag/wallabag/issues/3479
+ * @see https://github.com/doctrine/dbal/issues/2868
+ */
+class CustomPostgreSqlSchemaManager extends PostgreSqlSchemaManager
+{
+    /**
+     * {@inheritdoc}
+     */
+    protected function _getPortableSequenceDefinition($sequence)
+    {
+        if ('public' !== $sequence['schemaname']) {
+            $sequenceName = $sequence['schemaname'] . '.' . $sequence['relname'];
+        } else {
+            $sequenceName = $sequence['relname'];
+        }
+
+        $query = 'SELECT min_value, increment_by FROM ' . $this->_platform->quoteIdentifier($sequenceName);
+
+        // patch for PostgreSql >= 10
+        if ((float) ($this->_conn->getWrappedConnection()->getServerVersion()) >= 10) {
+            $query = "SELECT min_value, increment_by FROM pg_sequences WHERE schemaname = 'public' AND sequencename = " . $this->_conn->quote($sequenceName);
+        }
+
+        $data = $this->_conn->fetchAll($query);
+
+        return new Sequence($sequenceName, $data[0]['increment_by'], $data[0]['min_value']);
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Documentation | https://github.com/wallabag/doc/pull/54
| Translation   | no
| CHANGELOG.md  | no
| Fixed tickets | #3479
| License       | MIT

Since DBAL guys are waiting for Travis to support PostgreSQL 10 ([which seems to be waited for months now](https://github.com/travis-ci/travis-ci/issues/8537)) we need to take action to fix migration for our PostgreSQL 10 users.

Introduce a custom driver & schema manager with the fix from the [DBAL issue](https://github.com/doctrine/dbal/issues/2868).
User using PostgreSQL 10 will need to add an extra line in the `parameters.yml`:

```diff
     database_driver: pdo_pgsql
+    database_driver_class: Wallabag\CoreBundle\Doctrine\DBAL\Driver\CustomPostgreSQLDriver
```