### PR TITLE
api: copy entry object before sending, to keep id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@
 
 ### Fixes
 
- - Fix empty title and domain_name when exception is thrown during fetch [#3442](https://github.com/wallabag/wallabag/pull/3442)
+- Fix empty title and domain_name when exception is thrown during fetch [#3442](https://github.com/wallabag/wallabag/pull/3442)
+- api: copy entry object before sending, to keep id [#3516](https://github.com/wallabag/wallabag/pull/3516)
 
 ### Changes
 

--- a/src/Wallabag/ApiBundle/Controller/EntryRestController.php
+++ b/src/Wallabag/ApiBundle/Controller/EntryRestController.php
@@ -575,6 +575,9 @@ class EntryRestController extends WallabagRestController
         $this->validateAuthentication();
         $this->validateUserAccess($entry->getUser()->getId());
 
+        // We copy $entry to keep id in returned object
+        $e = $entry;
+
         $em = $this->getDoctrine()->getManager();
         $em->remove($entry);
         $em->flush();
@@ -582,7 +585,7 @@ class EntryRestController extends WallabagRestController
         // entry deleted, dispatch event about it!
         $this->get('event_dispatcher')->dispatch(EntryDeletedEvent::NAME, new EntryDeletedEvent($entry));
 
-        return $this->sendResponse($entry);
+        return $this->sendResponse($e);
     }
 
     /**

--- a/tests/Wallabag/ApiBundle/Controller/EntryRestControllerTest.php
+++ b/tests/Wallabag/ApiBundle/Controller/EntryRestControllerTest.php
@@ -408,6 +408,7 @@ class EntryRestControllerTest extends WallabagApiTestCase
 
         $this->assertSame($entry->getTitle(), $content['title']);
         $this->assertSame($entry->getUrl(), $content['url']);
+        $this->assertSame($entry->getId(), $content['id']);
 
         // We'll try to delete this entry again
         $this->client->request('DELETE', '/api/entries/' . $entry->getId() . '.json');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | _sort of_
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Documentation | no
| Translation   | no
| CHANGELOG.md  | yes
| Fixed tickets | -
| License       | MIT

Workaround for https://github.com/wallabag/android-app/issues/646