### PR TITLE
Abort running install and update script if root

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -2,6 +2,12 @@
 # You can execute this file to install wallabag
 # eg: `sh install.sh prod`
 
+# Abort running this script if root
+if [ "$EUID" == "0" ]; then
+    echo "Do not run this script as root!" >&2
+    exit 1
+fi
+
 COMPOSER_COMMAND='composer'
 
 DIR="${BASH_SOURCE}"

--- a/scripts/update.sh
+++ b/scripts/update.sh
@@ -2,6 +2,12 @@
 # You can execute this file to update wallabag
 # eg: `sh update.sh prod`
 
+# Abort running this script if root
+if [ "$EUID" == "0" ]; then
+    echo "Do not run this script as root!" >&2
+    exit 1
+fi
+
 set -e
 set -u
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Documentation | no
| Translation   | no
| CHANGELOG.md  | no
| Fixed tickets | #3590 
| License       | MIT

This pull request makes the `make install` and `make update` scripts stop if they are run as root.