### PR TITLE
material: fix missing thumbnail on list view

### DIFF
--- a/app/Resources/static/themes/material/css/cards.scss
+++ b/app/Resources/static/themes/material/css/cards.scss
@@ -116,18 +116,6 @@ main {
     height: 13.5em;
   }
 
-  .card-image .preview,
-  .card-fullimage .preview {
-    height: 100%;
-    background: no-repeat 50%/cover;
-    background-color: #efefef;
-    display: block;
-
-    &--default {
-      background-size: contain;
-    }
-  }
-
   &.sw {
     max-width: 370px;
     margin-left: auto;
@@ -140,6 +128,19 @@ a.original:not(.waves-effect) {
   white-space: nowrap;
   overflow: hidden;
   display: block;
+}
+
+.card .card-image .preview,
+.card .card-fullimage .preview,
+.card-stacked .preview {
+  height: 100%;
+  background: no-repeat 50%/cover;
+  background-color: #efefef;
+  display: block;
+
+  &--default {
+    background-size: contain;
+  }
 }
 
 .card-entry-labels li,
@@ -210,16 +211,11 @@ a.original:not(.waves-effect) {
     text-align: right;
   }
 
-  .preview {
+  .card-preview {
     max-width: 100px;
-    height: auto;
+    max-height: 50px;
     margin-right: 10px;
     flex: 1;
-
-    img {
-      max-width: 100%;
-      max-height: 100%;
-    }
   }
 
   div.metadata {

--- a/src/Wallabag/CoreBundle/Resources/views/themes/material/Entry/_card_list.html.twig
+++ b/src/Wallabag/CoreBundle/Resources/views/themes/material/Entry/_card_list.html.twig
@@ -1,10 +1,9 @@
 <div class="card-stacked">
-    <div class="preview">
-        {% if entry.previewPicture is not null %}
-            <a href="{{ path('view', { 'id': entry.id }) }}">
-                <img src="{{ entry.previewPicture }}" />
-            </a>
-        {% endif %}
+    <div class="card-preview">
+        <a href="{{ path('view', { 'id': entry.id }) }}">
+            {% set previewClassModifier = entry.previewPicture ? '' : ' preview--default' %}
+            <span class="preview{{ previewClassModifier }}" style="background-image: url({{ entry.previewPicture | default(asset('wallassets/themes/_global/img/logo-square.svg')) }})"></span>
+        </a>
     </div>
     {% include "@WallabagCore/themes/material/Entry/Card/_content.html.twig" with {'entry': entry, 'withTags': true, 'subClass': 'metadata'} only %}
     <ul class="tools-list hide-on-small-only">


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | -
| Documentation | no
| Translation   | no
| CHANGELOG.md  | no
| License       | MIT

Fixes #3779 

This PR fixes missing placeholder and normalizes the size of thumbnails in the list view.

![wallabag-3779-wideview](https://user-images.githubusercontent.com/226063/48980162-d0605d80-f0c5-11e8-8f2c-15a5f7c92efd.png)

![wallabag-3779-mobile](https://user-images.githubusercontent.com/226063/48980163-d3f3e480-f0c5-11e8-8eb5-79718510554c.png)


I'll push compiled prod assets after review.
