### PR TITLE
command: replace note regarding server:run --env=prod

### DIFF
--- a/src/Wallabag/CoreBundle/Command/InstallCommand.php
+++ b/src/Wallabag/CoreBundle/Command/InstallCommand.php
@@ -64,7 +64,7 @@ class InstallCommand extends ContainerAwareCommand
         ;
 
         $this->io->success('Wallabag has been successfully installed.');
-        $this->io->note('Just execute `php bin/console server:run --env=prod` for using wallabag: http://localhost:8000');
+        $this->io->success('You can now configure your web server, see https://doc.wallabag.org');
     }
 
     protected function checkRequirements()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | -
| Deprecations? | -
| Tests pass?   | -
| Documentation | no
| Translation   | no
| CHANGELOG.md  | no
| Fixed tickets | -
| License       | MIT

server:run --env=prod does not exist anymore