### PR TITLE
Fix documentation wording for matches/notmatches tagging rules

### DIFF
--- a/src/Wallabag/CoreBundle/Resources/translations/messages.da.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.da.yml
@@ -157,8 +157,8 @@ config:
         #         not_equal_to: 'Not equal to...'
         #         or: 'One rule OR another'
         #         and: 'One rule AND another'
-        #         matches: 'Tests that a <i>subject</i> is matches a <i>search</i> (case-insensitive).<br />Example: <code>title matches "football"</code>'
-        #         notmatches: 'Tests that a <i>subject</i> is not matches a <i>search</i> (case-insensitive).<br />Example: <code>title notmatches "football"</code>'
+        #         matches: 'Tests that a <i>subject</i> matches a <i>search</i> (case-insensitive).<br />Example: <code>title matches "football"</code>'
+        #         notmatches: 'Tests that a <i>subject</i> doesn't match a <i>search</i> (case-insensitive).<br />Example: <code>title notmatches "football"</code>'
 
 entry:
     # default_title: 'Title of the entry'

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.da.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.da.yml
@@ -158,7 +158,7 @@ config:
         #         or: 'One rule OR another'
         #         and: 'One rule AND another'
         #         matches: 'Tests that a <i>subject</i> matches a <i>search</i> (case-insensitive).<br />Example: <code>title matches "football"</code>'
-        #         notmatches: 'Tests that a <i>subject</i> doesn\'t match match match a <i>search</i> (case-insensitive).<br />Example: <code>title notmatches "football"</code>'
+        #         notmatches: 'Tests that a <i>subject</i> doesn''t match match a <i>search</i> (case-insensitive).<br />Example: <code>title notmatches "football"</code>'
 
 entry:
     # default_title: 'Title of the entry'

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.da.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.da.yml
@@ -158,7 +158,7 @@ config:
         #         or: 'One rule OR another'
         #         and: 'One rule AND another'
         #         matches: 'Tests that a <i>subject</i> matches a <i>search</i> (case-insensitive).<br />Example: <code>title matches "football"</code>'
-        #         notmatches: 'Tests that a <i>subject</i> doesn't match a <i>search</i> (case-insensitive).<br />Example: <code>title notmatches "football"</code>'
+        #         notmatches: 'Tests that a <i>subject</i> doesn\'t match match match a <i>search</i> (case-insensitive).<br />Example: <code>title notmatches "football"</code>'
 
 entry:
     # default_title: 'Title of the entry'

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.en.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.en.yml
@@ -158,7 +158,7 @@ config:
                 or: 'One rule OR another'
                 and: 'One rule AND another'
                 matches: 'Tests that a <i>subject</i> matches a <i>search</i> (case-insensitive).<br />Example: <code>title matches "football"</code>'
-                notmatches: 'Tests that a <i>subject</i> doesn't match a <i>search</i> (case-insensitive).<br />Example: <code>title notmatches "football"</code>'
+                notmatches: 'Tests that a <i>subject</i> doesn\'t match match match a <i>search</i> (case-insensitive).<br />Example: <code>title notmatches "football"</code>'
 
 entry:
     default_title: 'Title of the entry'

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.en.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.en.yml
@@ -157,8 +157,8 @@ config:
                 not_equal_to: 'Not equal to...'
                 or: 'One rule OR another'
                 and: 'One rule AND another'
-                matches: 'Tests that a <i>subject</i> is matches a <i>search</i> (case-insensitive).<br />Example: <code>title matches "football"</code>'
-                notmatches: 'Tests that a <i>subject</i> is not matches a <i>search</i> (case-insensitive).<br />Example: <code>title notmatches "football"</code>'
+                matches: 'Tests that a <i>subject</i> matches a <i>search</i> (case-insensitive).<br />Example: <code>title matches "football"</code>'
+                notmatches: 'Tests that a <i>subject</i> doesn't match a <i>search</i> (case-insensitive).<br />Example: <code>title notmatches "football"</code>'
 
 entry:
     default_title: 'Title of the entry'

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.en.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.en.yml
@@ -158,7 +158,7 @@ config:
                 or: 'One rule OR another'
                 and: 'One rule AND another'
                 matches: 'Tests that a <i>subject</i> matches a <i>search</i> (case-insensitive).<br />Example: <code>title matches "football"</code>'
-                notmatches: 'Tests that a <i>subject</i> doesn\'t match match match a <i>search</i> (case-insensitive).<br />Example: <code>title notmatches "football"</code>'
+                notmatches: 'Tests that a <i>subject</i> doesn''t match match a <i>search</i> (case-insensitive).<br />Example: <code>title notmatches "football"</code>'
 
 entry:
     default_title: 'Title of the entry'

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.es.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.es.yml
@@ -158,7 +158,7 @@ config:
                 or: 'Una regla U otra'
                 and: 'Una regla Y la otra'
                 matches: 'Prueba si un <i>sujeto</i> corresponde a una <i>búsqueda</i> (insensible a mayusculas).<br />Ejemplo : <code>title matches "fútbol"</code>'
-                # notmatches: 'Tests that a <i>subject</i> is not matches a <i>search</i> (case-insensitive).<br />Example: <code>title notmatches "football"</code>'
+                # notmatches: 'Tests that a <i>subject</i> doesn't match a <i>search</i> (case-insensitive).<br />Example: <code>title notmatches "football"</code>'
 
 entry:
     default_title: 'Título del artículo'

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.es.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.es.yml
@@ -158,7 +158,7 @@ config:
                 or: 'Una regla U otra'
                 and: 'Una regla Y la otra'
                 matches: 'Prueba si un <i>sujeto</i> corresponde a una <i>búsqueda</i> (insensible a mayusculas).<br />Ejemplo : <code>title matches "fútbol"</code>'
-                # notmatches: 'Tests that a <i>subject</i> doesn't match a <i>search</i> (case-insensitive).<br />Example: <code>title notmatches "football"</code>'
+                # notmatches: 'Tests that a <i>subject</i> doesn\'t match match match a <i>search</i> (case-insensitive).<br />Example: <code>title notmatches "football"</code>'
 
 entry:
     default_title: 'Título del artículo'

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.es.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.es.yml
@@ -158,7 +158,7 @@ config:
                 or: 'Una regla U otra'
                 and: 'Una regla Y la otra'
                 matches: 'Prueba si un <i>sujeto</i> corresponde a una <i>búsqueda</i> (insensible a mayusculas).<br />Ejemplo : <code>title matches "fútbol"</code>'
-                # notmatches: 'Tests that a <i>subject</i> doesn\'t match match match a <i>search</i> (case-insensitive).<br />Example: <code>title notmatches "football"</code>'
+                # notmatches: 'Tests that a <i>subject</i> doesn''t match match a <i>search</i> (case-insensitive).<br />Example: <code>title notmatches "football"</code>'
 
 entry:
     default_title: 'Título del artículo'

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.fa.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.fa.yml
@@ -157,8 +157,8 @@ config:
         #         not_equal_to: 'Not equal to...'
         #         or: 'One rule OR another'
         #         and: 'One rule AND another'
-        #         matches: 'Tests that a <i>subject</i> is matches a <i>search</i> (case-insensitive).<br />Example: <code>title matches "football"</code>'
-        #         notmatches: 'Tests that a <i>subject</i> is not matches a <i>search</i> (case-insensitive).<br />Example: <code>title notmatches "football"</code>'
+        #         matches: 'Tests that a <i>subject</i> matches a <i>search</i> (case-insensitive).<br />Example: <code>title matches "football"</code>'
+        #         notmatches: 'Tests that a <i>subject</i> doesn't match a <i>search</i> (case-insensitive).<br />Example: <code>title notmatches "football"</code>'
 
 entry:
     # default_title: 'Title of the entry'

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.fa.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.fa.yml
@@ -158,7 +158,7 @@ config:
         #         or: 'One rule OR another'
         #         and: 'One rule AND another'
         #         matches: 'Tests that a <i>subject</i> matches a <i>search</i> (case-insensitive).<br />Example: <code>title matches "football"</code>'
-        #         notmatches: 'Tests that a <i>subject</i> doesn\'t match match match a <i>search</i> (case-insensitive).<br />Example: <code>title notmatches "football"</code>'
+        #         notmatches: 'Tests that a <i>subject</i> doesn''t match match a <i>search</i> (case-insensitive).<br />Example: <code>title notmatches "football"</code>'
 
 entry:
     # default_title: 'Title of the entry'

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.fa.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.fa.yml
@@ -158,7 +158,7 @@ config:
         #         or: 'One rule OR another'
         #         and: 'One rule AND another'
         #         matches: 'Tests that a <i>subject</i> matches a <i>search</i> (case-insensitive).<br />Example: <code>title matches "football"</code>'
-        #         notmatches: 'Tests that a <i>subject</i> doesn't match a <i>search</i> (case-insensitive).<br />Example: <code>title notmatches "football"</code>'
+        #         notmatches: 'Tests that a <i>subject</i> doesn\'t match match match a <i>search</i> (case-insensitive).<br />Example: <code>title notmatches "football"</code>'
 
 entry:
     # default_title: 'Title of the entry'

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.it.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.it.yml
@@ -158,7 +158,7 @@ config:
                 or: "Una regola O un'altra"
                 and: "Una regola E un'altra"
                 matches: 'Verifica che un <i>oggetto</i> risulti in una <i>ricerca</i> (case-insensitive).<br />Esempio: <code>titolo contiene "football"</code>'
-                # notmatches: 'Tests that a <i>subject</i> is not matches a <i>search</i> (case-insensitive).<br />Example: <code>title notmatches "football"</code>'
+                # notmatches: 'Tests that a <i>subject</i> doesn't match a <i>search</i> (case-insensitive).<br />Example: <code>title notmatches "football"</code>'
 
 entry:
     default_title: "Titolo del contenuto"

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.it.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.it.yml
@@ -158,7 +158,7 @@ config:
                 or: "Una regola O un'altra"
                 and: "Una regola E un'altra"
                 matches: 'Verifica che un <i>oggetto</i> risulti in una <i>ricerca</i> (case-insensitive).<br />Esempio: <code>titolo contiene "football"</code>'
-                # notmatches: 'Tests that a <i>subject</i> doesn\'t match match match a <i>search</i> (case-insensitive).<br />Example: <code>title notmatches "football"</code>'
+                # notmatches: 'Tests that a <i>subject</i> doesn''t match match a <i>search</i> (case-insensitive).<br />Example: <code>title notmatches "football"</code>'
 
 entry:
     default_title: "Titolo del contenuto"

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.it.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.it.yml
@@ -158,7 +158,7 @@ config:
                 or: "Una regola O un'altra"
                 and: "Una regola E un'altra"
                 matches: 'Verifica che un <i>oggetto</i> risulti in una <i>ricerca</i> (case-insensitive).<br />Esempio: <code>titolo contiene "football"</code>'
-                # notmatches: 'Tests that a <i>subject</i> doesn't match a <i>search</i> (case-insensitive).<br />Example: <code>title notmatches "football"</code>'
+                # notmatches: 'Tests that a <i>subject</i> doesn\'t match match match a <i>search</i> (case-insensitive).<br />Example: <code>title notmatches "football"</code>'
 
 entry:
     default_title: "Titolo del contenuto"

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.pt.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.pt.yml
@@ -158,7 +158,7 @@ config:
                 or: 'Uma regra OU outra'
                 and: 'Uma regra E outra'
                 matches: 'Testa que um <i>assunto</i> corresponde a uma <i>pesquisa</i> (maiúscula ou minúscula).<br />Exemplo: <code>título corresponde a "futebol"</code>'
-                # notmatches: 'Tests that a <i>subject</i> is not matches a <i>search</i> (case-insensitive).<br />Example: <code>title notmatches "football"</code>'
+                # notmatches: 'Tests that a <i>subject</i> doesn't match a <i>search</i> (case-insensitive).<br />Example: <code>title notmatches "football"</code>'
 
 entry:
     default_title: 'Título da entrada'

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.pt.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.pt.yml
@@ -158,7 +158,7 @@ config:
                 or: 'Uma regra OU outra'
                 and: 'Uma regra E outra'
                 matches: 'Testa que um <i>assunto</i> corresponde a uma <i>pesquisa</i> (maiúscula ou minúscula).<br />Exemplo: <code>título corresponde a "futebol"</code>'
-                # notmatches: 'Tests that a <i>subject</i> doesn't match a <i>search</i> (case-insensitive).<br />Example: <code>title notmatches "football"</code>'
+                # notmatches: 'Tests that a <i>subject</i> doesn\'t match match match a <i>search</i> (case-insensitive).<br />Example: <code>title notmatches "football"</code>'
 
 entry:
     default_title: 'Título da entrada'

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.pt.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.pt.yml
@@ -158,7 +158,7 @@ config:
                 or: 'Uma regra OU outra'
                 and: 'Uma regra E outra'
                 matches: 'Testa que um <i>assunto</i> corresponde a uma <i>pesquisa</i> (maiúscula ou minúscula).<br />Exemplo: <code>título corresponde a "futebol"</code>'
-                # notmatches: 'Tests that a <i>subject</i> doesn\'t match match match a <i>search</i> (case-insensitive).<br />Example: <code>title notmatches "football"</code>'
+                # notmatches: 'Tests that a <i>subject</i> doesn''t match match a <i>search</i> (case-insensitive).<br />Example: <code>title notmatches "football"</code>'
 
 entry:
     default_title: 'Título da entrada'

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.ro.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.ro.yml
@@ -157,8 +157,8 @@ config:
         #         not_equal_to: 'Not equal to...'
         #         or: 'One rule OR another'
         #         and: 'One rule AND another'
-        #         matches: 'Tests that a <i>subject</i> is matches a <i>search</i> (case-insensitive).<br />Example: <code>title matches "football"</code>'
-        #         notmatches: 'Tests that a <i>subject</i> is not matches a <i>search</i> (case-insensitive).<br />Example: <code>title notmatches "football"</code>'
+        #         matches: 'Tests that a <i>subject</i> matches a <i>search</i> (case-insensitive).<br />Example: <code>title matches "football"</code>'
+        #         notmatches: 'Tests that a <i>subject</i> doesn't match a <i>search</i> (case-insensitive).<br />Example: <code>title notmatches "football"</code>'
 
 entry:
     # default_title: 'Title of the entry'

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.ro.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.ro.yml
@@ -158,7 +158,7 @@ config:
         #         or: 'One rule OR another'
         #         and: 'One rule AND another'
         #         matches: 'Tests that a <i>subject</i> matches a <i>search</i> (case-insensitive).<br />Example: <code>title matches "football"</code>'
-        #         notmatches: 'Tests that a <i>subject</i> doesn\'t match match match a <i>search</i> (case-insensitive).<br />Example: <code>title notmatches "football"</code>'
+        #         notmatches: 'Tests that a <i>subject</i> doesn''t match match a <i>search</i> (case-insensitive).<br />Example: <code>title notmatches "football"</code>'
 
 entry:
     # default_title: 'Title of the entry'

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.ro.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.ro.yml
@@ -158,7 +158,7 @@ config:
         #         or: 'One rule OR another'
         #         and: 'One rule AND another'
         #         matches: 'Tests that a <i>subject</i> matches a <i>search</i> (case-insensitive).<br />Example: <code>title matches "football"</code>'
-        #         notmatches: 'Tests that a <i>subject</i> doesn't match a <i>search</i> (case-insensitive).<br />Example: <code>title notmatches "football"</code>'
+        #         notmatches: 'Tests that a <i>subject</i> doesn\'t match match match a <i>search</i> (case-insensitive).<br />Example: <code>title notmatches "football"</code>'
 
 entry:
     # default_title: 'Title of the entry'

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.tr.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.tr.yml
@@ -158,7 +158,7 @@ config:
                 or: 'Bir kural veya birbaşkası'
                 and: 'Bir kural ve diğeri'
                 # matches: 'Tests that a <i>subject</i> matches a <i>search</i> (case-insensitive).<br />Example: <code>title matches "football"</code>'
-                # notmatches: 'Tests that a <i>subject</i> doesn't match a <i>search</i> (case-insensitive).<br />Example: <code>title notmatches "football"</code>'
+                # notmatches: 'Tests that a <i>subject</i> doesn\'t match match match a <i>search</i> (case-insensitive).<br />Example: <code>title notmatches "football"</code>'
 
 entry:
     default_title: 'Makalenin başlığı'

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.tr.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.tr.yml
@@ -157,8 +157,8 @@ config:
                 not_equal_to: 'Eşit değildir…'
                 or: 'Bir kural veya birbaşkası'
                 and: 'Bir kural ve diğeri'
-                # matches: 'Tests that a <i>subject</i> is matches a <i>search</i> (case-insensitive).<br />Example: <code>title matches "football"</code>'
-                # notmatches: 'Tests that a <i>subject</i> is not matches a <i>search</i> (case-insensitive).<br />Example: <code>title notmatches "football"</code>'
+                # matches: 'Tests that a <i>subject</i> matches a <i>search</i> (case-insensitive).<br />Example: <code>title matches "football"</code>'
+                # notmatches: 'Tests that a <i>subject</i> doesn't match a <i>search</i> (case-insensitive).<br />Example: <code>title notmatches "football"</code>'
 
 entry:
     default_title: 'Makalenin başlığı'

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.tr.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.tr.yml
@@ -158,7 +158,7 @@ config:
                 or: 'Bir kural veya birbaşkası'
                 and: 'Bir kural ve diğeri'
                 # matches: 'Tests that a <i>subject</i> matches a <i>search</i> (case-insensitive).<br />Example: <code>title matches "football"</code>'
-                # notmatches: 'Tests that a <i>subject</i> doesn\'t match match match a <i>search</i> (case-insensitive).<br />Example: <code>title notmatches "football"</code>'
+                # notmatches: 'Tests that a <i>subject</i> doesn''t match match a <i>search</i> (case-insensitive).<br />Example: <code>title notmatches "football"</code>'
 
 entry:
     default_title: 'Makalenin başlığı'


### PR DESCRIPTION
Signed-off-by: Olivier Mehani <shtrom@ssji.net>

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | didn't try
| Documentation | yes
| Translation   | yes
| CHANGELOG.md  | no
| License       | MIT

This is a minor fix that correct some English language in the documentation for tagging rules. It also updates the string in the translations.