### PR TITLE
Fix title card HTML parsing

### DIFF
--- a/src/Wallabag/CoreBundle/Resources/views/themes/baggy/Entry/entries.html.twig
+++ b/src/Wallabag/CoreBundle/Resources/views/themes/baggy/Entry/entries.html.twig
@@ -38,7 +38,7 @@
 
     {% for entry in entries %}
         <div id="entry-{{ entry.id|e }}" class="{% if listMode == 0 %}entry{% else %}listmode entry{% endif %}">
-            <h2><a href="{{ path('view', { 'id': entry.id }) }}" title="{{ entry.title|e|raw }}">{{ entry.title | striptags | truncate(80, true, '…') | raw | default('entry.default_title'|trans) }}</a></h2>
+            <h2><a href="{{ path('view', { 'id': entry.id }) }}" title="{{ entry.title|e|raw }}">{{ entry.title | striptags | truncate(80, true, '…') | default('entry.default_title'|trans) | raw }}</a></h2>
 
             {% set readingTime = entry.readingTime / app.user.config.readingSpeed %}
             <div class="estimatedTime">

--- a/src/Wallabag/CoreBundle/Resources/views/themes/baggy/Entry/entry.html.twig
+++ b/src/Wallabag/CoreBundle/Resources/views/themes/baggy/Entry/entry.html.twig
@@ -1,11 +1,11 @@
 {% extends "WallabagCoreBundle::layout.html.twig" %}
 
-{% block title %}{{ entry.title|e|raw|default('entry.default_title'|trans) }} ({{ entry.domainName|removeWww }}){% endblock %}
+{% block title %}{{ entry.title|e|default('entry.default_title'|trans)|raw }} ({{ entry.domainName|removeWww }}){% endblock %}
 
 {% block content %}
     <div id="article">
         <header class="mbm">
-            <h1>{{ entry.title|e|raw |default('entry.default_title'|trans) }} <a href="{{ path('edit', { 'id': entry.id }) }}" class="nostyle" title="{{ 'entry.view.edit_title'|trans }}">✎</a></h1>
+            <h1>{{ entry.title|e|default('entry.default_title'|trans)|raw }} <a href="{{ path('edit', { 'id': entry.id }) }}" class="nostyle" title="{{ 'entry.view.edit_title'|trans }}">✎</a></h1>
         </header>
 
         <div id="article_toolbar">

--- a/src/Wallabag/CoreBundle/Resources/views/themes/material/Entry/Card/_content.html.twig
+++ b/src/Wallabag/CoreBundle/Resources/views/themes/material/Entry/Card/_content.html.twig
@@ -3,7 +3,7 @@
         <i class="grey-text text-darken-4 activator material-icons right">more_vert</i>
     {% endif %}
     <a href="{{ path('view', { 'id': entry.id }) }}" title="{{ entry.title| striptags | e('html_attr') }}" class="card-title dot-ellipsis dot-resize-update">
-        {{ entry.title | striptags | truncate(80, true, '…') | raw | default('entry.default_title'|trans) }}
+        {{ entry.title | striptags | truncate(80, true, '…') | default('entry.default_title'|trans) | raw }}
     </a>
 
     <div class="{{ subClass|default('original grey-text') }}">

--- a/src/Wallabag/CoreBundle/Resources/views/themes/material/Entry/entry.html.twig
+++ b/src/Wallabag/CoreBundle/Resources/views/themes/material/Entry/entry.html.twig
@@ -1,6 +1,6 @@
 {% extends "WallabagCoreBundle::layout.html.twig" %}
 
-{% block title %}{{ entry.title|striptags|raw|default('entry.default_title'|trans) }} ({{ entry.domainName|removeWww }}){% endblock %}
+{% block title %}{{ entry.title|striptags|default('entry.default_title'|trans)|raw }} ({{ entry.domainName|removeWww }}){% endblock %}
 
 {% block body_class %}entry{% endblock %}
 
@@ -223,7 +223,7 @@
 {% block content %}
     <div id="article">
         <header class="mbm">
-            <h1>{{ entry.title|striptags|raw|default('entry.default_title'|trans) }} <a href="{{ path('edit', { 'id': entry.id }) }}" title="{{ 'entry.view.edit_title'|trans }}">✎</a></h1>
+            <h1>{{ entry.title|striptags|default('entry.default_title'|trans)|raw }} <a href="{{ path('edit', { 'id': entry.id }) }}" title="{{ 'entry.view.edit_title'|trans }}">✎</a></h1>
         </header>
         <aside>
             <div class="tools">


### PR DESCRIPTION
This is a bug fix for the entry title. Adding a default value ends with this issue.

Before:
![title-issue-before](https://user-images.githubusercontent.com/582666/36120433-74df8566-1043-11e8-9bb6-55f08a628610.png)

After:
![title-issue-after](https://user-images.githubusercontent.com/582666/36120440-7a70907e-1043-11e8-82c6-2ef1ab801824.png)
