### PR TITLE
Add PHP 7.2 compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,9 @@
 ### Changes
 
 - material: replace exit_to_app, redo and autorenew icons [#3513](https://github.com/wallabag/wallabag/pull/3513)
+- Add PHP 7.2 compatibility [#3515](https://github.com/wallabag/wallabag/pull/3515)
 
-##  [2.3.0](https://github.com/wallabag/wallabag/tree/2.3.0) (2017-12-11)
+## [2.3.0](https://github.com/wallabag/wallabag/tree/2.3.0) (2017-12-11)
    [Full Changelog](https://github.com/wallabag/wallabag/compare/2.2.3...2.3.0)
 
 ### API
@@ -44,7 +45,7 @@
 ### Features
 
 - Share articles to Scuttle (https://github.com/scronide/scuttle) instance [#2999](https://github.com/wallabag/wallabag/pull/2999)
-- Allow to remove all archived entries [#3020](https://github.com/wallabag/wallabag/pull/3020) 
+- Allow to remove all archived entries [#3020](https://github.com/wallabag/wallabag/pull/3020)
 - Added publication date and author [#3024](https://github.com/wallabag/wallabag/pull/3024)
 - Added `notmatches` operator for automatic tagging rule [#3047](https://github.com/wallabag/wallabag/pull/3047)
 - Search & paginate users [#3060](https://github.com/wallabag/wallabag/pull/3060)
@@ -67,7 +68,7 @@
 - Changed default value for list mode (grid instead of list) [#3014](https://github.com/wallabag/wallabag/pull/3014)
 - Remove `isPublic` from Entry entity [#3030](https://github.com/wallabag/wallabag/pull/3030)
 - Use username to import [#3080](https://github.com/wallabag/wallabag/pull/3080)
-- Adds Webpack support and remove Grunt [#3022](https://github.com/wallabag/wallabag/pull/3022) 
+- Adds Webpack support and remove Grunt [#3022](https://github.com/wallabag/wallabag/pull/3022)
 - Improved Guzzle subscribers extensibility [#2751](https://github.com/wallabag/wallabag/pull/2751)
 - Added logger when we match Tagging rules [#3110](https://github.com/wallabag/wallabag/pull/3110)
 - unify Download/Export wording. [#3130](https://github.com/wallabag/wallabag/pull/3130)

--- a/app/config/parameters_test.yml
+++ b/app/config/parameters_test.yml
@@ -8,3 +8,4 @@ parameters:
     test_database_path: "%env(TEST_DATABASE_PATH)%"
     env(TEST_DATABASE_PATH): "%kernel.project_dir%/data/db/wallabag_test.sqlite"
     test_database_charset: utf8
+    test_database_driver_class: ~

--- a/composer.json
+++ b/composer.json
@@ -94,7 +94,7 @@
         "symfony/phpunit-bridge": "^3.3",
         "friendsofphp/php-cs-fixer": "~2.0",
         "m6web/redis-mock": "^2.0",
-        "dama/doctrine-test-bundle": "^3.0"
+        "dama/doctrine-test-bundle": "^4.0"
     },
     "scripts": {
         "post-cmd": [

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -32,6 +32,6 @@
     </filter>
 
     <listeners>
-        <listener class="\DAMA\DoctrineTestBundle\PHPUnit\LegacyPHPUnitListener" />
+        <listener class="\DAMA\DoctrineTestBundle\PHPUnit\PHPUnitListener" />
     </listeners>
 </phpunit>

--- a/tests/Wallabag/CoreBundle/Controller/EntryControllerTest.php
+++ b/tests/Wallabag/CoreBundle/Controller/EntryControllerTest.php
@@ -10,7 +10,7 @@ use Wallabag\CoreBundle\Helper\ContentProxy;
 
 class EntryControllerTest extends WallabagCoreTestCase
 {
-    const An_URL_CONTAINING_AN_ARTICLE_WITH_IMAGE = 'http://www.lemonde.fr/judo/article/2017/11/11/judo-la-decima-de-teddy-riner_5213605_1556020.html';
+    const AN_URL_CONTAINING_AN_ARTICLE_WITH_IMAGE = 'http://www.lemonde.fr/judo/article/2017/11/11/judo-la-decima-de-teddy-riner_5213605_1556020.html';
     public $downloadImagesEnabled = false;
     public $url = 'http://www.lemonde.fr/pixels/article/2015/03/28/plongee-dans-l-univers-d-ingress-le-jeu-de-google-aux-frontieres-du-reel_4601155_4408996.html';
 
@@ -1018,7 +1018,7 @@ class EntryControllerTest extends WallabagCoreTestCase
         $this->logInAs('admin');
         $client = $this->getClient();
 
-        $url = self::An_URL_CONTAINING_AN_ARTICLE_WITH_IMAGE;
+        $url = self::AN_URL_CONTAINING_AN_ARTICLE_WITH_IMAGE;
         $client->getContainer()->get('craue_config')->set('download_images_enabled', 1);
 
         $crawler = $client->request('GET', '/new');
@@ -1060,7 +1060,7 @@ class EntryControllerTest extends WallabagCoreTestCase
         $this->logInAs('admin');
         $client = $this->getClient();
 
-        $url = self::An_URL_CONTAINING_AN_ARTICLE_WITH_IMAGE;
+        $url = self::AN_URL_CONTAINING_AN_ARTICLE_WITH_IMAGE;
         $client->getContainer()->get('craue_config')->set('download_images_enabled', 1);
 
         $crawler = $client->request('GET', '/new');

--- a/tests/Wallabag/CoreBundle/Event/Listener/LocaleListenerTest.php
+++ b/tests/Wallabag/CoreBundle/Event/Listener/LocaleListenerTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Wallabag\CoreBundle\Event\Listener;
 
+use PHPUnit\Framework\TestCase;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Session\Session;
@@ -11,7 +12,7 @@ use Symfony\Component\HttpKernel\HttpKernelInterface;
 use Symfony\Component\HttpKernel\KernelEvents;
 use Wallabag\CoreBundle\Event\Listener\LocaleListener;
 
-class LocaleListenerTest extends \PHPUnit_Framework_TestCase
+class LocaleListenerTest extends TestCase
 {
     public function testWithoutSession()
     {

--- a/tests/Wallabag/CoreBundle/Event/Listener/UserLocaleListenerTest.php
+++ b/tests/Wallabag/CoreBundle/Event/Listener/UserLocaleListenerTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Wallabag\CoreBundle\Event\Listener;
 
+use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Session\Session;
 use Symfony\Component\HttpFoundation\Session\Storage\MockArraySessionStorage;
@@ -11,7 +12,7 @@ use Wallabag\CoreBundle\Entity\Config;
 use Wallabag\CoreBundle\Event\Listener\UserLocaleListener;
 use Wallabag\UserBundle\Entity\User;
 
-class UserLocaleListenerTest extends \PHPUnit_Framework_TestCase
+class UserLocaleListenerTest extends TestCase
 {
     public function testWithLanguage()
     {

--- a/tests/Wallabag/CoreBundle/Event/Subscriber/TablePrefixSubscriberTest.php
+++ b/tests/Wallabag/CoreBundle/Event/Subscriber/TablePrefixSubscriberTest.php
@@ -5,9 +5,10 @@ namespace Tests\Wallabag\CoreBundle\Event\Subscriber;
 use Doctrine\Common\EventManager;
 use Doctrine\ORM\Event\LoadClassMetadataEventArgs;
 use Doctrine\ORM\Mapping\ClassMetadata;
+use PHPUnit\Framework\TestCase;
 use Wallabag\CoreBundle\Event\Subscriber\TablePrefixSubscriber;
 
-class TablePrefixSubscriberTest extends \PHPUnit_Framework_TestCase
+class TablePrefixSubscriberTest extends TestCase
 {
     public function dataForPrefix()
     {

--- a/tests/Wallabag/CoreBundle/Form/DataTransformer/StringToListTransformerTest.php
+++ b/tests/Wallabag/CoreBundle/Form/DataTransformer/StringToListTransformerTest.php
@@ -2,9 +2,10 @@
 
 namespace Tests\Wallabag\CoreBundle\Form\DataTransformer;
 
+use PHPUnit\Framework\TestCase;
 use Wallabag\CoreBundle\Form\DataTransformer\StringToListTransformer;
 
-class StringToListTransformerTest extends \PHPUnit_Framework_TestCase
+class StringToListTransformerTest extends TestCase
 {
     /**
      * @dataProvider transformProvider

--- a/tests/Wallabag/CoreBundle/GuzzleSiteAuthenticator/GrabySiteConfigBuilderTest.php
+++ b/tests/Wallabag/CoreBundle/GuzzleSiteAuthenticator/GrabySiteConfigBuilderTest.php
@@ -5,11 +5,12 @@ namespace Tests\Wallabag\CoreBundle\GuzzleSiteAuthenticator;
 use Graby\SiteConfig\SiteConfig as GrabySiteConfig;
 use Monolog\Handler\TestHandler;
 use Monolog\Logger;
+use PHPUnit\Framework\TestCase;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorage;
 use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
 use Wallabag\CoreBundle\GuzzleSiteAuthenticator\GrabySiteConfigBuilder;
 
-class GrabySiteConfigBuilderTest extends \PHPUnit_Framework_TestCase
+class GrabySiteConfigBuilderTest extends TestCase
 {
     /** @var \Wallabag\CoreBundle\GuzzleSiteAuthenticator\GrabySiteConfigBuilder */
     protected $builder;

--- a/tests/Wallabag/CoreBundle/Helper/ContentProxyTest.php
+++ b/tests/Wallabag/CoreBundle/Helper/ContentProxyTest.php
@@ -5,6 +5,7 @@ namespace Tests\Wallabag\CoreBundle\Helper;
 use Graby\Graby;
 use Monolog\Handler\TestHandler;
 use Monolog\Logger;
+use PHPUnit\Framework\TestCase;
 use Psr\Log\NullLogger;
 use Symfony\Component\Validator\ConstraintViolation;
 use Symfony\Component\Validator\ConstraintViolationList;
@@ -15,7 +16,7 @@ use Wallabag\CoreBundle\Helper\ContentProxy;
 use Wallabag\CoreBundle\Helper\RuleBasedTagger;
 use Wallabag\UserBundle\Entity\User;
 
-class ContentProxyTest extends \PHPUnit_Framework_TestCase
+class ContentProxyTest extends TestCase
 {
     private $fetchingErrorMessage = 'wallabag can\'t retrieve contents for this article. Please <a href="http://doc.wallabag.org/en/user/errors_during_fetching.html#how-can-i-help-to-fix-that">troubleshoot this issue</a>.';
 

--- a/tests/Wallabag/CoreBundle/Helper/ContentProxyTest.php
+++ b/tests/Wallabag/CoreBundle/Helper/ContentProxyTest.php
@@ -221,7 +221,7 @@ class ContentProxyTest extends TestCase
         $tagger->expects($this->once())
             ->method('tag');
 
-        $validator = $this->getValidator();
+        $validator = $this->getValidator(false);
         $validator->expects($this->once())
             ->method('validate')
             ->willReturn(new ConstraintViolationList([new ConstraintViolation('oops', 'oops', [], 'oops', 'language', 'dontexist')]));
@@ -262,7 +262,7 @@ class ContentProxyTest extends TestCase
         $tagger->expects($this->once())
             ->method('tag');
 
-        $validator = $this->getValidator();
+        $validator = $this->getValidator(false);
         $validator->expects($this->exactly(2))
             ->method('validate')
             ->will($this->onConsecutiveCalls(
@@ -545,11 +545,19 @@ class ContentProxyTest extends TestCase
         return new NullLogger();
     }
 
-    private function getValidator()
+    private function getValidator($withDefaultMock = true)
     {
-        return $this->getMockBuilder(RecursiveValidator::class)
+        $mock = $this->getMockBuilder(RecursiveValidator::class)
             ->setMethods(['validate'])
             ->disableOriginalConstructor()
             ->getMock();
+
+        if ($withDefaultMock) {
+            $mock->expects($this->any())
+                ->method('validate')
+                ->willReturn(new ConstraintViolationList());
+        }
+
+        return $mock;
     }
 }

--- a/tests/Wallabag/CoreBundle/Helper/CryptoProxyTest.php
+++ b/tests/Wallabag/CoreBundle/Helper/CryptoProxyTest.php
@@ -4,10 +4,11 @@ namespace Tests\Wallabag\CoreBundle\Helper;
 
 use Monolog\Handler\TestHandler;
 use Monolog\Logger;
+use PHPUnit\Framework\TestCase;
 use Psr\Log\NullLogger;
 use Wallabag\CoreBundle\Helper\CryptoProxy;
 
-class CryptoProxyTest extends \PHPUnit_Framework_TestCase
+class CryptoProxyTest extends TestCase
 {
     public function testCrypto()
     {

--- a/tests/Wallabag/CoreBundle/Helper/DownloadImagesTest.php
+++ b/tests/Wallabag/CoreBundle/Helper/DownloadImagesTest.php
@@ -8,9 +8,10 @@ use GuzzleHttp\Stream\Stream;
 use GuzzleHttp\Subscriber\Mock;
 use Monolog\Handler\TestHandler;
 use Monolog\Logger;
+use PHPUnit\Framework\TestCase;
 use Wallabag\CoreBundle\Helper\DownloadImages;
 
-class DownloadImagesTest extends \PHPUnit_Framework_TestCase
+class DownloadImagesTest extends TestCase
 {
     public function dataForSuccessImage()
     {

--- a/tests/Wallabag/CoreBundle/Helper/RedirectTest.php
+++ b/tests/Wallabag/CoreBundle/Helper/RedirectTest.php
@@ -2,13 +2,14 @@
 
 namespace Tests\Wallabag\CoreBundle\Helper;
 
+use PHPUnit\Framework\TestCase;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorage;
 use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
 use Wallabag\CoreBundle\Entity\Config;
 use Wallabag\CoreBundle\Helper\Redirect;
 use Wallabag\UserBundle\Entity\User;
 
-class RedirectTest extends \PHPUnit_Framework_TestCase
+class RedirectTest extends TestCase
 {
     /** @var \PHPUnit_Framework_MockObject_MockObject */
     private $routerMock;

--- a/tests/Wallabag/CoreBundle/Helper/RuleBasedTaggerTest.php
+++ b/tests/Wallabag/CoreBundle/Helper/RuleBasedTaggerTest.php
@@ -4,6 +4,7 @@ namespace Tests\Wallabag\CoreBundle\Helper;
 
 use Monolog\Handler\TestHandler;
 use Monolog\Logger;
+use PHPUnit\Framework\TestCase;
 use Wallabag\CoreBundle\Entity\Config;
 use Wallabag\CoreBundle\Entity\Entry;
 use Wallabag\CoreBundle\Entity\Tag;
@@ -11,7 +12,7 @@ use Wallabag\CoreBundle\Entity\TaggingRule;
 use Wallabag\CoreBundle\Helper\RuleBasedTagger;
 use Wallabag\UserBundle\Entity\User;
 
-class RuleBasedTaggerTest extends \PHPUnit_Framework_TestCase
+class RuleBasedTaggerTest extends TestCase
 {
     private $rulerz;
     private $tagRepository;

--- a/tests/Wallabag/CoreBundle/Helper/TagsAssignerTest.php
+++ b/tests/Wallabag/CoreBundle/Helper/TagsAssignerTest.php
@@ -2,13 +2,14 @@
 
 namespace Tests\Wallabag\CoreBundle\Helper;
 
+use PHPUnit\Framework\TestCase;
 use Wallabag\CoreBundle\Entity\Entry;
 use Wallabag\CoreBundle\Entity\Tag;
 use Wallabag\CoreBundle\Helper\TagsAssigner;
 use Wallabag\CoreBundle\Repository\TagRepository;
 use Wallabag\UserBundle\Entity\User;
 
-class TagsAssignerTest extends \PHPUnit_Framework_TestCase
+class TagsAssignerTest extends TestCase
 {
     public function testAssignTagsWithArrayAndExtraSpaces()
     {

--- a/tests/Wallabag/CoreBundle/ParamConverter/UsernameRssTokenConverterTest.php
+++ b/tests/Wallabag/CoreBundle/ParamConverter/UsernameRssTokenConverterTest.php
@@ -2,12 +2,13 @@
 
 namespace Tests\Wallabag\CoreBundle\Command;
 
+use PHPUnit\Framework\TestCase;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\ParamConverter;
 use Symfony\Component\HttpFoundation\Request;
 use Wallabag\CoreBundle\ParamConverter\UsernameRssTokenConverter;
 use Wallabag\UserBundle\Entity\User;
 
-class UsernameRssTokenConverterTest extends \PHPUnit_Framework_TestCase
+class UsernameRssTokenConverterTest extends TestCase
 {
     public function testSupportsWithNoRegistry()
     {

--- a/tests/Wallabag/CoreBundle/Tools/UtilsTest.php
+++ b/tests/Wallabag/CoreBundle/Tools/UtilsTest.php
@@ -2,10 +2,11 @@
 
 namespace Tests\Wallabag\CoreBundle\Tools;
 
+use PHPUnit\Framework\TestCase;
 use Symfony\Component\Finder\Finder;
 use Wallabag\CoreBundle\Tools\Utils;
 
-class UtilsTest extends \PHPUnit_Framework_TestCase
+class UtilsTest extends TestCase
 {
     /**
      * @dataProvider examples

--- a/tests/Wallabag/CoreBundle/Twig/WallabagExtensionTest.php
+++ b/tests/Wallabag/CoreBundle/Twig/WallabagExtensionTest.php
@@ -2,9 +2,10 @@
 
 namespace Tests\Wallabag\CoreBundle\Twig;
 
+use PHPUnit\Framework\TestCase;
 use Wallabag\CoreBundle\Twig\WallabagExtension;
 
-class WallabagExtensionTest extends \PHPUnit_Framework_TestCase
+class WallabagExtensionTest extends TestCase
 {
     public function testRemoveWww()
     {

--- a/tests/Wallabag/ImportBundle/Command/ImportCommandTest.php
+++ b/tests/Wallabag/ImportBundle/Command/ImportCommandTest.php
@@ -97,5 +97,8 @@ class ImportCommandTest extends WallabagCoreTestCase
             '--useUserId' => true,
             '--importer' => 'v2',
         ]);
+
+        $this->assertContains('imported', $tester->getDisplay());
+        $this->assertContains('already saved', $tester->getDisplay());
     }
 }

--- a/tests/Wallabag/ImportBundle/Consumer/AMQPEntryConsumerTest.php
+++ b/tests/Wallabag/ImportBundle/Consumer/AMQPEntryConsumerTest.php
@@ -3,11 +3,12 @@
 namespace Tests\Wallabag\ImportBundle\Consumer\AMQP;
 
 use PhpAmqpLib\Message\AMQPMessage;
+use PHPUnit\Framework\TestCase;
 use Wallabag\CoreBundle\Entity\Entry;
 use Wallabag\ImportBundle\Consumer\AMQPEntryConsumer;
 use Wallabag\UserBundle\Entity\User;
 
-class AMQPEntryConsumerTest extends \PHPUnit_Framework_TestCase
+class AMQPEntryConsumerTest extends TestCase
 {
     public function testMessageOk()
     {

--- a/tests/Wallabag/ImportBundle/Consumer/RedisEntryConsumerTest.php
+++ b/tests/Wallabag/ImportBundle/Consumer/RedisEntryConsumerTest.php
@@ -2,11 +2,12 @@
 
 namespace Tests\Wallabag\ImportBundle\Consumer\AMQP;
 
+use PHPUnit\Framework\TestCase;
 use Wallabag\CoreBundle\Entity\Entry;
 use Wallabag\ImportBundle\Consumer\RedisEntryConsumer;
 use Wallabag\UserBundle\Entity\User;
 
-class RedisEntryConsumerTest extends \PHPUnit_Framework_TestCase
+class RedisEntryConsumerTest extends TestCase
 {
     public function testMessageOk()
     {

--- a/tests/Wallabag/ImportBundle/Import/ChromeImportTest.php
+++ b/tests/Wallabag/ImportBundle/Import/ChromeImportTest.php
@@ -5,13 +5,14 @@ namespace Tests\Wallabag\ImportBundle\Import;
 use M6Web\Component\RedisMock\RedisMockFactory;
 use Monolog\Handler\TestHandler;
 use Monolog\Logger;
+use PHPUnit\Framework\TestCase;
 use Simpleue\Queue\RedisQueue;
 use Wallabag\CoreBundle\Entity\Entry;
 use Wallabag\ImportBundle\Import\ChromeImport;
 use Wallabag\ImportBundle\Redis\Producer;
 use Wallabag\UserBundle\Entity\User;
 
-class ChromeImportTest extends \PHPUnit_Framework_TestCase
+class ChromeImportTest extends TestCase
 {
     protected $user;
     protected $em;

--- a/tests/Wallabag/ImportBundle/Import/FirefoxImportTest.php
+++ b/tests/Wallabag/ImportBundle/Import/FirefoxImportTest.php
@@ -5,13 +5,14 @@ namespace Tests\Wallabag\ImportBundle\Import;
 use M6Web\Component\RedisMock\RedisMockFactory;
 use Monolog\Handler\TestHandler;
 use Monolog\Logger;
+use PHPUnit\Framework\TestCase;
 use Simpleue\Queue\RedisQueue;
 use Wallabag\CoreBundle\Entity\Entry;
 use Wallabag\ImportBundle\Import\FirefoxImport;
 use Wallabag\ImportBundle\Redis\Producer;
 use Wallabag\UserBundle\Entity\User;
 
-class FirefoxImportTest extends \PHPUnit_Framework_TestCase
+class FirefoxImportTest extends TestCase
 {
     protected $user;
     protected $em;

--- a/tests/Wallabag/ImportBundle/Import/ImportChainTest.php
+++ b/tests/Wallabag/ImportBundle/Import/ImportChainTest.php
@@ -2,9 +2,10 @@
 
 namespace Tests\Wallabag\ImportBundle\Import;
 
+use PHPUnit\Framework\TestCase;
 use Wallabag\ImportBundle\Import\ImportChain;
 
-class ImportChainTest extends \PHPUnit_Framework_TestCase
+class ImportChainTest extends TestCase
 {
     public function testGetAll()
     {

--- a/tests/Wallabag/ImportBundle/Import/ImportCompilerPassTest.php
+++ b/tests/Wallabag/ImportBundle/Import/ImportCompilerPassTest.php
@@ -2,10 +2,11 @@
 
 namespace Tests\Wallabag\ImportBundle\Import;
 
+use PHPUnit\Framework\TestCase;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Wallabag\ImportBundle\Import\ImportCompilerPass;
 
-class ImportCompilerPassTest extends \PHPUnit_Framework_TestCase
+class ImportCompilerPassTest extends TestCase
 {
     public function testProcessNoDefinition()
     {

--- a/tests/Wallabag/ImportBundle/Import/InstapaperImportTest.php
+++ b/tests/Wallabag/ImportBundle/Import/InstapaperImportTest.php
@@ -5,13 +5,14 @@ namespace Tests\Wallabag\ImportBundle\Import;
 use M6Web\Component\RedisMock\RedisMockFactory;
 use Monolog\Handler\TestHandler;
 use Monolog\Logger;
+use PHPUnit\Framework\TestCase;
 use Simpleue\Queue\RedisQueue;
 use Wallabag\CoreBundle\Entity\Entry;
 use Wallabag\ImportBundle\Import\InstapaperImport;
 use Wallabag\ImportBundle\Redis\Producer;
 use Wallabag\UserBundle\Entity\User;
 
-class InstapaperImportTest extends \PHPUnit_Framework_TestCase
+class InstapaperImportTest extends TestCase
 {
     protected $user;
     protected $em;

--- a/tests/Wallabag/ImportBundle/Import/PocketImportTest.php
+++ b/tests/Wallabag/ImportBundle/Import/PocketImportTest.php
@@ -9,6 +9,7 @@ use GuzzleHttp\Subscriber\Mock;
 use M6Web\Component\RedisMock\RedisMockFactory;
 use Monolog\Handler\TestHandler;
 use Monolog\Logger;
+use PHPUnit\Framework\TestCase;
 use Simpleue\Queue\RedisQueue;
 use Wallabag\CoreBundle\Entity\Config;
 use Wallabag\CoreBundle\Entity\Entry;
@@ -16,7 +17,7 @@ use Wallabag\ImportBundle\Import\PocketImport;
 use Wallabag\ImportBundle\Redis\Producer;
 use Wallabag\UserBundle\Entity\User;
 
-class PocketImportTest extends \PHPUnit_Framework_TestCase
+class PocketImportTest extends TestCase
 {
     protected $token;
     protected $user;

--- a/tests/Wallabag/ImportBundle/Import/ReadabilityImportTest.php
+++ b/tests/Wallabag/ImportBundle/Import/ReadabilityImportTest.php
@@ -5,13 +5,14 @@ namespace Tests\Wallabag\ImportBundle\Import;
 use M6Web\Component\RedisMock\RedisMockFactory;
 use Monolog\Handler\TestHandler;
 use Monolog\Logger;
+use PHPUnit\Framework\TestCase;
 use Simpleue\Queue\RedisQueue;
 use Wallabag\CoreBundle\Entity\Entry;
 use Wallabag\ImportBundle\Import\ReadabilityImport;
 use Wallabag\ImportBundle\Redis\Producer;
 use Wallabag\UserBundle\Entity\User;
 
-class ReadabilityImportTest extends \PHPUnit_Framework_TestCase
+class ReadabilityImportTest extends TestCase
 {
     protected $user;
     protected $em;

--- a/tests/Wallabag/ImportBundle/Import/WallabagV1ImportTest.php
+++ b/tests/Wallabag/ImportBundle/Import/WallabagV1ImportTest.php
@@ -5,13 +5,14 @@ namespace Tests\Wallabag\ImportBundle\Import;
 use M6Web\Component\RedisMock\RedisMockFactory;
 use Monolog\Handler\TestHandler;
 use Monolog\Logger;
+use PHPUnit\Framework\TestCase;
 use Simpleue\Queue\RedisQueue;
 use Wallabag\CoreBundle\Entity\Entry;
 use Wallabag\ImportBundle\Import\WallabagV1Import;
 use Wallabag\ImportBundle\Redis\Producer;
 use Wallabag\UserBundle\Entity\User;
 
-class WallabagV1ImportTest extends \PHPUnit_Framework_TestCase
+class WallabagV1ImportTest extends TestCase
 {
     protected $user;
     protected $em;

--- a/tests/Wallabag/ImportBundle/Import/WallabagV2ImportTest.php
+++ b/tests/Wallabag/ImportBundle/Import/WallabagV2ImportTest.php
@@ -5,13 +5,14 @@ namespace Tests\Wallabag\ImportBundle\Import;
 use M6Web\Component\RedisMock\RedisMockFactory;
 use Monolog\Handler\TestHandler;
 use Monolog\Logger;
+use PHPUnit\Framework\TestCase;
 use Simpleue\Queue\RedisQueue;
 use Wallabag\CoreBundle\Entity\Entry;
 use Wallabag\ImportBundle\Import\WallabagV2Import;
 use Wallabag\ImportBundle\Redis\Producer;
 use Wallabag\UserBundle\Entity\User;
 
-class WallabagV2ImportTest extends \PHPUnit_Framework_TestCase
+class WallabagV2ImportTest extends TestCase
 {
     protected $user;
     protected $em;

--- a/tests/Wallabag/UserBundle/EventListener/AuthenticationFailureListenerTest.php
+++ b/tests/Wallabag/UserBundle/EventListener/AuthenticationFailureListenerTest.php
@@ -4,6 +4,7 @@ namespace Tests\Wallabag\UserBundle\EventListener;
 
 use Monolog\Handler\TestHandler;
 use Monolog\Logger;
+use PHPUnit\Framework\TestCase;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
@@ -11,7 +12,7 @@ use Symfony\Component\Security\Core\AuthenticationEvents;
 use Symfony\Component\Security\Core\Event\AuthenticationFailureEvent;
 use Wallabag\UserBundle\EventListener\AuthenticationFailureListener;
 
-class AuthenticationFailureListenerTest extends \PHPUnit_Framework_TestCase
+class AuthenticationFailureListenerTest extends TestCase
 {
     private $requestStack;
     private $logHandler;

--- a/tests/Wallabag/UserBundle/EventListener/CreateConfigListenerTest.php
+++ b/tests/Wallabag/UserBundle/EventListener/CreateConfigListenerTest.php
@@ -4,6 +4,7 @@ namespace Tests\Wallabag\UserBundle\EventListener;
 
 use FOS\UserBundle\Event\FilterUserResponseEvent;
 use FOS\UserBundle\FOSUserEvents;
+use PHPUnit\Framework\TestCase;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -11,7 +12,7 @@ use Wallabag\CoreBundle\Entity\Config;
 use Wallabag\UserBundle\Entity\User;
 use Wallabag\UserBundle\EventListener\CreateConfigListener;
 
-class CreateConfigListenerTest extends \PHPUnit_Framework_TestCase
+class CreateConfigListenerTest extends TestCase
 {
     private $em;
     private $listener;

--- a/tests/Wallabag/UserBundle/Mailer/AuthCodeMailerTest.php
+++ b/tests/Wallabag/UserBundle/Mailer/AuthCodeMailerTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Wallabag\UserBundle\Mailer;
 
+use PHPUnit\Framework\TestCase;
 use Wallabag\UserBundle\Entity\User;
 use Wallabag\UserBundle\Mailer\AuthCodeMailer;
 
@@ -21,7 +22,7 @@ final class CountableMemorySpool extends \Swift_MemorySpool implements \Countabl
     }
 }
 
-class AuthCodeMailerTest extends \PHPUnit_Framework_TestCase
+class AuthCodeMailerTest extends TestCase
 {
     protected $mailer;
     protected $spool;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Documentation | no
| Translation   | no
| CHANGELOG.md  | yes
| Fixed tickets | #...
| License       | MIT

Just update few things to make Travis build run PHP 7.2 properly. We'll see later to fix issue.

First issue found:

```
contentthis
is
my
contentthis
is
my
content</p>' contains "this is my content".

/Users/j0k/Sites/github/wallabag/tests/Wallabag/CoreBundle/Helper/ContentProxyTest.php:410
```