### PR TITLE
Add secure email

### DIFF
--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -79,10 +79,13 @@ doctrine_migrations:
 
 # Swiftmailer Configuration
 swiftmailer:
-    transport: "%mailer_transport%"
-    host: "%mailer_host%"
-    username: "%mailer_user%"
-    password: "%mailer_password%"
+    transport:   "%mailer_transport%"
+    username:    "%mailer_user%"
+    password:    "%mailer_password%"
+    host:        "%mailer_host%"
+    port:        "%mailer_port%"
+    encryption:  "%mailer_encryption%"
+    auth_mode:   "%mailer_auth_mode%"
     spool:
         type: memory
 

--- a/app/config/parameters.yml.dist
+++ b/app/config/parameters.yml.dist
@@ -27,10 +27,13 @@ parameters:
 
     domain_name: https://your-wallabag-url-instance.com
 
-    mailer_transport: smtp
-    mailer_host: 127.0.0.1
-    mailer_user: ~
-    mailer_password: ~
+    mailer_transport:  smtp
+    mailer_user:       ~
+    mailer_password:   ~
+    mailer_host:       127.0.0.1
+    mailer_port:       false
+    mailer_encryption: ~
+    mailer_auth_mode:  ~
 
     locale: en
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Documentation | no
| Translation   | no
| CHANGELOG.md  | no
| Fixed tickets | #2046
| License       | MIT

Added secure email to the swiftmailer configuration incl. port, encryption and authentication mode. 

Notes:
* Changes made also to the wallabag/docker repository (https://github.com/wallabag/docker/pull/106)
* Changes required in the Wallabag parameter documentation https://doc.wallabag.org/en/admin/parameters.html