### PR TITLE
Bugfix: Sanitize the title of a saved webpage from invalid UTF-8 characters.

### DIFF
--- a/src/Wallabag/CoreBundle/Helper/ContentProxy.php
+++ b/src/Wallabag/CoreBundle/Helper/ContentProxy.php
@@ -90,8 +90,8 @@ class ContentProxy
      * @return string (maybe contains invalid UTF-8 character)
      */
     private function convertPdfEncodingToUTF8($title) {
-        // first try UTF-16 (then UTF-8) because its easier to detect its present/absence
-        foreach (array('UTF-16BE', 'UTF-16LE', 'UTF-8', 'WINDOWS-1252') as $encoding) {
+        // first try UTF-8 because its easier to detect its present/absence
+        foreach (array('UTF-8', 'UTF-16BE', 'WINDOWS-1252') as $encoding) {
             if (mb_check_encoding($title, $encoding)) {
                 return mb_convert_encoding($title, 'UTF-8', $encoding);
             }

--- a/src/Wallabag/CoreBundle/Helper/ContentProxy.php
+++ b/src/Wallabag/CoreBundle/Helper/ContentProxy.php
@@ -76,7 +76,7 @@ class ContentProxy
      * @param String $rawText
      * @return string
      */
-    private function sanitizeUTF8Text(String $rawText) {
+    private function sanitizeUTF8Text($rawText) {
         if (mb_check_encoding($rawText, 'utf-8')) {
             return $rawText; // return because its valid utf-8 text
         }

--- a/src/Wallabag/CoreBundle/Helper/ContentProxy.php
+++ b/src/Wallabag/CoreBundle/Helper/ContentProxy.php
@@ -77,8 +77,7 @@ class ContentProxy
      */
     private function sanitizeContentTitle($title, $contentType) {
         if ('application/pdf' === $contentType) {
-            $convertedTitle = $this->convertPdfEncodingToUTF8($title);
-            return $this->sanitizeUTF8Text($convertedTitle);
+            $title = $this->convertPdfEncodingToUTF8($title);
         }
         return $this->sanitizeUTF8Text($title);
     }

--- a/src/Wallabag/CoreBundle/Helper/ContentProxy.php
+++ b/src/Wallabag/CoreBundle/Helper/ContentProxy.php
@@ -70,47 +70,6 @@ class ContentProxy
     }
 
     /**
-     * Try to sanitize the title of the fetched content from wrong character encodings and invalid UTF-8 character.
-     * @param $title
-     * @param $contentType
-     * @return string
-     */
-    private function sanitizeContentTitle($title, $contentType) {
-        if ('application/pdf' === $contentType) {
-            $title = $this->convertPdfEncodingToUTF8($title);
-        }
-        return $this->sanitizeUTF8Text($title);
-    }
-
-    /**
-     * If the title from the fetched content comes from a PDF, then its very possible that the character encoding is not
-     * UTF-8. This methods tries to identify the character encoding and translate the title to UTF-8.
-     * @param $title
-     * @return string (maybe contains invalid UTF-8 character)
-     */
-    private function convertPdfEncodingToUTF8($title) {
-        // first try UTF-8 because its easier to detect its present/absence
-        foreach (array('UTF-8', 'UTF-16BE', 'WINDOWS-1252') as $encoding) {
-            if (mb_check_encoding($title, $encoding)) {
-                return mb_convert_encoding($title, 'UTF-8', $encoding);
-            }
-        }
-        return $title;
-    }
-
-    /**
-     * Remove invalid UTF-8 characters from the given string.
-     * @param String $rawText
-     * @return string
-     */
-    private function sanitizeUTF8Text($rawText) {
-        if (mb_check_encoding($rawText, 'UTF-8')) {
-            return $rawText;
-        }
-        return iconv("UTF-8", "UTF-8//IGNORE", $rawText);
-    }
-
-    /**
      * Use a Symfony validator to ensure the language is well formatted.
      *
      * @param Entry  $entry
@@ -216,6 +175,59 @@ class ContentProxy
         }
 
         $entry->setTitle($path);
+    }
+
+    /**
+     * Try to sanitize the title of the fetched content from wrong character encodings and invalid UTF-8 character.
+     *
+     * @param $title
+     * @param $contentType
+     *
+     * @return string
+     */
+    private function sanitizeContentTitle($title, $contentType)
+    {
+        if ('application/pdf' === $contentType) {
+            $title = $this->convertPdfEncodingToUTF8($title);
+        }
+
+        return $this->sanitizeUTF8Text($title);
+    }
+
+    /**
+     * If the title from the fetched content comes from a PDF, then its very possible that the character encoding is not
+     * UTF-8. This methods tries to identify the character encoding and translate the title to UTF-8.
+     *
+     * @param $title
+     *
+     * @return string (maybe contains invalid UTF-8 character)
+     */
+    private function convertPdfEncodingToUTF8($title)
+    {
+        // first try UTF-8 because its easier to detect its present/absence
+        foreach (['UTF-8', 'UTF-16BE', 'WINDOWS-1252'] as $encoding) {
+            if (mb_check_encoding($title, $encoding)) {
+                return mb_convert_encoding($title, 'UTF-8', $encoding);
+            }
+        }
+
+        return $title;
+    }
+
+    /**
+     * Remove invalid UTF-8 characters from the given string.
+     *
+     * @param string $rawText
+     *
+     * @return string
+     */
+    private function sanitizeUTF8Text($rawText)
+    {
+        if (mb_check_encoding($rawText, 'UTF-8')) {
+            return $rawText;
+        }
+
+        return iconv('UTF-8', 'UTF-8//IGNORE', $rawText);
     }
 
     /**

--- a/tests/Wallabag/CoreBundle/Helper/ContentProxyTest.php
+++ b/tests/Wallabag/CoreBundle/Helper/ContentProxyTest.php
@@ -740,30 +740,38 @@ class ContentProxyTest extends TestCase
     }
 
     /**
-     * https://stackoverflow.com/a/18506801
+     * https://stackoverflow.com/a/18506801.
+     *
      * @param $string
+     *
      * @return string
      */
-    private function strToHex($string){
+    private function strToHex($string)
+    {
         $hex = '';
-        for ($i=0; $i<strlen($string); $i++){
-            $ord = ord($string[$i]);
+        for ($i = 0; $i < \strlen($string); ++$i) {
+            $ord = \ord($string[$i]);
             $hexCode = dechex($ord);
-            $hex .= substr('0'.$hexCode, -2);
+            $hex .= substr('0' . $hexCode, -2);
         }
-        return strToUpper($hex);
+
+        return strtoupper($hex);
     }
 
     /**
-     * https://stackoverflow.com/a/18506801
+     * https://stackoverflow.com/a/18506801.
+     *
      * @param $hex
+     *
      * @return string
      */
-    private function hexToStr($hex){
-        $string='';
-        for ($i=0; $i < strlen($hex)-1; $i+=2){
-            $string .= chr(hexdec($hex[$i].$hex[$i+1]));
+    private function hexToStr($hex)
+    {
+        $string = '';
+        for ($i = 0; $i < \strlen($hex) - 1; $i += 2) {
+            $string .= \chr(hexdec($hex[$i] . $hex[$i + 1]));
         }
+
         return $string;
     }
 

--- a/tests/Wallabag/CoreBundle/Helper/ContentProxyTest.php
+++ b/tests/Wallabag/CoreBundle/Helper/ContentProxyTest.php
@@ -744,7 +744,7 @@ class ContentProxyTest extends TestCase
      * @param $string
      * @return string
      */
-    function strToHex($string){
+    private function strToHex($string){
         $hex = '';
         for ($i=0; $i<strlen($string); $i++){
             $ord = ord($string[$i]);
@@ -759,7 +759,7 @@ class ContentProxyTest extends TestCase
      * @param $hex
      * @return string
      */
-    function hexToStr($hex){
+    private function hexToStr($hex){
         $string='';
         for ($i=0; $i < strlen($hex)-1; $i+=2){
             $string .= chr(hexdec($hex[$i].$hex[$i+1]));

--- a/tests/Wallabag/CoreBundle/Helper/ContentProxyTest.php
+++ b/tests/Wallabag/CoreBundle/Helper/ContentProxyTest.php
@@ -531,6 +531,242 @@ class ContentProxyTest extends TestCase
         $this->assertSame('1.1.1.1', $entry->getDomainName());
     }
 
+    public function testWebsiteWithValidUTF8Title_doNothing()
+    {
+        // You can use https://www.online-toolz.com/tools/text-hex-convertor.php to convert UTF-8 text <=> hex
+        // See http://graphemica.com for more info about the characters
+        // '😻ℤz' (U+1F63B or F09F98BB; U+2124 or E284A4; U+007A or 7A) in hexadecimal and UTF-8
+        $actualTitle = $this->hexToStr('F09F98BB' . 'E284A4' . '7A');
+
+        $tagger = $this->getTaggerMock();
+        $tagger->expects($this->once())
+            ->method('tag');
+
+        $graby = $this->getMockBuilder('Graby\Graby')
+            ->setMethods(['fetchContent'])
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $graby->expects($this->any())
+            ->method('fetchContent')
+            ->willReturn([
+                'html' => false,
+                'title' => $actualTitle,
+                'url' => '',
+                'content_type' => 'text/html',
+                'language' => '',
+            ]);
+
+        $proxy = new ContentProxy($graby, $tagger, $this->getValidator(), $this->getLogger(), $this->fetchingErrorMessage);
+        $entry = new Entry(new User());
+        $proxy->updateEntry($entry, 'http://0.0.0.0');
+
+        // '😻ℤz' (U+1F63B or F09F98BB; U+2124 or E284A4; U+007A or 7A) in hexadecimal and UTF-8
+        $expectedTitle = 'F09F98BB' . 'E284A4' . '7A';
+        $this->assertSame($expectedTitle, $this->strToHex($entry->getTitle()));
+    }
+
+    public function testWebsiteWithInvalidUTF8Title_removeInvalidCharacter()
+    {
+        // See http://graphemica.com for more info about the characters
+        // 'a€b' (61;80;62) in hexadecimal and WINDOWS-1252 - but 80 is a invalid UTF-8 character.
+        // The correct UTF-8 € character (U+20AC) is E282AC
+        $actualTitle = $this->hexToStr('61' . '80' . '62');
+
+        $tagger = $this->getTaggerMock();
+        $tagger->expects($this->once())
+            ->method('tag');
+
+        $graby = $this->getMockBuilder('Graby\Graby')
+            ->setMethods(['fetchContent'])
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $graby->expects($this->any())
+            ->method('fetchContent')
+            ->willReturn([
+                'html' => false,
+                'title' => $actualTitle,
+                'url' => '',
+                'content_type' => 'text/html',
+                'language' => '',
+            ]);
+
+        $proxy = new ContentProxy($graby, $tagger, $this->getValidator(), $this->getLogger(), $this->fetchingErrorMessage);
+        $entry = new Entry(new User());
+        $proxy->updateEntry($entry, 'http://0.0.0.0');
+
+        // 'ab' (61;62) because all invalid UTF-8 character (like 80) are removed
+        $expectedTitle = '61' . '62';
+        $this->assertSame($expectedTitle, $this->strToHex($entry->getTitle()));
+    }
+
+    public function testPdfWithUTF16BETitle_convertToUTF8()
+    {
+        // See http://graphemica.com for more info about the characters
+        // '😻' (U+1F63B;D83DDE3B) in hexadecimal and as UTF16BE
+        $actualTitle = $this->hexToStr('D83DDE3B');
+
+        $tagger = $this->getTaggerMock();
+        $tagger->expects($this->once())
+            ->method('tag');
+
+        $graby = $this->getMockBuilder('Graby\Graby')
+            ->setMethods(['fetchContent'])
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $graby->expects($this->any())
+            ->method('fetchContent')
+            ->willReturn([
+                'html' => false,
+                'title' => $actualTitle,
+                'url' => '',
+                'content_type' => 'application/pdf',
+                'language' => '',
+            ]);
+
+        $proxy = new ContentProxy($graby, $tagger, $this->getValidator(), $this->getLogger(), $this->fetchingErrorMessage);
+        $entry = new Entry(new User());
+        $proxy->updateEntry($entry, 'http://0.0.0.0');
+
+        // '😻' (U+1F63B or F09F98BB) in hexadecimal and UTF-8
+        $expectedTitle = 'F09F98BB';
+        $this->assertSame($expectedTitle, $this->strToHex($entry->getTitle()));
+    }
+
+    public function testPdfWithUTF8Title_doNothing()
+    {
+        // See http://graphemica.com for more info about the characters
+        // '😻' (U+1F63B;D83DDE3B) in hexadecimal and as UTF8
+        $actualTitle = $this->hexToStr('F09F98BB');
+
+        $tagger = $this->getTaggerMock();
+        $tagger->expects($this->once())
+            ->method('tag');
+
+        $graby = $this->getMockBuilder('Graby\Graby')
+            ->setMethods(['fetchContent'])
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $graby->expects($this->any())
+            ->method('fetchContent')
+            ->willReturn([
+                'html' => false,
+                'title' => $actualTitle,
+                'url' => '',
+                'content_type' => 'application/pdf',
+                'language' => '',
+            ]);
+
+        $proxy = new ContentProxy($graby, $tagger, $this->getValidator(), $this->getLogger(), $this->fetchingErrorMessage);
+        $entry = new Entry(new User());
+        $proxy->updateEntry($entry, 'http://0.0.0.0');
+
+        // '😻' (U+1F63B or F09F98BB) in hexadecimal and UTF-8
+        $expectedTitle = 'F09F98BB';
+        $this->assertSame($expectedTitle, $this->strToHex($entry->getTitle()));
+    }
+
+    public function testPdfWithWINDOWS1252Title_convertToUTF8()
+    {
+        // See http://graphemica.com for more info about the characters
+        // '€' (80) in hexadecimal and WINDOWS-1252
+        $actualTitle = $this->hexToStr('80');
+
+        $tagger = $this->getTaggerMock();
+        $tagger->expects($this->once())
+            ->method('tag');
+
+        $graby = $this->getMockBuilder('Graby\Graby')
+            ->setMethods(['fetchContent'])
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $graby->expects($this->any())
+            ->method('fetchContent')
+            ->willReturn([
+                'html' => false,
+                'title' => $actualTitle,
+                'url' => '',
+                'content_type' => 'application/pdf',
+                'language' => '',
+            ]);
+
+        $proxy = new ContentProxy($graby, $tagger, $this->getValidator(), $this->getLogger(), $this->fetchingErrorMessage);
+        $entry = new Entry(new User());
+        $proxy->updateEntry($entry, 'http://0.0.0.0');
+
+        // '€' (U+20AC or E282AC) in hexadecimal and UTF-8
+        $expectedTitle = 'E282AC';
+        $this->assertSame($expectedTitle, $this->strToHex($entry->getTitle()));
+    }
+
+    public function testPdfWithInvalidCharacterInTitle_removeInvalidCharacter()
+    {
+        // See http://graphemica.com for more info about the characters
+        // '😻ℤ�z' (U+1F63B or F09F98BB; U+2124 or E284A4; invalid character 81; U+007A or 7A) in hexadecimal and UTF-8
+        // 0x81 is not a valid character for UTF16, UTF8 and WINDOWS-1252
+        $actualTitle = $this->hexToStr('F09F98BB' . 'E284A4' . '81' . '7A');
+
+        $tagger = $this->getTaggerMock();
+        $tagger->expects($this->once())
+            ->method('tag');
+
+        $graby = $this->getMockBuilder('Graby\Graby')
+            ->setMethods(['fetchContent'])
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $graby->expects($this->any())
+            ->method('fetchContent')
+            ->willReturn([
+                'html' => false,
+                'title' => $actualTitle,
+                'url' => '',
+                'content_type' => 'application/pdf',
+                'language' => '',
+            ]);
+
+        $proxy = new ContentProxy($graby, $tagger, $this->getValidator(), $this->getLogger(), $this->fetchingErrorMessage);
+        $entry = new Entry(new User());
+        $proxy->updateEntry($entry, 'http://0.0.0.0');
+
+        // '😻ℤz' (U+1F63B or F09F98BB; U+2124 or E284A4; U+007A or 7A) in hexadecimal and UTF-8
+        // the 0x81 (represented by �) is invalid for UTF16, UTF8 and WINDOWS-1252 and is removed
+        $expectedTitle = 'F09F98BB' . 'E284A4' . '7A';
+        $this->assertSame($expectedTitle, $this->strToHex($entry->getTitle()));
+    }
+
+    /**
+     * https://stackoverflow.com/a/18506801
+     * @param $string
+     * @return string
+     */
+    function strToHex($string){
+        $hex = '';
+        for ($i=0; $i<strlen($string); $i++){
+            $ord = ord($string[$i]);
+            $hexCode = dechex($ord);
+            $hex .= substr('0'.$hexCode, -2);
+        }
+        return strToUpper($hex);
+    }
+
+    /**
+     * https://stackoverflow.com/a/18506801
+     * @param $hex
+     * @return string
+     */
+    function hexToStr($hex){
+        $string='';
+        for ($i=0; $i < strlen($hex)-1; $i+=2){
+            $string .= chr(hexdec($hex[$i].$hex[$i+1]));
+        }
+        return $string;
+    }
+
     private function getTaggerMock()
     {
         return $this->getMockBuilder(RuleBasedTagger::class)


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes (my changes doesn't cause any new failures, 8013f35d96c42b15c1da28cdff40e97289ad4e25 already cause 2 Errors)
| Documentation | no
| Translation   | no
| CHANGELOG.md  | no
| Fixed tickets | #3633
| License       | MIT

The issue described in https://github.com/wallabag/wallabag/issues/3633 was caused by <code>e('html_attr')</code> in [_content.html.twig](https://github.com/wallabag/wallabag/blob/e586d65b64089fc1cc230a18c470aae3f45f91a6/src/Wallabag/CoreBundle/Resources/views/themes/material/Entry/Card/_content.html.twig#L5). By replacing it with <code>e('html')</code> is a quick but not secure solution.

The real issue was caused by the library j0k3r/graby returning the title on a webpage in different encodings (like UTF-8 or ISO-8859-1). But wallabag always treaded the title as UTF-8 without converting the encoding.

For some webpages (like [https://www.impots.gouv.fr/portail/files/media/10_conventions/espagne/espagne_convention-avec-l-espagne-impot-sur-le-revenu-impot-sur-la-fortune_fd_1824.pdf](https://www.impots.gouv.fr/portail/files/media/10_conventions/espagne/espagne_convention-avec-l-espagne-impot-sur-le-revenu-impot-sur-la-fortune_fd_1824.pdf)) graphy returns the title (like "Convention avec l'Espagne - Impôt sur le revenu - Impôt sur la fortune - 1995") in the ISO-8859-1 encoding (can also be Windows-1252 because they are very simmilar).

But <code>ô</code> has the value 0xF4 [ISO_8859-1 table](https://de.wikipedia.org/wiki/ISO_8859-1#ISO/IEC_8859-1). For UTF-8 the value 0xF4 for a single character is invalid (because of the [algorithm](https://en.wikipedia.org/wiki/UTF-8#Description) of UTF-8).

My solution is to test if the title of a webpage contains only valid UTF-8 characters. If not, the title is treaded as ISO_8859-1, converted to UTF-8 and checked for invalid UTF-8 characters. If the titel still contains invalid UTF-8 characters, then the invalid characters will be replaced.

I hope that my code is good enough. I dont have much experience in open-source contributions, I'm not an expert in PHP and have no knowledge about Laravel.
