### PR TITLE
Replace SO url by lemonde.fr to avoid random failing test

### DIFF
--- a/tests/Wallabag/ImportBundle/Controller/FirefoxControllerTest.php
+++ b/tests/Wallabag/ImportBundle/Controller/FirefoxControllerTest.php
@@ -128,14 +128,14 @@ class FirefoxControllerTest extends WallabagCoreTestCase
             ->get('doctrine.orm.entity_manager')
             ->getRepository('WallabagCoreBundle:Entry')
             ->findByUrlAndUserId(
-                'https://stackoverflow.com/questions/15017163/parser-for-exported-bookmarks-html-file-of-google-chrome-and-mozilla-in-java',
+                'https://www.lemonde.fr/disparitions/article/2018/07/05/le-journaliste-et-cineaste-claude-lanzmann-est-mort_5326313_3382.html',
                 $this->getLoggedInUserId()
             );
 
         $this->assertInstanceOf('Wallabag\CoreBundle\Entity\Entry', $content);
-        $this->assertNotEmpty($content->getMimetype(), 'Mimetype for https://stackoverflow.com is ok');
-        $this->assertNotEmpty($content->getPreviewPicture(), 'Preview picture for https://stackoverflow.com is ok');
-        $this->assertEmpty($content->getLanguage(), 'Language for https://stackoverflow.com is ok');
+        $this->assertNotEmpty($content->getMimetype(), 'Mimetype for https://www.lemonde.fr is ok');
+        $this->assertNotEmpty($content->getPreviewPicture(), 'Preview picture for https://www.lemonde.fr is ok');
+        $this->assertNotEmpty($content->getLanguage(), 'Language for https://www.lemonde.fr is ok');
 
         $createdAt = $content->getCreatedAt();
         $this->assertSame('2013', $createdAt->format('Y'));

--- a/tests/Wallabag/ImportBundle/fixtures/firefox-bookmarks.json
+++ b/tests/Wallabag/ImportBundle/fixtures/firefox-bookmarks.json
@@ -39,13 +39,13 @@
                 },
                 {
                     "guid": "E385l9vZ_LVn",
-                    "title": "Parser for Exported Bookmarks HTML file of Google Chrome and Mozilla in Java",
+                    "title": "Le journaliste et cinéaste Claude Lanzmann est mort",
                     "index": 1,
                     "dateAdded": 1388166091544000,
                     "lastModified": 1388166091545000,
                     "id": 5,
                     "type": "text/x-moz-place",
-                    "uri": "http://stackoverflow.com/questions/15017163/parser-for-exported-bookmarks-html-file-of-google-chrome-and-mozilla-in-java"
+                    "uri": "https://www.lemonde.fr/disparitions/article/2018/07/05/le-journaliste-et-cineaste-claude-lanzmann-est-mort_5326313_3382.html"
                 }
             ]
         },


### PR DESCRIPTION
Looks like we got a lot of random failing while grabing SO content, replacing it might fix the problem.

See https://travis-ci.org/wallabag/wallabag/builds/400333598