### PR TITLE
Removed "make run" in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,9 +19,10 @@ Then you can install wallabag by executing the following commands:
 
 ```
 git clone https://github.com/wallabag/wallabag.git
-cd wallabag && make install
-make run
+cd wallabag && make install 
 ```
+
+Now, [configure a virtual host](https://doc.wallabag.org/en/admin/installation/virtualhosts.html) to use your wallabag. 
 
 # License
 Copyright © 2013-2018 Nicolas Lœuillet <nicolas@loeuillet.org>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Documentation | yes
| Translation   | no
| CHANGELOG.md  | no
| Fixed tickets | N/A
| License       | MIT

Because `make run` is only for dev environment.