### PR TITLE
Update translation when marking as read

### DIFF
--- a/src/Wallabag/CoreBundle/Resources/translations/messages.en.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.en.yml
@@ -72,9 +72,9 @@ config:
             300_word: 'I read ~300 words per minute'
             400_word: 'I read ~400 words per minute'
         action_mark_as_read:
-            label: 'Where do you want to be redirected to after marking an article as read?'
-            redirect_homepage: 'To the homepage'
-            redirect_current_page: 'To the current page'
+            label: 'What to do after removing, starring or marking as read an article?'
+            redirect_homepage: 'Go to the homepage'
+            redirect_current_page: 'Stay on the current page'
         pocket_consumer_key_label: Consumer key for Pocket to import contents
         android_configuration: Configure your Android application
         android_instruction: "Touch here to prefill your Android application"

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.fr.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.fr.yml
@@ -72,7 +72,7 @@ config:
             300_word: "Je lis environ 300 mots par minute"
             400_word: "Je lis environ 400 mots par minute"
         action_mark_as_read:
-            label: "Que souhaitez-vous après avoir marqué un article comme lu ou favoris ?"
+            label: "Que faire lorsqu'un article est supprimé, marqué comme lu ou marqué comme favoris ?"
             redirect_homepage: "Retourner à la page d’accueil"
             redirect_current_page: "Rester sur la page actuelle"
         pocket_consumer_key_label: "Clé d’authentification Pocket pour importer les données"

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.fr.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.fr.yml
@@ -72,9 +72,9 @@ config:
             300_word: "Je lis environ 300 mots par minute"
             400_word: "Je lis environ 400 mots par minute"
         action_mark_as_read:
-            label: "Où souhaitez-vous être redirigé après avoir marqué un article comme lu ?"
-            redirect_homepage: "À la page d’accueil"
-            redirect_current_page: "À la page courante"
+            label: "Que souhaitez-vous après avoir marqué un article comme lu ou favoris ?"
+            redirect_homepage: "Retourner à la page d’accueil"
+            redirect_current_page: "Rester sur la page actuelle"
         pocket_consumer_key_label: "Clé d’authentification Pocket pour importer les données"
         android_configuration: "Configurez votre application Android"
         android_instruction: "Appuyez ici pour préremplir votre application Android"


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | no
| Documentation | no
| Translation   | yes
| CHANGELOG.md  | yes
| License       | MIT

This very slight modification is to ensure that the option is well understood.
Indeed, it indicated the destination (go to home page or stay on the current page) when one article was mark as read. However, this option is actually also controlling where you go when you mark something as favorite, or when you delete one.

I think this modification will allow one to better understand what this option is doing (I personally couldn't understand why I was taken back to the home page when marking an article as favorite).