### PR TITLE
Rename getBuilderByUser and refactor query for untagged entries

### DIFF
--- a/src/Wallabag/AnnotationBundle/Repository/AnnotationRepository.php
+++ b/src/Wallabag/AnnotationBundle/Repository/AnnotationRepository.php
@@ -21,7 +21,7 @@ class AnnotationRepository extends EntityRepository
     public function getBuilderForAllByUser($userId)
     {
         return $this
-            ->getBuilderByUser($userId)
+            ->getSortedQueryBuilderByUser($userId)
         ;
     }
 
@@ -133,7 +133,7 @@ class AnnotationRepository extends EntityRepository
      *
      * @return QueryBuilder
      */
-    private function getBuilderByUser($userId)
+    private function getSortedQueryBuilderByUser($userId)
     {
         return $this->createQueryBuilder('a')
             ->leftJoin('a.user', 'u')

--- a/src/Wallabag/CoreBundle/Repository/EntryRepository.php
+++ b/src/Wallabag/CoreBundle/Repository/EntryRepository.php
@@ -116,9 +116,9 @@ class EntryRepository extends EntityRepository
 
     /**
      * Retrieve untagged entries for a user.
-     * 
+     *
      * @param int $userId
-     * 
+     *
      * @return QueryBuilder
      */
     public function getRawBuilderForUntaggedByUser($userId)
@@ -429,7 +429,7 @@ class EntryRepository extends EntityRepository
     /**
      * Return a query builder to be used by other getBuilderFor* method.
      *
-     * @param int    $userId
+     * @param int $userId
      *
      * @return QueryBuilder
      */
@@ -454,11 +454,11 @@ class EntryRepository extends EntityRepository
     }
 
     /**
-     * Return the given QueryBuilder with an orderBy() call
-     * 
+     * Return the given QueryBuilder with an orderBy() call.
+     *
      * @param QueryBuilder $qb
-     * @param string $sortBy
-     * @param string $direction
+     * @param string       $sortBy
+     * @param string       $direction
      *
      * @return QueryBuilder
      */

--- a/src/Wallabag/CoreBundle/Repository/EntryRepository.php
+++ b/src/Wallabag/CoreBundle/Repository/EntryRepository.php
@@ -102,7 +102,7 @@ class EntryRepository extends EntityRepository
     }
 
     /**
-     * Retrieves untagged entries for a user.
+     * Retrieve a sorted list of untagged entries for a user.
      *
      * @param int $userId
      *
@@ -111,8 +111,21 @@ class EntryRepository extends EntityRepository
     public function getBuilderForUntaggedByUser($userId)
     {
         return $this
-            ->getSortedQueryBuilderByUser($userId)
-            ->andWhere('size(e.tags) = 0');
+            ->sortQueryBuilder($this->getRawBuilderForUntaggedByUser($userId));
+    }
+
+    /**
+     * Retrieve untagged entries for a user.
+     * 
+     * @param int $userId
+     * 
+     * @return QueryBuilder
+     */
+    public function getRawBuilderForUntaggedByUser($userId)
+    {
+        return $this->getQueryBuilderByUser($userId)
+            ->leftJoin('e.tags', 't')
+            ->andWhere('t.id is null');
     }
 
     /**

--- a/src/Wallabag/CoreBundle/Repository/EntryRepository.php
+++ b/src/Wallabag/CoreBundle/Repository/EntryRepository.php
@@ -21,7 +21,7 @@ class EntryRepository extends EntityRepository
     public function getBuilderForAllByUser($userId)
     {
         return $this
-            ->getBuilderByUser($userId)
+            ->getSortedQueryBuilderByUser($userId)
         ;
     }
 
@@ -35,7 +35,7 @@ class EntryRepository extends EntityRepository
     public function getBuilderForUnreadByUser($userId)
     {
         return $this
-            ->getBuilderByUser($userId)
+            ->getSortedQueryBuilderByUser($userId)
             ->andWhere('e.isArchived = false')
         ;
     }
@@ -50,7 +50,7 @@ class EntryRepository extends EntityRepository
     public function getBuilderForArchiveByUser($userId)
     {
         return $this
-            ->getBuilderByUser($userId)
+            ->getSortedQueryBuilderByUser($userId)
             ->andWhere('e.isArchived = true')
         ;
     }
@@ -65,7 +65,7 @@ class EntryRepository extends EntityRepository
     public function getBuilderForStarredByUser($userId)
     {
         return $this
-            ->getBuilderByUser($userId, 'starredAt', 'desc')
+            ->getSortedQueryBuilderByUser($userId, 'starredAt', 'desc')
             ->andWhere('e.isStarred = true')
         ;
     }
@@ -82,7 +82,7 @@ class EntryRepository extends EntityRepository
     public function getBuilderForSearchByUser($userId, $term, $currentRoute)
     {
         $qb = $this
-            ->getBuilderByUser($userId);
+            ->getSortedQueryBuilderByUser($userId);
 
         if ('starred' === $currentRoute) {
             $qb->andWhere('e.isStarred = true');
@@ -111,7 +111,7 @@ class EntryRepository extends EntityRepository
     public function getBuilderForUntaggedByUser($userId)
     {
         return $this
-            ->getBuilderByUser($userId)
+            ->getSortedQueryBuilderByUser($userId)
             ->andWhere('size(e.tags) = 0');
     }
 
@@ -260,7 +260,7 @@ class EntryRepository extends EntityRepository
      */
     public function removeTag($userId, Tag $tag)
     {
-        $entries = $this->getBuilderByUser($userId)
+        $entries = $this->getSortedQueryBuilderByUser($userId)
             ->innerJoin('e.tags', 't')
             ->andWhere('t.id = :tagId')->setParameter('tagId', $tag->getId())
             ->getQuery()
@@ -296,7 +296,7 @@ class EntryRepository extends EntityRepository
      */
     public function findAllByTagId($userId, $tagId)
     {
-        return $this->getBuilderByUser($userId)
+        return $this->getSortedQueryBuilderByUser($userId)
             ->innerJoin('e.tags', 't')
             ->andWhere('t.id = :tagId')->setParameter('tagId', $tagId)
             ->getQuery()
@@ -414,7 +414,20 @@ class EntryRepository extends EntityRepository
     }
 
     /**
-     * Return a query builder to used by other getBuilderFor* method.
+     * Return a query builder to be used by other getBuilderFor* method.
+     *
+     * @param int    $userId
+     *
+     * @return QueryBuilder
+     */
+    private function getQueryBuilderByUser($userId)
+    {
+        return $this->createQueryBuilder('e')
+            ->andWhere('e.user = :userId')->setParameter('userId', $userId);
+    }
+
+    /**
+     * Return a sorted query builder to be used by other getBuilderFor* method.
      *
      * @param int    $userId
      * @param string $sortBy
@@ -422,10 +435,23 @@ class EntryRepository extends EntityRepository
      *
      * @return QueryBuilder
      */
-    private function getBuilderByUser($userId, $sortBy = 'createdAt', $direction = 'desc')
+    private function getSortedQueryBuilderByUser($userId, $sortBy = 'createdAt', $direction = 'desc')
     {
-        return $this->createQueryBuilder('e')
-            ->andWhere('e.user = :userId')->setParameter('userId', $userId)
+        return $this->sortQueryBuilder($this->getQueryBuilderByUser($userId));
+    }
+
+    /**
+     * Return the given QueryBuilder with an orderBy() call
+     * 
+     * @param QueryBuilder $qb
+     * @param string $sortBy
+     * @param string $direction
+     *
+     * @return QueryBuilder
+     */
+    private function sortQueryBuilder(QueryBuilder $qb, $sortBy = 'createdAt', $direction = 'desc')
+    {
+        return $qb
             ->orderBy(sprintf('e.%s', $sortBy), $direction);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Documentation | no
| Translation   | no
| Fixed tickets | -
| License       | MIT

This PR renames methods which return a `QueryBuilder` with an `orderBy()` and improves the performance of the query for `getBuilderForUntaggedByUser()`.

The improvement may not be seen on this PR, but for an upcoming PR it definitely improves things:

A `count()` with the current `size(e.tags) = 0` for retrieving untagged entries:

```
wallabag=# EXPLAIN ANALYZE SELECT count(w0_.id) AS sclr_0 FROM "wallabag_entry" w0_ WHERE w0_.user_id = 1 AND (SELECT COUNT(*) FROM wallabag_entry_tag w1_ WHERE w1_.entry_id = w0_.id) = 0;
                                                                               QUERY PLAN
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 Aggregate  (cost=16162.06..16162.07 rows=1 width=8) (actual time=18.850..18.851 rows=1 loops=1)
   ->  Seq Scan on wallabag_entry w0_  (cost=0.00..16162.04 rows=10 width=4) (actual time=0.079..18.212 rows=1498 loops=1)
         Filter: ((user_id = 1) AND ((SubPlan 1) = 0))
         Rows Removed by Filter: 431
         SubPlan 1
           ->  Aggregate  (cost=8.29..8.30 rows=1 width=8) (actual time=0.006..0.006 rows=1 loops=1929)
                 ->  Index Only Scan using idx_c9f0dd7cba364942 on wallabag_entry_tag w1_  (cost=0.28..8.29 rows=1 width=0) (actual time=0.004..0.005 rows=0 loops=1929)
                       Index Cond: (entry_id = w0_.id)
                       Heap Fetches: 571
 Planning time: 0.268 ms
 Execution time: 18.932 ms
(11 rows)
```

A `count()` with a new left join and null condition for retrieving untagged entries:

```
wallabag=# explain analyze SELECT count(w0_.id) AS sclr_0 FROM "wallabag_entry" w0_ LEFT JOIN wallabag_entry_tag w2_ ON w0_.id = w2_.entry_id LEFT JOIN "wallabag_tag" w1_ ON w1_.id = w2_.tag_id WHERE w0_.user_id = 1 AND w1_.id IS NULL;                                      
                                                                 QUERY PLAN
--------------------------------------------------------------------------------------------------------------------------------------------
 Aggregate  (cost=237.95..237.96 rows=1 width=8) (actual time=3.410..3.410 rows=1 loops=1)
   ->  Hash Anti Join  (cost=18.05..237.95 rows=1 width=4) (actual time=0.382..3.083 rows=1498 loops=1)
         Hash Cond: (w2_.tag_id = w1_.id)
         ->  Hash Left Join  (cost=16.71..229.40 rows=1922 width=8) (actual time=0.350..2.426 rows=2069 loops=1)
               Hash Cond: (w0_.id = w2_.entry_id)
               ->  Seq Scan on wallabag_entry w0_  (cost=0.00..195.03 rows=1922 width=4) (actual time=0.014..1.167 rows=1929 loops=1)
                     Filter: (user_id = 1)
               ->  Hash  (cost=9.65..9.65 rows=565 width=8) (actual time=0.325..0.325 rows=571 loops=1)
                     Buckets: 1024  Batches: 1  Memory Usage: 31kB
                     ->  Seq Scan on wallabag_entry_tag w2_  (cost=0.00..9.65 rows=565 width=8) (actual time=0.019..0.151 rows=571 loops=1)
         ->  Hash  (cost=1.15..1.15 rows=15 width=4) (actual time=0.018..0.019 rows=17 loops=1)
               Buckets: 1024  Batches: 1  Memory Usage: 9kB
               ->  Seq Scan on wallabag_tag w1_  (cost=0.00..1.15 rows=15 width=4) (actual time=0.006..0.009 rows=17 loops=1)
 Planning time: 0.685 ms
 Execution time: 3.486 ms
(15 rows)
``` 
