### PR TITLE
WIP on automatic migrations.

### DIFF
--- a/app/config/wallabag.yml
+++ b/app/config/wallabag.yml
@@ -23,6 +23,7 @@ wallabag_core:
     reading_speed: 1
     cache_lifetime: 10
     action_mark_as_read: 1
+    run_migration_on_request: false
     list_mode: 0
     fetching_error_message_title: 'No title found'
     fetching_error_message: |

--- a/src/Wallabag/CoreBundle/DependencyInjection/Configuration.php
+++ b/src/Wallabag/CoreBundle/DependencyInjection/Configuration.php
@@ -65,6 +65,9 @@ class Configuration implements ConfigurationInterface
                 ->end()
                 ->scalarNode('encryption_key_path')
                 ->end()
+                ->booleanNode('run_migration_on_request')
+                    ->defaultFalse()
+                ->end()
             ->end()
         ;
 

--- a/src/Wallabag/CoreBundle/DependencyInjection/WallabagCoreExtension.php
+++ b/src/Wallabag/CoreBundle/DependencyInjection/WallabagCoreExtension.php
@@ -6,6 +6,7 @@ use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Loader;
 use Symfony\Component\HttpKernel\DependencyInjection\Extension;
+use Wallabag\CoreBundle\Listener\MigrationListener;
 
 class WallabagCoreExtension extends Extension
 {
@@ -30,6 +31,7 @@ class WallabagCoreExtension extends Extension
         $container->setParameter('wallabag_core.api_limit_mass_actions', $config['api_limit_mass_actions']);
         $container->setParameter('wallabag_core.default_internal_settings', $config['default_internal_settings']);
         $container->setParameter('wallabag_core.site_credentials.encryption_key_path', $config['encryption_key_path']);
+        $container->setParameter('wallabag_core.run_migrations_on_request', $config['run_migration_on_request']);
 
         $loader = new Loader\YamlFileLoader($container, new FileLocator(__DIR__ . '/../Resources/config'));
         $loader->load('services.yml');

--- a/src/Wallabag/CoreBundle/Listener/MigrationListener.php
+++ b/src/Wallabag/CoreBundle/Listener/MigrationListener.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace Wallabag\CoreBundle\Listener;
+
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Migrations\Configuration\Configuration;
+use Doctrine\DBAL\Migrations\Migration;
+use Symfony\Component\DependencyInjection\Container;
+use Symfony\Component\DependencyInjection\ContainerAwareInterface;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpKernel\KernelEvents;
+
+class MigrationListener implements EventSubscriberInterface
+{
+    /**
+     * @var Connection
+     */
+    private $connection;
+
+    /**
+     * @var string
+     */
+    private $migrationPath;
+
+    /**
+     * @var string
+     */
+    private $migrationNamespace;
+
+    /**
+     * @var Container
+     */
+    private $container;
+
+    /**
+     * @var boolean
+     */
+    private $enabled;
+
+    /**
+     * MigrationListener constructor.
+     *
+     * @param $connection
+     * @param $migrationPath
+     * @param $migrationNamespace
+     * @param $container
+     * @param $enabled
+     */
+    public function __construct($connection, $migrationPath, $migrationNamespace, $container, $enabled)
+    {
+        $this->connection = $connection;
+        $this->migrationPath = $migrationPath;
+        $this->migrationNamespace = $migrationNamespace;
+
+        $this->container = $container;
+        $this->enabled = $enabled;
+    }
+
+    /**
+     * @return array
+     */
+    public static function getSubscribedEvents()
+    {
+        return [
+            KernelEvents::REQUEST => 'checkMigrations'
+        ];
+    }
+
+    /**
+     * @throws \Doctrine\DBAL\Migrations\MigrationException
+     */
+    public function checkMigrations()
+    {
+        if ($this->enabled !== true) {
+            return;
+        }
+
+        $config = new Configuration($this->connection);#
+        $config->setMigrationsDirectory($this->migrationPath);
+        $config->setMigrationsNamespace($this->migrationNamespace);
+
+        $config->registerMigrationsFromDirectory($this->migrationPath);
+        foreach ($config->getMigrations() as $version) {
+            $migration = $version->getMigration();
+            if ($migration instanceof ContainerAwareInterface) {
+                $migration->setContainer($this->container);
+            }
+        }
+
+        $migration = new Migration($config);
+        $migration->migrate(null, false, false, null);
+    }
+}

--- a/src/Wallabag/CoreBundle/Resources/config/services.yml
+++ b/src/Wallabag/CoreBundle/Resources/config/services.yml
@@ -218,3 +218,15 @@ services:
         arguments:
             - "%wallabag_core.site_credentials.encryption_key_path%"
             - "@logger"
+
+    wallabag_core.listener.migration_listener:
+        public: false
+        class: Wallabag\CoreBundle\Listener\MigrationListener
+        arguments:
+            - "@doctrine.dbal.default_connection"
+            - %doctrine_migrations.dir_name%
+            - %doctrine_migrations.namespace%
+            - "@service_container"
+            - %wallabag_core.run_migrations_on_request%
+        tags:
+            - "kernel.event_subscriber"


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Documentation | no
| Translation   | no
| CHANGELOG.md  | no
| Fixed tickets | 
| License       | MIT

Hi,

The whole point of this PR is to be able, to run doctrine-migrations on every request. It can be usefull for those who don't have a ssh access to their servers. 

To enable the behaviour all one has to do, is edit the `wallabag.yml` file and set the `run_migration_on_request` to `true`. 

