### PR TITLE
material: replace exit_to_app, redo and autorenew icons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
 
  - Fix empty title and domain_name when exception is thrown during fetch [#3442](https://github.com/wallabag/wallabag/pull/3442)
 
+### Changes
+
+- material: replace exit_to_app, redo and autorenew icons [#3513](https://github.com/wallabag/wallabag/pull/3513)
+
 ##  [2.3.0](https://github.com/wallabag/wallabag/tree/2.3.0) (2017-12-11)
    [Full Changelog](https://github.com/wallabag/wallabag/compare/2.2.3...2.3.0)
 

--- a/src/Wallabag/CoreBundle/Resources/views/themes/material/Entry/_card_actions.html.twig
+++ b/src/Wallabag/CoreBundle/Resources/views/themes/material/Entry/_card_actions.html.twig
@@ -7,7 +7,7 @@
 
     <ul class="tools right">
         <li>
-            <a title="{{ 'entry.list.toogle_as_read'|trans }}" class="tool grey-text" href="{{ path('archive_entry', { 'id': entry.id }) }}"><i class="material-icons">{% if entry.isArchived == 0 %}done{% else %}redo{% endif %}</i></a>
+            <a title="{{ 'entry.list.toogle_as_read'|trans }}" class="tool grey-text" href="{{ path('archive_entry', { 'id': entry.id }) }}"><i class="material-icons">{% if entry.isArchived == 0 %}done{% else %}unarchive{% endif %}</i></a>
             <a title="{{ 'entry.list.toogle_as_star'|trans }}" class="tool grey-text" href="{{ path('star_entry', { 'id': entry.id }) }}"><i class="material-icons">{% if entry.isStarred == 0 %}star_border{% else %}star{% endif %}</i></a>
             <a title="{{ 'entry.list.delete'|trans }}" onclick="return confirm('{{ 'entry.confirm.delete'|trans|escape('js') }}')" class="tool grey-text delete" href="{{ path('delete_entry', { 'id': entry.id }) }}"><i class="material-icons">delete</i></a>
         </li>

--- a/src/Wallabag/CoreBundle/Resources/views/themes/material/Entry/_card_list.html.twig
+++ b/src/Wallabag/CoreBundle/Resources/views/themes/material/Entry/_card_list.html.twig
@@ -26,7 +26,7 @@
     </div>
     <ul class="tools-list hide-on-small-only">
         <li>
-            <a title="{{ 'entry.list.toogle_as_read'|trans }}" class="tool grey-text" href="{{ path('archive_entry', { 'id': entry.id }) }}"><i class="material-icons">{% if entry.isArchived == 0 %}done{% else %}redo{% endif %}</i></a>
+            <a title="{{ 'entry.list.toogle_as_read'|trans }}" class="tool grey-text" href="{{ path('archive_entry', { 'id': entry.id }) }}"><i class="material-icons">{% if entry.isArchived == 0 %}done{% else %}unarchive{% endif %}</i></a>
             <a title="{{ 'entry.list.toogle_as_star'|trans }}" class="tool grey-text" href="{{ path('star_entry', { 'id': entry.id }) }}"><i class="material-icons">{% if entry.isStarred == 0 %}star_border{% else %}star{% endif %}</i></a>
             <a title="{{ 'entry.list.delete'|trans }}" onclick="return confirm('{{ 'entry.confirm.delete'|trans|escape('js') }}')" class="tool grey-text delete" href="{{ path('delete_entry', { 'id': entry.id }) }}"><i class="material-icons">delete</i></a>
         </li>

--- a/src/Wallabag/CoreBundle/Resources/views/themes/material/Entry/entry.html.twig
+++ b/src/Wallabag/CoreBundle/Resources/views/themes/material/Entry/entry.html.twig
@@ -18,14 +18,14 @@
                 </li>
                 <li>
                     <a class="waves-effect" href="{{ path('homepage') }}">
-                        <i class="material-icons">exit_to_app</i>
+                        <i class="material-icons">arrow_back</i>
                     </a>
                 </li>
             </ul>
             <ul class="right">
                 <li>
                     <a class="waves-effect" title="{{ 'entry.view.left_menu.set_as_read'|trans }}" href="{{ path('archive_entry', { 'id': entry.id }) }}" id="markAsRead">
-                        <i class="material-icons small">{% if entry.isArchived == 0 %}done{% else %}redo{% endif %}</i>
+                        <i class="material-icons small">{% if entry.isArchived == 0 %}done{% else %}unarchive{% endif %}</i>
                     </a>
                 </li>
                 <li>
@@ -39,7 +39,7 @@
     <ul id="slide-out" class="collapsible side-nav fixed reader-mode" data-collapsible="accordion">
         <li class="bold border-bottom hide-on-med-and-down">
             <a class="waves-effect collapsible-header" href="{{ path('homepage') }}">
-                <i class="material-icons small">exit_to_app</i>
+                <i class="material-icons small">arrow_back</i>
                 <span>{{ 'entry.view.left_menu.back_to_homepage'|trans }}</span>
             </a>
             <div class="collapsible-body"></div>
@@ -55,7 +55,7 @@
 
         <li class="bold">
             <a class="waves-effect collapsible-header" title="{{ 'entry.view.left_menu.re_fetch_content'|trans }}" href="{{ path('reload_entry', { 'id': entry.id }) }}" id="reload">
-                <i class="material-icons small">autorenew</i>
+                <i class="material-icons small">refresh</i>
                 <span>{{ 'entry.view.left_menu.re_fetch_content'|trans }}</span>
             </a>
             <div class="collapsible-body"></div>
@@ -68,7 +68,7 @@
 
         <li class="bold hide-on-med-and-down">
             <a class="waves-effect collapsible-header markasread" title="{{ markAsReadLabel|trans }}" href="{{ path('archive_entry', { 'id': entry.id }) }}" id="markAsRead">
-                <i class="material-icons small">{% if entry.isArchived == 0 %}done{% else %}redo{% endif %}</i>
+                <i class="material-icons small">{% if entry.isArchived == 0 %}done{% else %}unarchive{% endif %}</i>
                 <span>{{ markAsReadLabel|trans }}</span>
             </a>
             <div class="collapsible-body"></div>
@@ -298,8 +298,8 @@
               <i class="material-icons">menu</i>
             </a>
             <ul>
-              <li><a class="btn-floating" href="{{ path('archive_entry', { 'id': entry.id }) }}"><i class="material-icons">done</i></a></li>
-              <li><a class="btn-floating" href="{{ path('star_entry', { 'id': entry.id }) }}"><i class="material-icons">star_outline</i></a></li>
+              <li><a class="btn-floating" href="{{ path('archive_entry', { 'id': entry.id }) }}"><i class="material-icons">{% if entry.isArchived == 0 %}done{% else %}unarchive{% endif %}</i></a></li>
+              <li><a class="btn-floating" href="{{ path('star_entry', { 'id': entry.id }) }}"><i class="material-icons">{% if entry.isStarred == 0 %}star_outline{% else %}star{% endif %}</i></a></li>
               <li><a class="btn-floating" href="{{ path('delete_entry', { 'id': entry.id }) }}" onclick="return confirm('{{ 'entry.confirm.delete'|trans|escape('js') }}')"><i class="material-icons">delete</i></a></li>
             </ul>
         </div>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | -
| Documentation | -
| Translation   | -
| CHANGELOG.md  | yes
| Fixed tickets | #3437 
| License       | MIT

Fixes #3437 

Here are some screens with updated icons:

![2017-12-16-194946_1920x1080](https://user-images.githubusercontent.com/226063/34073524-d55f633c-e29b-11e7-8189-bc2eb325f49c.png)
![2017-12-16-194954_1920x1080](https://user-images.githubusercontent.com/226063/34073525-d6a39f10-e29b-11e7-9f61-64882205f059.png)
![2017-12-16-195004_1920x1080](https://user-images.githubusercontent.com/226063/34073526-d7f0d8a6-e29b-11e7-9d5c-a11310160e55.png)
![2017-12-16-195017_1920x1080](https://user-images.githubusercontent.com/226063/34073527-d94f4da4-e29b-11e7-9adf-c334bdd4f199.png)
![2017-12-16-195020_1920x1080](https://user-images.githubusercontent.com/226063/34073528-da8c16ca-e29b-11e7-8744-a344cb504948.png)
![2017-12-16-195045_1920x1080](https://user-images.githubusercontent.com/226063/34073529-dc024a2e-e29b-11e7-92ff-1807831ea28b.png)

I also fixed the icons (_unarchive, star_) of bottom menu on mobile view:

![2017-12-16-195800_1920x1080](https://user-images.githubusercontent.com/226063/34073534-ee4772ea-e29b-11e7-9b47-5cbcb26e716a.png)
