### PR TITLE
Execute bash scripts with bash

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,13 +10,13 @@ clean: ## Clear the application cache
 	rm -rf var/cache/*
 
 install: ## Install wallabag with the latest version
-	@sh scripts/install.sh $(ENV)
+	@bash scripts/install.sh $(ENV)
 
 update: ## Update the wallabag installation to the latest version
-	@sh scripts/update.sh $(ENV)
+	@bash scripts/update.sh $(ENV)
 
 dev: ## Install the latest dev version
-	@sh scripts/dev.sh
+	@bash scripts/dev.sh
 
 run: ## Run the wallabag built-in server
 	@php bin/console server:run --env=dev


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Documentation | no
| Translation   | no
| CHANGELOG.md  | no
| Fixed tickets | #...
| License       | MIT

The sh does not have to be bash on all systems.