### PR TITLE
Fix link to wallabag requirements in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ If you do not have your own server, consider [the wallabag.it hosting solution](
 ![wallabag logo](https://raw.githubusercontent.com/wallabag/logo/master/_default/typo-horizontal/png/sm/logo-typo-horizontal-black-no-bg-no-border-sm.png)
 
 # Install wallabag
-Please read [the documentation to see the wallabag requirements](http://doc.wallabag.org/en/master/user/installation.html#requirements).
+Please read [the documentation to see the wallabag requirements](https://doc.wallabag.org/en/admin/installation/requirements.html).
 
 Then you can install wallabag by executing the following commands:
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Documentation | yes
| Translation   | no
| CHANGELOG.md  | no
| License       | MIT

Fix link to Wallabag requirements in documentation