### PR TITLE
Remove remaining deprecation notices

### DIFF
--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -26,7 +26,6 @@ framework:
         engines: ['twig']
     default_locale: "%locale%"
     trusted_hosts: ~
-    trusted_proxies: ~
     session:
         # handler_id set to null will use default session handler from php.ini
         handler_id: session.handler.native_file


### PR DESCRIPTION
```
Remaining deprecation notices (2)

  2x: The "framework.trusted_proxies" configuration key has been deprecated in Symfony 3.3. Use the Request::setTrustedProxies() method in your front controller instead.
    1x in InstallCommandTest::testRunInstallCommandChooseNothing from Tests\Wallabag\CoreBundle\Command
    1x in AnnotationControllerTest::setUp from Tests\AnnotationBundle\Controller
```