### PR TITLE
Fix error when withRemove variable is not defined.

### DIFF
--- a/src/Wallabag/CoreBundle/Resources/views/themes/material/Entry/_tags.html.twig
+++ b/src/Wallabag/CoreBundle/Resources/views/themes/material/Entry/_tags.html.twig
@@ -3,7 +3,7 @@
         {% for tag in tags %}
             <li class="chip">
                 <a href="{{ path('tag_entries', {'slug': tag.slug}) }}">{{ tag.label }}</a>
-                {% if withRemove %}
+                {% if withRemove is defined and withRemove == true %}
                     <a href="{{ path('remove_tag', { 'entry': entryId, 'tag': tag.id }) }}" onclick="return confirm('{{ 'entry.confirm.delete_tag'|trans|escape('js') }}')">
                         <i class="material-icons vertical-align-middle">delete</i>
                     </a>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Documentation | no
| Translation   | no
| CHANGELOG.md  | no
| Fixed tickets | 
| License       | MIT

Since the `withRemove` variable is a template flag, it can be undefined.

In the `Entry\Card\_content.html.twig` template for example, the `withRemove` variable is not defined and I got an `Exception` when changing the `view-mode` :

```
Twig_Error_Runtime: Variable "withRemove" does not exist.
```