### PR TITLE
Swap entry url with origin url if graby provides an updated one

### DIFF
--- a/src/Wallabag/CoreBundle/Helper/ContentProxy.php
+++ b/src/Wallabag/CoreBundle/Helper/ContentProxy.php
@@ -68,9 +68,8 @@ class ContentProxy
 
         // In one case (at least in tests), url is empty here
         // so we set it using $url provided in the updateEntry call.
-        // Not sure what are the other possible cases where this property is empty 
-        if (empty($entry->getUrl()) && !empty($url))
-        {
+        // Not sure what are the other possible cases where this property is empty
+        if (empty($entry->getUrl()) && !empty($url)) {
             $entry->setUrl($url);
         }
 
@@ -247,7 +246,15 @@ class ContentProxy
      */
     private function stockEntry(Entry $entry, array $content)
     {
-        $entry->setUrl($content['url']);
+        // When a redirection occurs while fetching an entry
+        // we move the original url in origin_url property if empty
+        // and set the entry url with the final value
+        if (!empty($content['url']) && $entry->getUrl() !== $content['url']) {
+            if (empty($entry->getOriginUrl())) {
+                $entry->setOriginUrl($entry->getUrl());
+            }
+            $entry->setUrl($content['url']);
+        }
 
         $this->setEntryDomainName($entry);
 

--- a/src/Wallabag/CoreBundle/Helper/ContentProxy.php
+++ b/src/Wallabag/CoreBundle/Helper/ContentProxy.php
@@ -328,6 +328,18 @@ class ContentProxy
         $parsed_entry_url = parse_url($entry->getUrl());
         $parsed_content_url = parse_url($url);
 
+        /**
+         * The following part computes the list of part changes between two
+         * parse_url arrays.
+         *
+         * As array_diff_assoc only computes changes to go from the left array
+         * to the right one, we make two differents arrays to have both
+         * directions. We merge these two arrays and sort keys before passing
+         * the result to the switch.
+         *
+         * The resulting array gives us all changing parts between the two
+         * urls: scheme, host, path, query and/or fragment.
+         */
         $diff_ec = array_diff_assoc($parsed_entry_url, $parsed_content_url);
         $diff_ce = array_diff_assoc($parsed_content_url, $parsed_entry_url);
 
@@ -340,6 +352,17 @@ class ContentProxy
             return false;
         }
 
+        /**
+         * This switch case lets us apply different behaviors according to
+         * changing parts of urls.
+         *
+         * As $diff_keys is an array, we provide arrays as cases. ['path'] means
+         * 'only the path is different between the two urls' whereas
+         * ['fragment', 'query'] means 'only fragment and query string parts are
+         * different between the two urls'.
+         * 
+         * Note that values in $diff_keys are sorted.
+         */
         switch ($diff_keys) {
             case ['path']:
                 if (($parsed_entry_url['path'] . '/' === $parsed_content_url['path']) // diff is trailing slash, we only replace the url of the entry

--- a/src/Wallabag/CoreBundle/Helper/ContentProxy.php
+++ b/src/Wallabag/CoreBundle/Helper/ContentProxy.php
@@ -321,43 +321,46 @@ class ContentProxy
      */
     private function updateOriginUrl(Entry $entry, $url)
     {
-        if (!empty($url) && $entry->getUrl() !== $url) {
-            $parsed_entry_url = parse_url($entry->getUrl());
-            $parsed_content_url = parse_url($url);
+        if (empty($url) || $entry->getUrl() === $url) {
+            return false;
+        }
 
-            $diff_ec = array_diff_assoc($parsed_entry_url, $parsed_content_url);
-            $diff_ce = array_diff_assoc($parsed_content_url, $parsed_entry_url);
+        $parsed_entry_url = parse_url($entry->getUrl());
+        $parsed_content_url = parse_url($url);
 
-            $diff = array_merge($diff_ec, $diff_ce);
-            $diff_keys = array_keys($diff);
-            sort($diff_keys);
+        $diff_ec = array_diff_assoc($parsed_entry_url, $parsed_content_url);
+        $diff_ce = array_diff_assoc($parsed_content_url, $parsed_entry_url);
 
-            if ($this->ignoreUrl($entry->getUrl())) {
-                $entry->setUrl($url);
-            } else {
-                switch ($diff_keys) {
-                    case ['path']:
-                        if (($parsed_entry_url['path'] . '/' === $parsed_content_url['path']) // diff is trailing slash, we only replace the url of the entry
-                            || ($url === urldecode($entry->getUrl()))) { // we update entry url if new url is a decoded version of it, see EntryRepository#findByUrlAndUserId
-                            $entry->setUrl($url);
-                        }
-                        break;
-                    case ['scheme']:
-                        $entry->setUrl($url);
-                        break;
-                    case ['fragment']:
-                    case ['query']:
-                    case ['fragment', 'query']:
-                        // noop
-                        break;
-                    default:
-                        if (empty($entry->getOriginUrl())) {
-                            $entry->setOriginUrl($entry->getUrl());
-                        }
-                        $entry->setUrl($url);
-                        break;
+        $diff = array_merge($diff_ec, $diff_ce);
+        $diff_keys = array_keys($diff);
+        sort($diff_keys);
+
+        if ($this->ignoreUrl($entry->getUrl())) {
+            $entry->setUrl($url);
+            return false;
+        }
+
+        switch ($diff_keys) {
+            case ['path']:
+                if (($parsed_entry_url['path'] . '/' === $parsed_content_url['path']) // diff is trailing slash, we only replace the url of the entry
+                    || ($url === urldecode($entry->getUrl()))) { // we update entry url if new url is a decoded version of it, see EntryRepository#findByUrlAndUserId
+                    $entry->setUrl($url);
                 }
-            }
+                break;
+            case ['scheme']:
+                $entry->setUrl($url);
+                break;
+            case ['fragment']:
+            case ['query']:
+            case ['fragment', 'query']:
+                // noop
+                break;
+            default:
+                if (empty($entry->getOriginUrl())) {
+                    $entry->setOriginUrl($entry->getUrl());
+                }
+                $entry->setUrl($url);
+                break;
         }
     }
 

--- a/src/Wallabag/CoreBundle/Helper/ContentProxy.php
+++ b/src/Wallabag/CoreBundle/Helper/ContentProxy.php
@@ -349,6 +349,7 @@ class ContentProxy
 
         if ($this->ignoreUrl($entry->getUrl())) {
             $entry->setUrl($url);
+
             return false;
         }
 
@@ -360,7 +361,7 @@ class ContentProxy
          * 'only the path is different between the two urls' whereas
          * ['fragment', 'query'] means 'only fragment and query string parts are
          * different between the two urls'.
-         * 
+         *
          * Note that values in $diff_keys are sorted.
          */
         switch ($diff_keys) {

--- a/src/Wallabag/CoreBundle/Helper/ContentProxy.php
+++ b/src/Wallabag/CoreBundle/Helper/ContentProxy.php
@@ -374,8 +374,6 @@ class ContentProxy
                 $entry->setUrl($url);
                 break;
             case ['fragment']:
-            case ['query']:
-            case ['fragment', 'query']:
                 // noop
                 break;
             default:

--- a/src/Wallabag/CoreBundle/Helper/ContentProxy.php
+++ b/src/Wallabag/CoreBundle/Helper/ContentProxy.php
@@ -66,6 +66,14 @@ class ContentProxy
         // so we'll be able to refetch it in the future
         $content['url'] = !empty($content['url']) ? $content['url'] : $url;
 
+        // In one case (at least in tests), url is empty here
+        // so we set it using $url provided in the updateEntry call.
+        // Not sure what are the other possible cases where this property is empty 
+        if (empty($entry->getUrl()) && !empty($url))
+        {
+            $entry->setUrl($url);
+        }
+
         $this->stockEntry($entry, $content);
     }
 

--- a/src/Wallabag/CoreBundle/Helper/ContentProxy.php
+++ b/src/Wallabag/CoreBundle/Helper/ContentProxy.php
@@ -344,6 +344,7 @@ class ContentProxy
                     break;
                 case ['fragment']:
                 case ['query']:
+                case ['fragment', 'query']:
                     // noop
                     break;
                 default:

--- a/tests/Wallabag/CoreBundle/Helper/ContentProxyTest.php
+++ b/tests/Wallabag/CoreBundle/Helper/ContentProxyTest.php
@@ -808,7 +808,39 @@ class ContentProxyTest extends TestCase
                 'https://example.org/hello',
                 null,
                 'example.org',
-            ]
+            ],
+            'different path and query string in fetch content' => [
+                'https://example.org/hello',
+                null,
+                'https://example.org/world?foo',
+                'https://example.org/world?foo',
+                'https://example.org/hello',
+                'example.org',
+            ],
+            'feedproxy ignore list test' => [
+                'http://feedproxy.google.com/~r/Wallabag/~3/helloworld',
+                null,
+                'https://example.org/hello-wallabag',
+                'https://example.org/hello-wallabag',
+                null,
+                'example.org',
+            ],
+            'feedproxy ignore list test with origin url already set' => [
+                'http://feedproxy.google.com/~r/Wallabag/~3/helloworld',
+                'https://example.org/this-is-source',
+                'https://example.org/hello-wallabag',
+                'https://example.org/hello-wallabag',
+                'https://example.org/this-is-source',
+                'example.org',
+            ],
+            'lemonde ignore pattern test' => [
+                'http://www.lemonde.fr/tiny/url',
+                null,
+                'http://example.com/hello-world',
+                'http://example.com/hello-world',
+                null,
+                'example.com',
+            ],
         ];
     }
 

--- a/tests/Wallabag/CoreBundle/Helper/ContentProxyTest.php
+++ b/tests/Wallabag/CoreBundle/Helper/ContentProxyTest.php
@@ -775,6 +775,32 @@ class ContentProxyTest extends TestCase
         return $string;
     }
 
+    public function testWithChangedUrl()
+    {
+        $tagger = $this->getTaggerMock();
+        $tagger->expects($this->once())
+            ->method('tag');
+
+        $proxy = new ContentProxy((new Graby()), $tagger, $this->getValidator(), $this->getLogger(), $this->fetchingErrorMessage, true);
+        $entry = new Entry(new User());
+        $proxy->updateEntry(
+            $entry,
+            'http://0.0.0.0',
+            [
+                'html' => false,
+                'title' => '',
+                'url' => 'http://1.1.1.1',
+                'content_type' => '',
+                'language' => '',
+            ],
+            true
+        );
+
+        $this->assertSame('http://1.1.1.1', $entry->getUrl());
+        $this->assertSame('1.1.1.1', $entry->getDomainName());
+        $this->assertSame('http://0.0.0.0', $entry->getOriginUrl());
+    }
+
     private function getTaggerMock()
     {
         return $this->getMockBuilder(RuleBasedTagger::class)

--- a/tests/Wallabag/CoreBundle/Helper/ContentProxyTest.php
+++ b/tests/Wallabag/CoreBundle/Helper/ContentProxyTest.php
@@ -777,20 +777,12 @@ class ContentProxyTest extends TestCase
                 null,
                 'example.com',
             ],
-            'no query string in fetched content' => [
-                'https://example.org/hello?world=1',
-                null,
-                'https://example.org/hello',
-                'https://example.org/hello?world=1',
-                null,
-                'example.org',
-            ],
             'query string in fetched content' => [
                 'https://example.org/hello',
                 null,
                 'https://example.org/hello?world=1',
+                'https://example.org/hello?world=1',
                 'https://example.org/hello',
-                null,
                 'example.org',
             ],
             'fragment in fetched content' => [
@@ -805,8 +797,8 @@ class ContentProxyTest extends TestCase
                 'https://example.org/hello',
                 null,
                 'https://example.org/hello?foo#world',
+                'https://example.org/hello?foo#world',
                 'https://example.org/hello',
-                null,
                 'example.org',
             ],
             'different path and query string in fetch content' => [

--- a/tests/Wallabag/CoreBundle/Helper/ContentProxyTest.php
+++ b/tests/Wallabag/CoreBundle/Helper/ContentProxyTest.php
@@ -801,6 +801,14 @@ class ContentProxyTest extends TestCase
                 null,
                 'example.org',
             ],
+            'fragment and query string in fetched content' => [
+                'https://example.org/hello',
+                null,
+                'https://example.org/hello?foo#world',
+                'https://example.org/hello',
+                null,
+                'example.org',
+            ]
         ];
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | _sort of_
| New feature?  | _sort of_
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Documentation | no
| Translation   | no
| CHANGELOG.md  | no
| Fixed tickets | #3529 
| License       | MIT

Fixes #3529 

This PR is a partial fix for #3529: it still set the final url as the actual entry url, but now it sets origin_url field to the former url.

Ex:
Current behavior:
- User saves a reddit.com to Wallabag
- Graby fetchs the page and finds a new link to follow (llvm.org)
- Entry is saved with llvm.org as the entry url

| Given url | Fetched url | Stored url | Stored origin url |
| - | - | - | - |
| `https://www.reddit.com/r/li[…]` | `http://lists.llvm.org/pip[…]` | `http://lists.llvm.org/pip[…]` | - |

New behavior:
- User saves a reddit.com to Wallabag
- Graby fetchs the page and finds a new link to follow (llvm.org)
- Entry is saved with llvm.org as the entry url and reddit.com as the origin url

| Given url | Given origin url | Fetched url | Stored url | Stored origin url | Diff |
| - | - | - | - | - | - |
| `https://www.reddit.com/r/li[…]` | - | `http://lists.llvm.org/pip[…]` | `http://lists.llvm.org/pip[…]` |  `https://www.reddit.com/r/li[…]` | url |
| `https://www.lemonde.fr/tiny[…]` | - | `https://www.lemonde.fr/m-deco[…]` | `https://www.lemonde.fr/m-deco[…]` | - | lemonde regex |
| `http://www.example.org/blah[…]` | - | `https://www.example.org/blah[…]` | `https://www.example.org/blah[…]` | - | scheme |
| `https://www.medium.com/hello[…]` | - | `https://www.medium.com/hello#world[…]` | `https://www.medium.com/hello[…]` | - | fragment
| `https://www.mylink.com/foo[…]` | `https://twitter.com[…]` | `https://www.anotherlink.com/bar[…]` | `https://www.anotherlink.com/bar[…]` | `https://twitter.com[…]` | origin url already set |
| `http://feedproxy.google.com/~r/Wa[…]` | - | `https://example.org/hello-wallabag[…]` | `https://example.org/hello-wallabag[…]` | - | host ignore list |

Here is the hardcoded ignore list for specific patterns : 
- `feedproxy.google.com`
- `feeds.reuters.com`
- `https?://www\.lemonde\.fr/tiny.*`

Todo
- [x] leave origin_url unchanged if difference is an ending slash
- [x] leave origin_url unchanged if difference is a fragment
- [x] leave origin_url unchanged if new value matches the ignore list