### PR TITLE
php-cs-fixer: native_function_invocation

### DIFF
--- a/app/DoctrineMigrations/Version20170719231144.php
+++ b/app/DoctrineMigrations/Version20170719231144.php
@@ -55,7 +55,7 @@ class Version20170719231144 extends WallabagMigration
             }
 
             // Just in case...
-            if (count($ids) > 0) {
+            if (\count($ids) > 0) {
                 // Merge tags
                 $this->addSql('
                     UPDATE ' . $this->getTable('entry_tag') . '

--- a/src/Wallabag/AnnotationBundle/Controller/WallabagAnnotationController.php
+++ b/src/Wallabag/AnnotationBundle/Controller/WallabagAnnotationController.php
@@ -28,7 +28,7 @@ class WallabagAnnotationController extends FOSRestController
             ->getDoctrine()
             ->getRepository('WallabagAnnotationBundle:Annotation')
             ->findAnnotationsByPageId($entry->getId(), $this->getUser()->getId());
-        $total = count($annotationRows);
+        $total = \count($annotationRows);
         $annotations = ['total' => $total, 'rows' => $annotationRows];
 
         $json = $this->get('jms_serializer')->serialize($annotations, 'json');

--- a/src/Wallabag/ApiBundle/Controller/EntryRestController.php
+++ b/src/Wallabag/ApiBundle/Controller/EntryRestController.php
@@ -102,7 +102,7 @@ class EntryRestController extends WallabagRestController
         $order = $request->query->get('order', 'desc');
         $page = (int) $request->query->get('page', 1);
         $perPage = (int) $request->query->get('perPage', 30);
-        $tags = is_array($request->query->get('tags')) ? '' : (string) $request->query->get('tags', '');
+        $tags = \is_array($request->query->get('tags')) ? '' : (string) $request->query->get('tags', '');
         $since = $request->query->get('since', 0);
 
         /** @var \Pagerfanta\Pagerfanta $pager */
@@ -253,7 +253,7 @@ class EntryRestController extends WallabagRestController
 
         $limit = $this->container->getParameter('wallabag_core.api_limit_mass_actions');
 
-        if (count($urls) > $limit) {
+        if (\count($urls) > $limit) {
             throw new HttpException(400, 'API limit reached');
         }
 
@@ -347,7 +347,7 @@ class EntryRestController extends WallabagRestController
                     'open_graph' => [
                         'og_image' => !empty($data['picture']) ? $data['picture'] : $entry->getPreviewPicture(),
                     ],
-                    'authors' => is_string($data['authors']) ? explode(',', $data['authors']) : $entry->getPublishedBy(),
+                    'authors' => \is_string($data['authors']) ? explode(',', $data['authors']) : $entry->getPublishedBy(),
                 ]
             );
         } catch (\Exception $e) {
@@ -461,7 +461,7 @@ class EntryRestController extends WallabagRestController
             $contentProxy->updateLanguage($entry, $data['language']);
         }
 
-        if (!empty($data['authors']) && is_string($data['authors'])) {
+        if (!empty($data['authors']) && \is_string($data['authors'])) {
             $entry->setPublishedBy(explode(',', $data['authors']));
         }
 

--- a/src/Wallabag/ApiBundle/Controller/TagRestController.php
+++ b/src/Wallabag/ApiBundle/Controller/TagRestController.php
@@ -138,14 +138,14 @@ class TagRestController extends WallabagRestController
      */
     private function cleanOrphanTag($tags)
     {
-        if (!is_array($tags)) {
+        if (!\is_array($tags)) {
             $tags = [$tags];
         }
 
         $em = $this->getDoctrine()->getManager();
 
         foreach ($tags as $tag) {
-            if (0 === count($tag->getEntries())) {
+            if (0 === \count($tag->getEntries())) {
                 $em->remove($tag);
             }
         }

--- a/src/Wallabag/CoreBundle/Command/CleanDuplicatesCommand.php
+++ b/src/Wallabag/CoreBundle/Command/CleanDuplicatesCommand.php
@@ -51,7 +51,7 @@ class CleanDuplicatesCommand extends ContainerAwareCommand
         } else {
             $users = $this->getContainer()->get('wallabag_user.user_repository')->findAll();
 
-            $this->io->text(sprintf('Cleaning through <info>%d</info> user accounts', count($users)));
+            $this->io->text(sprintf('Cleaning through <info>%d</info> user accounts', \count($users)));
 
             foreach ($users as $user) {
                 $this->io->text(sprintf('Processing user <info>%s</info>', $user->getUsername()));
@@ -79,7 +79,7 @@ class CleanDuplicatesCommand extends ContainerAwareCommand
             $url = $this->similarUrl($entry['url']);
 
             /* @var $entry Entry */
-            if (in_array($url, $urls, true)) {
+            if (\in_array($url, $urls, true)) {
                 ++$duplicatesCount;
 
                 $em->remove($repo->find($entry['id']));
@@ -96,8 +96,8 @@ class CleanDuplicatesCommand extends ContainerAwareCommand
 
     private function similarUrl($url)
     {
-        if (in_array(substr($url, -1), ['/', '#'], true)) { // get rid of "/" and "#" and the end of urls
-            return substr($url, 0, strlen($url));
+        if (\in_array(substr($url, -1), ['/', '#'], true)) { // get rid of "/" and "#" and the end of urls
+            return substr($url, 0, \strlen($url));
         }
 
         return $url;

--- a/src/Wallabag/CoreBundle/Command/ExportCommand.php
+++ b/src/Wallabag/CoreBundle/Command/ExportCommand.php
@@ -47,7 +47,7 @@ class ExportCommand extends ContainerAwareCommand
             ->getQuery()
             ->getResult();
 
-        $io->text(sprintf('Exporting <info>%d</info> entrie(s) for user <info>%s</info>...', count($entries), $user->getUserName()));
+        $io->text(sprintf('Exporting <info>%d</info> entrie(s) for user <info>%s</info>...', \count($entries), $user->getUserName()));
 
         $filePath = $input->getArgument('filepath');
 

--- a/src/Wallabag/CoreBundle/Command/InstallCommand.php
+++ b/src/Wallabag/CoreBundle/Command/InstallCommand.php
@@ -81,7 +81,7 @@ class InstallCommand extends ContainerAwareCommand
         $status = '<info>OK!</info>';
         $help = '';
 
-        if (!extension_loaded($this->getContainer()->getParameter('database_driver'))) {
+        if (!\extension_loaded($this->getContainer()->getParameter('database_driver'))) {
             $fulfilled = false;
             $status = '<error>ERROR!</error>';
             $help = 'Database driver "' . $this->getContainer()->getParameter('database_driver') . '" is not installed.';
@@ -146,7 +146,7 @@ class InstallCommand extends ContainerAwareCommand
             $status = '<info>OK!</info>';
             $help = '';
 
-            if (!function_exists($functionRequired)) {
+            if (!\function_exists($functionRequired)) {
                 $fulfilled = false;
                 $status = '<error>ERROR!</error>';
                 $help = 'You need the ' . $functionRequired . ' function activated';
@@ -371,7 +371,7 @@ class InstallCommand extends ContainerAwareCommand
         }
 
         try {
-            return in_array($databaseName, $schemaManager->listDatabases(), true);
+            return \in_array($databaseName, $schemaManager->listDatabases(), true);
         } catch (\Doctrine\DBAL\Exception\DriverException $e) {
             // it means we weren't able to get database list, assume the database doesn't exist
 
@@ -389,6 +389,6 @@ class InstallCommand extends ContainerAwareCommand
     {
         $schemaManager = $this->getContainer()->get('doctrine')->getManager()->getConnection()->getSchemaManager();
 
-        return count($schemaManager->listTableNames()) > 0 ? true : false;
+        return \count($schemaManager->listTableNames()) > 0 ? true : false;
     }
 }

--- a/src/Wallabag/CoreBundle/Command/ListUserCommand.php
+++ b/src/Wallabag/CoreBundle/Command/ListUserCommand.php
@@ -50,7 +50,7 @@ class ListUserCommand extends ContainerAwareCommand
         $io->success(
             sprintf(
                 '%s/%s%s user(s) displayed.',
-                count($users),
+                \count($users),
                 $nbUsers,
                 null === $input->getArgument('search') ? '' : ' (filtered)'
             )

--- a/src/Wallabag/CoreBundle/Command/ReloadEntryCommand.php
+++ b/src/Wallabag/CoreBundle/Command/ReloadEntryCommand.php
@@ -43,7 +43,7 @@ class ReloadEntryCommand extends ContainerAwareCommand
         $entryRepository = $this->getContainer()->get('wallabag_core.entry_repository');
         $entryIds = $entryRepository->findAllEntriesIdByUserId($userId);
 
-        $nbEntries = count($entryIds);
+        $nbEntries = \count($entryIds);
         if (!$nbEntries) {
             $io->success('No entry to reload.');
 

--- a/src/Wallabag/CoreBundle/Controller/ConfigController.php
+++ b/src/Wallabag/CoreBundle/Controller/ConfigController.php
@@ -348,7 +348,7 @@ class ConfigController extends Controller
         $em = $this->getDoctrine()->getManager();
 
         foreach ($tags as $tag) {
-            if (0 === count($tag->getEntries())) {
+            if (0 === \count($tag->getEntries())) {
                 $em->remove($tag);
             }
         }

--- a/src/Wallabag/CoreBundle/Controller/TagController.php
+++ b/src/Wallabag/CoreBundle/Controller/TagController.php
@@ -65,7 +65,7 @@ class TagController extends Controller
         $em->flush();
 
         // remove orphan tag in case no entries are associated to it
-        if (0 === count($tag->getEntries())) {
+        if (0 === \count($tag->getEntries())) {
             $em->remove($tag);
             $em->flush();
         }

--- a/src/Wallabag/CoreBundle/Form/Type/EntryFilterType.php
+++ b/src/Wallabag/CoreBundle/Form/Type/EntryFilterType.php
@@ -33,7 +33,7 @@ class EntryFilterType extends AbstractType
 
         $this->user = $tokenStorage->getToken() ? $tokenStorage->getToken()->getUser() : null;
 
-        if (null === $this->user || !is_object($this->user)) {
+        if (null === $this->user || !\is_object($this->user)) {
             return;
         }
     }
@@ -96,7 +96,7 @@ class EntryFilterType extends AbstractType
             ->add('domainName', TextFilterType::class, [
                 'apply_filter' => function (QueryInterface $filterQuery, $field, $values) {
                     $value = $values['value'];
-                    if (strlen($value) <= 2 || empty($value)) {
+                    if (\strlen($value) <= 2 || empty($value)) {
                         return;
                     }
                     $expression = $filterQuery->getExpr()->like($field, $filterQuery->getExpr()->lower($filterQuery->getExpr()->literal('%' . $value . '%')));

--- a/src/Wallabag/CoreBundle/GuzzleSiteAuthenticator/GrabySiteConfigBuilder.php
+++ b/src/Wallabag/CoreBundle/GuzzleSiteAuthenticator/GrabySiteConfigBuilder.php
@@ -107,7 +107,7 @@ class GrabySiteConfigBuilder implements SiteConfigBuilder
      */
     protected function processExtraFields($extraFieldsStrings)
     {
-        if (!is_array($extraFieldsStrings)) {
+        if (!\is_array($extraFieldsStrings)) {
             return [];
         }
 

--- a/src/Wallabag/CoreBundle/Helper/ContentProxy.php
+++ b/src/Wallabag/CoreBundle/Helper/ContentProxy.php
@@ -85,7 +85,7 @@ class ContentProxy
             (new LocaleConstraint())
         );
 
-        if (0 === count($errors)) {
+        if (0 === \count($errors)) {
             $entry->setLanguage($value);
 
             return;
@@ -107,7 +107,7 @@ class ContentProxy
             (new UrlConstraint())
         );
 
-        if (0 === count($errors)) {
+        if (0 === \count($errors)) {
             $entry->setPreviewPicture($value);
 
             return;
@@ -212,7 +212,7 @@ class ContentProxy
             $entry->setHttpStatus($content['status']);
         }
 
-        if (!empty($content['authors']) && is_array($content['authors'])) {
+        if (!empty($content['authors']) && \is_array($content['authors'])) {
             $entry->setPublishedBy($content['authors']);
         }
 
@@ -233,7 +233,7 @@ class ContentProxy
         }
 
         // if content is an image, define it as a preview too
-        if (!empty($content['content_type']) && in_array($this->mimeGuesser->guess($content['content_type']), ['jpeg', 'jpg', 'gif', 'png'], true)) {
+        if (!empty($content['content_type']) && \in_array($this->mimeGuesser->guess($content['content_type']), ['jpeg', 'jpg', 'gif', 'png'], true)) {
             $this->updatePreviewPicture($entry, $content['url']);
         }
 

--- a/src/Wallabag/CoreBundle/Helper/CryptoProxy.php
+++ b/src/Wallabag/CoreBundle/Helper/CryptoProxy.php
@@ -81,6 +81,6 @@ class CryptoProxy
      */
     private function mask($value)
     {
-        return strlen($value) > 0 ? $value[0] . '*****' . $value[strlen($value) - 1] : 'Empty value';
+        return \strlen($value) > 0 ? $value[0] . '*****' . $value[\strlen($value) - 1] : 'Empty value';
     }
 }

--- a/src/Wallabag/CoreBundle/Helper/DownloadImages.php
+++ b/src/Wallabag/CoreBundle/Helper/DownloadImages.php
@@ -198,7 +198,7 @@ class DownloadImages
                 // Must be one or more digits followed by w OR x
                 $pattern = "/(?:[^\"'\s]+\s*(?:\d+[wx])+)/";
                 preg_match_all($pattern, $srcsetAttribute, $matches);
-                $srcset = call_user_func_array('array_merge', $matches);
+                $srcset = \call_user_func_array('array_merge', $matches);
                 $srcsetUrls = array_map(function ($src) {
                     return trim(explode(' ', $src, 2)[0]);
                 }, $srcset);
@@ -308,7 +308,7 @@ class DownloadImages
             $this->logger->debug('DownloadImages: Checking extension (alternative)', ['ext' => $ext]);
         }
 
-        if (!in_array($ext, ['jpeg', 'jpg', 'gif', 'png'], true)) {
+        if (!\in_array($ext, ['jpeg', 'jpg', 'gif', 'png'], true)) {
             $this->logger->error('DownloadImages: Processed image with not allowed extension. Skipping: ' . $imagePath);
 
             return false;

--- a/src/Wallabag/CoreBundle/Helper/EntriesExport.php
+++ b/src/Wallabag/CoreBundle/Helper/EntriesExport.php
@@ -45,7 +45,7 @@ class EntriesExport
      */
     public function setEntries($entries)
     {
-        if (!is_array($entries)) {
+        if (!\is_array($entries)) {
             $this->language = $entries->getLanguage();
             $entries = [$entries];
         }
@@ -325,7 +325,7 @@ class EntriesExport
     {
         $delimiter = ';';
         $enclosure = '"';
-        $handle = fopen('php://memory', 'rb+');
+        $handle = fopen('php://memory', 'b+r');
 
         fputcsv($handle, ['Title', 'URL', 'Content', 'Tags', 'MIME Type', 'Language', 'Creation date'], $delimiter, $enclosure);
 

--- a/src/Wallabag/CoreBundle/Helper/PreparePagerForEntries.php
+++ b/src/Wallabag/CoreBundle/Helper/PreparePagerForEntries.php
@@ -31,7 +31,7 @@ class PreparePagerForEntries
             $user = $this->tokenStorage->getToken() ? $this->tokenStorage->getToken()->getUser() : null;
         }
 
-        if (null === $user || !is_object($user)) {
+        if (null === $user || !\is_object($user)) {
             return;
         }
 

--- a/src/Wallabag/CoreBundle/Helper/Redirect.php
+++ b/src/Wallabag/CoreBundle/Helper/Redirect.php
@@ -31,7 +31,7 @@ class Redirect
     {
         $user = $this->tokenStorage->getToken() ? $this->tokenStorage->getToken()->getUser() : null;
 
-        if (null === $user || !is_object($user)) {
+        if (null === $user || !\is_object($user)) {
             return $url;
         }
 

--- a/src/Wallabag/CoreBundle/Helper/TagsAssigner.php
+++ b/src/Wallabag/CoreBundle/Helper/TagsAssigner.php
@@ -32,7 +32,7 @@ class TagsAssigner
     {
         $tagsEntities = [];
 
-        if (!is_array($tags)) {
+        if (!\is_array($tags)) {
             $tags = explode(',', $tags);
         }
 
@@ -48,7 +48,7 @@ class TagsAssigner
             $label = trim(mb_convert_case($label, MB_CASE_LOWER));
 
             // avoid empty tag
-            if (0 === strlen($label)) {
+            if (0 === \strlen($label)) {
                 continue;
             }
 

--- a/src/Wallabag/CoreBundle/ParamConverter/UsernameRssTokenConverter.php
+++ b/src/Wallabag/CoreBundle/ParamConverter/UsernameRssTokenConverter.php
@@ -36,7 +36,7 @@ class UsernameRssTokenConverter implements ParamConverterInterface
     {
         // If there is no manager, this means that only Doctrine DBAL is configured
         // In this case we can do nothing and just return
-        if (null === $this->registry || !count($this->registry->getManagers())) {
+        if (null === $this->registry || !\count($this->registry->getManagers())) {
             return false;
         }
 

--- a/src/Wallabag/CoreBundle/Repository/EntryRepository.php
+++ b/src/Wallabag/CoreBundle/Repository/EntryRepository.php
@@ -151,7 +151,7 @@ class EntryRepository extends EntityRepository
             $qb->andWhere('e.updatedAt > :since')->setParameter('since', new \DateTime(date('Y-m-d H:i:s', $since)));
         }
 
-        if (is_string($tags) && '' !== $tags) {
+        if (\is_string($tags) && '' !== $tags) {
             foreach (explode(',', $tags) as $i => $tag) {
                 $entryAlias = 'e' . $i;
                 $tagAlias = 't' . $i;
@@ -320,7 +320,7 @@ class EntryRepository extends EntityRepository
             ->getQuery()
             ->getResult();
 
-        if (count($res)) {
+        if (\count($res)) {
             return current($res);
         }
 

--- a/src/Wallabag/CoreBundle/Repository/TagRepository.php
+++ b/src/Wallabag/CoreBundle/Repository/TagRepository.php
@@ -30,7 +30,7 @@ class TagRepository extends EntityRepository
             $query->setResultCacheLifetime($cacheLifeTime);
         }
 
-        return count($query->getArrayResult());
+        return \count($query->getArrayResult());
     }
 
     /**

--- a/src/Wallabag/CoreBundle/Tools/Utils.php
+++ b/src/Wallabag/CoreBundle/Tools/Utils.php
@@ -29,6 +29,6 @@ class Utils
      */
     public static function getReadingTime($text)
     {
-        return floor(count(preg_split('~[^\p{L}\p{N}\']+~u', strip_tags($text))) / 200);
+        return floor(\count(preg_split('~[^\p{L}\p{N}\']+~u', strip_tags($text))) / 200);
     }
 }

--- a/src/Wallabag/CoreBundle/Twig/WallabagExtension.php
+++ b/src/Wallabag/CoreBundle/Twig/WallabagExtension.php
@@ -64,7 +64,7 @@ class WallabagExtension extends \Twig_Extension implements \Twig_Extension_Globa
     {
         $user = $this->tokenStorage->getToken() ? $this->tokenStorage->getToken()->getUser() : null;
 
-        if (null === $user || !is_object($user)) {
+        if (null === $user || !\is_object($user)) {
             return 0;
         }
 
@@ -96,7 +96,7 @@ class WallabagExtension extends \Twig_Extension implements \Twig_Extension_Globa
         $query->useResultCache(true);
         $query->setResultCacheLifetime($this->lifeTime);
 
-        return count($query->getArrayResult());
+        return \count($query->getArrayResult());
     }
 
     /**
@@ -108,7 +108,7 @@ class WallabagExtension extends \Twig_Extension implements \Twig_Extension_Globa
     {
         $user = $this->tokenStorage->getToken() ? $this->tokenStorage->getToken()->getUser() : null;
 
-        if (null === $user || !is_object($user)) {
+        if (null === $user || !\is_object($user)) {
             return 0;
         }
 
@@ -124,7 +124,7 @@ class WallabagExtension extends \Twig_Extension implements \Twig_Extension_Globa
     {
         $user = $this->tokenStorage->getToken() ? $this->tokenStorage->getToken()->getUser() : null;
 
-        if (null === $user || !is_object($user)) {
+        if (null === $user || !\is_object($user)) {
             return 0;
         }
 
@@ -137,7 +137,7 @@ class WallabagExtension extends \Twig_Extension implements \Twig_Extension_Globa
         $query->useResultCache(true);
         $query->setResultCacheLifetime($this->lifeTime);
 
-        $nbArchives = count($query->getArrayResult());
+        $nbArchives = \count($query->getArrayResult());
 
         $interval = $user->getCreatedAt()->diff(new \DateTime('now'));
         $nbDays = (int) $interval->format('%a') ?: 1;

--- a/src/Wallabag/ImportBundle/Command/ImportCommand.php
+++ b/src/Wallabag/ImportBundle/Command/ImportCommand.php
@@ -43,7 +43,7 @@ class ImportCommand extends ContainerAwareCommand
             $user = $em->getRepository('WallabagUserBundle:User')->findOneByUsername($input->getArgument('username'));
         }
 
-        if (!is_object($user)) {
+        if (!\is_object($user)) {
             throw new Exception(sprintf('User "%s" not found', $input->getArgument('username')));
         }
 

--- a/src/Wallabag/ImportBundle/Controller/BrowserController.php
+++ b/src/Wallabag/ImportBundle/Controller/BrowserController.php
@@ -30,7 +30,7 @@ abstract class BrowserController extends Controller
             $markAsRead = $form->get('mark_as_read')->getData();
             $name = $this->getUser()->getId() . '.json';
 
-            if (null !== $file && in_array($file->getClientMimeType(), $this->getParameter('wallabag_import.allow_mimetypes'), true) && $file->move($this->getParameter('wallabag_import.resource_dir'), $name)) {
+            if (null !== $file && \in_array($file->getClientMimeType(), $this->getParameter('wallabag_import.allow_mimetypes'), true) && $file->move($this->getParameter('wallabag_import.resource_dir'), $name)) {
                 $res = $wallabag
                     ->setFilepath($this->getParameter('wallabag_import.resource_dir') . '/' . $name)
                     ->setMarkAsRead($markAsRead)

--- a/src/Wallabag/ImportBundle/Controller/InstapaperController.php
+++ b/src/Wallabag/ImportBundle/Controller/InstapaperController.php
@@ -31,7 +31,7 @@ class InstapaperController extends Controller
             $markAsRead = $form->get('mark_as_read')->getData();
             $name = 'instapaper_' . $this->getUser()->getId() . '.csv';
 
-            if (null !== $file && in_array($file->getClientMimeType(), $this->getParameter('wallabag_import.allow_mimetypes'), true) && $file->move($this->getParameter('wallabag_import.resource_dir'), $name)) {
+            if (null !== $file && \in_array($file->getClientMimeType(), $this->getParameter('wallabag_import.allow_mimetypes'), true) && $file->move($this->getParameter('wallabag_import.resource_dir'), $name)) {
                 $res = $instapaper
                     ->setFilepath($this->getParameter('wallabag_import.resource_dir') . '/' . $name)
                     ->setMarkAsRead($markAsRead)

--- a/src/Wallabag/ImportBundle/Controller/PinboardController.php
+++ b/src/Wallabag/ImportBundle/Controller/PinboardController.php
@@ -31,7 +31,7 @@ class PinboardController extends Controller
             $markAsRead = $form->get('mark_as_read')->getData();
             $name = 'pinboard_' . $this->getUser()->getId() . '.json';
 
-            if (null !== $file && in_array($file->getClientMimeType(), $this->getParameter('wallabag_import.allow_mimetypes'), true) && $file->move($this->getParameter('wallabag_import.resource_dir'), $name)) {
+            if (null !== $file && \in_array($file->getClientMimeType(), $this->getParameter('wallabag_import.allow_mimetypes'), true) && $file->move($this->getParameter('wallabag_import.resource_dir'), $name)) {
                 $res = $pinboard
                     ->setFilepath($this->getParameter('wallabag_import.resource_dir') . '/' . $name)
                     ->setMarkAsRead($markAsRead)

--- a/src/Wallabag/ImportBundle/Controller/ReadabilityController.php
+++ b/src/Wallabag/ImportBundle/Controller/ReadabilityController.php
@@ -31,7 +31,7 @@ class ReadabilityController extends Controller
             $markAsRead = $form->get('mark_as_read')->getData();
             $name = 'readability_' . $this->getUser()->getId() . '.json';
 
-            if (null !== $file && in_array($file->getClientMimeType(), $this->getParameter('wallabag_import.allow_mimetypes'), true) && $file->move($this->getParameter('wallabag_import.resource_dir'), $name)) {
+            if (null !== $file && \in_array($file->getClientMimeType(), $this->getParameter('wallabag_import.allow_mimetypes'), true) && $file->move($this->getParameter('wallabag_import.resource_dir'), $name)) {
                 $res = $readability
                     ->setFilepath($this->getParameter('wallabag_import.resource_dir') . '/' . $name)
                     ->setMarkAsRead($markAsRead)

--- a/src/Wallabag/ImportBundle/Controller/WallabagController.php
+++ b/src/Wallabag/ImportBundle/Controller/WallabagController.php
@@ -33,7 +33,7 @@ abstract class WallabagController extends Controller
             $markAsRead = $form->get('mark_as_read')->getData();
             $name = $this->getUser()->getId() . '.json';
 
-            if (null !== $file && in_array($file->getClientMimeType(), $this->getParameter('wallabag_import.allow_mimetypes'), true) && $file->move($this->getParameter('wallabag_import.resource_dir'), $name)) {
+            if (null !== $file && \in_array($file->getClientMimeType(), $this->getParameter('wallabag_import.allow_mimetypes'), true) && $file->move($this->getParameter('wallabag_import.resource_dir'), $name)) {
                 $res = $wallabag
                     ->setFilepath($this->getParameter('wallabag_import.resource_dir') . '/' . $name)
                     ->setMarkAsRead($markAsRead)

--- a/src/Wallabag/ImportBundle/Import/BrowserImport.php
+++ b/src/Wallabag/ImportBundle/Import/BrowserImport.php
@@ -77,7 +77,7 @@ abstract class BrowserImport extends AbstractImport
      */
     public function parseEntry(array $importedEntry)
     {
-        if ((!array_key_exists('guid', $importedEntry) || (!array_key_exists('id', $importedEntry))) && is_array(reset($importedEntry))) {
+        if ((!array_key_exists('guid', $importedEntry) || (!array_key_exists('id', $importedEntry))) && \is_array(reset($importedEntry))) {
             if ($this->producer) {
                 $this->parseEntriesForProducer($importedEntry);
 

--- a/src/Wallabag/ImportBundle/Import/InstapaperImport.php
+++ b/src/Wallabag/ImportBundle/Import/InstapaperImport.php
@@ -62,7 +62,7 @@ class InstapaperImport extends AbstractImport
         }
 
         $entries = [];
-        $handle = fopen($this->filepath, 'r');
+        $handle = fopen($this->filepath, 'rb');
         while (false !== ($data = fgetcsv($handle, 10240))) {
             if ('URL' === $data[0]) {
                 continue;
@@ -72,7 +72,7 @@ class InstapaperImport extends AbstractImport
             // BUT it can also be the status (since status = folder in Instapaper)
             // and we don't want archive, unread & starred to become a tag
             $tags = null;
-            if (false === in_array($data[3], ['Archive', 'Unread', 'Starred'], true)) {
+            if (false === \in_array($data[3], ['Archive', 'Unread', 'Starred'], true)) {
                 $tags = [$data[3]];
             }
 

--- a/src/Wallabag/ImportBundle/Import/PocketImport.php
+++ b/src/Wallabag/ImportBundle/Import/PocketImport.php
@@ -149,7 +149,7 @@ class PocketImport extends AbstractImport
         //  - first call get 5k offset 0
         //  - second call get 5k offset 5k
         //  - and so on
-        if (self::NB_ELEMENTS === count($entries['list'])) {
+        if (self::NB_ELEMENTS === \count($entries['list'])) {
             ++$run;
 
             return $this->import(self::NB_ELEMENTS * $run);

--- a/src/Wallabag/ImportBundle/Import/WallabagV1Import.php
+++ b/src/Wallabag/ImportBundle/Import/WallabagV1Import.php
@@ -56,7 +56,7 @@ class WallabagV1Import extends WallabagImport
 
         // In case of a bad fetch in v1, replace title and content with v2 error strings
         // If fetching fails again, they will get this instead of the v1 strings
-        if (in_array($entry['title'], $this->untitled, true)) {
+        if (\in_array($entry['title'], $this->untitled, true)) {
             $data['title'] = $this->fetchingErrorMessageTitle;
             $data['html'] = $this->fetchingErrorMessage;
         }

--- a/tests/Wallabag/ApiBundle/Controller/DeveloperControllerTest.php
+++ b/tests/Wallabag/ApiBundle/Controller/DeveloperControllerTest.php
@@ -28,7 +28,7 @@ class DeveloperControllerTest extends WallabagCoreTestCase
         $this->assertSame(200, $client->getResponse()->getStatusCode());
 
         $newNbClients = $em->getRepository('WallabagApiBundle:Client')->findAll();
-        $this->assertGreaterThan(count($nbClients), count($newNbClients));
+        $this->assertGreaterThan(\count($nbClients), \count($newNbClients));
 
         $this->assertGreaterThan(1, $alert = $crawler->filter('.settings ul li strong')->extract(['_text']));
         $this->assertContains('My app', $alert[0]);
@@ -65,7 +65,7 @@ class DeveloperControllerTest extends WallabagCoreTestCase
 
         $crawler = $client->request('GET', '/developer');
         $this->assertSame(200, $client->getResponse()->getStatusCode());
-        $this->assertSame(count($nbClients), $crawler->filter('ul[class=collapsible] li')->count());
+        $this->assertSame(\count($nbClients), $crawler->filter('ul[class=collapsible] li')->count());
     }
 
     public function testDeveloperHowto()

--- a/tests/Wallabag/ApiBundle/Controller/EntryRestControllerTest.php
+++ b/tests/Wallabag/ApiBundle/Controller/EntryRestControllerTest.php
@@ -28,7 +28,7 @@ class EntryRestControllerTest extends WallabagApiTestCase
 
         $this->assertSame($entry->getTitle(), $content['title']);
         $this->assertSame($entry->getUrl(), $content['url']);
-        $this->assertCount(count($entry->getTags()), $content['tags']);
+        $this->assertCount(\count($entry->getTags()), $content['tags']);
         $this->assertSame($entry->getUserName(), $content['user_name']);
         $this->assertSame($entry->getUserEmail(), $content['user_email']);
         $this->assertSame($entry->getUserId(), $content['user_id']);
@@ -127,7 +127,7 @@ class EntryRestControllerTest extends WallabagApiTestCase
 
         $content = json_decode($this->client->getResponse()->getContent(), true);
 
-        $this->assertGreaterThanOrEqual(1, count($content));
+        $this->assertGreaterThanOrEqual(1, \count($content));
         $this->assertNotEmpty($content['_embedded']['items']);
         $this->assertGreaterThanOrEqual(1, $content['total']);
         $this->assertSame(1, $content['page']);
@@ -154,7 +154,7 @@ class EntryRestControllerTest extends WallabagApiTestCase
 
         $content = json_decode($this->client->getResponse()->getContent(), true);
 
-        $this->assertGreaterThanOrEqual(1, count($content));
+        $this->assertGreaterThanOrEqual(1, \count($content));
         $this->assertArrayHasKey('items', $content['_embedded']);
         $this->assertGreaterThanOrEqual(0, $content['total']);
         $this->assertSame(1, $content['page']);
@@ -206,7 +206,7 @@ class EntryRestControllerTest extends WallabagApiTestCase
 
         $content = json_decode($this->client->getResponse()->getContent(), true);
 
-        $this->assertGreaterThanOrEqual(1, count($content));
+        $this->assertGreaterThanOrEqual(1, \count($content));
         $this->assertArrayHasKey('items', $content['_embedded']);
         $this->assertGreaterThanOrEqual(1, $content['total']);
         $this->assertSame(1, $content['page']);
@@ -250,7 +250,7 @@ class EntryRestControllerTest extends WallabagApiTestCase
 
         $content = json_decode($this->client->getResponse()->getContent(), true);
 
-        $this->assertGreaterThanOrEqual(1, count($content));
+        $this->assertGreaterThanOrEqual(1, \count($content));
         $this->assertNotEmpty($content['_embedded']['items']);
         $this->assertGreaterThanOrEqual(1, $content['total']);
         $this->assertSame(1, $content['page']);
@@ -278,7 +278,7 @@ class EntryRestControllerTest extends WallabagApiTestCase
 
         $content = json_decode($this->client->getResponse()->getContent(), true);
 
-        $this->assertGreaterThanOrEqual(1, count($content));
+        $this->assertGreaterThanOrEqual(1, \count($content));
         $this->assertNotEmpty($content['_embedded']['items']);
         $this->assertGreaterThanOrEqual(1, $content['total']);
         $this->assertSame(1, $content['page']);
@@ -305,7 +305,7 @@ class EntryRestControllerTest extends WallabagApiTestCase
 
         $content = json_decode($this->client->getResponse()->getContent(), true);
 
-        $this->assertGreaterThanOrEqual(1, count($content));
+        $this->assertGreaterThanOrEqual(1, \count($content));
         $this->assertNotEmpty($content['_embedded']['items']);
         $this->assertGreaterThanOrEqual(1, $content['total']);
         $this->assertSame(1, $content['page']);
@@ -342,7 +342,7 @@ class EntryRestControllerTest extends WallabagApiTestCase
 
         $content = json_decode($this->client->getResponse()->getContent(), true);
 
-        $this->assertGreaterThanOrEqual(1, count($content));
+        $this->assertGreaterThanOrEqual(1, \count($content));
         $this->assertNotEmpty($content['_embedded']['items']);
         $this->assertGreaterThanOrEqual(1, $content['total']);
         $this->assertSame(1, $content['page']);
@@ -370,7 +370,7 @@ class EntryRestControllerTest extends WallabagApiTestCase
 
         $content = json_decode($this->client->getResponse()->getContent(), true);
 
-        $this->assertGreaterThanOrEqual(1, count($content));
+        $this->assertGreaterThanOrEqual(1, \count($content));
         $this->assertEmpty($content['_embedded']['items']);
         $this->assertSame(0, $content['total']);
         $this->assertSame(1, $content['page']);
@@ -608,7 +608,7 @@ class EntryRestControllerTest extends WallabagApiTestCase
         $this->assertSame($entry->getId(), $content['id']);
         $this->assertSame($entry->getUrl(), $content['url']);
         $this->assertSame('New awesome title', $content['title']);
-        $this->assertGreaterThanOrEqual(1, count($content['tags']), 'We force only one tag');
+        $this->assertGreaterThanOrEqual(1, \count($content['tags']), 'We force only one tag');
         $this->assertSame(1, $content['user_id']);
         $this->assertSame('de_AT', $content['language']);
         $this->assertSame('http://preview.io/picture.jpg', $content['preview_picture']);
@@ -647,7 +647,7 @@ class EntryRestControllerTest extends WallabagApiTestCase
 
         $this->assertSame($entry->getId(), $content['id']);
         $this->assertSame($entry->getUrl(), $content['url']);
-        $this->assertGreaterThanOrEqual(1, count($content['tags']), 'We force only one tag');
+        $this->assertGreaterThanOrEqual(1, \count($content['tags']), 'We force only one tag');
         $this->assertEmpty($content['published_by'], 'Authors were not saved because of an array instead of a string');
         $this->assertSame($previousContent, $content['content'], 'Ensure content has not moved');
         $this->assertSame($previousLanguage, $content['language'], 'Ensure language has not moved');
@@ -772,7 +772,7 @@ class EntryRestControllerTest extends WallabagApiTestCase
             $this->markTestSkipped('No content found in db.');
         }
 
-        $nbTags = count($entry->getTags());
+        $nbTags = \count($entry->getTags());
 
         $newTags = 'tag1,tag2,tag3';
 
@@ -783,7 +783,7 @@ class EntryRestControllerTest extends WallabagApiTestCase
         $content = json_decode($this->client->getResponse()->getContent(), true);
 
         $this->assertArrayHasKey('tags', $content);
-        $this->assertSame($nbTags + 3, count($content['tags']));
+        $this->assertSame($nbTags + 3, \count($content['tags']));
 
         $entryDB = $this->client->getContainer()
             ->get('doctrine.orm.entity_manager')
@@ -813,7 +813,7 @@ class EntryRestControllerTest extends WallabagApiTestCase
         }
 
         // hydrate the tags relations
-        $nbTags = count($entry->getTags());
+        $nbTags = \count($entry->getTags());
         $tag = $entry->getTags()[0];
 
         $this->client->request('DELETE', '/api/entries/' . $entry->getId() . '/tags/' . $tag->getId() . '.json');
@@ -823,7 +823,7 @@ class EntryRestControllerTest extends WallabagApiTestCase
         $content = json_decode($this->client->getResponse()->getContent(), true);
 
         $this->assertArrayHasKey('tags', $content);
-        $this->assertSame($nbTags - 1, count($content['tags']));
+        $this->assertSame($nbTags - 1, \count($content['tags']));
     }
 
     public function testSaveIsArchivedAfterPost()

--- a/tests/Wallabag/CoreBundle/Controller/EntryControllerTest.php
+++ b/tests/Wallabag/CoreBundle/Controller/EntryControllerTest.php
@@ -524,7 +524,7 @@ class EntryControllerTest extends WallabagCoreTestCase
 
         $this->assertGreaterThan(1, $title = $crawler->filter('div[id=article] h1')->extract(['_text']));
         $this->assertContains('My updated title hehe :)', $title[0]);
-        $this->assertSame(1, count($stats = $crawler->filter('div[class=tools] ul[class=stats] li a[class=tool]')->extract(['_text'])));
+        $this->assertSame(1, \count($stats = $crawler->filter('div[class=tools] ul[class=stats] li a[class=tool]')->extract(['_text'])));
         $this->assertNotContains('example.io', trim($stats[0]));
     }
 

--- a/tests/Wallabag/CoreBundle/Controller/ExportControllerTest.php
+++ b/tests/Wallabag/CoreBundle/Controller/ExportControllerTest.php
@@ -180,7 +180,7 @@ class ExportControllerTest extends WallabagCoreTestCase
 
         $this->assertGreaterThan(1, $csv);
         // +1 for title line
-        $this->assertSame(count($contentInDB) + 1, count($csv));
+        $this->assertSame(\count($contentInDB) + 1, \count($csv));
         $this->assertSame('Title;URL;Content;Tags;"MIME Type";Language;"Creation date"', $csv[0]);
         $this->assertContains($contentInDB[0]['title'], $csv[1]);
         $this->assertContains($contentInDB[0]['url'], $csv[1]);
@@ -272,7 +272,7 @@ class ExportControllerTest extends WallabagCoreTestCase
 
         $content = new \SimpleXMLElement($client->getResponse()->getContent());
         $this->assertGreaterThan(0, $content->count());
-        $this->assertSame(count($contentInDB), $content->count());
+        $this->assertSame(\count($contentInDB), $content->count());
         $this->assertNotEmpty('id', (string) $content->entry[0]->id);
         $this->assertNotEmpty('title', (string) $content->entry[0]->title);
         $this->assertNotEmpty('url', (string) $content->entry[0]->url);

--- a/tests/Wallabag/CoreBundle/Controller/TagControllerTest.php
+++ b/tests/Wallabag/CoreBundle/Controller/TagControllerTest.php
@@ -98,7 +98,7 @@ class TagControllerTest extends WallabagCoreTestCase
             $tags[$key] = $tag->getLabel();
         }
 
-        $this->assertGreaterThanOrEqual(2, count($tags));
+        $this->assertGreaterThanOrEqual(2, \count($tags));
         $this->assertNotFalse(array_search('foo2', $tags, true), 'Tag foo2 is assigned to the entry');
         $this->assertNotFalse(array_search('bar2', $tags, true), 'Tag bar2 is assigned to the entry');
     }

--- a/tests/Wallabag/ImportBundle/Controller/ChromeControllerTest.php
+++ b/tests/Wallabag/ImportBundle/Controller/ChromeControllerTest.php
@@ -121,7 +121,7 @@ class ChromeControllerTest extends WallabagCoreTestCase
         $this->assertInstanceOf('Wallabag\CoreBundle\Entity\Entry', $content);
         $this->assertNotEmpty($content->getPreviewPicture(), 'Preview picture for http://www.usinenouvelle.com is ok');
         $this->assertNotEmpty($content->getLanguage(), 'Language for http://www.usinenouvelle.com is ok');
-        $this->assertSame(1, count($content->getTags()));
+        $this->assertSame(1, \count($content->getTags()));
 
         $createdAt = $content->getCreatedAt();
         $this->assertSame('2011', $createdAt->format('Y'));

--- a/tests/Wallabag/ImportBundle/Controller/FirefoxControllerTest.php
+++ b/tests/Wallabag/ImportBundle/Controller/FirefoxControllerTest.php
@@ -122,7 +122,7 @@ class FirefoxControllerTest extends WallabagCoreTestCase
         $this->assertNotEmpty($content->getMimetype(), 'Mimetype for http://lexpansion.lexpress.fr is ok');
         $this->assertNotEmpty($content->getPreviewPicture(), 'Preview picture for http://lexpansion.lexpress.fr is ok');
         $this->assertNotEmpty($content->getLanguage(), 'Language for http://lexpansion.lexpress.fr is ok');
-        $this->assertSame(3, count($content->getTags()));
+        $this->assertSame(3, \count($content->getTags()));
 
         $content = $client->getContainer()
             ->get('doctrine.orm.entity_manager')

--- a/tests/Wallabag/ImportBundle/Controller/InstapaperControllerTest.php
+++ b/tests/Wallabag/ImportBundle/Controller/InstapaperControllerTest.php
@@ -122,7 +122,7 @@ class InstapaperControllerTest extends WallabagCoreTestCase
         $this->assertNotEmpty($content->getPreviewPicture(), 'Preview picture for http://www.liberation.fr is ok');
         $this->assertNotEmpty($content->getLanguage(), 'Language for http://www.liberation.fr is ok');
         $this->assertContains('foot', $content->getTags(), 'It includes the "foot" tag');
-        $this->assertSame(1, count($content->getTags()));
+        $this->assertSame(1, \count($content->getTags()));
         $this->assertInstanceOf(\DateTime::class, $content->getCreatedAt());
 
         $content = $client->getContainer()
@@ -136,7 +136,7 @@ class InstapaperControllerTest extends WallabagCoreTestCase
         $this->assertContains('foot', $content->getTags());
         $this->assertContains('test_tag', $content->getTags());
 
-        $this->assertSame(2, count($content->getTags()));
+        $this->assertSame(2, \count($content->getTags()));
     }
 
     public function testImportInstapaperWithFileAndMarkAllAsRead()

--- a/tests/Wallabag/ImportBundle/Controller/PinboardControllerTest.php
+++ b/tests/Wallabag/ImportBundle/Controller/PinboardControllerTest.php
@@ -127,7 +127,7 @@ class PinboardControllerTest extends WallabagCoreTestCase
         $this->assertContains('foot', $tags, 'It includes the "foot" tag');
         $this->assertContains('varnish', $tags, 'It includes the "varnish" tag');
         $this->assertContains('php', $tags, 'It includes the "php" tag');
-        $this->assertSame(3, count($tags));
+        $this->assertSame(3, \count($tags));
 
         $this->assertInstanceOf(\DateTime::class, $content->getCreatedAt());
         $this->assertSame('2016-10-26', $content->getCreatedAt()->format('Y-m-d'));

--- a/tests/Wallabag/ImportBundle/Controller/ReadabilityControllerTest.php
+++ b/tests/Wallabag/ImportBundle/Controller/ReadabilityControllerTest.php
@@ -125,7 +125,7 @@ class ReadabilityControllerTest extends WallabagCoreTestCase
 
         $tags = $content->getTags();
         $this->assertContains('foot', $tags, 'It includes the "foot" tag');
-        $this->assertSame(1, count($tags));
+        $this->assertSame(1, \count($tags));
 
         $this->assertInstanceOf(\DateTime::class, $content->getCreatedAt());
         $this->assertSame('2016-09-08', $content->getCreatedAt()->format('Y-m-d'));

--- a/tests/Wallabag/ImportBundle/Controller/WallabagV1ControllerTest.php
+++ b/tests/Wallabag/ImportBundle/Controller/WallabagV1ControllerTest.php
@@ -127,7 +127,7 @@ class WallabagV1ControllerTest extends WallabagCoreTestCase
         $tags = $content->getTags();
         $this->assertContains('foot', $tags, 'It includes the "foot" tag');
         $this->assertContains('framabag', $tags, 'It includes the "framabag" tag');
-        $this->assertSame(2, count($tags));
+        $this->assertSame(2, \count($tags));
 
         $this->assertInstanceOf(\DateTime::class, $content->getCreatedAt());
     }

--- a/tests/Wallabag/ImportBundle/Controller/WallabagV2ControllerTest.php
+++ b/tests/Wallabag/ImportBundle/Controller/WallabagV2ControllerTest.php
@@ -128,7 +128,7 @@ class WallabagV2ControllerTest extends WallabagCoreTestCase
 
         $tags = $content->getTags();
         $this->assertContains('foot', $tags, 'It includes the "foot" tag');
-        $this->assertSame(1, count($tags));
+        $this->assertSame(1, \count($tags));
 
         $content = $client->getContainer()
             ->get('doctrine.orm.entity_manager')
@@ -147,7 +147,7 @@ class WallabagV2ControllerTest extends WallabagCoreTestCase
         $this->assertContains('foot', $tags, 'It includes the "foot" tag');
         $this->assertContains('mediapart', $tags, 'It includes the "mediapart" tag');
         $this->assertContains('blog', $tags, 'It includes the "blog" tag');
-        $this->assertSame(3, count($tags));
+        $this->assertSame(3, \count($tags));
 
         $this->assertInstanceOf(\DateTime::class, $content->getCreatedAt());
         $this->assertSame('2016-09-08', $content->getCreatedAt()->format('Y-m-d'));

--- a/tests/Wallabag/UserBundle/Mailer/AuthCodeMailerTest.php
+++ b/tests/Wallabag/UserBundle/Mailer/AuthCodeMailerTest.php
@@ -13,7 +13,7 @@ final class CountableMemorySpool extends \Swift_MemorySpool implements \Countabl
 {
     public function count()
     {
-        return count($this->messages);
+        return \count($this->messages);
     }
 
     public function getMessages()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Documentation | no
| Translation   | no
| Fixed tickets | N/A
| License       | MIT

This PR fixes all `native_function_invocation` issues reported by `php-cs-fixer`. This behavior change may come from v2.12.3 ~ v2.13. See https://github.com/FriendsOfPHP/PHP-CS-Fixer/pull/3798