### PR TITLE
Entry: add archived_at property and updateArchived method

### DIFF
--- a/app/DoctrineMigrations/Version20180405182455.php
+++ b/app/DoctrineMigrations/Version20180405182455.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace Application\Migrations;
+
+use Doctrine\DBAL\Migrations\AbstractMigration;
+use Doctrine\DBAL\Schema\Schema;
+use Symfony\Component\DependencyInjection\ContainerAwareInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Add archived_at column and set its value to updated_at for is_archived entries.
+ */
+class Version20180405182455 extends AbstractMigration implements ContainerAwareInterface
+{
+    /**
+     * @var ContainerInterface
+     */
+    private $container;
+
+    public function setContainer(ContainerInterface $container = null)
+    {
+        $this->container = $container;
+    }
+
+    /**
+     * @param Schema $schema
+     */
+    public function up(Schema $schema)
+    {
+        $entryTable = $schema->getTable($this->getTable('entry'));
+
+        $this->skipIf($entryTable->hasColumn('archived_at'), 'It seems that you already played this migration.');
+
+        $entryTable->addColumn('archived_at', 'datetime', [
+            'notnull' => false,
+        ]);
+    }
+
+    public function postUp(Schema $schema)
+    {
+        $entryTable = $schema->getTable($this->getTable('entry'));
+        $this->skipIf(!$entryTable->hasColumn('archived_at'), 'Unable to add archived_at colum');
+
+        $this->connection->executeQuery(
+            'UPDATE ' . $this->getTable('entry') . ' SET archived_at = updated_at WHERE is_archived = :is_archived',
+            [
+                'is_archived' => true,
+            ]
+        );
+    }
+
+    /**
+     * @param Schema $schema
+     */
+    public function down(Schema $schema)
+    {
+        $entryTable = $schema->getTable($this->getTable('entry'));
+
+        $this->skipIf(!$entryTable->hasColumn('archived_at'), 'It seems that you already played this migration.');
+
+        $entryTable->dropColumn('archived_at');
+    }
+
+    private function getTable($tableName)
+    {
+        return $this->container->getParameter('database_table_prefix') . $tableName;
+    }
+}

--- a/src/Wallabag/ApiBundle/Controller/EntryRestController.php
+++ b/src/Wallabag/ApiBundle/Controller/EntryRestController.php
@@ -79,7 +79,7 @@ class EntryRestController extends WallabagRestController
      *       parameters={
      *          {"name"="archive", "dataType"="integer", "required"=false, "format"="1 or 0, all entries by default", "description"="filter by archived status."},
      *          {"name"="starred", "dataType"="integer", "required"=false, "format"="1 or 0, all entries by default", "description"="filter by starred status."},
-     *          {"name"="sort", "dataType"="string", "required"=false, "format"="'created' or 'updated', default 'created'", "description"="sort entries by date."},
+     *          {"name"="sort", "dataType"="string", "required"=false, "format"="'created' or 'updated' or 'archived', default 'created'", "description"="sort entries by date."},
      *          {"name"="order", "dataType"="string", "required"=false, "format"="'asc' or 'desc', default 'desc'", "description"="order of sort."},
      *          {"name"="page", "dataType"="integer", "required"=false, "format"="default '1'", "description"="what page you want."},
      *          {"name"="perPage", "dataType"="integer", "required"=false, "format"="default'30'", "description"="results per page."},

--- a/src/Wallabag/ApiBundle/Controller/EntryRestController.php
+++ b/src/Wallabag/ApiBundle/Controller/EntryRestController.php
@@ -358,7 +358,7 @@ class EntryRestController extends WallabagRestController
         }
 
         if (null !== $data['isArchived']) {
-            $entry->setArchived((bool) $data['isArchived']);
+            $entry->updateArchived((bool) $data['isArchived']);
         }
 
         if (null !== $data['isStarred']) {
@@ -474,7 +474,7 @@ class EntryRestController extends WallabagRestController
         }
 
         if (null !== $data['isArchived']) {
-            $entry->setArchived((bool) $data['isArchived']);
+            $entry->updateArchived((bool) $data['isArchived']);
         }
 
         if (null !== $data['isStarred']) {

--- a/src/Wallabag/CoreBundle/Controller/EntryController.php
+++ b/src/Wallabag/CoreBundle/Controller/EntryController.php
@@ -532,11 +532,9 @@ class EntryController extends Controller
         switch ($type) {
             case 'search':
                 $qb = $repository->getBuilderForSearchByUser($this->getUser()->getId(), $searchTerm, $currentRoute);
-
                 break;
             case 'untagged':
                 $qb = $repository->getBuilderForUntaggedByUser($this->getUser()->getId());
-
                 break;
             case 'starred':
                 $qb = $repository->getBuilderForStarredByUser($this->getUser()->getId());

--- a/src/Wallabag/CoreBundle/DataFixtures/ORM/LoadEntryData.php
+++ b/src/Wallabag/CoreBundle/DataFixtures/ORM/LoadEntryData.php
@@ -98,7 +98,7 @@ class LoadEntryData extends AbstractFixture implements OrderedFixtureInterface
         $entry6->setMimetype('text/html');
         $entry6->setTitle('test title entry6');
         $entry6->setContent('This is my content /o/');
-        $entry6->setArchived(true);
+        $entry6->updateArchived(true);
         $entry6->setLanguage('de');
         $entry6->addTag($this->getReference('bar-tag'));
 

--- a/src/Wallabag/CoreBundle/Entity/Entry.php
+++ b/src/Wallabag/CoreBundle/Entity/Entry.php
@@ -87,6 +87,15 @@ class Entry
     private $isArchived = false;
 
     /**
+     * @var \DateTime
+     *
+     * @ORM\Column(name="archived_at", type="datetime", nullable=true)
+     *
+     * @Groups({"entries_for_user", "export_all"})
+     */
+    private $archivedAt = null;
+
+    /**
      * @var bool
      *
      * @Exclude
@@ -336,6 +345,44 @@ class Entry
     }
 
     /**
+     * update isArchived and archive_at fields.
+     *
+     * @param bool $isArchived
+     *
+     * @return Entry
+     */
+    public function updateArchived($isArchived = false)
+    {
+        $this->setArchived($isArchived);
+        $this->setArchivedAt(null);
+        if ($this->isArchived()) {
+            $this->setArchivedAt(new \DateTime());
+        }
+
+        return $this;
+    }
+
+    /**
+     * @return \DateTime|null
+     */
+    public function getArchivedAt()
+    {
+        return $this->archivedAt;
+    }
+
+    /**
+     * @param \DateTime|null $archivedAt
+     *
+     * @return Entry
+     */
+    public function setArchivedAt($archivedAt = null)
+    {
+        $this->archivedAt = $archivedAt;
+
+        return $this;
+    }
+
+    /**
      * Get isArchived.
      *
      * @return bool
@@ -357,7 +404,7 @@ class Entry
 
     public function toggleArchive()
     {
-        $this->isArchived = $this->isArchived() ^ 1;
+        $this->updateArchived($this->isArchived() ^ 1);
 
         return $this;
     }

--- a/src/Wallabag/CoreBundle/Repository/EntryRepository.php
+++ b/src/Wallabag/CoreBundle/Repository/EntryRepository.php
@@ -50,7 +50,7 @@ class EntryRepository extends EntityRepository
     public function getBuilderForArchiveByUser($userId)
     {
         return $this
-            ->getSortedQueryBuilderByUser($userId)
+            ->getSortedQueryBuilderByUser($userId, 'archivedAt', 'desc')
             ->andWhere('e.isArchived = true')
         ;
     }

--- a/src/Wallabag/CoreBundle/Repository/EntryRepository.php
+++ b/src/Wallabag/CoreBundle/Repository/EntryRepository.php
@@ -189,7 +189,7 @@ class EntryRepository extends EntityRepository
             $qb->orderBy('e.id', $order);
         } elseif ('updated' === $sort) {
             $qb->orderBy('e.updatedAt', $order);
-        } else if ('archived' === $sort) {
+        } elseif ('archived' === $sort) {
             $qb->orderBy('e.archivedAt', $order);
         }
 

--- a/src/Wallabag/CoreBundle/Repository/EntryRepository.php
+++ b/src/Wallabag/CoreBundle/Repository/EntryRepository.php
@@ -189,6 +189,8 @@ class EntryRepository extends EntityRepository
             $qb->orderBy('e.id', $order);
         } elseif ('updated' === $sort) {
             $qb->orderBy('e.updatedAt', $order);
+        } else if ('archived' === $sort) {
+            $qb->orderBy('e.archivedAt', $order);
         }
 
         $pagerAdapter = new DoctrineORMAdapter($qb, true, false);

--- a/src/Wallabag/ImportBundle/Import/BrowserImport.php
+++ b/src/Wallabag/ImportBundle/Import/BrowserImport.php
@@ -133,7 +133,7 @@ abstract class BrowserImport extends AbstractImport
             );
         }
 
-        $entry->setArchived($data['is_archived']);
+        $entry->updateArchived($data['is_archived']);
 
         if (!empty($data['created_at'])) {
             $dt = new \DateTime();

--- a/src/Wallabag/ImportBundle/Import/InstapaperImport.php
+++ b/src/Wallabag/ImportBundle/Import/InstapaperImport.php
@@ -135,7 +135,7 @@ class InstapaperImport extends AbstractImport
             );
         }
 
-        $entry->setArchived($importedEntry['is_archived']);
+        $entry->updateArchived($importedEntry['is_archived']);
         $entry->setStarred($importedEntry['is_starred']);
 
         $this->em->persist($entry);

--- a/src/Wallabag/ImportBundle/Import/PinboardImport.php
+++ b/src/Wallabag/ImportBundle/Import/PinboardImport.php
@@ -119,7 +119,7 @@ class PinboardImport extends AbstractImport
             );
         }
 
-        $entry->setArchived($data['is_archived']);
+        $entry->updateArchived($data['is_archived']);
         $entry->setStarred($data['is_starred']);
         $entry->setCreatedAt(new \DateTime($data['created_at']));
 

--- a/src/Wallabag/ImportBundle/Import/PocketImport.php
+++ b/src/Wallabag/ImportBundle/Import/PocketImport.php
@@ -194,7 +194,7 @@ class PocketImport extends AbstractImport
         $this->fetchContent($entry, $url);
 
         // 0, 1, 2 - 1 if the item is archived - 2 if the item should be deleted
-        $entry->setArchived(1 === $importedEntry['status'] || $this->markAsRead);
+        $entry->updateArchived(1 === $importedEntry['status'] || $this->markAsRead);
 
         // 0 or 1 - 1 If the item is starred
         $entry->setStarred(1 === $importedEntry['favorite']);

--- a/src/Wallabag/ImportBundle/Import/ReadabilityImport.php
+++ b/src/Wallabag/ImportBundle/Import/ReadabilityImport.php
@@ -111,7 +111,7 @@ class ReadabilityImport extends AbstractImport
         // update entry with content (in case fetching failed, the given entry will be return)
         $this->fetchContent($entry, $data['url'], $data);
 
-        $entry->setArchived($data['is_archived']);
+        $entry->updateArchived($data['is_archived']);
         $entry->setStarred($data['is_starred']);
         $entry->setCreatedAt(new \DateTime($data['created_at']));
 

--- a/src/Wallabag/ImportBundle/Import/WallabagImport.php
+++ b/src/Wallabag/ImportBundle/Import/WallabagImport.php
@@ -122,7 +122,7 @@ abstract class WallabagImport extends AbstractImport
             $entry->setPreviewPicture($importedEntry['preview_picture']);
         }
 
-        $entry->setArchived($data['is_archived']);
+        $entry->updateArchived($data['is_archived']);
         $entry->setStarred($data['is_starred']);
 
         if (!empty($data['created_at'])) {

--- a/tests/Wallabag/ApiBundle/Controller/EntryRestControllerTest.php
+++ b/tests/Wallabag/ApiBundle/Controller/EntryRestControllerTest.php
@@ -438,6 +438,7 @@ class EntryRestControllerTest extends WallabagApiTestCase
         $this->assertSame(0, $content['is_archived']);
         $this->assertSame(0, $content['is_starred']);
         $this->assertNull($content['starred_at']);
+        $this->assertNull($content['archived_at']);
         $this->assertSame('New title for my article', $content['title']);
         $this->assertSame(1, $content['user_id']);
         $this->assertCount(2, $content['tags']);
@@ -533,6 +534,7 @@ class EntryRestControllerTest extends WallabagApiTestCase
         $this->assertSame(1, $content['is_archived']);
         $this->assertSame(1, $content['is_starred']);
         $this->assertGreaterThanOrEqual($now->getTimestamp(), (new \DateTime($content['starred_at']))->getTimestamp());
+        $this->assertGreaterThanOrEqual($now->getTimestamp(), (new \DateTime($content['archived_at']))->getTimestamp());
         $this->assertSame(1, $content['user_id']);
     }
 

--- a/tests/Wallabag/CoreBundle/Controller/ConfigControllerTest.php
+++ b/tests/Wallabag/CoreBundle/Controller/ConfigControllerTest.php
@@ -849,7 +849,7 @@ class ConfigControllerTest extends WallabagCoreTestCase
         $entryArchived->setContent('Youhou');
         $entryArchived->setTitle('Youhou');
         $entryArchived->addTag($tagArchived);
-        $entryArchived->setArchived(true);
+        $entryArchived->updateArchived(true);
         $em->persist($entryArchived);
 
         $annotationArchived = new Annotation($user);

--- a/tests/Wallabag/CoreBundle/Controller/EntryControllerTest.php
+++ b/tests/Wallabag/CoreBundle/Controller/EntryControllerTest.php
@@ -621,7 +621,7 @@ class EntryControllerTest extends WallabagCoreTestCase
         $content->setMimetype('text/html');
         $content->setTitle('test title entry');
         $content->setContent('This is my content /o/');
-        $content->setArchived(true);
+        $content->updateArchived(true);
         $content->setLanguage('fr');
 
         $em->persist($content);
@@ -774,7 +774,7 @@ class EntryControllerTest extends WallabagCoreTestCase
 
         $entry = new Entry($this->getLoggedInUser());
         $entry->setUrl($this->url);
-        $entry->setArchived(false);
+        $entry->updateArchived(false);
         $this->getEntityManager()->persist($entry);
         $this->getEntityManager()->flush();
 
@@ -1245,7 +1245,7 @@ class EntryControllerTest extends WallabagCoreTestCase
         $entry = new Entry($this->getLoggedInUser());
         $entry->setUrl('http://0.0.0.0/foo/baz/qux');
         $entry->setTitle('Le manège');
-        $entry->setArchived(true);
+        $entry->updateArchived(true);
         $this->getEntityManager()->persist($entry);
         $this->getEntityManager()->flush();
 
@@ -1275,7 +1275,7 @@ class EntryControllerTest extends WallabagCoreTestCase
         $entry = new Entry($this->getLoggedInUser());
         $entry->setUrl('http://domain/qux');
         $entry->setTitle('Le manège');
-        $entry->setArchived(true);
+        $entry->updateArchived(true);
         $this->getEntityManager()->persist($entry);
         $this->getEntityManager()->flush();
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Documentation | no
| Translation   | no
| CHANGELOG.md  | no
| Fixed tickets | #2716 #3556 
| License       | MIT

Add archived_at date this changes will allow:
* order entries by date of reading
* consistency => tagging or updating some metadata on an entry does'nt change date of reading (third app can rely on this date for stats ex : list all entries read for each week)
