### PR TITLE
Fix image downloading on null image path

### DIFF
--- a/src/Wallabag/CoreBundle/Helper/DownloadImages.php
+++ b/src/Wallabag/CoreBundle/Helper/DownloadImages.php
@@ -85,6 +85,10 @@ class DownloadImages
      */
     public function processSingleImage($entryId, $imagePath, $url, $relativePath = null)
     {
+        if (null === $imagePath) {
+            return false;
+        }
+
         if (null === $relativePath) {
             $relativePath = $this->getRelativePath($entryId);
         }

--- a/tests/Wallabag/CoreBundle/Helper/DownloadImagesTest.php
+++ b/tests/Wallabag/CoreBundle/Helper/DownloadImagesTest.php
@@ -204,4 +204,27 @@ class DownloadImagesTest extends TestCase
 
         $this->assertNotContains('http://piketty.blog.lemonde.fr/', $res, 'Image srcset attribute were not replaced');
     }
+
+    public function testProcessImageWithNullPath()
+    {
+        $client = new Client();
+
+        $mock = new Mock([
+            new Response(200, ['content-type' => null], Stream::factory(file_get_contents(__DIR__ . '/../fixtures/image-no-content-type.jpg'))),
+        ]);
+
+        $client->getEmitter()->attach($mock);
+
+        $logHandler = new TestHandler();
+        $logger = new Logger('test', [$logHandler]);
+
+        $download = new DownloadImages($client, sys_get_temp_dir() . '/wallabag_test', 'http://wallabag.io/', $logger);
+
+        $res = $download->processSingleImage(
+            123,
+            null,
+            'https://framablog.org/2018/06/30/engagement-atypique/'
+        );
+        $this->assertFalse($res);
+    }
 }


### PR DESCRIPTION
Hi,
Image path could be null resulting in this error `PHP Warning:  imagecreatefromstring(): Data is not in a recognized format in /wallabag/src/Wallabag/CoreBundle/Helper/DownloadImages.php on line 121`.
Encountered with https://framablog.org/2018/06/30/engagement-atypique/ .
Have a nice day.