### PR TITLE
Add note on GitHub PR template to auto-close issues

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -8,8 +8,14 @@
 | Documentation | yes/no
 | Translation   | yes/no
 | CHANGELOG.md  | yes/no
-| Fixed tickets | #...
 | License       | MIT
+
+<!--
+Please list the issues your PR fixes using special keywords, see
+https://help.github.com/articles/closing-issues-using-keywords/
+
+Fixes #…
+-->
 
 <!--
 - Please fill in this template according to the PR you're about to submit.


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | -
| Documentation | -
| Translation   | no
| CHANGELOG.md  | no
| Fixed tickets | -
| License       | MIT

This PR is a little one to move 'Fixed tickets' off of the template's table and use GitHub special keywords to auto-close issues on merge.