### PR TITLE
Better encoding of the URI for the bookmarklet

### DIFF
--- a/src/Wallabag/CoreBundle/Resources/views/themes/common/Static/_bookmarklet.html.twig
+++ b/src/Wallabag/CoreBundle/Resources/views/themes/common/Static/_bookmarklet.html.twig
@@ -1,1 +1,1 @@
-<a id="bookmarklet" ondragend="this.click();" href="javascript:(function(){var url=location.href||url;var wllbg=window.open('{{ url('bookmarklet') }}?url=' + encodeURI(url),'_blank');})();">bag it!</a>
+<a id="bookmarklet" ondragend="this.click();" href="javascript:(function(){var url=location.href||url;var wllbg=window.open('{{ url('bookmarklet') }}?url=' + encodeURIComponent(url),'_blank');})();">bag it!</a>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Documentation | no
| Translation   | no
| CHANGELOG.md  | no
| Fixed tickets | #3405
| License       | MIT

fix #3405

The bookmarklet use the current url as query string so the function encodeURIComponent must be used instead of encodeURI.