### PR TITLE
Show tags on non-image gallery preview card

### DIFF
--- a/src/Wallabag/CoreBundle/Resources/views/themes/material/Entry/_card_no_preview.html.twig
+++ b/src/Wallabag/CoreBundle/Resources/views/themes/material/Entry/_card_no_preview.html.twig
@@ -1,5 +1,12 @@
 <div class="card">
     <div class="card-body">
+        <div class="card-image waves-effect waves-block waves-light">
+            <ul class="card-entry-labels">
+            {% for tag in entry.tags | slice(0, 3) %}
+                <li><a href="{{ path('tag_entries', {'slug': tag.slug}) }}">{{ tag.label }}</a></li>
+            {% endfor %}
+            </ul>
+        </div>
         {% include "@WallabagCore/themes/material/Entry/Card/_content.html.twig" with {'entry': entry} only %}
     </div>
 


### PR DESCRIPTION
Tags and images aren't coupled, so they shouldn't be coupled in
the UI, either. This also makes the titles and source domains show
up consistently for image and non-image entry cards.

| Q             | A
| ------------- | ---
| Bug fix?      | yes/no
| New feature?  | yes/no
| BC breaks?    | yes/no
| Deprecations? | no
| Tests pass?   | yes/no
| Documentation | no
| Translation   | no
| CHANGELOG.md  | yes/no
| Fixed tickets | 
| License       | MIT

I'm not sure what all of the questions are actually asking, so
I can't answer them very well.