### PR TITLE
Fix 'x-varnish1' test failure by replacing key

### DIFF
--- a/tests/Wallabag/CoreBundle/Controller/EntryControllerTest.php
+++ b/tests/Wallabag/CoreBundle/Controller/EntryControllerTest.php
@@ -168,7 +168,7 @@ class EntryControllerTest extends WallabagCoreTestCase
         $this->assertSame('fr', $content->getLanguage());
         $this->assertSame('2015-03-28 11:43:19', $content->getPublishedAt()->format('Y-m-d H:i:s'));
         $this->assertSame('Morgane Tual', $author[0]);
-        $this->assertArrayHasKey('x-varnish1', $content->getHeaders());
+        $this->assertArrayHasKey('x-served-by', $content->getHeaders());
         $client->getContainer()->get('craue_config')->set('store_article_headers', 0);
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Documentation | no
| Translation   | no
| CHANGELOG.md  | no
| Fixed tickets | -
| License       | MIT

Requests to lemonde.fr are handled by two types of infrastructure, one
with Varnish and another with Sqreen. 'x-varnish1' is only set on the
first one. Replacing the assertion with the key 'x-served-by' which is
set on the two platforms.