### PR TITLE
Add a basic Search REST endpoint

### DIFF
--- a/src/Wallabag/ApiBundle/Controller/EntryRestController.php
+++ b/src/Wallabag/ApiBundle/Controller/EntryRestController.php
@@ -10,7 +10,6 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
 use Symfony\Component\HttpKernel\Exception\HttpException;
-use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Wallabag\CoreBundle\Entity\Entry;
 use Wallabag\CoreBundle\Entity\Tag;
 use Wallabag\CoreBundle\Event\EntryDeletedEvent;
@@ -140,7 +139,7 @@ class EntryRestController extends WallabagRestController
                     'tags' => $tags,
                     'since' => $since,
                 ],
-                UrlGeneratorInterface::ABSOLUTE_URL
+                true
             )
         );
 

--- a/src/Wallabag/ApiBundle/Controller/EntryRestController.php
+++ b/src/Wallabag/ApiBundle/Controller/EntryRestController.php
@@ -4,7 +4,6 @@ namespace Wallabag\ApiBundle\Controller;
 
 use Hateoas\Configuration\Route;
 use Hateoas\Representation\Factory\PagerfantaFactory;
-use JMS\Serializer\SerializationContext;
 use Nelmio\ApiDocBundle\Annotation\ApiDoc;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
@@ -771,24 +770,6 @@ class EntryRestController extends WallabagRestController
         }
 
         return $this->sendResponse($results);
-    }
-
-    /**
-     * Shortcut to send data serialized in json.
-     *
-     * @param mixed $data
-     *
-     * @return JsonResponse
-     */
-    private function sendResponse($data)
-    {
-        // https://github.com/schmittjoh/JMSSerializerBundle/issues/293
-        $context = new SerializationContext();
-        $context->setSerializeNull(true);
-
-        $json = $this->get('jms_serializer')->serialize($data, 'json', $context);
-
-        return (new JsonResponse())->setJson($json);
     }
 
     /**

--- a/src/Wallabag/ApiBundle/Controller/SearchRestController.php
+++ b/src/Wallabag/ApiBundle/Controller/SearchRestController.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace Wallabag\ApiBundle\Controller;
+
+use Hateoas\Configuration\Route;
+use Hateoas\Representation\Factory\PagerfantaFactory;
+use JMS\Serializer\SerializationContext;
+use Nelmio\ApiDocBundle\Annotation\ApiDoc;
+use Pagerfanta\Adapter\DoctrineORMAdapter;
+use Pagerfanta\Pagerfanta;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Exception\HttpException;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+use Wallabag\CoreBundle\Entity\Entry;
+use Wallabag\CoreBundle\Entity\Tag;
+use Wallabag\CoreBundle\Event\EntryDeletedEvent;
+use Wallabag\CoreBundle\Event\EntrySavedEvent;
+
+class SearchRestController extends WallabagRestController
+{
+    /**
+     * Search all entries by term.
+     *
+     * @ApiDoc(
+     *       parameters={
+     *          {"name"="term", "dataType"="string", "required"=false, "format"="any", "description"="Any query term"},
+     *          {"name"="page", "dataType"="integer", "required"=false, "format"="default '1'", "description"="what page you want."},
+     *          {"name"="perPage", "dataType"="integer", "required"=false, "format"="default'30'", "description"="results per page."}
+     *       }
+     * )
+     *
+     * @return JsonResponse
+     */
+    public function getSearchAction(Request $request)
+    {
+        $this->validateAuthentication();
+
+        $term = $request->query->get('term');
+        $page = (int) $request->query->get('page', 1);
+        $perPage = (int) $request->query->get('perPage', 30);
+
+        $qb = $this->get('wallabag_core.entry_repository')
+            ->getBuilderForSearchByUser(
+                $this->getUser()->getId(),
+                $term,
+                null
+            );
+
+        $pagerAdapter = new DoctrineORMAdapter($qb->getQuery(), true, false);
+        $pager = new Pagerfanta($pagerAdapter);
+
+        $pager->setMaxPerPage($perPage);
+        $pager->setCurrentPage($page);
+
+        $pagerfantaFactory = new PagerfantaFactory('page', 'perPage');
+        $paginatedCollection = $pagerfantaFactory->createRepresentation(
+            $pager,
+            new Route(
+                'api_get_search',
+                [
+                    'term' => $term,
+                    'page' => $page,
+                    'perPage' => $perPage,
+                ],
+                UrlGeneratorInterface::ABSOLUTE_URL
+            )
+        );
+
+        return $this->sendResponse($paginatedCollection);
+    }
+
+    /**
+     * Shortcut to send data serialized in json.
+     *
+     * @param mixed $data
+     *
+     * @return JsonResponse
+     */
+    private function sendResponse($data)
+    {
+        // https://github.com/schmittjoh/JMSSerializerBundle/issues/293
+        $context = new SerializationContext();
+        $context->setSerializeNull(true);
+
+        $json = $this->get('jms_serializer')->serialize($data, 'json', $context);
+
+        return (new JsonResponse())->setJson($json);
+    }
+}

--- a/src/Wallabag/ApiBundle/Controller/SearchRestController.php
+++ b/src/Wallabag/ApiBundle/Controller/SearchRestController.php
@@ -9,7 +9,6 @@ use Pagerfanta\Adapter\DoctrineORMAdapter;
 use Pagerfanta\Pagerfanta;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
 class SearchRestController extends WallabagRestController
 {
@@ -57,7 +56,7 @@ class SearchRestController extends WallabagRestController
                     'page' => $page,
                     'perPage' => $perPage,
                 ],
-                UrlGeneratorInterface::ABSOLUTE_URL
+                true
             )
         );
 

--- a/src/Wallabag/ApiBundle/Controller/SearchRestController.php
+++ b/src/Wallabag/ApiBundle/Controller/SearchRestController.php
@@ -10,13 +10,7 @@ use Pagerfanta\Adapter\DoctrineORMAdapter;
 use Pagerfanta\Pagerfanta;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\HttpKernel\Exception\HttpException;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
-use Wallabag\CoreBundle\Entity\Entry;
-use Wallabag\CoreBundle\Entity\Tag;
-use Wallabag\CoreBundle\Event\EntryDeletedEvent;
-use Wallabag\CoreBundle\Event\EntrySavedEvent;
 
 class SearchRestController extends WallabagRestController
 {

--- a/src/Wallabag/ApiBundle/Controller/SearchRestController.php
+++ b/src/Wallabag/ApiBundle/Controller/SearchRestController.php
@@ -4,7 +4,6 @@ namespace Wallabag\ApiBundle\Controller;
 
 use Hateoas\Configuration\Route;
 use Hateoas\Representation\Factory\PagerfantaFactory;
-use JMS\Serializer\SerializationContext;
 use Nelmio\ApiDocBundle\Annotation\ApiDoc;
 use Pagerfanta\Adapter\DoctrineORMAdapter;
 use Pagerfanta\Pagerfanta;
@@ -63,23 +62,5 @@ class SearchRestController extends WallabagRestController
         );
 
         return $this->sendResponse($paginatedCollection);
-    }
-
-    /**
-     * Shortcut to send data serialized in json.
-     *
-     * @param mixed $data
-     *
-     * @return JsonResponse
-     */
-    private function sendResponse($data)
-    {
-        // https://github.com/schmittjoh/JMSSerializerBundle/issues/293
-        $context = new SerializationContext();
-        $context->setSerializeNull(true);
-
-        $json = $this->get('jms_serializer')->serialize($data, 'json', $context);
-
-        return (new JsonResponse())->setJson($json);
     }
 }

--- a/src/Wallabag/ApiBundle/Controller/WallabagRestController.php
+++ b/src/Wallabag/ApiBundle/Controller/WallabagRestController.php
@@ -3,6 +3,7 @@
 namespace Wallabag\ApiBundle\Controller;
 
 use FOS\RestBundle\Controller\FOSRestController;
+use JMS\Serializer\SerializationContext;
 use Nelmio\ApiDocBundle\Annotation\ApiDoc;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\Security\Core\Exception\AccessDeniedException;
@@ -63,5 +64,23 @@ class WallabagRestController extends FOSRestController
         if ($requestUserId !== $user->getId()) {
             throw $this->createAccessDeniedException('Access forbidden. Entry user id: ' . $requestUserId . ', logged user id: ' . $user->getId());
         }
+    }
+
+    /**
+     * Shortcut to send data serialized in json.
+     *
+     * @param mixed $data
+     *
+     * @return JsonResponse
+     */
+    protected function sendResponse($data)
+    {
+        // https://github.com/schmittjoh/JMSSerializerBundle/issues/293
+        $context = new SerializationContext();
+        $context->setSerializeNull(true);
+
+        $json = $this->get('jms_serializer')->serialize($data, 'json', $context);
+
+        return (new JsonResponse())->setJson($json);
     }
 }

--- a/src/Wallabag/ApiBundle/Resources/config/routing_rest.yml
+++ b/src/Wallabag/ApiBundle/Resources/config/routing_rest.yml
@@ -3,6 +3,11 @@ entry:
   resource: "WallabagApiBundle:EntryRest"
   name_prefix:  api_
 
+search:
+  type: rest
+  resource: "WallabagApiBundle:SearchRest"
+  name_prefix:  api_
+
 tag:
   type: rest
   resource: "WallabagApiBundle:TagRest"

--- a/tests/Wallabag/ApiBundle/Controller/SearchRestControllerTest.php
+++ b/tests/Wallabag/ApiBundle/Controller/SearchRestControllerTest.php
@@ -4,9 +4,6 @@ namespace Tests\Wallabag\ApiBundle\Controller;
 
 use Tests\Wallabag\ApiBundle\WallabagApiTestCase;
 use Wallabag\CoreBundle\Entity\Entry;
-use Wallabag\CoreBundle\Entity\Tag;
-use Wallabag\CoreBundle\Helper\ContentProxy;
-use Wallabag\UserBundle\Entity\User;
 
 class SearchRestControllerTest extends WallabagApiTestCase
 {
@@ -15,7 +12,7 @@ class SearchRestControllerTest extends WallabagApiTestCase
         $this->client->request('GET', '/api/search', [
             'page' => 1,
             'perPage' => 2,
-            'term' => 'entry' // 6 results
+            'term' => 'entry', // 6 results
         ]);
 
         $this->assertSame(200, $this->client->getResponse()->getStatusCode());
@@ -45,7 +42,7 @@ class SearchRestControllerTest extends WallabagApiTestCase
     public function testGetSearchWithNoLimit()
     {
         $this->client->request('GET', '/api/search', [
-            'term' => 'entry'
+            'term' => 'entry',
         ]);
 
         $this->assertSame(200, $this->client->getResponse()->getStatusCode());

--- a/tests/Wallabag/ApiBundle/Controller/SearchRestControllerTest.php
+++ b/tests/Wallabag/ApiBundle/Controller/SearchRestControllerTest.php
@@ -3,7 +3,6 @@
 namespace Tests\Wallabag\ApiBundle\Controller;
 
 use Tests\Wallabag\ApiBundle\WallabagApiTestCase;
-use Wallabag\CoreBundle\Entity\Entry;
 
 class SearchRestControllerTest extends WallabagApiTestCase
 {
@@ -19,7 +18,7 @@ class SearchRestControllerTest extends WallabagApiTestCase
 
         $content = json_decode($this->client->getResponse()->getContent(), true);
 
-        $this->assertGreaterThanOrEqual(1, count($content));
+        $this->assertGreaterThanOrEqual(1, \count($content));
         $this->assertArrayHasKey('items', $content['_embedded']);
         $this->assertGreaterThanOrEqual(0, $content['total']);
         $this->assertSame(1, $content['page']);
@@ -49,7 +48,7 @@ class SearchRestControllerTest extends WallabagApiTestCase
 
         $content = json_decode($this->client->getResponse()->getContent(), true);
 
-        $this->assertGreaterThanOrEqual(1, count($content));
+        $this->assertGreaterThanOrEqual(1, \count($content));
         $this->assertArrayHasKey('items', $content['_embedded']);
         $this->assertGreaterThanOrEqual(0, $content['total']);
         $this->assertSame(1, $content['page']);

--- a/tests/Wallabag/ApiBundle/Controller/SearchRestControllerTest.php
+++ b/tests/Wallabag/ApiBundle/Controller/SearchRestControllerTest.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace Tests\Wallabag\ApiBundle\Controller;
+
+use Tests\Wallabag\ApiBundle\WallabagApiTestCase;
+use Wallabag\CoreBundle\Entity\Entry;
+use Wallabag\CoreBundle\Entity\Tag;
+use Wallabag\CoreBundle\Helper\ContentProxy;
+use Wallabag\UserBundle\Entity\User;
+
+class SearchRestControllerTest extends WallabagApiTestCase
+{
+    public function testGetSearchWithFullOptions()
+    {
+        $this->client->request('GET', '/api/search', [
+            'page' => 1,
+            'perPage' => 2,
+            'term' => 'entry' // 6 results
+        ]);
+
+        $this->assertSame(200, $this->client->getResponse()->getStatusCode());
+
+        $content = json_decode($this->client->getResponse()->getContent(), true);
+
+        $this->assertGreaterThanOrEqual(1, count($content));
+        $this->assertArrayHasKey('items', $content['_embedded']);
+        $this->assertGreaterThanOrEqual(0, $content['total']);
+        $this->assertSame(1, $content['page']);
+        $this->assertSame(2, $content['limit']);
+        $this->assertGreaterThanOrEqual(1, $content['pages']);
+
+        $this->assertArrayHasKey('_links', $content);
+        $this->assertArrayHasKey('self', $content['_links']);
+        $this->assertArrayHasKey('first', $content['_links']);
+        $this->assertArrayHasKey('last', $content['_links']);
+
+        foreach (['self', 'first', 'last'] as $link) {
+            $this->assertArrayHasKey('href', $content['_links'][$link]);
+            $this->assertContains('term=entry', $content['_links'][$link]['href']);
+        }
+
+        $this->assertSame('application/json', $this->client->getResponse()->headers->get('Content-Type'));
+    }
+
+    public function testGetSearchWithNoLimit()
+    {
+        $this->client->request('GET', '/api/search', [
+            'term' => 'entry'
+        ]);
+
+        $this->assertSame(200, $this->client->getResponse()->getStatusCode());
+
+        $content = json_decode($this->client->getResponse()->getContent(), true);
+
+        $this->assertGreaterThanOrEqual(1, count($content));
+        $this->assertArrayHasKey('items', $content['_embedded']);
+        $this->assertGreaterThanOrEqual(0, $content['total']);
+        $this->assertSame(1, $content['page']);
+        $this->assertGreaterThanOrEqual(1, $content['pages']);
+
+        $this->assertArrayHasKey('_links', $content);
+        $this->assertArrayHasKey('self', $content['_links']);
+        $this->assertArrayHasKey('first', $content['_links']);
+        $this->assertArrayHasKey('last', $content['_links']);
+
+        foreach (['self', 'first', 'last'] as $link) {
+            $this->assertArrayHasKey('href', $content['_links'][$link]);
+            $this->assertContains('term=entry', $content['_links'][$link]['href']);
+        }
+
+        $this->assertSame('application/json', $this->client->getResponse()->headers->get('Content-Type'));
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Documentation | no
| Translation   | no
| CHANGELOG.md  | no
| Fixed tickets | #2611
| License       | MIT

I was hoping to find a search API for a separate project to add search support to the Firefox omnibox, but it turns out Wallabag doesn't have one - I'm not too familiar with Symfony, but I've taken a crack at it:

- Adds a new `search` key to `src/Wallabag/ApiBundle/Resources/config/routing_rest.yml`
- Reuses the `getBuilderForSearchByUser` method from the EntryRepository
- Supports, `term`, `page`, and `perPage` query parameters
- Some very basic tests

The test are a little limited, since it's basically a proxy for the existing search functionality. Do drop any feedback and I'll update the branch as necessary :upside_down_face: 