### PR TITLE
Fix tests

### DIFF
--- a/tests/Wallabag/CoreBundle/Controller/EntryControllerTest.php
+++ b/tests/Wallabag/CoreBundle/Controller/EntryControllerTest.php
@@ -1309,9 +1309,9 @@ class EntryControllerTest extends WallabagCoreTestCase
                 'https://www.pravda.ru/world/09-06-2017/1337283-qatar-0/',
                 'ru',
             ],
-            'fr-FR' => [
-                'https://www.zataz.com/90-des-dossiers-medicaux-des-coreens-du-sud-vendus-a-des-entreprises-privees/',
-                'fr_FR',
+            'fr' => [
+                'https://fr.wikipedia.org/wiki/Wallabag',
+                'fr',
             ],
             'de' => [
                 'https://www.bild.de/politik/ausland/theresa-may/wahlbeben-grossbritannien-analyse-52108924.bild.html',

--- a/tests/Wallabag/CoreBundle/Controller/EntryControllerTest.php
+++ b/tests/Wallabag/CoreBundle/Controller/EntryControllerTest.php
@@ -1314,7 +1314,7 @@ class EntryControllerTest extends WallabagCoreTestCase
                 'fr_FR',
             ],
             'de' => [
-                'http://www.bild.de/politik/ausland/theresa-may/wahlbeben-grossbritannien-analyse-52108924.bild.html',
+                'https://www.bild.de/politik/ausland/theresa-may/wahlbeben-grossbritannien-analyse-52108924.bild.html',
                 'de',
             ],
             'it' => [

--- a/tests/Wallabag/CoreBundle/Tools/UtilsTest.php
+++ b/tests/Wallabag/CoreBundle/Tools/UtilsTest.php
@@ -13,7 +13,7 @@ class UtilsTest extends TestCase
      */
     public function testCorrectWordsCountForDifferentLanguages($text, $expectedCount)
     {
-        static::assertEquals((float) $expectedCount, Utils::getReadingTime($text));
+        static::assertSame((float) $expectedCount, Utils::getReadingTime($text));
     }
 
     public function examples()

--- a/tests/Wallabag/ImportBundle/Controller/ReadabilityControllerTest.php
+++ b/tests/Wallabag/ImportBundle/Controller/ReadabilityControllerTest.php
@@ -111,7 +111,7 @@ class ReadabilityControllerTest extends WallabagCoreTestCase
             ->get('doctrine.orm.entity_manager')
             ->getRepository('WallabagCoreBundle:Entry')
             ->findByUrlAndUserId(
-                'https://www.zataz.com/90-des-dossiers-medicaux-des-coreens-du-sud-vendus-a-des-entreprises-privees/',
+                'https://www.20minutes.fr/bordeaux/2120479-20170823-bordeaux-poche-chocolatine-association-traduit-etudiants-etrangers-mots-sud-ouest',
                 $this->getLoggedInUserId()
             );
 
@@ -119,9 +119,9 @@ class ReadabilityControllerTest extends WallabagCoreTestCase
         $this->assertContains('flashes.import.notice.summary', $body[0]);
 
         $this->assertInstanceOf('Wallabag\CoreBundle\Entity\Entry', $content);
-        $this->assertNotEmpty($content->getMimetype(), 'Mimetype for http://www.zataz.com is ok');
-        $this->assertNotEmpty($content->getPreviewPicture(), 'Preview picture for http://www.zataz.com is ok');
-        $this->assertNotEmpty($content->getLanguage(), 'Language for http://www.zataz.com is ok');
+        $this->assertNotEmpty($content->getMimetype(), 'Mimetype for https://www.20minutes.fr is ok');
+        $this->assertNotEmpty($content->getPreviewPicture(), 'Preview picture for https://www.20minutes.fr is ok');
+        $this->assertNotEmpty($content->getLanguage(), 'Language for https://www.20minutes.fr is ok');
 
         $tags = $content->getTags();
         $this->assertContains('foot', $tags, 'It includes the "foot" tag');

--- a/tests/Wallabag/ImportBundle/fixtures/readability.json
+++ b/tests/Wallabag/ImportBundle/fixtures/readability.json
@@ -21,8 +21,8 @@
             "archive": 0,
             "date_added": "2016-09-08T11:55:58+0200",
             "favorite": 0,
-            "article__title": "90% des dossiers médicaux des Coréens du sud vendus à des entreprises privées - ZATAZ",
-            "article__url": "https://www.zataz.com/90-des-dossiers-medicaux-des-coreens-du-sud-vendus-a-des-entreprises-privees/"
+            "article__title": "Bordeaux: Poche, chocolatine… Une association traduit aux étudiants étrangers les mots du Sud-Ouest",
+            "article__url": "https://www.20minutes.fr/bordeaux/2120479-20170823-bordeaux-poche-chocolatine-association-traduit-etudiants-etrangers-mots-sud-ouest"
         }
    ],
     "recommendations": []


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | no
| Documentation | no
| Translation   | no
| CHANGELOG.md  | no
| Fixed tickets | 
| License       | MIT

3 tests failed :

```
1) Tests\Wallabag\CoreBundle\Controller\EntryControllerTest::testLanguageValidation with data set "fr-FR" ('https://www.zataz.com/90-des-...ivees/', 'fr_FR')
Failed asserting that two strings are identical.
--- Expected
+++ Actual
@@ @@
-fr_FR
+en_US
/home/travis/build/wallabag/wallabag/tests/Wallabag/CoreBundle/Controller/EntryControllerTest.php:1380

2) Tests\Wallabag\CoreBundle\Controller\EntryControllerTest::testLanguageValidation with data set "de" ('http://www.bild.de/politik/au...d.html', 'de')
Failed asserting that false is an instance of class "Wallabag\CoreBundle\Entity\Entry".
/home/travis/build/wallabag/wallabag/tests/Wallabag/CoreBundle/Controller/EntryControllerTest.php:1378

3) Tests\Wallabag\ImportBundle\Controller\ReadabilityControllerTest::testImportReadabilityWithFile
Mimetype for http://www.zataz.com is ok
Failed asserting that a NULL is not empty.
/home/travis/build/wallabag/wallabag/tests/Wallabag/ImportBundle/Controller/ReadabilityControllerTest.php:122
```

For the second test use https instead of http for bild.de fix the test.

For the other tests the problem come from Cloudflare : the DDoS protection blocks the request to `https://www.zataz.com/90-des-dossiers-medicaux-des-coreens-du-sud-vendus-a-des-entreprises-privees/` (see https://travis-ci.org/notFloran/wallabag/jobs/360030872).
I don't know how to fix that.