### PR TITLE
Allow login by email

### DIFF
--- a/app/config/security.yml
+++ b/app/config/security.yml
@@ -12,7 +12,7 @@ security:
                 class: WallabagUserBundle:User
                 property: username
         fos_userbundle:
-            id: fos_user.user_provider.username
+            id: fos_user.user_provider.username_email
 
     # the main part of the security, where you can set up firewalls
     # for specific sections of your app

--- a/tests/Wallabag/CoreBundle/Controller/SecurityControllerTest.php
+++ b/tests/Wallabag/CoreBundle/Controller/SecurityControllerTest.php
@@ -6,6 +6,16 @@ use Tests\Wallabag\CoreBundle\WallabagCoreTestCase;
 
 class SecurityControllerTest extends WallabagCoreTestCase
 {
+    public function testLoginWithEmail()
+    {
+        $this->logInAsUsingHttp('bigboss@wallabag.org');
+        $client = $this->getClient();
+        $client->followRedirects();
+
+        $crawler = $client->request('GET', '/config');
+        $this->assertContains('config.form_rss.description', $crawler->filter('body')->extract(['_text'])[0]);
+    }
+
     public function testLoginWithout2Factor()
     {
         $this->logInAs('admin');
@@ -81,7 +91,7 @@ class SecurityControllerTest extends WallabagCoreTestCase
         }
 
         $client->followRedirects();
-        $crawler = $client->request('GET', '/register');
+        $client->request('GET', '/register');
         $this->assertContains('registration.submit', $client->getResponse()->getContent());
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Documentation | no
| Translation   | no
| CHANGELOG.md  | no
| Fixed tickets | #3612 
| License       | MIT

fix #3612

Allow user to use email to login.