### PR TITLE
call set -eu only after env vars are tested

### DIFF
--- a/scripts/update.sh
+++ b/scripts/update.sh
@@ -2,15 +2,14 @@
 # You can execute this file to update wallabag
 # eg: `sh update.sh prod`
 
-set -e
-
 COMPOSER_COMMAND='composer'
 
 DIR="${BASH_SOURCE}"
 if [ ! -d "$DIR" ]; then DIR="$PWD/scripts"; fi
 . "$DIR/require.sh"
 
-# starting from here, update shall abort if a variable is not set
+# starting from here, update shall abort if a variable is not set or command errors
+set -e
 set -u
 ENV=$1
 

--- a/scripts/update.sh
+++ b/scripts/update.sh
@@ -3,7 +3,6 @@
 # eg: `sh update.sh prod`
 
 set -e
-set -u
 
 COMPOSER_COMMAND='composer'
 
@@ -11,6 +10,8 @@ DIR="${BASH_SOURCE}"
 if [ ! -d "$DIR" ]; then DIR="$PWD/scripts"; fi
 . "$DIR/require.sh"
 
+# starting from here, update shall abort if a variable is not set
+set -u
 ENV=$1
 
 rm -rf var/cache/*


### PR DESCRIPTION
This commit fixes a race condition where we search for variable
BASH_SOURCE, but it is not set. In that case the update.sh would abort.
But it should not abort, because in the following lines we are going to
set DIR variable by another way.
To avoid this case where BASH_SOURCE is not set, the `set -u` command is
moved after the code, where we expect all variables to be valid.

| Q             | A
| ------------- | ---
| Bug fix?      | yes/
| New feature?  | /no
| BC breaks?    | /no
| Deprecations? | /no
| Tests pass?   | yes/no
| Documentation | /no
| Translation   | /no
| CHANGELOG.md  | /no
| Fixed tickets | #...
| License       | MIT

<!--
- Please fill in this template according to the PR you're about to submit.
- Replace this comment by a description of what your PR is solving.
-->
