### PR TITLE
Fix Android app login issue

### DIFF
--- a/src/Wallabag/UserBundle/Resources/views/layout.html.twig
+++ b/src/Wallabag/UserBundle/Resources/views/layout.html.twig
@@ -11,7 +11,7 @@
 <main class="valign-wrapper">
     <div class="valign row">
         <div class="card sw">
-            <div class="center"><img src="{{ asset('wallassets/themes/_global/img/logo-wallabag.svg') }}" alt="wallabag logo" class="typo-logo" /></div>
+            <div class="center"><img src="{{ asset('wallassets/themes/_global/img/logo-wallabag.svg') }}" class="typo-logo" alt="wallabag logo" /></div>
             {% block fos_user_content %}
             {% endblock fos_user_content %}
         </div>


### PR DESCRIPTION
class and alt tags must be in the correct order for the android app to recognize the wallabag server
as per @msebald finding. 

installed it today and got the same login error. 

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | yes/no
| BC breaks?    | yes/no
| Deprecations? | yes/no
| Tests pass?   | yes/no
| Documentation | yes/no
| Translation   | yes/no
| CHANGELOG.md  | yes/no
| License       | MIT


Fixes https://github.com/wallabag/android-app/issues/744


<!--
- Please fill in this template according to the PR you're about to submit.
- Replace this comment by a description of what your PR is solving.
-->
