### PR TITLE
Remove preview picture from single entry view page for #1875

### DIFF
--- a/src/Wallabag/CoreBundle/Resources/views/themes/baggy/Entry/entry.html.twig
+++ b/src/Wallabag/CoreBundle/Resources/views/themes/baggy/Entry/entry.html.twig
@@ -96,9 +96,6 @@
                 </div>
             </aside>
         </div>
-        {% if entry.previewPicture is not null %}
-            <div><img class="preview" src="{{ entry.previewPicture }}" alt="{{ entry.title|e|raw }}" /></div>
-        {% endif %}
         <article>
             {{ entry.content | raw }}
         </article>

--- a/src/Wallabag/CoreBundle/Resources/views/themes/material/Entry/entry.html.twig
+++ b/src/Wallabag/CoreBundle/Resources/views/themes/material/Entry/entry.html.twig
@@ -275,10 +275,6 @@
                 {{ render(controller( "WallabagCoreBundle:Tag:addTagForm", { 'id': entry.id } )) }}
             </div>
 
-            {% if entry.previewPicture is not null %}
-                <div><img class="preview" src="{{ entry.previewPicture }}" alt="{{ entry.title|striptags|default('entry.default_title'|trans)|raw }}" /></div>
-            {% endif %}
-
         </aside>
         <article>
             {{ entry.content | raw }}


### PR DESCRIPTION
Showing the preview picture usually leads to showing a duplicate
image, and frequently leads to showing duplicate images directly
adjacent to each other.

before

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | yes/no
| Deprecations? | no
| Tests pass?   | yes/no
| Documentation | yes/no
| Translation   | yes/no
| CHANGELOG.md  | yes/no
| License       | MIT

Before:
<img width="1221" alt="screen shot 2018-11-03 at 12 48 24 pm" src="https://user-images.githubusercontent.com/665792/47955023-2c710f80-df68-11e8-8c66-96023ee7c5b9.png">

After:
<img width="1162" alt="screen shot 2018-11-03 at 12 57 02 pm" src="https://user-images.githubusercontent.com/665792/47955024-30049680-df68-11e8-9adc-8424b4f89b6b.png">

Fixes #1875 