### PR TITLE
Fix 3484: hide the share toggle button if no service is enabled

### DIFF
--- a/src/Wallabag/CoreBundle/Resources/views/themes/material/Entry/entry.html.twig
+++ b/src/Wallabag/CoreBundle/Resources/views/themes/material/Entry/entry.html.twig
@@ -97,6 +97,15 @@
             <div class="collapsible-body"></div>
         </li>
 
+        {% if craue_setting('share_public')
+           or craue_setting('share_twitter')
+           or craue_setting('share_shaarli')
+           or craue_setting('share_scuttle')
+           or craue_setting('share_diaspora')
+           or craue_setting('share_unmark')
+           or craue_setting('carrot')
+           or craue_setting('share_mail')
+        %}
         <li class="bold">
             <a class="waves-effect collapsible-header">
                 <i class="material-icons small">share</i>
@@ -169,6 +178,7 @@
                 </ul>
             </div>
         </li>
+        {% endif %}
 
         {% if craue_setting('show_printlink') %}
         <li class="bold border-bottom hide-on-med-and-down">


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | aye
| Documentation | no
| Translation   | no
| CHANGELOG.md  | no
| Fixed tickets | #3484
| License       | MIT

Hides the "Share" toolbar entry completely if all the share services are disabled.

I'm not really happy with the big "if" block, but I'd say it'd be overdoing it to change it without having a more modulare sharing system (e.g. be able to add/remove supported services). The list is hardcoded in the template, it can be hardcoded in the condition for it.