### PR TITLE
Fix authors and preview alt encoding display

### DIFF
--- a/src/Wallabag/CoreBundle/Resources/views/themes/material/Entry/entry.html.twig
+++ b/src/Wallabag/CoreBundle/Resources/views/themes/material/Entry/entry.html.twig
@@ -245,7 +245,7 @@
                         <li>
                             <i class="material-icons" title="{{ 'entry.view.published_by'|trans }}">person</i>
                             {% for author in entry.publishedBy %}
-                                {{ author }}{% if not loop.last %}, {% endif %}
+                                {{ author|raw }}{% if not loop.last %}, {% endif %}
                             {% endfor %}
                         </li>
                     {% endif %}
@@ -276,7 +276,7 @@
             </div>
 
             {% if entry.previewPicture is not null %}
-                <div><img class="preview" src="{{ entry.previewPicture }}" alt="{{ entry.title|striptags|e('html_attr') }}" /></div>
+                <div><img class="preview" src="{{ entry.previewPicture }}" alt="{{ entry.title|striptags|default('entry.default_title'|trans)|raw }}" /></div>
             {% endif %}
 
         </aside>


### PR DESCRIPTION
Hello,
Fixing some encoding issues. cc #3663 
Before:
![wallabag-author-encoding-before](https://user-images.githubusercontent.com/582666/40911718-e01d785c-67ef-11e8-8309-047c6783168b.png)

After:
![wallabag-author-encoding-after](https://user-images.githubusercontent.com/582666/40911728-e4e5404a-67ef-11e8-9676-bd03cc29c791.png)

Have a nice day.