### PR TITLE
Highlight code in articles using highlight.js

### DIFF
--- a/app/Resources/static/themes/_global/index.js
+++ b/app/Resources/static/themes/_global/index.js
@@ -13,8 +13,10 @@ import './global.scss';
 import './js/shortcuts/entry';
 import './js/shortcuts/main';
 
-import { savePercent, retrievePercent } from './js/tools';
+/* Hightlight */
+import './js/highlight';
 
+import { savePercent, retrievePercent } from './js/tools';
 
 /* ==========================================================================
  Annotations & Remember position

--- a/app/Resources/static/themes/_global/js/highlight.js
+++ b/app/Resources/static/themes/_global/js/highlight.js
@@ -1,0 +1,8 @@
+import 'highlight.js/styles/atom-one-light.css';
+import * as hljs from 'highlight.js';
+
+window.addEventListener('load', () => {
+  document.querySelectorAll('pre').forEach((node) => {
+    hljs.highlightBlock(node);
+  });
+});

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
   "dependencies": {
     "annotator": "git://github.com/wallabag/annotator.git#0f076c7d371ed25eb0793346f46982d90f2c4c85",
     "hammerjs": "^2.0.8",
+    "highlight.js": "^9.12.0",
     "icomoon-free-npm": "^0.0.0",
     "jquery": "^2.1.4",
     "jquery.cookie": "^1.4.1",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? |no
| Tests pass?   | yes
| Documentation | no
| Translation   | no
| CHANGELOG.md  | no
| Fixed tickets | #2722
| License       | MIT

This PR enable syntax highlighting for code blocs on articles. It adds the `highlight.js` dependency (NPM).

* I do not know if I made the change at the right place as I am new on this project,
* I used the "Atom One Light" style for the highlighting because it is neutral enough, but I do not know if it is a good choice or if it will be useful to add an option later to change the color scheme 

Feedback welcome :)
