### PR TITLE
Enable OTP 2FA

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -13,5 +13,5 @@ insert_final_newline = true
 indent_style = space
 indent_size = 2
 
-[Makefile]
+[*akefile]
 indent_style = tab

--- a/.travis.yml
+++ b/.travis.yml
@@ -51,15 +51,17 @@ install:
 
 before_script:
     - PHP=$TRAVIS_PHP_VERSION
-    - if [[ ! $PHP = hhvm* ]]; then echo "memory_limit=-1" >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini; fi;
-    # xdebug isn't enable for PHP 7.1
-    - if [[ ! $PHP = hhvm* ]]; then phpenv config-rm xdebug.ini || echo "xdebug not available"; fi
+    - echo "memory_limit=-1" >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
+    - phpenv config-rm xdebug.ini || echo "xdebug not available"
     - composer self-update --no-progress
 
 script:
     - travis_wait bash composer install -o --no-interaction --no-progress --prefer-dist
+
     - echo "travis_fold:start:prepare"
-    - make prepare DB=$DB
+    # custom "prepare" for PG because the database should be created with a different user (see "before_script")
+    - if [[ ! $DB = pgsql ]]; then make prepare DB=$DB; fi;
+    - if [[ $DB = pgsql ]]; then make prepare-travis-pg DB=$DB; fi;
     - echo "travis_fold:end:prepare"
 
     - make fixtures

--- a/.travis.yml
+++ b/.travis.yml
@@ -59,9 +59,7 @@ script:
     - travis_wait bash composer install -o --no-interaction --no-progress --prefer-dist
 
     - echo "travis_fold:start:prepare"
-    # custom "prepare" for PG because the database should be created with a different user (see "before_script")
-    - if [[ ! $DB = pgsql ]]; then make prepare DB=$DB; fi;
-    - if [[ $DB = pgsql ]]; then make prepare-travis-pg DB=$DB; fi;
+    - make prepare DB=$DB
     - echo "travis_fold:end:prepare"
 
     - make fixtures

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -25,6 +25,12 @@ run: ## Run the wallabag built-in server
 build: ## Run webpack
 	@npm run build:$(ENV)
 
+prepare-travis-pg: ## Custom prepare for Travis & Postgres (do not drop/create the database)
+ifdef DB
+	cp app/config/tests/parameters_test.$(DB).yml app/config/parameters_test.yml
+endif
+	php bin/console doctrine:migrations:migrate --no-interaction --env=test
+
 prepare: clean ## Prepare database for testsuite
 ifdef DB
 	cp app/config/tests/parameters_test.$(DB).yml app/config/parameters_test.yml

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -25,12 +25,6 @@ run: ## Run the wallabag built-in server
 build: ## Run webpack
 	@npm run build:$(ENV)
 
-prepare-travis-pg: ## Custom prepare for Travis & Postgres (do not drop/create the database)
-ifdef DB
-	cp app/config/tests/parameters_test.$(DB).yml app/config/parameters_test.yml
-endif
-	php bin/console doctrine:migrations:migrate --no-interaction --env=test
-
 prepare: clean ## Prepare database for testsuite
 ifdef DB
 	cp app/config/tests/parameters_test.$(DB).yml app/config/parameters_test.yml

--- a/app/DoctrineMigrations/Version20181202073750.php
+++ b/app/DoctrineMigrations/Version20181202073750.php
@@ -12,11 +12,29 @@ final class Version20181202073750 extends WallabagMigration
 {
     public function up(Schema $schema): void
     {
-        $this->addSql('ALTER TABLE ' . $this->getTable('user') . ' ADD googleAuthenticatorSecret VARCHAR(191) DEFAULT NULL, CHANGE twoFactorAuthentication emailTwoFactor BOOLEAN NOT NULL, DROP trusted');
+        $tableName = $this->getTable('annotation');
+
+        switch ($this->connection->getDatabasePlatform()->getName()) {
+            case 'sqlite':
+                break;
+            case 'mysql':
+                $this->addSql('ALTER TABLE ' . $this->getTable('user') . ' ADD googleAuthenticatorSecret VARCHAR(191) DEFAULT NULL, CHANGE twoFactorAuthentication emailTwoFactor BOOLEAN NOT NULL, DROP trusted, ADD backupCodes LONGTEXT DEFAULT NULL COMMENT \'(DC2Type:json_array)\'');
+                break;
+            case 'postgresql':
+                break;
+        }
     }
 
     public function down(Schema $schema): void
     {
-        $this->addSql('ALTER TABLE `' . $this->getTable('user') . '` DROP googleAuthenticatorSecret, CHANGE emailtwofactor twoFactorAuthentication BOOLEAN NOT NULL, ADD trusted TEXT DEFAULT NULL');
+        switch ($this->connection->getDatabasePlatform()->getName()) {
+            case 'sqlite':
+                break;
+            case 'mysql':
+                $this->addSql('ALTER TABLE `' . $this->getTable('user') . '` DROP googleAuthenticatorSecret, CHANGE emailtwofactor twoFactorAuthentication BOOLEAN NOT NULL, ADD trusted TEXT DEFAULT NULL, DROP backupCodes');
+                break;
+            case 'postgresql':
+                break;
+        }
     }
 }

--- a/app/DoctrineMigrations/Version20181202073750.php
+++ b/app/DoctrineMigrations/Version20181202073750.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Application\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Wallabag\CoreBundle\Doctrine\WallabagMigration;
+
+/**
+ * Add 2fa OTP (named google authenticator).
+ */
+final class Version20181202073750 extends WallabagMigration
+{
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE ' . $this->getTable('user') . ' ADD googleAuthenticatorSecret VARCHAR(191) DEFAULT NULL, CHANGE twoFactorAuthentication emailTwoFactor BOOLEAN NOT NULL, DROP trusted');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE `' . $this->getTable('user') . '` DROP googleAuthenticatorSecret, CHANGE emailtwofactor twoFactorAuthentication BOOLEAN NOT NULL, ADD trusted TEXT DEFAULT NULL');
+    }
+}

--- a/app/DoctrineMigrations/Version20181202073750.php
+++ b/app/DoctrineMigrations/Version20181202073750.php
@@ -6,21 +6,39 @@ use Doctrine\DBAL\Schema\Schema;
 use Wallabag\CoreBundle\Doctrine\WallabagMigration;
 
 /**
- * Add 2fa OTP (named google authenticator).
+ * Add 2fa OTP stuff.
  */
 final class Version20181202073750 extends WallabagMigration
 {
     public function up(Schema $schema): void
     {
-        $tableName = $this->getTable('annotation');
-
         switch ($this->connection->getDatabasePlatform()->getName()) {
             case 'sqlite':
+                $this->addSql('DROP INDEX UNIQ_1D63E7E5C05FB297');
+                $this->addSql('DROP INDEX UNIQ_1D63E7E5A0D96FBF');
+                $this->addSql('DROP INDEX UNIQ_1D63E7E592FC23A8');
+                $this->addSql('CREATE TEMPORARY TABLE __temp__' . $this->getTable('user', true) . ' AS SELECT id, username, username_canonical, email, email_canonical, enabled, salt, password, last_login, confirmation_token, password_requested_at, roles, name, created_at, updated_at, authCode, twoFactorAuthentication FROM ' . $this->getTable('user', true) . '');
+                $this->addSql('DROP TABLE ' . $this->getTable('user', true) . '');
+                $this->addSql('CREATE TABLE ' . $this->getTable('user', true) . ' (id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, username VARCHAR(180) NOT NULL COLLATE BINARY, username_canonical VARCHAR(180) NOT NULL COLLATE BINARY, email VARCHAR(180) NOT NULL COLLATE BINARY, email_canonical VARCHAR(180) NOT NULL COLLATE BINARY, enabled BOOLEAN NOT NULL, password VARCHAR(255) NOT NULL COLLATE BINARY, last_login DATETIME DEFAULT NULL, password_requested_at DATETIME DEFAULT NULL, name CLOB DEFAULT NULL COLLATE BINARY, created_at DATETIME NOT NULL, updated_at DATETIME NOT NULL, authCode INTEGER DEFAULT NULL, emailTwoFactor BOOLEAN NOT NULL, salt VARCHAR(255) DEFAULT NULL, confirmation_token VARCHAR(180) DEFAULT NULL, roles CLOB NOT NULL --(DC2Type:array)
+                , googleAuthenticatorSecret VARCHAR(255) DEFAULT NULL, backupCodes CLOB DEFAULT NULL --(DC2Type:json_array)
+                )');
+                $this->addSql('INSERT INTO ' . $this->getTable('user', true) . ' (id, username, username_canonical, email, email_canonical, enabled, salt, password, last_login, confirmation_token, password_requested_at, roles, name, created_at, updated_at, authCode, emailTwoFactor) SELECT id, username, username_canonical, email, email_canonical, enabled, salt, password, last_login, confirmation_token, password_requested_at, roles, name, created_at, updated_at, authCode, twoFactorAuthentication FROM __temp__' . $this->getTable('user', true) . '');
+                $this->addSql('DROP TABLE __temp__' . $this->getTable('user', true) . '');
+                $this->addSql('CREATE UNIQUE INDEX UNIQ_1D63E7E5C05FB297 ON ' . $this->getTable('user', true) . ' (confirmation_token)');
+                $this->addSql('CREATE UNIQUE INDEX UNIQ_1D63E7E5A0D96FBF ON ' . $this->getTable('user', true) . ' (email_canonical)');
+                $this->addSql('CREATE UNIQUE INDEX UNIQ_1D63E7E592FC23A8 ON ' . $this->getTable('user', true) . ' (username_canonical)');
                 break;
             case 'mysql':
-                $this->addSql('ALTER TABLE ' . $this->getTable('user') . ' ADD googleAuthenticatorSecret VARCHAR(191) DEFAULT NULL, CHANGE twoFactorAuthentication emailTwoFactor BOOLEAN NOT NULL, DROP trusted, ADD backupCodes LONGTEXT DEFAULT NULL COMMENT \'(DC2Type:json_array)\'');
+                $this->addSql('ALTER TABLE ' . $this->getTable('user') . ' ADD googleAuthenticatorSecret VARCHAR(191) DEFAULT NULL');
+                $this->addSql('ALTER TABLE ' . $this->getTable('user') . ' CHANGE twoFactorAuthentication emailTwoFactor BOOLEAN NOT NULL');
+                $this->addSql('ALTER TABLE ' . $this->getTable('user') . ' DROP trusted');
+                $this->addSql('ALTER TABLE ' . $this->getTable('user') . ' ADD backupCodes LONGTEXT DEFAULT NULL COMMENT \'(DC2Type:json_array)\'');
                 break;
             case 'postgresql':
+                $this->addSql('ALTER TABLE ' . $this->getTable('user') . ' ADD googleAuthenticatorSecret VARCHAR(191) DEFAULT NULL');
+                $this->addSql('ALTER TABLE ' . $this->getTable('user') . ' RENAME COLUMN twofactorauthentication TO emailTwoFactor');
+                $this->addSql('ALTER TABLE ' . $this->getTable('user') . ' DROP trusted');
+                $this->addSql('ALTER TABLE ' . $this->getTable('user') . ' ADD backupCodes TEXT DEFAULT NULL');
                 break;
         }
     }
@@ -29,11 +47,29 @@ final class Version20181202073750 extends WallabagMigration
     {
         switch ($this->connection->getDatabasePlatform()->getName()) {
             case 'sqlite':
+                $this->addSql('DROP INDEX UNIQ_1D63E7E592FC23A8');
+                $this->addSql('DROP INDEX UNIQ_1D63E7E5A0D96FBF');
+                $this->addSql('DROP INDEX UNIQ_1D63E7E5C05FB297');
+                $this->addSql('CREATE TEMPORARY TABLE __temp__' . $this->getTable('user', true) . ' AS SELECT id, username, username_canonical, email, email_canonical, enabled, salt, password, last_login, confirmation_token, password_requested_at, roles, name, created_at, updated_at, authCode, emailTwoFactor FROM "' . $this->getTable('user', true) . '"');
+                $this->addSql('DROP TABLE "' . $this->getTable('user', true) . '"');
+                $this->addSql('CREATE TABLE "' . $this->getTable('user', true) . '" (id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, username VARCHAR(180) NOT NULL, username_canonical VARCHAR(180) NOT NULL, email VARCHAR(180) NOT NULL, email_canonical VARCHAR(180) NOT NULL, enabled BOOLEAN NOT NULL, password VARCHAR(255) NOT NULL, last_login DATETIME DEFAULT NULL, password_requested_at DATETIME DEFAULT NULL, name CLOB DEFAULT NULL, created_at DATETIME NOT NULL, updated_at DATETIME NOT NULL, authCode INTEGER DEFAULT NULL, twoFactorAuthentication BOOLEAN NOT NULL, salt VARCHAR(255) NOT NULL COLLATE BINARY, confirmation_token VARCHAR(255) DEFAULT NULL COLLATE BINARY, roles CLOB NOT NULL COLLATE BINARY, trusted CLOB DEFAULT NULL COLLATE BINARY)');
+                $this->addSql('INSERT INTO "' . $this->getTable('user', true) . '" (id, username, username_canonical, email, email_canonical, enabled, salt, password, last_login, confirmation_token, password_requested_at, roles, name, created_at, updated_at, authCode, twoFactorAuthentication) SELECT id, username, username_canonical, email, email_canonical, enabled, salt, password, last_login, confirmation_token, password_requested_at, roles, name, created_at, updated_at, authCode, emailTwoFactor FROM __temp__' . $this->getTable('user', true) . '');
+                $this->addSql('DROP TABLE __temp__' . $this->getTable('user', true) . '');
+                $this->addSql('CREATE UNIQUE INDEX UNIQ_1D63E7E592FC23A8 ON "' . $this->getTable('user', true) . '" (username_canonical)');
+                $this->addSql('CREATE UNIQUE INDEX UNIQ_1D63E7E5A0D96FBF ON "' . $this->getTable('user', true) . '" (email_canonical)');
+                $this->addSql('CREATE UNIQUE INDEX UNIQ_1D63E7E5C05FB297 ON "' . $this->getTable('user', true) . '" (confirmation_token)');
                 break;
             case 'mysql':
-                $this->addSql('ALTER TABLE `' . $this->getTable('user') . '` DROP googleAuthenticatorSecret, CHANGE emailtwofactor twoFactorAuthentication BOOLEAN NOT NULL, ADD trusted TEXT DEFAULT NULL, DROP backupCodes');
+                $this->addSql('ALTER TABLE `' . $this->getTable('user') . '` DROP googleAuthenticatorSecret');
+                $this->addSql('ALTER TABLE `' . $this->getTable('user') . '` CHANGE emailtwofactor twoFactorAuthentication BOOLEAN NOT NULL');
+                $this->addSql('ALTER TABLE `' . $this->getTable('user') . '` ADD trusted TEXT DEFAULT NULL');
+                $this->addSql('ALTER TABLE `' . $this->getTable('user') . '` DROP backupCodes');
                 break;
             case 'postgresql':
+                $this->addSql('ALTER TABLE ' . $this->getTable('user') . ' DROP googleAuthenticatorSecret');
+                $this->addSql('ALTER TABLE ' . $this->getTable('user') . ' RENAME COLUMN emailTwoFactor TO twofactorauthentication');
+                $this->addSql('ALTER TABLE ' . $this->getTable('user') . ' ADD trusted TEXT DEFAULT NULL');
+                $this->addSql('ALTER TABLE ' . $this->getTable('user') . ' DROP backupCodes');
                 break;
         }
     }

--- a/app/Resources/static/themes/_global/index.js
+++ b/app/Resources/static/themes/_global/index.js
@@ -89,4 +89,22 @@ $(document).ready(() => {
       }
     };
   });
+
+  // mimic radio button because emailTwoFactor is a boolean
+  $('#update_user_googleTwoFactor').on('change', () => {
+    $('#update_user_emailTwoFactor').prop('checked', false);
+  });
+
+  $('#update_user_emailTwoFactor').on('change', () => {
+    $('#update_user_googleTwoFactor').prop('checked', false);
+  });
+
+  // same mimic for super admin
+  $('#user_googleTwoFactor').on('change', () => {
+    $('#user_emailTwoFactor').prop('checked', false);
+  });
+
+  $('#user_emailTwoFactor').on('change', () => {
+    $('#user_googleTwoFactor').prop('checked', false);
+  });
 });

--- a/app/Resources/static/themes/material/index.js
+++ b/app/Resources/static/themes/material/index.js
@@ -50,25 +50,30 @@ $(document).ready(() => {
     $('#tag_label').focus();
     return false;
   });
+
   $('#nav-btn-add').on('click', () => {
     toggleNav('.nav-panel-add', '#entry_url');
     return false;
   });
+
   const materialAddForm = $('.nav-panel-add');
   materialAddForm.on('submit', () => {
     materialAddForm.addClass('disabled');
     $('input#entry_url', materialAddForm).prop('readonly', true).trigger('blur');
   });
+
   $('#nav-btn-search').on('click', () => {
     toggleNav('.nav-panel-search', '#search_entry_term');
     return false;
   });
+
   $('.close').on('click', (e) => {
     $(e.target).parent('.nav-panel-item').hide(100);
     $('.nav-panel-actions').show(100);
     $('.nav-panels').css('background', 'transparent');
     return false;
   });
+
   $(window).scroll(() => {
     const s = $(window).scrollTop();
     const d = $(document).height();

--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -198,10 +198,14 @@ fos_oauth_server:
             refresh_token_lifetime: 1209600
 
 scheb_two_factor:
-    trusted_computer:
+    trusted_device:
         enabled: true
         cookie_name: wllbg_trusted_computer
-        cookie_lifetime: 2592000
+        lifetime: 2592000
+
+    google:
+        enabled: "%twofactor_auth%"
+        template: WallabagUserBundle:Authentication:form.html.twig
 
     email:
         enabled: "%twofactor_auth%"

--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -203,6 +203,9 @@ scheb_two_factor:
         cookie_name: wllbg_trusted_computer
         lifetime: 2592000
 
+    backup_codes:
+        enabled: "%twofactor_auth%"
+
     google:
         enabled: "%twofactor_auth%"
         template: WallabagUserBundle:Authentication:form.html.twig

--- a/app/config/routing.yml
+++ b/app/config/routing.yml
@@ -51,3 +51,11 @@ craue_config_settings_modify:
 
 fos_js_routing:
     resource: "@FOSJsRoutingBundle/Resources/config/routing/routing.xml"
+
+2fa_login:
+    path: /2fa
+    defaults:
+        _controller: "scheb_two_factor.form_controller:form"
+
+2fa_login_check:
+    path: /2fa_check

--- a/app/config/security.yml
+++ b/app/config/security.yml
@@ -56,9 +56,17 @@ security:
                 path:   /logout
                 target: /
 
+            two_factor:
+                provider: fos_userbundle
+                auth_form_path: 2fa_login
+                check_path: 2fa_login_check
+
     access_control:
         - { path: ^/api/(doc|version|info|user), roles: IS_AUTHENTICATED_ANONYMOUSLY }
         - { path: ^/login, roles: IS_AUTHENTICATED_ANONYMOUSLY }
+        # force role for logout otherwise when 2fa enable, you won't be able to logout
+        # https://github.com/scheb/two-factor-bundle/issues/168#issuecomment-430822478
+        - { path: ^/logout, roles: [IS_AUTHENTICATED_ANONYMOUSLY, IS_AUTHENTICATED_2FA_IN_PROGRESS] }
         - { path: ^/register, role: IS_AUTHENTICATED_ANONYMOUSLY }
         - { path: ^/resetting, role: IS_AUTHENTICATED_ANONYMOUSLY }
         - { path: /(unread|starred|archive|all).xml$, roles: IS_AUTHENTICATED_ANONYMOUSLY }
@@ -67,5 +75,6 @@ security:
         - { path: ^/share, roles: IS_AUTHENTICATED_ANONYMOUSLY }
         - { path: ^/settings, roles: ROLE_SUPER_ADMIN }
         - { path: ^/annotations, roles: ROLE_USER }
+        - { path: ^/2fa, role: IS_AUTHENTICATED_2FA_IN_PROGRESS }
         - { path: ^/users, roles: ROLE_SUPER_ADMIN }
         - { path: ^/, roles: ROLE_USER }

--- a/composer.json
+++ b/composer.json
@@ -87,7 +87,8 @@
         "friendsofsymfony/jsrouting-bundle": "^2.2",
         "bdunogier/guzzle-site-authenticator": "^1.0.0",
         "defuse/php-encryption": "^2.1",
-        "html2text/html2text": "^4.1"
+        "html2text/html2text": "^4.1",
+        "pragmarx/recovery": "^0.1.0"
     },
     "require-dev": {
         "doctrine/doctrine-fixtures-bundle": "~3.0",

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
         "issues": "https://github.com/wallabag/wallabag/issues"
     },
     "require": {
-        "php": ">=7.1.0",
+        "php": ">=7.1.3",
         "ext-pcre": "*",
         "ext-dom": "*",
         "ext-curl": "*",
@@ -70,7 +70,7 @@
         "friendsofsymfony/user-bundle": "2.0.*",
         "friendsofsymfony/oauth-server-bundle": "^1.5",
         "stof/doctrine-extensions-bundle": "^1.2",
-        "scheb/two-factor-bundle": "^2.14",
+        "scheb/two-factor-bundle": "^3.0",
         "grandt/phpepub": "dev-master",
         "wallabag/php-mobi": "~1.0",
         "kphoen/rulerz-bundle": "~0.13",
@@ -147,7 +147,7 @@
     "config": {
         "bin-dir": "bin",
         "platform": {
-            "php": "7.1"
+            "php": "7.1.3"
         }
     },
     "minimum-stability": "dev",

--- a/src/Wallabag/CoreBundle/Command/ShowUserCommand.php
+++ b/src/Wallabag/CoreBundle/Command/ShowUserCommand.php
@@ -57,7 +57,8 @@ class ShowUserCommand extends ContainerAwareCommand
             sprintf('Display name: %s', $user->getName()),
             sprintf('Creation date: %s', $user->getCreatedAt()->format('Y-m-d H:i:s')),
             sprintf('Last login: %s', null !== $user->getLastLogin() ? $user->getLastLogin()->format('Y-m-d H:i:s') : 'never'),
-            sprintf('2FA activated: %s', $user->isTwoFactorAuthentication() ? 'yes' : 'no'),
+            sprintf('2FA (email) activated: %s', $user->isEmailTwoFactor() ? 'yes' : 'no'),
+            sprintf('2FA (OTP) activated: %s', $user->isGoogleAuthenticatorEnabled() ? 'yes' : 'no'),
         ]);
     }
 

--- a/src/Wallabag/CoreBundle/Controller/ConfigController.php
+++ b/src/Wallabag/CoreBundle/Controller/ConfigController.php
@@ -161,11 +161,9 @@ class ConfigController extends Controller
     /**
      * Enable 2FA using email.
      *
-     * @param Request $request
-     *
      * @Route("/config/otp/email", name="config_otp_email")
      */
-    public function otpEmailAction(Request $request)
+    public function otpEmailAction()
     {
         if (!$this->getParameter('twofactor_auth')) {
             return $this->createNotFoundException('two_factor not enabled');

--- a/src/Wallabag/CoreBundle/Controller/ConfigController.php
+++ b/src/Wallabag/CoreBundle/Controller/ConfigController.php
@@ -2,6 +2,7 @@
 
 namespace Wallabag\CoreBundle\Controller;
 
+use PragmaRX\Recovery\Recovery as BackupCodes;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\RedirectResponse;
@@ -93,10 +94,12 @@ class ConfigController extends Controller
 
                     $user->setGoogleAuthenticatorSecret($secret);
                     $user->setEmailTwoFactor(false);
+                    $user->setBackupCodes((new BackupCodes())->toArray());
 
                     $this->addFlash('OtpQrCode', $this->get('scheb_two_factor.security.google_authenticator')->getQRContent($user));
                 } elseif (false === $userForm->get('googleTwoFactor')->getData() && true === $user->isGoogleAuthenticatorEnabled()) {
                     $user->setGoogleAuthenticatorSecret(null);
+                    $user->setBackupCodes(null);
                 }
             }
 

--- a/src/Wallabag/CoreBundle/Form/Type/UserInformationType.php
+++ b/src/Wallabag/CoreBundle/Form/Type/UserInformationType.php
@@ -21,9 +21,14 @@ class UserInformationType extends AbstractType
             ->add('email', EmailType::class, [
                 'label' => 'config.form_user.email_label',
             ])
-            ->add('twoFactorAuthentication', CheckboxType::class, [
+            ->add('emailTwoFactor', CheckboxType::class, [
                 'required' => false,
-                'label' => 'config.form_user.twoFactorAuthentication_label',
+                'label' => 'config.form_user.emailTwoFactor_label',
+            ])
+            ->add('googleTwoFactor', CheckboxType::class, [
+                'required' => false,
+                'label' => 'config.form_user.googleTwoFactor_label',
+                'mapped' => false,
             ])
             ->add('save', SubmitType::class, [
                 'label' => 'config.form.save',

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.da.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.da.yml
@@ -99,11 +99,11 @@ config:
             # all: 'All'
         # rss_limit: 'Number of items in the feed'
     form_user:
-        # two_factor_description: "Enabling two factor authentication means you'll receive an email with a code on every new untrusted connexion"
+        # two_factor_description: "Enabling two factor authentication means you'll receive an email with a code OR need to use an OTP app (like Google Authenticator) to get a one time code on every new untrusted connection. You can't choose both option."
         name_label: 'Navn'
         email_label: 'Emailadresse'
-        # twoFactorAuthentication_label: 'Two factor authentication'
-        # help_twoFactorAuthentication: "If you enable 2FA, each time you want to login to wallabag, you'll receive a code by email."
+        # emailTwoFactor_label: 'Using email (receive a code by email)'
+        # googleTwoFactor_label: 'Using an OTP app (open the app, like Google Authenticator, to get a one time code)'
         delete:
             # title: Delete my account (a.k.a danger zone)
             # description: If you remove your account, ALL your articles, ALL your tags, ALL your annotations and your account will be PERMANENTLY removed (it can't be UNDONE). You'll then be logged out.
@@ -533,7 +533,8 @@ user:
         email_label: 'Emailadresse'
         # enabled_label: 'Enabled'
         # last_login_label: 'Last login'
-        # twofactor_label: Two factor authentication
+        # twofactor_email_label: Two factor authentication by email
+        # twofactor_google_label: Two factor authentication by Google
         # save: Save
         # delete: Delete
         # delete_confirm: Are you sure?

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.da.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.da.yml
@@ -107,6 +107,7 @@ config:
         # two_factor_code_description_1: You just enabled the OTP two factor authentication, open your OTP app and use that code to get a one time password. It'll disapear after a page reload.
         # two_factor_code_description_2: 'You can scan that QR Code with your app:'
         # two_factor_code_description_3: 'Or use that code:'
+        # two_factor_code_description_4: 'Also, save these backup codes in a safe place, you can use them in case you lose access to your OTP app:'
         delete:
             # title: Delete my account (a.k.a danger zone)
             # description: If you remove your account, ALL your articles, ALL your tags, ALL your annotations and your account will be PERMANENTLY removed (it can't be UNDONE). You'll then be logged out.

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.da.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.da.yml
@@ -59,6 +59,7 @@ config:
         password: 'Adgangskode'
         # rules: 'Tagging rules'
         new_user: 'Tilføj bruger'
+        # reset: 'Reset area'
     form:
         save: 'Gem'
     form_settings:

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.da.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.da.yml
@@ -538,7 +538,7 @@ user:
         # enabled_label: 'Enabled'
         # last_login_label: 'Last login'
         # twofactor_email_label: Two factor authentication by email
-        # twofactor_google_label: Two factor authentication by Google
+        # twofactor_google_label: Two factor authentication by OTP app
         # save: Save
         # delete: Delete
         # delete_confirm: Are you sure?

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.da.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.da.yml
@@ -99,11 +99,14 @@ config:
             # all: 'All'
         # rss_limit: 'Number of items in the feed'
     form_user:
-        # two_factor_description: "Enabling two factor authentication means you'll receive an email with a code OR need to use an OTP app (like Google Authenticator) to get a one time code on every new untrusted connection. You can't choose both option."
+        # two_factor_description: "Enabling two factor authentication means you'll receive an email with a code OR need to use an OTP app (like Google Authenticator, Authy or FreeOTP) to get a one time code on every new untrusted connection. You can't choose both option."
         name_label: 'Navn'
         email_label: 'Emailadresse'
         # emailTwoFactor_label: 'Using email (receive a code by email)'
-        # googleTwoFactor_label: 'Using an OTP app (open the app, like Google Authenticator, to get a one time code)'
+        # googleTwoFactor_label: 'Using an OTP app (open the app, like Google Authenticator, Authy or FreeOTP, to get a one time code)'
+        # two_factor_code_description_1: You just enabled the OTP two factor authentication, open your OTP app and use that code to get a one time password. It'll disapear after a page reload.
+        # two_factor_code_description_2: 'You can scan that QR Code with your app:'
+        # two_factor_code_description_3: 'Or use that code:'
         delete:
             # title: Delete my account (a.k.a danger zone)
             # description: If you remove your account, ALL your articles, ALL your tags, ALL your annotations and your account will be PERMANENTLY removed (it can't be UNDONE). You'll then be logged out.

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.da.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.da.yml
@@ -102,12 +102,16 @@ config:
         # two_factor_description: "Enabling two factor authentication means you'll receive an email with a code OR need to use an OTP app (like Google Authenticator, Authy or FreeOTP) to get a one time code on every new untrusted connection. You can't choose both option."
         name_label: 'Navn'
         email_label: 'Emailadresse'
-        # emailTwoFactor_label: 'Using email (receive a code by email)'
-        # googleTwoFactor_label: 'Using an OTP app (open the app, like Google Authenticator, Authy or FreeOTP, to get a one time code)'
-        # two_factor_code_description_1: You just enabled the OTP two factor authentication, open your OTP app and use that code to get a one time password. It'll disapear after a page reload.
-        # two_factor_code_description_2: 'You can scan that QR Code with your app:'
-        # two_factor_code_description_3: 'Or use that code:'
-        # two_factor_code_description_4: 'Also, save these backup codes in a safe place, you can use them in case you lose access to your OTP app:'
+        two_factor:
+            # emailTwoFactor_label: 'Using email (receive a code by email)'
+            # googleTwoFactor_label: 'Using an OTP app (open the app, like Google Authenticator, Authy or FreeOTP, to get a one time code)'
+            # table_method: Method
+            # table_state: State
+            # table_action: Action
+            # state_enabled: Enabled
+            # state_disabled: Disabled
+            # action_email: Use email
+            # action_app: Use OTP App
         delete:
             # title: Delete my account (a.k.a danger zone)
             # description: If you remove your account, ALL your articles, ALL your tags, ALL your annotations and your account will be PERMANENTLY removed (it can't be UNDONE). You'll then be logged out.
@@ -165,6 +169,15 @@ config:
         #         and: 'One rule AND another'
         #         matches: 'Tests that a <i>subject</i> matches a <i>search</i> (case-insensitive).<br />Example: <code>title matches "football"</code>'
         #         notmatches: 'Tests that a <i>subject</i> doesn''t match match a <i>search</i> (case-insensitive).<br />Example: <code>title notmatches "football"</code>'
+    otp:
+        # page_title: Two-factor authentication
+        # app:
+        #     two_factor_code_description_1: You just enabled the OTP two factor authentication, open your OTP app and use that code to get a one time password. It'll disapear after a page reload.
+        #     two_factor_code_description_2: 'You can scan that QR Code with your app:'
+        #     two_factor_code_description_3: 'Also, save these backup codes in a safe place, you can use them in case you lose access to your OTP app:'
+        #     two_factor_code_description_4: 'Test an OTP code from your configured app:'
+        #     cancel: Cancel
+        #     enable: Enable
 
 entry:
     # default_title: 'Title of the entry'

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.de.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.de.yml
@@ -99,11 +99,14 @@ config:
             all: 'Alle'
         rss_limit: 'Anzahl der Einträge pro Feed'
     form_user:
-        # two_factor_description: "Enabling two factor authentication means you'll receive an email with a code OR need to use an OTP app (like Google Authenticator) to get a one time code on every new untrusted connection. You can't choose both option."
+        # two_factor_description: "Enabling two factor authentication means you'll receive an email with a code OR need to use an OTP app (like Google Authenticator, Authy or FreeOTP) to get a one time code on every new untrusted connection. You can't choose both option."
         name_label: 'Name'
         email_label: 'E-Mail-Adresse'
         # emailTwoFactor_label: 'Using email (receive a code by email)'
-        # googleTwoFactor_label: 'Using an OTP app (open the app, like Google Authenticator, to get a one time code)'
+        # googleTwoFactor_label: 'Using an OTP app (open the app, like Google Authenticator, Authy or FreeOTP, to get a one time code)'
+        # two_factor_code_description_1: You just enabled the OTP two factor authentication, open your OTP app and use that code to get a one time password. It'll disapear after a page reload.
+        # two_factor_code_description_2: 'You can scan that QR Code with your app:'
+        # two_factor_code_description_3: 'Or use that code:'
         delete:
             title: 'Lösche mein Konto (a.k.a Gefahrenzone)'
             description: 'Wenn du dein Konto löschst, werden ALL deine Artikel, ALL deine Tags, ALL deine Anmerkungen und dein Konto dauerhaft gelöscht (kann NICHT RÜCKGÄNGIG gemacht werden). Du wirst anschließend ausgeloggt.'

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.de.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.de.yml
@@ -99,11 +99,11 @@ config:
             all: 'Alle'
         rss_limit: 'Anzahl der Einträge pro Feed'
     form_user:
-        two_factor_description: "Wenn du die Zwei-Faktor-Authentifizierung aktivierst, erhältst du eine E-Mail mit einem Code bei jeder nicht vertrauenswürdigen Verbindung"
+        # two_factor_description: "Enabling two factor authentication means you'll receive an email with a code OR need to use an OTP app (like Google Authenticator) to get a one time code on every new untrusted connection. You can't choose both option."
         name_label: 'Name'
         email_label: 'E-Mail-Adresse'
-        twoFactorAuthentication_label: 'Zwei-Faktor-Authentifizierung'
-        help_twoFactorAuthentication: "Wenn du 2FA aktivierst, wirst du bei jedem Login einen Code per E-Mail bekommen."
+        # emailTwoFactor_label: 'Using email (receive a code by email)'
+        # googleTwoFactor_label: 'Using an OTP app (open the app, like Google Authenticator, to get a one time code)'
         delete:
             title: 'Lösche mein Konto (a.k.a Gefahrenzone)'
             description: 'Wenn du dein Konto löschst, werden ALL deine Artikel, ALL deine Tags, ALL deine Anmerkungen und dein Konto dauerhaft gelöscht (kann NICHT RÜCKGÄNGIG gemacht werden). Du wirst anschließend ausgeloggt.'
@@ -533,7 +533,8 @@ user:
         email_label: 'E-Mail-Adresse'
         enabled_label: 'Aktiviert'
         last_login_label: 'Letzter Login'
-        twofactor_label: 'Zwei-Faktor-Authentifizierung'
+        # twofactor_email_label: Two factor authentication by email
+        # twofactor_google_label: Two factor authentication by Google
         save: 'Speichern'
         delete: 'Löschen'
         delete_confirm: 'Bist du sicher?'

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.de.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.de.yml
@@ -102,12 +102,16 @@ config:
         # two_factor_description: "Enabling two factor authentication means you'll receive an email with a code OR need to use an OTP app (like Google Authenticator, Authy or FreeOTP) to get a one time code on every new untrusted connection. You can't choose both option."
         name_label: 'Name'
         email_label: 'E-Mail-Adresse'
-        # emailTwoFactor_label: 'Using email (receive a code by email)'
-        # googleTwoFactor_label: 'Using an OTP app (open the app, like Google Authenticator, Authy or FreeOTP, to get a one time code)'
-        # two_factor_code_description_1: You just enabled the OTP two factor authentication, open your OTP app and use that code to get a one time password. It'll disapear after a page reload.
-        # two_factor_code_description_2: 'You can scan that QR Code with your app:'
-        # two_factor_code_description_3: 'Or use that code:'
-        # two_factor_code_description_4: 'Also, save these backup codes in a safe place, you can use them in case you lose access to your OTP app:'
+        two_factor:
+            # emailTwoFactor_label: 'Using email (receive a code by email)'
+            # googleTwoFactor_label: 'Using an OTP app (open the app, like Google Authenticator, Authy or FreeOTP, to get a one time code)'
+            # table_method: Method
+            # table_state: State
+            # table_action: Action
+            # state_enabled: Enabled
+            # state_disabled: Disabled
+            # action_email: Use email
+            # action_app: Use OTP App
         delete:
             title: 'Lösche mein Konto (a.k.a Gefahrenzone)'
             description: 'Wenn du dein Konto löschst, werden ALL deine Artikel, ALL deine Tags, ALL deine Anmerkungen und dein Konto dauerhaft gelöscht (kann NICHT RÜCKGÄNGIG gemacht werden). Du wirst anschließend ausgeloggt.'

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.de.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.de.yml
@@ -107,6 +107,7 @@ config:
         # two_factor_code_description_1: You just enabled the OTP two factor authentication, open your OTP app and use that code to get a one time password. It'll disapear after a page reload.
         # two_factor_code_description_2: 'You can scan that QR Code with your app:'
         # two_factor_code_description_3: 'Or use that code:'
+        # two_factor_code_description_4: 'Also, save these backup codes in a safe place, you can use them in case you lose access to your OTP app:'
         delete:
             title: 'Lösche mein Konto (a.k.a Gefahrenzone)'
             description: 'Wenn du dein Konto löschst, werden ALL deine Artikel, ALL deine Tags, ALL deine Anmerkungen und dein Konto dauerhaft gelöscht (kann NICHT RÜCKGÄNGIG gemacht werden). Du wirst anschließend ausgeloggt.'

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.de.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.de.yml
@@ -59,6 +59,7 @@ config:
         password: 'Kennwort'
         rules: 'Tagging-Regeln'
         new_user: 'Benutzer hinzufügen'
+        reset: 'Zurücksetzen'
     form:
         save: 'Speichern'
     form_settings:

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.de.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.de.yml
@@ -538,7 +538,7 @@ user:
         enabled_label: 'Aktiviert'
         last_login_label: 'Letzter Login'
         # twofactor_email_label: Two factor authentication by email
-        # twofactor_google_label: Two factor authentication by Google
+        # twofactor_google_label: Two factor authentication by OTP app
         save: 'Speichern'
         delete: 'Löschen'
         delete_confirm: 'Bist du sicher?'

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.en.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.en.yml
@@ -59,6 +59,7 @@ config:
         password: 'Password'
         rules: 'Tagging rules'
         new_user: 'Add a user'
+        reset: 'Reset area'
     form:
         save: 'Save'
     form_settings:

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.en.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.en.yml
@@ -538,7 +538,7 @@ user:
         enabled_label: 'Enabled'
         last_login_label: 'Last login'
         twofactor_email_label: Two factor authentication by email
-        twofactor_google_label: Two factor authentication by Google
+        twofactor_google_label: Two factor authentication by OTP app
         save: Save
         delete: Delete
         delete_confirm: Are you sure?

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.en.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.en.yml
@@ -102,12 +102,16 @@ config:
         two_factor_description: "Enabling two factor authentication means you'll receive an email with a code OR need to use an OTP app (like Google Authenticator, Authy or FreeOTP) to get a one time code on every new untrusted connection. You can't choose both option."
         name_label: 'Name'
         email_label: 'Email'
-        emailTwoFactor_label: 'Using email (receive a code by email)'
-        googleTwoFactor_label: 'Using an OTP app (open the app, like Google Authenticator, Authy or FreeOTP, to get a one time code)'
-        two_factor_code_description_1: You just enabled the OTP two factor authentication, open your OTP app and use that code to get a one time password. It'll disapear after a page reload.
-        two_factor_code_description_2: 'You can scan that QR Code with your app:'
-        two_factor_code_description_3: 'Or use that code:'
-        two_factor_code_description_4: 'Also, save these backup codes in a safe place, you can use them in case you lose access to your OTP app:'
+        two_factor:
+            emailTwoFactor_label: 'Using email (receive a code by email)'
+            googleTwoFactor_label: 'Using an OTP app (open the app, like Google Authenticator, Authy or FreeOTP, to get a one time code)'
+            table_method: Method
+            table_state: State
+            table_action: Action
+            state_enabled: Enabled
+            state_disabled: Disabled
+            action_email: Use email
+            action_app: Use OTP App
         delete:
             title: Delete my account (a.k.a danger zone)
             description: If you remove your account, ALL your articles, ALL your tags, ALL your annotations and your account will be PERMANENTLY removed (it can't be UNDONE). You'll then be logged out.
@@ -165,6 +169,15 @@ config:
                 and: 'One rule AND another'
                 matches: 'Tests that a <i>subject</i> matches a <i>search</i> (case-insensitive).<br />Example: <code>title matches "football"</code>'
                 notmatches: 'Tests that a <i>subject</i> doesn''t match match a <i>search</i> (case-insensitive).<br />Example: <code>title notmatches "football"</code>'
+    otp:
+        page_title: Two-factor authentication
+        app:
+            two_factor_code_description_1: You just enabled the OTP two factor authentication, open your OTP app and use that code to get a one time password. It'll disapear after a page reload.
+            two_factor_code_description_2: 'You can scan that QR Code with your app:'
+            two_factor_code_description_3: 'Also, save these backup codes in a safe place, you can use them in case you lose access to your OTP app:'
+            two_factor_code_description_4: 'Test an OTP code from your configured app:'
+            cancel: Cancel
+            enable: Enable
 
 entry:
     default_title: 'Title of the entry'
@@ -584,6 +597,7 @@ flashes:
             tags_reset: Tags reset
             entries_reset: Entries reset
             archived_reset: Archived entries deleted
+            otp_enabled: Two-factor authentication enabled
     entry:
         notice:
             entry_already_saved: 'Entry already saved on %date%'

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.en.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.en.yml
@@ -99,11 +99,14 @@ config:
             all: 'All'
         rss_limit: 'Number of items in the feed'
     form_user:
-        two_factor_description: "Enabling two factor authentication means you'll receive an email with a code OR need to use an OTP app (like Google Authenticator) to get a one time code on every new untrusted connection. You can't choose both option."
+        two_factor_description: "Enabling two factor authentication means you'll receive an email with a code OR need to use an OTP app (like Google Authenticator, Authy or FreeOTP) to get a one time code on every new untrusted connection. You can't choose both option."
         name_label: 'Name'
         email_label: 'Email'
         emailTwoFactor_label: 'Using email (receive a code by email)'
-        googleTwoFactor_label: 'Using an OTP app (open the app, like Google Authenticator, to get a one time code)'
+        googleTwoFactor_label: 'Using an OTP app (open the app, like Google Authenticator, Authy or FreeOTP, to get a one time code)'
+        two_factor_code_description_1: You just enabled the OTP two factor authentication, open your OTP app and use that code to get a one time password. It'll disapear after a page reload.
+        two_factor_code_description_2: 'You can scan that QR Code with your app:'
+        two_factor_code_description_3: 'Or use that code:'
         delete:
             title: Delete my account (a.k.a danger zone)
             description: If you remove your account, ALL your articles, ALL your tags, ALL your annotations and your account will be PERMANENTLY removed (it can't be UNDONE). You'll then be logged out.

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.en.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.en.yml
@@ -107,6 +107,7 @@ config:
         two_factor_code_description_1: You just enabled the OTP two factor authentication, open your OTP app and use that code to get a one time password. It'll disapear after a page reload.
         two_factor_code_description_2: 'You can scan that QR Code with your app:'
         two_factor_code_description_3: 'Or use that code:'
+        two_factor_code_description_4: 'Also, save these backup codes in a safe place, you can use them in case you lose access to your OTP app:'
         delete:
             title: Delete my account (a.k.a danger zone)
             description: If you remove your account, ALL your articles, ALL your tags, ALL your annotations and your account will be PERMANENTLY removed (it can't be UNDONE). You'll then be logged out.

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.en.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.en.yml
@@ -99,11 +99,11 @@ config:
             all: 'All'
         rss_limit: 'Number of items in the feed'
     form_user:
-        two_factor_description: "Enabling two factor authentication means you'll receive an email with a code on every new untrusted connection."
+        two_factor_description: "Enabling two factor authentication means you'll receive an email with a code OR need to use an OTP app (like Google Authenticator) to get a one time code on every new untrusted connection. You can't choose both option."
         name_label: 'Name'
         email_label: 'Email'
-        twoFactorAuthentication_label: 'Two factor authentication'
-        help_twoFactorAuthentication: "If you enable 2FA, each time you want to login to wallabag, you'll receive a code by email."
+        emailTwoFactor_label: 'Using email (receive a code by email)'
+        googleTwoFactor_label: 'Using an OTP app (open the app, like Google Authenticator, to get a one time code)'
         delete:
             title: Delete my account (a.k.a danger zone)
             description: If you remove your account, ALL your articles, ALL your tags, ALL your annotations and your account will be PERMANENTLY removed (it can't be UNDONE). You'll then be logged out.
@@ -533,7 +533,8 @@ user:
         email_label: 'Email'
         enabled_label: 'Enabled'
         last_login_label: 'Last login'
-        twofactor_label: Two factor authentication
+        twofactor_email_label: Two factor authentication by email
+        twofactor_google_label: Two factor authentication by Google
         save: Save
         delete: Delete
         delete_confirm: Are you sure?

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.es.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.es.yml
@@ -99,11 +99,11 @@ config:
             # all: 'All'
         rss_limit: 'Límite de artículos en feed RSS'
     form_user:
-        two_factor_description: "Con la autenticación en dos pasos recibirá código por e-mail en cada nueva conexión que no sea de confianza."
+        # two_factor_description: "Enabling two factor authentication means you'll receive an email with a code OR need to use an OTP app (like Google Authenticator) to get a one time code on every new untrusted connection. You can't choose both option."
         name_label: 'Nombre'
         email_label: 'Dirección de e-mail'
-        twoFactorAuthentication_label: 'Autenticación en dos pasos'
-        help_twoFactorAuthentication: "Si activas la autenticación en dos pasos, cada vez que quieras iniciar sesión en wallabag recibirás un código por e-mail."
+        # emailTwoFactor_label: 'Using email (receive a code by email)'
+        # googleTwoFactor_label: 'Using an OTP app (open the app, like Google Authenticator, to get a one time code)'
         delete:
             title: Eliminar mi cuenta (Zona peligrosa)
             description: Si eliminas tu cuenta, TODOS tus artículos, TODAS tus etiquetas, TODAS tus anotaciones y tu cuenta serán eliminadas de forma PERMANENTE (no se puede deshacer). Después serás desconectado.
@@ -533,7 +533,8 @@ user:
         email_label: 'E-mail'
         enabled_label: 'Activado'
         last_login_label: 'Último inicio de sesión'
-        twofactor_label: Autenticación en dos pasos
+        # twofactor_email_label: Two factor authentication by email
+        # twofactor_google_label: Two factor authentication by Google
         save: Guardar
         delete: Eliminar
         delete_confirm: ¿Estás seguro?

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.es.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.es.yml
@@ -59,6 +59,7 @@ config:
         password: 'Contraseña'
         rules: 'Reglas de etiquetado automáticas'
         new_user: 'Añadir un usuario'
+        reset: 'Reiniciar mi cuenta'
     form:
         save: 'Guardar'
     form_settings:

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.es.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.es.yml
@@ -107,6 +107,7 @@ config:
         # two_factor_code_description_1: You just enabled the OTP two factor authentication, open your OTP app and use that code to get a one time password. It'll disapear after a page reload.
         # two_factor_code_description_2: 'You can scan that QR Code with your app:'
         # two_factor_code_description_3: 'Or use that code:'
+        # two_factor_code_description_4: 'Also, save these backup codes in a safe place, you can use them in case you lose access to your OTP app:'
         delete:
             title: Eliminar mi cuenta (Zona peligrosa)
             description: Si eliminas tu cuenta, TODOS tus artículos, TODAS tus etiquetas, TODAS tus anotaciones y tu cuenta serán eliminadas de forma PERMANENTE (no se puede deshacer). Después serás desconectado.

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.es.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.es.yml
@@ -538,7 +538,7 @@ user:
         enabled_label: 'Activado'
         last_login_label: 'Último inicio de sesión'
         # twofactor_email_label: Two factor authentication by email
-        # twofactor_google_label: Two factor authentication by Google
+        # twofactor_google_label: Two factor authentication by OTP app
         save: Guardar
         delete: Eliminar
         delete_confirm: ¿Estás seguro?

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.es.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.es.yml
@@ -99,11 +99,14 @@ config:
             # all: 'All'
         rss_limit: 'Límite de artículos en feed RSS'
     form_user:
-        # two_factor_description: "Enabling two factor authentication means you'll receive an email with a code OR need to use an OTP app (like Google Authenticator) to get a one time code on every new untrusted connection. You can't choose both option."
+        # two_factor_description: "Enabling two factor authentication means you'll receive an email with a code OR need to use an OTP app (like Google Authenticator, Authy or FreeOTP) to get a one time code on every new untrusted connection. You can't choose both option."
         name_label: 'Nombre'
         email_label: 'Dirección de e-mail'
         # emailTwoFactor_label: 'Using email (receive a code by email)'
-        # googleTwoFactor_label: 'Using an OTP app (open the app, like Google Authenticator, to get a one time code)'
+        # googleTwoFactor_label: 'Using an OTP app (open the app, like Google Authenticator, Authy or FreeOTP, to get a one time code)'
+        # two_factor_code_description_1: You just enabled the OTP two factor authentication, open your OTP app and use that code to get a one time password. It'll disapear after a page reload.
+        # two_factor_code_description_2: 'You can scan that QR Code with your app:'
+        # two_factor_code_description_3: 'Or use that code:'
         delete:
             title: Eliminar mi cuenta (Zona peligrosa)
             description: Si eliminas tu cuenta, TODOS tus artículos, TODAS tus etiquetas, TODAS tus anotaciones y tu cuenta serán eliminadas de forma PERMANENTE (no se puede deshacer). Después serás desconectado.

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.es.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.es.yml
@@ -102,12 +102,16 @@ config:
         # two_factor_description: "Enabling two factor authentication means you'll receive an email with a code OR need to use an OTP app (like Google Authenticator, Authy or FreeOTP) to get a one time code on every new untrusted connection. You can't choose both option."
         name_label: 'Nombre'
         email_label: 'Dirección de e-mail'
-        # emailTwoFactor_label: 'Using email (receive a code by email)'
-        # googleTwoFactor_label: 'Using an OTP app (open the app, like Google Authenticator, Authy or FreeOTP, to get a one time code)'
-        # two_factor_code_description_1: You just enabled the OTP two factor authentication, open your OTP app and use that code to get a one time password. It'll disapear after a page reload.
-        # two_factor_code_description_2: 'You can scan that QR Code with your app:'
-        # two_factor_code_description_3: 'Or use that code:'
-        # two_factor_code_description_4: 'Also, save these backup codes in a safe place, you can use them in case you lose access to your OTP app:'
+        two_factor:
+            # emailTwoFactor_label: 'Using email (receive a code by email)'
+            # googleTwoFactor_label: 'Using an OTP app (open the app, like Google Authenticator, Authy or FreeOTP, to get a one time code)'
+            # table_method: Method
+            # table_state: State
+            # table_action: Action
+            # state_enabled: Enabled
+            # state_disabled: Disabled
+            # action_email: Use email
+            # action_app: Use OTP App
         delete:
             title: Eliminar mi cuenta (Zona peligrosa)
             description: Si eliminas tu cuenta, TODOS tus artículos, TODAS tus etiquetas, TODAS tus anotaciones y tu cuenta serán eliminadas de forma PERMANENTE (no se puede deshacer). Después serás desconectado.
@@ -165,6 +169,15 @@ config:
                 and: 'Una regla Y la otra'
                 matches: 'Prueba si un <i>sujeto</i> corresponde a una <i>búsqueda</i> (insensible a mayusculas).<br />Ejemplo : <code>title matches "fútbol"</code>'
                 # notmatches: 'Tests that a <i>subject</i> doesn''t match match a <i>search</i> (case-insensitive).<br />Example: <code>title notmatches "football"</code>'
+    otp:
+        # page_title: Two-factor authentication
+        # app:
+        #     two_factor_code_description_1: You just enabled the OTP two factor authentication, open your OTP app and use that code to get a one time password. It'll disapear after a page reload.
+        #     two_factor_code_description_2: 'You can scan that QR Code with your app:'
+        #     two_factor_code_description_3: 'Also, save these backup codes in a safe place, you can use them in case you lose access to your OTP app:'
+        #     two_factor_code_description_4: 'Test an OTP code from your configured app:'
+        #     cancel: Cancel
+        #     enable: Enable
 
 entry:
     default_title: 'Título del artículo'

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.fa.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.fa.yml
@@ -102,12 +102,16 @@ config:
         # two_factor_description: "Enabling two factor authentication means you'll receive an email with a code OR need to use an OTP app (like Google Authenticator, Authy or FreeOTP) to get a one time code on every new untrusted connection. You can't choose both option."
         name_label: 'نام'
         email_label: 'نشانی ایمیل'
-        # emailTwoFactor_label: 'Using email (receive a code by email)'
-        # googleTwoFactor_label: 'Using an OTP app (open the app, like Google Authenticator, Authy or FreeOTP, to get a one time code)'
-        # two_factor_code_description_1: You just enabled the OTP two factor authentication, open your OTP app and use that code to get a one time password. It'll disapear after a page reload.
-        # two_factor_code_description_2: 'You can scan that QR Code with your app:'
-        # two_factor_code_description_3: 'Or use that code:'
-        # two_factor_code_description_4: 'Also, save these backup codes in a safe place, you can use them in case you lose access to your OTP app:'
+        two_factor:
+            # emailTwoFactor_label: 'Using email (receive a code by email)'
+            # googleTwoFactor_label: 'Using an OTP app (open the app, like Google Authenticator, Authy or FreeOTP, to get a one time code)'
+            # table_method: Method
+            # table_state: State
+            # table_action: Action
+            # state_enabled: Enabled
+            # state_disabled: Disabled
+            # action_email: Use email
+            # action_app: Use OTP App
         delete:
             # title: Delete my account (a.k.a danger zone)
             # description: If you remove your account, ALL your articles, ALL your tags, ALL your annotations and your account will be PERMANENTLY removed (it can't be UNDONE). You'll then be logged out.
@@ -165,6 +169,15 @@ config:
         #         and: 'One rule AND another'
         #         matches: 'Tests that a <i>subject</i> matches a <i>search</i> (case-insensitive).<br />Example: <code>title matches "football"</code>'
         #         notmatches: 'Tests that a <i>subject</i> doesn''t match match a <i>search</i> (case-insensitive).<br />Example: <code>title notmatches "football"</code>'
+    otp:
+        # page_title: Two-factor authentication
+        # app:
+        #     two_factor_code_description_1: You just enabled the OTP two factor authentication, open your OTP app and use that code to get a one time password. It'll disapear after a page reload.
+        #     two_factor_code_description_2: 'You can scan that QR Code with your app:'
+        #     two_factor_code_description_3: 'Also, save these backup codes in a safe place, you can use them in case you lose access to your OTP app:'
+        #     two_factor_code_description_4: 'Test an OTP code from your configured app:'
+        #     cancel: Cancel
+        #     enable: Enable
 
 entry:
     # default_title: 'Title of the entry'

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.fa.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.fa.yml
@@ -107,6 +107,7 @@ config:
         # two_factor_code_description_1: You just enabled the OTP two factor authentication, open your OTP app and use that code to get a one time password. It'll disapear after a page reload.
         # two_factor_code_description_2: 'You can scan that QR Code with your app:'
         # two_factor_code_description_3: 'Or use that code:'
+        # two_factor_code_description_4: 'Also, save these backup codes in a safe place, you can use them in case you lose access to your OTP app:'
         delete:
             # title: Delete my account (a.k.a danger zone)
             # description: If you remove your account, ALL your articles, ALL your tags, ALL your annotations and your account will be PERMANENTLY removed (it can't be UNDONE). You'll then be logged out.

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.fa.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.fa.yml
@@ -99,11 +99,11 @@ config:
             # all: 'All'
         rss_limit: 'محدودیت آر-اس-اس'
     form_user:
-        two_factor_description: "با فعال‌کردن تأیید ۲مرحله‌ای هر بار که اتصال تأییدنشده‌ای برقرار شد، به شما یک کد از راه ایمیل فرستاده می‌شود"
+        # two_factor_description: "Enabling two factor authentication means you'll receive an email with a code OR need to use an OTP app (like Google Authenticator) to get a one time code on every new untrusted connection. You can't choose both option."
         name_label: 'نام'
         email_label: 'نشانی ایمیل'
-        twoFactorAuthentication_label: 'تأیید ۲مرحله‌ای'
-        # help_twoFactorAuthentication: "If you enable 2FA, each time you want to login to wallabag, you'll receive a code by email."
+        # emailTwoFactor_label: 'Using email (receive a code by email)'
+        # googleTwoFactor_label: 'Using an OTP app (open the app, like Google Authenticator, to get a one time code)'
         delete:
             # title: Delete my account (a.k.a danger zone)
             # description: If you remove your account, ALL your articles, ALL your tags, ALL your annotations and your account will be PERMANENTLY removed (it can't be UNDONE). You'll then be logged out.
@@ -533,7 +533,8 @@ user:
         email_label: 'نشانی ایمیل'
         # enabled_label: 'Enabled'
         # last_login_label: 'Last login'
-        # twofactor_label: Two factor authentication
+        # twofactor_email_label: Two factor authentication by email
+        # twofactor_google_label: Two factor authentication by Google
         # save: Save
         # delete: Delete
         # delete_confirm: Are you sure?

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.fa.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.fa.yml
@@ -59,6 +59,7 @@ config:
         password: 'رمز'
         rules: 'برچسب‌گذاری خودکار'
         new_user: 'افزودن کاربر'
+        # reset: 'Reset area'
     form:
         save: 'ذخیره'
     form_settings:

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.fa.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.fa.yml
@@ -538,7 +538,7 @@ user:
         # enabled_label: 'Enabled'
         # last_login_label: 'Last login'
         # twofactor_email_label: Two factor authentication by email
-        # twofactor_google_label: Two factor authentication by Google
+        # twofactor_google_label: Two factor authentication by OTP app
         # save: Save
         # delete: Delete
         # delete_confirm: Are you sure?

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.fa.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.fa.yml
@@ -99,11 +99,14 @@ config:
             # all: 'All'
         rss_limit: 'محدودیت آر-اس-اس'
     form_user:
-        # two_factor_description: "Enabling two factor authentication means you'll receive an email with a code OR need to use an OTP app (like Google Authenticator) to get a one time code on every new untrusted connection. You can't choose both option."
+        # two_factor_description: "Enabling two factor authentication means you'll receive an email with a code OR need to use an OTP app (like Google Authenticator, Authy or FreeOTP) to get a one time code on every new untrusted connection. You can't choose both option."
         name_label: 'نام'
         email_label: 'نشانی ایمیل'
         # emailTwoFactor_label: 'Using email (receive a code by email)'
-        # googleTwoFactor_label: 'Using an OTP app (open the app, like Google Authenticator, to get a one time code)'
+        # googleTwoFactor_label: 'Using an OTP app (open the app, like Google Authenticator, Authy or FreeOTP, to get a one time code)'
+        # two_factor_code_description_1: You just enabled the OTP two factor authentication, open your OTP app and use that code to get a one time password. It'll disapear after a page reload.
+        # two_factor_code_description_2: 'You can scan that QR Code with your app:'
+        # two_factor_code_description_3: 'Or use that code:'
         delete:
             # title: Delete my account (a.k.a danger zone)
             # description: If you remove your account, ALL your articles, ALL your tags, ALL your annotations and your account will be PERMANENTLY removed (it can't be UNDONE). You'll then be logged out.

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.fr.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.fr.yml
@@ -59,6 +59,7 @@ config:
         password: "Mot de passe"
         rules: "Règles de tag automatiques"
         new_user: "Créer un compte"
+        reset: "Réinitialisation"
     form:
         save: "Enregistrer"
     form_settings:

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.fr.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.fr.yml
@@ -99,11 +99,14 @@ config:
             all: "Tous"
         rss_limit: "Nombre d’articles dans le flux"
     form_user:
-        two_factor_description: "Activer l’authentification double-facteur veut dire que vous allez recevoir un code par courriel OU que vous devriez utiliser une application de mot de passe à usage unique (comme Google Authenticator) pour obtenir un code temporaire à chaque nouvelle connexion non approuvée. Vous ne pouvez pas choisir les deux options."
+        two_factor_description: "Activer l’authentification double-facteur veut dire que vous allez recevoir un code par courriel OU que vous devriez utiliser une application de mot de passe à usage unique (comme Google Authenticator, Authy or FreeOTP) pour obtenir un code temporaire à chaque nouvelle connexion non approuvée. Vous ne pouvez pas choisir les deux options."
         name_label: "Nom"
         email_label: "Adresse courriel"
         emailTwoFactor_label: 'En utlisant l’email (recevez un code par email)'
-        googleTwoFactor_label: 'En utilisant une application de mot de passe à usage unique (ouvrez l’app, comme Google Authenticator, pour obtenir un mot de passe à usage unique)'
+        googleTwoFactor_label: 'En utilisant une application de mot de passe à usage unique (ouvrez l’app, comme Google Authenticator, Authy or FreeOTP, pour obtenir un mot de passe à usage unique)'
+        two_factor_code_description_1: Vous venez d’activer l’authentification double-facteur, ouvrez votre application OTP pour configurer la génération du mot de passe à usage unique. Ces informations disparaîtront après un rechargement de la page.
+        two_factor_code_description_2: 'Vous pouvez scanner le QR code avec votre application :'
+        two_factor_code_description_3: 'Ou utiliser le code suivant :'
         delete:
             title: "Supprimer mon compte (attention danger !)"
             description: "Si vous confirmez la suppression de votre compte, TOUS les articles, TOUS les tags, TOUTES les annotations et votre compte seront DÉFINITIVEMENT supprimé (c’est IRRÉVERSIBLE). Vous serez ensuite déconnecté."

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.fr.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.fr.yml
@@ -102,12 +102,16 @@ config:
         two_factor_description: "Activer l’authentification double-facteur veut dire que vous allez recevoir un code par courriel OU que vous devriez utiliser une application de mot de passe à usage unique (comme Google Authenticator, Authy or FreeOTP) pour obtenir un code temporaire à chaque nouvelle connexion non approuvée. Vous ne pouvez pas choisir les deux options."
         name_label: "Nom"
         email_label: "Adresse courriel"
-        emailTwoFactor_label: 'En utlisant l’email (recevez un code par email)'
-        googleTwoFactor_label: 'En utilisant une application de mot de passe à usage unique (ouvrez l’app, comme Google Authenticator, Authy or FreeOTP, pour obtenir un mot de passe à usage unique)'
-        two_factor_code_description_1: Vous venez d’activer l’authentification double-facteur, ouvrez votre application OTP pour configurer la génération du mot de passe à usage unique. Ces informations disparaîtront après un rechargement de la page.
-        two_factor_code_description_2: 'Vous pouvez scanner le QR code avec votre application :'
-        two_factor_code_description_3: 'Ou utiliser le code suivant :'
-        two_factor_code_description_4: 'N’oubliez pas de sauvegarder ces codes de secours dans un endroit sûr, vous pourrez les utiliser si vous ne pouvez plus accéder à votre application OTP :'
+        two_factor:
+            emailTwoFactor_label: 'En utlisant l’email (recevez un code par email)'
+            googleTwoFactor_label: 'En utilisant une application de mot de passe à usage unique (ouvrez l’app, comme Google Authenticator, Authy or FreeOTP, pour obtenir un mot de passe à usage unique)'
+            table_method: Méthode
+            table_state: État
+            table_action: Action
+            state_enabled: Activé
+            state_disabled: Désactivé
+            action_email: Utiliser l'email
+            action_app: Utiliser une app OTP
         delete:
             title: "Supprimer mon compte (attention danger !)"
             description: "Si vous confirmez la suppression de votre compte, TOUS les articles, TOUS les tags, TOUTES les annotations et votre compte seront DÉFINITIVEMENT supprimé (c’est IRRÉVERSIBLE). Vous serez ensuite déconnecté."
@@ -165,6 +169,15 @@ config:
                 and: "Une règle ET l’autre"
                 matches: "Teste si un <i>sujet</i> correspond à une <i>recherche</i> (non sensible à la casse).<br />Exemple : <code>title matches \"football\"</code>"
                 notmatches: "Teste si un <i>sujet</i> ne correspond pas à une <i>recherche</i> (non sensible à la casse).<br />Exemple : <code>title notmatches \"football\"</code>"
+    otp:
+        page_title: Authentification double-facteur
+        app:
+            two_factor_code_description_1: Vous venez d’activer l’authentification double-facteur, ouvrez votre application OTP pour configurer la génération du mot de passe à usage unique. Ces informations disparaîtront après un rechargement de la page.
+            two_factor_code_description_2: 'Vous pouvez scanner le QR code avec votre application :'
+            two_factor_code_description_3: 'N’oubliez pas de sauvegarder ces codes de secours dans un endroit sûr, vous pourrez les utiliser si vous ne pouvez plus accéder à votre application OTP :'
+            two_factor_code_description_4: 'Testez un code généré par votre application OTP :'
+            cancel: Annuler
+            enable: Activer
 
 entry:
     default_title: "Titre de l’article"
@@ -585,6 +598,7 @@ flashes:
             tags_reset: "Tags supprimés"
             entries_reset: "Articles supprimés"
             archived_reset: "Articles archivés supprimés"
+            otp_enabled: "Authentification à double-facteur activée"
     entry:
         notice:
             entry_already_saved: "Article déjà sauvegardé le %date%"

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.fr.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.fr.yml
@@ -539,7 +539,7 @@ user:
         last_login_label: "Dernière connexion"
         twofactor_label: "Double authentification"
         twofactor_email_label: Double authentification par email
-        twofactor_google_label: Double authentification par Google
+        twofactor_google_label: Double authentification par OTP app
         save: "Sauvegarder"
         delete: "Supprimer"
         delete_confirm: "Êtes-vous sûr ?"

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.fr.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.fr.yml
@@ -107,6 +107,7 @@ config:
         two_factor_code_description_1: Vous venez d’activer l’authentification double-facteur, ouvrez votre application OTP pour configurer la génération du mot de passe à usage unique. Ces informations disparaîtront après un rechargement de la page.
         two_factor_code_description_2: 'Vous pouvez scanner le QR code avec votre application :'
         two_factor_code_description_3: 'Ou utiliser le code suivant :'
+        two_factor_code_description_4: 'N’oubliez pas de sauvegarder ces codes de secours dans un endroit sûr, vous pourrez les utiliser si vous ne pouvez plus accéder à votre application OTP :'
         delete:
             title: "Supprimer mon compte (attention danger !)"
             description: "Si vous confirmez la suppression de votre compte, TOUS les articles, TOUS les tags, TOUTES les annotations et votre compte seront DÉFINITIVEMENT supprimé (c’est IRRÉVERSIBLE). Vous serez ensuite déconnecté."

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.fr.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.fr.yml
@@ -99,11 +99,11 @@ config:
             all: "Tous"
         rss_limit: "Nombre d’articles dans le flux"
     form_user:
-        two_factor_description: "Activer l’authentification double-facteur veut dire que vous allez recevoir un code par courriel à chaque nouvelle connexion non approuvée."
+        two_factor_description: "Activer l’authentification double-facteur veut dire que vous allez recevoir un code par courriel OU que vous devriez utiliser une application de mot de passe à usage unique (comme Google Authenticator) pour obtenir un code temporaire à chaque nouvelle connexion non approuvée. Vous ne pouvez pas choisir les deux options."
         name_label: "Nom"
         email_label: "Adresse courriel"
-        twoFactorAuthentication_label: "Double authentification"
-        help_twoFactorAuthentication: "Si vous activez 2FA, à chaque tentative de connexion à wallabag, vous recevrez un code par email."
+        emailTwoFactor_label: 'En utlisant l’email (recevez un code par email)'
+        googleTwoFactor_label: 'En utilisant une application de mot de passe à usage unique (ouvrez l’app, comme Google Authenticator, pour obtenir un mot de passe à usage unique)'
         delete:
             title: "Supprimer mon compte (attention danger !)"
             description: "Si vous confirmez la suppression de votre compte, TOUS les articles, TOUS les tags, TOUTES les annotations et votre compte seront DÉFINITIVEMENT supprimé (c’est IRRÉVERSIBLE). Vous serez ensuite déconnecté."
@@ -534,6 +534,8 @@ user:
         enabled_label: "Activé"
         last_login_label: "Dernière connexion"
         twofactor_label: "Double authentification"
+        twofactor_email_label: Double authentification par email
+        twofactor_google_label: Double authentification par Google
         save: "Sauvegarder"
         delete: "Supprimer"
         delete_confirm: "Êtes-vous sûr ?"

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.it.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.it.yml
@@ -107,6 +107,7 @@ config:
         # two_factor_code_description_1: You just enabled the OTP two factor authentication, open your OTP app and use that code to get a one time password. It'll disapear after a page reload.
         # two_factor_code_description_2: 'You can scan that QR Code with your app:'
         # two_factor_code_description_3: 'Or use that code:'
+        # two_factor_code_description_4: 'Also, save these backup codes in a safe place, you can use them in case you lose access to your OTP app:'
         delete:
             title: Cancella il mio account (zona pericolosa)
             description: Rimuovendo il tuo account, TUTTI i tuoi articoli, TUTTE le tue etichette, TUTTE le tue annotazioni ed il tuo account verranno rimossi PERMANENTEMENTE (impossibile da ANNULLARE). Verrai poi disconnesso.

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.it.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.it.yml
@@ -102,12 +102,15 @@ config:
         # two_factor_description: "Enabling two factor authentication means you'll receive an email with a code OR need to use an OTP app (like Google Authenticator, Authy or FreeOTP) to get a one time code on every new untrusted connection. You can't choose both option."
         name_label: 'Nome'
         email_label: 'E-mail'
-        # emailTwoFactor_label: 'Using email (receive a code by email)'
-        # googleTwoFactor_label: 'Using an OTP app (open the app, like Google Authenticator, Authy or FreeOTP, to get a one time code)'
-        # two_factor_code_description_1: You just enabled the OTP two factor authentication, open your OTP app and use that code to get a one time password. It'll disapear after a page reload.
-        # two_factor_code_description_2: 'You can scan that QR Code with your app:'
-        # two_factor_code_description_3: 'Or use that code:'
-        # two_factor_code_description_4: 'Also, save these backup codes in a safe place, you can use them in case you lose access to your OTP app:'
+            # emailTwoFactor_label: 'Using email (receive a code by email)'
+            # googleTwoFactor_label: 'Using an OTP app (open the app, like Google Authenticator, Authy or FreeOTP, to get a one time code)'
+            # table_method: Method
+            # table_state: State
+            # table_action: Action
+            # state_enabled: Enabled
+            # state_disabled: Disabled
+            # action_email: Use email
+            # action_app: Use OTP App
         delete:
             title: Cancella il mio account (zona pericolosa)
             description: Rimuovendo il tuo account, TUTTI i tuoi articoli, TUTTE le tue etichette, TUTTE le tue annotazioni ed il tuo account verranno rimossi PERMANENTEMENTE (impossibile da ANNULLARE). Verrai poi disconnesso.
@@ -165,6 +168,15 @@ config:
                 and: "Una regola E un'altra"
                 matches: 'Verifica che un <i>oggetto</i> risulti in una <i>ricerca</i> (case-insensitive).<br />Esempio: <code>titolo contiene "football"</code>'
                 # notmatches: 'Tests that a <i>subject</i> doesn''t match match a <i>search</i> (case-insensitive).<br />Example: <code>title notmatches "football"</code>'
+    otp:
+        # page_title: Two-factor authentication
+        # app:
+        #     two_factor_code_description_1: You just enabled the OTP two factor authentication, open your OTP app and use that code to get a one time password. It'll disapear after a page reload.
+        #     two_factor_code_description_2: 'You can scan that QR Code with your app:'
+        #     two_factor_code_description_3: 'Also, save these backup codes in a safe place, you can use them in case you lose access to your OTP app:'
+        #     two_factor_code_description_4: 'Test an OTP code from your configured app:'
+        #     cancel: Cancel
+        #     enable: Enable
 
 entry:
     default_title: "Titolo del contenuto"

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.it.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.it.yml
@@ -99,11 +99,11 @@ config:
             # all: 'All'
         rss_limit: 'Numero di elementi nel feed'
     form_user:
-        two_factor_description: "Abilitando l'autenticazione a due fattori riceverai una e-mail con un codice per ogni nuova connesione non verificata"
+        # two_factor_description: "Enabling two factor authentication means you'll receive an email with a code OR need to use an OTP app (like Google Authenticator) to get a one time code on every new untrusted connection. You can't choose both option."
         name_label: 'Nome'
         email_label: 'E-mail'
-        twoFactorAuthentication_label: 'Autenticazione a due fattori'
-        help_twoFactorAuthentication: "Se abiliti l'autenticazione a due fattori, ogni volta che vorrai connetterti a wallabag, riceverai un codice via E-mail."
+        # emailTwoFactor_label: 'Using email (receive a code by email)'
+        # googleTwoFactor_label: 'Using an OTP app (open the app, like Google Authenticator, to get a one time code)'
         delete:
             title: Cancella il mio account (zona pericolosa)
             description: Rimuovendo il tuo account, TUTTI i tuoi articoli, TUTTE le tue etichette, TUTTE le tue annotazioni ed il tuo account verranno rimossi PERMANENTEMENTE (impossibile da ANNULLARE). Verrai poi disconnesso.
@@ -533,7 +533,8 @@ user:
         email_label: 'E-mail'
         enabled_label: 'Abilitato'
         last_login_label: 'Ultima connessione'
-        twofactor_label: Autenticazione a due fattori
+        # twofactor_email_label: Two factor authentication by email
+        # twofactor_google_label: Two factor authentication by Google
         save: Salva
         delete: Cancella
         delete_confirm: Sei sicuro?

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.it.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.it.yml
@@ -99,11 +99,14 @@ config:
             # all: 'All'
         rss_limit: 'Numero di elementi nel feed'
     form_user:
-        # two_factor_description: "Enabling two factor authentication means you'll receive an email with a code OR need to use an OTP app (like Google Authenticator) to get a one time code on every new untrusted connection. You can't choose both option."
+        # two_factor_description: "Enabling two factor authentication means you'll receive an email with a code OR need to use an OTP app (like Google Authenticator, Authy or FreeOTP) to get a one time code on every new untrusted connection. You can't choose both option."
         name_label: 'Nome'
         email_label: 'E-mail'
         # emailTwoFactor_label: 'Using email (receive a code by email)'
-        # googleTwoFactor_label: 'Using an OTP app (open the app, like Google Authenticator, to get a one time code)'
+        # googleTwoFactor_label: 'Using an OTP app (open the app, like Google Authenticator, Authy or FreeOTP, to get a one time code)'
+        # two_factor_code_description_1: You just enabled the OTP two factor authentication, open your OTP app and use that code to get a one time password. It'll disapear after a page reload.
+        # two_factor_code_description_2: 'You can scan that QR Code with your app:'
+        # two_factor_code_description_3: 'Or use that code:'
         delete:
             title: Cancella il mio account (zona pericolosa)
             description: Rimuovendo il tuo account, TUTTI i tuoi articoli, TUTTE le tue etichette, TUTTE le tue annotazioni ed il tuo account verranno rimossi PERMANENTEMENTE (impossibile da ANNULLARE). Verrai poi disconnesso.

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.it.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.it.yml
@@ -538,7 +538,7 @@ user:
         enabled_label: 'Abilitato'
         last_login_label: 'Ultima connessione'
         # twofactor_email_label: Two factor authentication by email
-        # twofactor_google_label: Two factor authentication by Google
+        # twofactor_google_label: Two factor authentication by OTP app
         save: Salva
         delete: Cancella
         delete_confirm: Sei sicuro?

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.it.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.it.yml
@@ -59,6 +59,7 @@ config:
         password: 'Password'
         rules: 'Regole di etichettatura'
         new_user: 'Aggiungi utente'
+        reset: 'Area di reset'
     form:
         save: 'Salva'
     form_settings:

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.oc.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.oc.yml
@@ -99,11 +99,14 @@ config:
             all: 'Totes'
         rss_limit: "Nombre d'articles dins un flux RSS"
     form_user:
-        # two_factor_description: "Enabling two factor authentication means you'll receive an email with a code OR need to use an OTP app (like Google Authenticator) to get a one time code on every new untrusted connection. You can't choose both option."
+        # two_factor_description: "Enabling two factor authentication means you'll receive an email with a code OR need to use an OTP app (like Google Authenticator, Authy or FreeOTP) to get a one time code on every new untrusted connection. You can't choose both option."
         name_label: 'Nom'
         email_label: 'Adreça de corrièl'
         # emailTwoFactor_label: 'Using email (receive a code by email)'
-        # googleTwoFactor_label: 'Using an OTP app (open the app, like Google Authenticator, to get a one time code)'
+        # googleTwoFactor_label: 'Using an OTP app (open the app, like Google Authenticator, Authy or FreeOTP, to get a one time code)'
+        # two_factor_code_description_1: You just enabled the OTP two factor authentication, open your OTP app and use that code to get a one time password. It'll disapear after a page reload.
+        # two_factor_code_description_2: 'You can scan that QR Code with your app:'
+        # two_factor_code_description_3: 'Or use that code:'
         delete:
             title: Suprimir mon compte (Mèfi zòna perilhosa)
             description: Se confirmatz la supression de vòstre compte, TOTES vòstres articles, TOTAS vòstras etiquetas, TOTAS vòstras anotacions e vòstre compte seràn suprimits per totjorn. E aquò es IRREVERSIBLE. Puèi seretz desconnectat.

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.oc.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.oc.yml
@@ -99,11 +99,11 @@ config:
             all: 'Totes'
         rss_limit: "Nombre d'articles dins un flux RSS"
     form_user:
-        two_factor_description: "Activar l'autentificacion en dos temps vòl dire que recebretz un còdi per corrièl per cada novèla connexion pas aprovada."
+        # two_factor_description: "Enabling two factor authentication means you'll receive an email with a code OR need to use an OTP app (like Google Authenticator) to get a one time code on every new untrusted connection. You can't choose both option."
         name_label: 'Nom'
         email_label: 'Adreça de corrièl'
-        twoFactorAuthentication_label: 'Dobla autentificacion'
-        help_twoFactorAuthentication: "S'avètz activat l'autentificacion en dos temps, cada còp que volètz vos connectar a wallabag, recebretz un còdi per corrièl."
+        # emailTwoFactor_label: 'Using email (receive a code by email)'
+        # googleTwoFactor_label: 'Using an OTP app (open the app, like Google Authenticator, to get a one time code)'
         delete:
             title: Suprimir mon compte (Mèfi zòna perilhosa)
             description: Se confirmatz la supression de vòstre compte, TOTES vòstres articles, TOTAS vòstras etiquetas, TOTAS vòstras anotacions e vòstre compte seràn suprimits per totjorn. E aquò es IRREVERSIBLE. Puèi seretz desconnectat.
@@ -533,7 +533,8 @@ user:
         email_label: 'Adreça de corrièl'
         enabled_label: 'Actiu'
         last_login_label: 'Darrièra connexion'
-        twofactor_label: 'Autentificacion doble-factor'
+        # twofactor_email_label: Two factor authentication by email
+        # twofactor_google_label: Two factor authentication by Google
         save: 'Enregistrar'
         delete: 'Suprimir'
         delete_confirm: 'Sètz segur ?'

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.oc.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.oc.yml
@@ -107,6 +107,7 @@ config:
         # two_factor_code_description_1: You just enabled the OTP two factor authentication, open your OTP app and use that code to get a one time password. It'll disapear after a page reload.
         # two_factor_code_description_2: 'You can scan that QR Code with your app:'
         # two_factor_code_description_3: 'Or use that code:'
+        # two_factor_code_description_4: 'Also, save these backup codes in a safe place, you can use them in case you lose access to your OTP app:'
         delete:
             title: Suprimir mon compte (Mèfi zòna perilhosa)
             description: Se confirmatz la supression de vòstre compte, TOTES vòstres articles, TOTAS vòstras etiquetas, TOTAS vòstras anotacions e vòstre compte seràn suprimits per totjorn. E aquò es IRREVERSIBLE. Puèi seretz desconnectat.

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.oc.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.oc.yml
@@ -102,12 +102,15 @@ config:
         # two_factor_description: "Enabling two factor authentication means you'll receive an email with a code OR need to use an OTP app (like Google Authenticator, Authy or FreeOTP) to get a one time code on every new untrusted connection. You can't choose both option."
         name_label: 'Nom'
         email_label: 'Adreça de corrièl'
-        # emailTwoFactor_label: 'Using email (receive a code by email)'
-        # googleTwoFactor_label: 'Using an OTP app (open the app, like Google Authenticator, Authy or FreeOTP, to get a one time code)'
-        # two_factor_code_description_1: You just enabled the OTP two factor authentication, open your OTP app and use that code to get a one time password. It'll disapear after a page reload.
-        # two_factor_code_description_2: 'You can scan that QR Code with your app:'
-        # two_factor_code_description_3: 'Or use that code:'
-        # two_factor_code_description_4: 'Also, save these backup codes in a safe place, you can use them in case you lose access to your OTP app:'
+            # emailTwoFactor_label: 'Using email (receive a code by email)'
+            # googleTwoFactor_label: 'Using an OTP app (open the app, like Google Authenticator, Authy or FreeOTP, to get a one time code)'
+            # table_method: Method
+            # table_state: State
+            # table_action: Action
+            # state_enabled: Enabled
+            # state_disabled: Disabled
+            # action_email: Use email
+            # action_app: Use OTP App
         delete:
             title: Suprimir mon compte (Mèfi zòna perilhosa)
             description: Se confirmatz la supression de vòstre compte, TOTES vòstres articles, TOTAS vòstras etiquetas, TOTAS vòstras anotacions e vòstre compte seràn suprimits per totjorn. E aquò es IRREVERSIBLE. Puèi seretz desconnectat.
@@ -165,6 +168,15 @@ config:
                 and: "Una règla E l'autra"
                 matches: 'Teste se un <i>subjècte</i> correspond a una <i>recèrca</i> (non sensibla a la cassa).<br />Exemple : <code>title matches \"football\"</code>'
                 notmatches: 'Teste se <i>subjècte</i> correspond pas a una <i>recèrca</i> (sensibla a la cassa).<br />Example : <code>title notmatches "football"</code>'
+    otp:
+        # page_title: Two-factor authentication
+        # app:
+        #     two_factor_code_description_1: You just enabled the OTP two factor authentication, open your OTP app and use that code to get a one time password. It'll disapear after a page reload.
+        #     two_factor_code_description_2: 'You can scan that QR Code with your app:'
+        #     two_factor_code_description_3: 'Also, save these backup codes in a safe place, you can use them in case you lose access to your OTP app:'
+        #     two_factor_code_description_4: 'Test an OTP code from your configured app:'
+        #     cancel: Cancel
+        #     enable: Enable
 
 entry:
     default_title: "Títol de l'article"

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.oc.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.oc.yml
@@ -538,7 +538,7 @@ user:
         enabled_label: 'Actiu'
         last_login_label: 'Darrièra connexion'
         # twofactor_email_label: Two factor authentication by email
-        # twofactor_google_label: Two factor authentication by Google
+        # twofactor_google_label: Two factor authentication by OTP app
         save: 'Enregistrar'
         delete: 'Suprimir'
         delete_confirm: 'Sètz segur ?'

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.oc.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.oc.yml
@@ -59,6 +59,7 @@ config:
         password: 'Senhal'
         rules: "Règlas d'etiquetas automaticas"
         new_user: 'Crear un compte'
+        reset: 'Zòna de reïnicializacion'
     form:
         save: 'Enregistrar'
     form_settings:

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.pl.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.pl.yml
@@ -59,6 +59,7 @@ config:
         password: 'Hasło'
         rules: 'Zasady tagowania'
         new_user: 'Dodaj użytkownika'
+        reset: 'Reset'
     form:
         save: 'Zapisz'
     form_settings:

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.pl.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.pl.yml
@@ -99,11 +99,11 @@ config:
             all: 'Wszystkie'
         rss_limit: 'Link do RSS'
     form_user:
-        two_factor_description: "Włączenie autoryzacji dwuetapowej oznacza, że będziesz otrzymywał maile z kodem przy każdym nowym, niezaufanym połączeniu"
+        two_factor_description: "Enabling two factor authentication means you'll receive an email with a code OR need to use an OTP app (like Google Authenticator) to get a one time code on every new untrusted connection. You can't choose both option."
         name_label: 'Nazwa'
         email_label: 'Adres email'
-        twoFactorAuthentication_label: 'Autoryzacja dwuetapowa'
-        help_twoFactorAuthentication: "Jeżeli włączysz autoryzację dwuetapową. Za każdym razem, kiedy będziesz chciał się zalogować, dostaniesz kod na swój e-mail."
+        # emailTwoFactor_label: 'Using email (receive a code by email)'
+        # googleTwoFactor_label: 'Using an OTP app (open the app, like Google Authenticator, to get a one time code)'
         delete:
             title: Usuń moje konto (niebezpieczna strefa !)
             description: Jeżeli usuniesz swoje konto, wszystkie twoje artykuły, tagi, adnotacje, oraz konto zostaną trwale usunięte (operacja jest NIEODWRACALNA). Następnie zostaniesz wylogowany.
@@ -533,7 +533,8 @@ user:
         email_label: 'Adres email'
         enabled_label: 'Włączony'
         last_login_label: 'Ostatnie logowanie'
-        twofactor_label: Autoryzacja dwuetapowa
+        # twofactor_email_label: Two factor authentication by email
+        # twofactor_google_label: Two factor authentication by Google
         save: Zapisz
         delete: Usuń
         delete_confirm: Jesteś pewien?

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.pl.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.pl.yml
@@ -107,6 +107,7 @@ config:
         # two_factor_code_description_1: You just enabled the OTP two factor authentication, open your OTP app and use that code to get a one time password. It'll disapear after a page reload.
         # two_factor_code_description_2: 'You can scan that QR Code with your app:'
         # two_factor_code_description_3: 'Or use that code:'
+        # two_factor_code_description_4: 'Also, save these backup codes in a safe place, you can use them in case you lose access to your OTP app:'
         delete:
             title: Usuń moje konto (niebezpieczna strefa !)
             description: Jeżeli usuniesz swoje konto, wszystkie twoje artykuły, tagi, adnotacje, oraz konto zostaną trwale usunięte (operacja jest NIEODWRACALNA). Następnie zostaniesz wylogowany.

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.pl.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.pl.yml
@@ -99,11 +99,14 @@ config:
             all: 'Wszystkie'
         rss_limit: 'Link do RSS'
     form_user:
-        two_factor_description: "Enabling two factor authentication means you'll receive an email with a code OR need to use an OTP app (like Google Authenticator) to get a one time code on every new untrusted connection. You can't choose both option."
+        two_factor_description: "Enabling two factor authentication means you'll receive an email with a code OR need to use an OTP app (like Google Authenticator, Authy or FreeOTP) to get a one time code on every new untrusted connection. You can't choose both option."
         name_label: 'Nazwa'
         email_label: 'Adres email'
         # emailTwoFactor_label: 'Using email (receive a code by email)'
-        # googleTwoFactor_label: 'Using an OTP app (open the app, like Google Authenticator, to get a one time code)'
+        # googleTwoFactor_label: 'Using an OTP app (open the app, like Google Authenticator, Authy or FreeOTP, to get a one time code)'
+        # two_factor_code_description_1: You just enabled the OTP two factor authentication, open your OTP app and use that code to get a one time password. It'll disapear after a page reload.
+        # two_factor_code_description_2: 'You can scan that QR Code with your app:'
+        # two_factor_code_description_3: 'Or use that code:'
         delete:
             title: Usuń moje konto (niebezpieczna strefa !)
             description: Jeżeli usuniesz swoje konto, wszystkie twoje artykuły, tagi, adnotacje, oraz konto zostaną trwale usunięte (operacja jest NIEODWRACALNA). Następnie zostaniesz wylogowany.

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.pl.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.pl.yml
@@ -538,7 +538,7 @@ user:
         enabled_label: 'Włączony'
         last_login_label: 'Ostatnie logowanie'
         # twofactor_email_label: Two factor authentication by email
-        # twofactor_google_label: Two factor authentication by Google
+        # twofactor_google_label: Two factor authentication by OTP app
         save: Zapisz
         delete: Usuń
         delete_confirm: Jesteś pewien?

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.pl.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.pl.yml
@@ -99,15 +99,18 @@ config:
             all: 'Wszystkie'
         rss_limit: 'Link do RSS'
     form_user:
-        two_factor_description: "Enabling two factor authentication means you'll receive an email with a code OR need to use an OTP app (like Google Authenticator, Authy or FreeOTP) to get a one time code on every new untrusted connection. You can't choose both option."
+        # two_factor_description: "Enabling two factor authentication means you'll receive an email with a code OR need to use an OTP app (like Google Authenticator, Authy or FreeOTP) to get a one time code on every new untrusted connection. You can't choose both option."
         name_label: 'Nazwa'
         email_label: 'Adres email'
-        # emailTwoFactor_label: 'Using email (receive a code by email)'
-        # googleTwoFactor_label: 'Using an OTP app (open the app, like Google Authenticator, Authy or FreeOTP, to get a one time code)'
-        # two_factor_code_description_1: You just enabled the OTP two factor authentication, open your OTP app and use that code to get a one time password. It'll disapear after a page reload.
-        # two_factor_code_description_2: 'You can scan that QR Code with your app:'
-        # two_factor_code_description_3: 'Or use that code:'
-        # two_factor_code_description_4: 'Also, save these backup codes in a safe place, you can use them in case you lose access to your OTP app:'
+            # emailTwoFactor_label: 'Using email (receive a code by email)'
+            # googleTwoFactor_label: 'Using an OTP app (open the app, like Google Authenticator, Authy or FreeOTP, to get a one time code)'
+            # table_method: Method
+            # table_state: State
+            # table_action: Action
+            # state_enabled: Enabled
+            # state_disabled: Disabled
+            # action_email: Use email
+            # action_app: Use OTP App
         delete:
             title: Usuń moje konto (niebezpieczna strefa !)
             description: Jeżeli usuniesz swoje konto, wszystkie twoje artykuły, tagi, adnotacje, oraz konto zostaną trwale usunięte (operacja jest NIEODWRACALNA). Następnie zostaniesz wylogowany.
@@ -165,6 +168,15 @@ config:
                 and: 'Jedna reguła I inna'
                 matches: 'Sprawdź czy <i>temat</i> pasuje <i>szukaj</i> (duże lub małe litery).<br />Przykład: <code>tytuł zawiera "piłka nożna"</code>'
                 notmatches: 'Sprawdź czy <i>temat</i> nie zawiera <i>szukaj</i> (duże lub małe litery).<br />Przykład: <code>tytuł nie zawiera "piłka nożna"</code>'
+    otp:
+        # page_title: Two-factor authentication
+        # app:
+        #     two_factor_code_description_1: You just enabled the OTP two factor authentication, open your OTP app and use that code to get a one time password. It'll disapear after a page reload.
+        #     two_factor_code_description_2: 'You can scan that QR Code with your app:'
+        #     two_factor_code_description_3: 'Also, save these backup codes in a safe place, you can use them in case you lose access to your OTP app:'
+        #     two_factor_code_description_4: 'Test an OTP code from your configured app:'
+        #     cancel: Cancel
+        #     enable: Enable
 
 entry:
     default_title: 'Tytuł wpisu'

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.pt.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.pt.yml
@@ -99,11 +99,14 @@ config:
             # all: 'All'
         rss_limit: 'Número de itens no feed'
     form_user:
-        # two_factor_description: "Enabling two factor authentication means you'll receive an email with a code OR need to use an OTP app (like Google Authenticator) to get a one time code on every new untrusted connection. You can't choose both option."
+        # two_factor_description: "Enabling two factor authentication means you'll receive an email with a code OR need to use an OTP app (like Google Authenticator, Authy or FreeOTP) to get a one time code on every new untrusted connection. You can't choose both option."
         name_label: 'Nome'
         email_label: 'E-mail'
         # emailTwoFactor_label: 'Using email (receive a code by email)'
-        # googleTwoFactor_label: 'Using an OTP app (open the app, like Google Authenticator, to get a one time code)'
+        # googleTwoFactor_label: 'Using an OTP app (open the app, like Google Authenticator, Authy or FreeOTP, to get a one time code)'
+        # two_factor_code_description_1: You just enabled the OTP two factor authentication, open your OTP app and use that code to get a one time password. It'll disapear after a page reload.
+        # two_factor_code_description_2: 'You can scan that QR Code with your app:'
+        # two_factor_code_description_3: 'Or use that code:'
         delete:
             # title: Delete my account (a.k.a danger zone)
             # description: If you remove your account, ALL your articles, ALL your tags, ALL your annotations and your account will be PERMANENTLY removed (it can't be UNDONE). You'll then be logged out.

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.pt.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.pt.yml
@@ -102,12 +102,15 @@ config:
         # two_factor_description: "Enabling two factor authentication means you'll receive an email with a code OR need to use an OTP app (like Google Authenticator, Authy or FreeOTP) to get a one time code on every new untrusted connection. You can't choose both option."
         name_label: 'Nome'
         email_label: 'E-mail'
-        # emailTwoFactor_label: 'Using email (receive a code by email)'
-        # googleTwoFactor_label: 'Using an OTP app (open the app, like Google Authenticator, Authy or FreeOTP, to get a one time code)'
-        # two_factor_code_description_1: You just enabled the OTP two factor authentication, open your OTP app and use that code to get a one time password. It'll disapear after a page reload.
-        # two_factor_code_description_2: 'You can scan that QR Code with your app:'
-        # two_factor_code_description_3: 'Or use that code:'
-        # two_factor_code_description_4: 'Also, save these backup codes in a safe place, you can use them in case you lose access to your OTP app:'
+            # emailTwoFactor_label: 'Using email (receive a code by email)'
+            # googleTwoFactor_label: 'Using an OTP app (open the app, like Google Authenticator, Authy or FreeOTP, to get a one time code)'
+            # table_method: Method
+            # table_state: State
+            # table_action: Action
+            # state_enabled: Enabled
+            # state_disabled: Disabled
+            # action_email: Use email
+            # action_app: Use OTP App
         delete:
             # title: Delete my account (a.k.a danger zone)
             # description: If you remove your account, ALL your articles, ALL your tags, ALL your annotations and your account will be PERMANENTLY removed (it can't be UNDONE). You'll then be logged out.
@@ -165,6 +168,15 @@ config:
                 and: 'Uma regra E outra'
                 matches: 'Testa que um <i>assunto</i> corresponde a uma <i>pesquisa</i> (maiúscula ou minúscula).<br />Exemplo: <code>título corresponde a "futebol"</code>'
                 # notmatches: 'Tests that a <i>subject</i> doesn''t match match a <i>search</i> (case-insensitive).<br />Example: <code>title notmatches "football"</code>'
+    otp:
+        # page_title: Two-factor authentication
+        # app:
+        #     two_factor_code_description_1: You just enabled the OTP two factor authentication, open your OTP app and use that code to get a one time password. It'll disapear after a page reload.
+        #     two_factor_code_description_2: 'You can scan that QR Code with your app:'
+        #     two_factor_code_description_3: 'Also, save these backup codes in a safe place, you can use them in case you lose access to your OTP app:'
+        #     two_factor_code_description_4: 'Test an OTP code from your configured app:'
+        #     cancel: Cancel
+        #     enable: Enable
 
 entry:
     default_title: 'Título da entrada'

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.pt.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.pt.yml
@@ -99,11 +99,11 @@ config:
             # all: 'All'
         rss_limit: 'Número de itens no feed'
     form_user:
-        two_factor_description: 'Habilitar autenticação de dois passos significa que você receberá um e-mail com um código a cada nova conexão desconhecida.'
+        # two_factor_description: "Enabling two factor authentication means you'll receive an email with a code OR need to use an OTP app (like Google Authenticator) to get a one time code on every new untrusted connection. You can't choose both option."
         name_label: 'Nome'
         email_label: 'E-mail'
-        twoFactorAuthentication_label: 'Autenticação de dois passos'
-        # help_twoFactorAuthentication: "If you enable 2FA, each time you want to login to wallabag, you'll receive a code by email."
+        # emailTwoFactor_label: 'Using email (receive a code by email)'
+        # googleTwoFactor_label: 'Using an OTP app (open the app, like Google Authenticator, to get a one time code)'
         delete:
             # title: Delete my account (a.k.a danger zone)
             # description: If you remove your account, ALL your articles, ALL your tags, ALL your annotations and your account will be PERMANENTLY removed (it can't be UNDONE). You'll then be logged out.
@@ -533,7 +533,8 @@ user:
         email_label: 'E-mail'
         enabled_label: 'Habilitado'
         last_login_label: 'Último login'
-        twofactor_label: 'Autenticação de dois passos'
+        # twofactor_email_label: Two factor authentication by email
+        # twofactor_google_label: Two factor authentication by Google
         save: 'Salvar'
         delete: 'Apagar'
         delete_confirm: 'Tem certeza?'

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.pt.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.pt.yml
@@ -107,6 +107,7 @@ config:
         # two_factor_code_description_1: You just enabled the OTP two factor authentication, open your OTP app and use that code to get a one time password. It'll disapear after a page reload.
         # two_factor_code_description_2: 'You can scan that QR Code with your app:'
         # two_factor_code_description_3: 'Or use that code:'
+        # two_factor_code_description_4: 'Also, save these backup codes in a safe place, you can use them in case you lose access to your OTP app:'
         delete:
             # title: Delete my account (a.k.a danger zone)
             # description: If you remove your account, ALL your articles, ALL your tags, ALL your annotations and your account will be PERMANENTLY removed (it can't be UNDONE). You'll then be logged out.

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.pt.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.pt.yml
@@ -59,6 +59,7 @@ config:
         password: 'Senha'
         rules: 'Regras de tags'
         new_user: 'Adicionar um usuário'
+        # reset: 'Reset area'
     form:
         save: 'Salvar'
     form_settings:

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.pt.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.pt.yml
@@ -538,7 +538,7 @@ user:
         enabled_label: 'Habilitado'
         last_login_label: 'Último login'
         # twofactor_email_label: Two factor authentication by email
-        # twofactor_google_label: Two factor authentication by Google
+        # twofactor_google_label: Two factor authentication by OTP app
         save: 'Salvar'
         delete: 'Apagar'
         delete_confirm: 'Tem certeza?'

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.ro.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.ro.yml
@@ -107,6 +107,7 @@ config:
         # two_factor_code_description_1: You just enabled the OTP two factor authentication, open your OTP app and use that code to get a one time password. It'll disapear after a page reload.
         # two_factor_code_description_2: 'You can scan that QR Code with your app:'
         # two_factor_code_description_3: 'Or use that code:'
+        # two_factor_code_description_4: 'Also, save these backup codes in a safe place, you can use them in case you lose access to your OTP app:'
         delete:
             # title: Delete my account (a.k.a danger zone)
             # description: If you remove your account, ALL your articles, ALL your tags, ALL your annotations and your account will be PERMANENTLY removed (it can't be UNDONE). You'll then be logged out.

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.ro.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.ro.yml
@@ -538,7 +538,7 @@ user:
         # enabled_label: 'Enabled'
         # last_login_label: 'Last login'
         # twofactor_email_label: Two factor authentication by email
-        # twofactor_google_label: Two factor authentication by Google
+        # twofactor_google_label: Two factor authentication by OTP app
         # save: Save
         # delete: Delete
         # delete_confirm: Are you sure?

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.ro.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.ro.yml
@@ -102,12 +102,15 @@ config:
         # two_factor_description: "Enabling two factor authentication means you'll receive an email with a code OR need to use an OTP app (like Google Authenticator, Authy or FreeOTP) to get a one time code on every new untrusted connection. You can't choose both option."
         name_label: 'Nume'
         email_label: 'E-mail'
-        # emailTwoFactor_label: 'Using email (receive a code by email)'
-        # googleTwoFactor_label: 'Using an OTP app (open the app, like Google Authenticator, Authy or FreeOTP, to get a one time code)'
-        # two_factor_code_description_1: You just enabled the OTP two factor authentication, open your OTP app and use that code to get a one time password. It'll disapear after a page reload.
-        # two_factor_code_description_2: 'You can scan that QR Code with your app:'
-        # two_factor_code_description_3: 'Or use that code:'
-        # two_factor_code_description_4: 'Also, save these backup codes in a safe place, you can use them in case you lose access to your OTP app:'
+            # emailTwoFactor_label: 'Using email (receive a code by email)'
+            # googleTwoFactor_label: 'Using an OTP app (open the app, like Google Authenticator, Authy or FreeOTP, to get a one time code)'
+            # table_method: Method
+            # table_state: State
+            # table_action: Action
+            # state_enabled: Enabled
+            # state_disabled: Disabled
+            # action_email: Use email
+            # action_app: Use OTP App
         delete:
             # title: Delete my account (a.k.a danger zone)
             # description: If you remove your account, ALL your articles, ALL your tags, ALL your annotations and your account will be PERMANENTLY removed (it can't be UNDONE). You'll then be logged out.
@@ -165,6 +168,15 @@ config:
         #         and: 'One rule AND another'
         #         matches: 'Tests that a <i>subject</i> matches a <i>search</i> (case-insensitive).<br />Example: <code>title matches "football"</code>'
         #         notmatches: 'Tests that a <i>subject</i> doesn''t match match a <i>search</i> (case-insensitive).<br />Example: <code>title notmatches "football"</code>'
+    otp:
+        # page_title: Two-factor authentication
+        # app:
+        #     two_factor_code_description_1: You just enabled the OTP two factor authentication, open your OTP app and use that code to get a one time password. It'll disapear after a page reload.
+        #     two_factor_code_description_2: 'You can scan that QR Code with your app:'
+        #     two_factor_code_description_3: 'Also, save these backup codes in a safe place, you can use them in case you lose access to your OTP app:'
+        #     two_factor_code_description_4: 'Test an OTP code from your configured app:'
+        #     cancel: Cancel
+        #     enable: Enable
 
 entry:
     # default_title: 'Title of the entry'

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.ro.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.ro.yml
@@ -59,6 +59,7 @@ config:
         password: 'Parolă'
         # rules: 'Tagging rules'
         new_user: 'Crează un utilizator'
+        # reset: 'Reset area'
     form:
         save: 'Salvează'
     form_settings:

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.ro.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.ro.yml
@@ -99,11 +99,14 @@ config:
             # all: 'All'
         rss_limit: 'Limită RSS'
     form_user:
-        # two_factor_description: "Enabling two factor authentication means you'll receive an email with a code OR need to use an OTP app (like Google Authenticator) to get a one time code on every new untrusted connection. You can't choose both option."
+        # two_factor_description: "Enabling two factor authentication means you'll receive an email with a code OR need to use an OTP app (like Google Authenticator, Authy or FreeOTP) to get a one time code on every new untrusted connection. You can't choose both option."
         name_label: 'Nume'
         email_label: 'E-mail'
         # emailTwoFactor_label: 'Using email (receive a code by email)'
-        # googleTwoFactor_label: 'Using an OTP app (open the app, like Google Authenticator, to get a one time code)'
+        # googleTwoFactor_label: 'Using an OTP app (open the app, like Google Authenticator, Authy or FreeOTP, to get a one time code)'
+        # two_factor_code_description_1: You just enabled the OTP two factor authentication, open your OTP app and use that code to get a one time password. It'll disapear after a page reload.
+        # two_factor_code_description_2: 'You can scan that QR Code with your app:'
+        # two_factor_code_description_3: 'Or use that code:'
         delete:
             # title: Delete my account (a.k.a danger zone)
             # description: If you remove your account, ALL your articles, ALL your tags, ALL your annotations and your account will be PERMANENTLY removed (it can't be UNDONE). You'll then be logged out.

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.ro.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.ro.yml
@@ -99,11 +99,11 @@ config:
             # all: 'All'
         rss_limit: 'Limită RSS'
     form_user:
-        # two_factor_description: "Enabling two factor authentication means you'll receive an email with a code on every new untrusted connexion"
+        # two_factor_description: "Enabling two factor authentication means you'll receive an email with a code OR need to use an OTP app (like Google Authenticator) to get a one time code on every new untrusted connection. You can't choose both option."
         name_label: 'Nume'
         email_label: 'E-mail'
-        # twoFactorAuthentication_label: 'Two factor authentication'
-        # help_twoFactorAuthentication: "If you enable 2FA, each time you want to login to wallabag, you'll receive a code by email."
+        # emailTwoFactor_label: 'Using email (receive a code by email)'
+        # googleTwoFactor_label: 'Using an OTP app (open the app, like Google Authenticator, to get a one time code)'
         delete:
             # title: Delete my account (a.k.a danger zone)
             # description: If you remove your account, ALL your articles, ALL your tags, ALL your annotations and your account will be PERMANENTLY removed (it can't be UNDONE). You'll then be logged out.
@@ -533,7 +533,8 @@ user:
         email_label: 'E-mail'
         # enabled_label: 'Enabled'
         # last_login_label: 'Last login'
-        # twofactor_label: Two factor authentication
+        # twofactor_email_label: Two factor authentication by email
+        # twofactor_google_label: Two factor authentication by Google
         # save: Save
         # delete: Delete
         # delete_confirm: Are you sure?

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.ru.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.ru.yml
@@ -96,11 +96,14 @@ config:
             archive: 'архивные'
         rss_limit: 'Количество записей в фиде'
     form_user:
-        # two_factor_description: "Enabling two factor authentication means you'll receive an email with a code OR need to use an OTP app (like Google Authenticator) to get a one time code on every new untrusted connection. You can't choose both option."
+        # two_factor_description: "Enabling two factor authentication means you'll receive an email with a code OR need to use an OTP app (like Google Authenticator, Authy or FreeOTP) to get a one time code on every new untrusted connection. You can't choose both option."
         name_label: 'Имя'
         email_label: 'Email'
         # emailTwoFactor_label: 'Using email (receive a code by email)'
-        # googleTwoFactor_label: 'Using an OTP app (open the app, like Google Authenticator, to get a one time code)'
+        # googleTwoFactor_label: 'Using an OTP app (open the app, like Google Authenticator, Authy or FreeOTP, to get a one time code)'
+        # two_factor_code_description_1: You just enabled the OTP two factor authentication, open your OTP app and use that code to get a one time password. It'll disapear after a page reload.
+        # two_factor_code_description_2: 'You can scan that QR Code with your app:'
+        # two_factor_code_description_3: 'Or use that code:'
         delete:
             title: "Удалить мой аккаунт (или опасная зона)"
             description: "Если Вы удалите ваш аккаунт, ВСЕ ваши записи, теги и другие данные, будут БЕЗВОЗВРАТНО удалены (операция не может быть отменена после). Затем Вы выйдете из системы."

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.ru.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.ru.yml
@@ -96,11 +96,11 @@ config:
             archive: 'архивные'
         rss_limit: 'Количество записей в фиде'
     form_user:
-        two_factor_description: "Включить двухфакторную аутентификацию, Вы получите сообщение на указанный email с кодом, при каждом новом непроверенном подключении."
+        # two_factor_description: "Enabling two factor authentication means you'll receive an email with a code OR need to use an OTP app (like Google Authenticator) to get a one time code on every new untrusted connection. You can't choose both option."
         name_label: 'Имя'
         email_label: 'Email'
-        twoFactorAuthentication_label: 'Двухфакторная аутентификация'
-        help_twoFactorAuthentication: "Если Вы включите двухфакторную аутентификацию, то Вы будете получать код на указанный ранее email, каждый раз при входе в wallabag."
+        # emailTwoFactor_label: 'Using email (receive a code by email)'
+        # googleTwoFactor_label: 'Using an OTP app (open the app, like Google Authenticator, to get a one time code)'
         delete:
             title: "Удалить мой аккаунт (или опасная зона)"
             description: "Если Вы удалите ваш аккаунт, ВСЕ ваши записи, теги и другие данные, будут БЕЗВОЗВРАТНО удалены (операция не может быть отменена после). Затем Вы выйдете из системы."
@@ -521,7 +521,8 @@ user:
         email_label: 'Email'
         enabled_label: 'Включить'
         last_login_label: 'Последний вход'
-        twofactor_label: "Двухфакторная аутентификация"
+        # twofactor_email_label: Two factor authentication by email
+        # twofactor_google_label: Two factor authentication by Google
         save: "Сохранить"
         delete: "Удалить"
         delete_confirm: "Вы уверены?"

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.ru.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.ru.yml
@@ -526,7 +526,7 @@ user:
         enabled_label: 'Включить'
         last_login_label: 'Последний вход'
         # twofactor_email_label: Two factor authentication by email
-        # twofactor_google_label: Two factor authentication by Google
+        # twofactor_google_label: Two factor authentication by OTP app
         save: "Сохранить"
         delete: "Удалить"
         delete_confirm: "Вы уверены?"

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.ru.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.ru.yml
@@ -104,6 +104,7 @@ config:
         # two_factor_code_description_1: You just enabled the OTP two factor authentication, open your OTP app and use that code to get a one time password. It'll disapear after a page reload.
         # two_factor_code_description_2: 'You can scan that QR Code with your app:'
         # two_factor_code_description_3: 'Or use that code:'
+        # two_factor_code_description_4: 'Also, save these backup codes in a safe place, you can use them in case you lose access to your OTP app:'
         delete:
             title: "Удалить мой аккаунт (или опасная зона)"
             description: "Если Вы удалите ваш аккаунт, ВСЕ ваши записи, теги и другие данные, будут БЕЗВОЗВРАТНО удалены (операция не может быть отменена после). Затем Вы выйдете из системы."

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.ru.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.ru.yml
@@ -58,6 +58,7 @@ config:
         password: 'Пароль'
         rules: 'Правила настройки простановки тегов'
         new_user: 'Добавить пользователя'
+        reset: 'Сброс данных'
     form:
         save: 'Сохранить'
     form_settings:

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.ru.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.ru.yml
@@ -99,12 +99,15 @@ config:
         # two_factor_description: "Enabling two factor authentication means you'll receive an email with a code OR need to use an OTP app (like Google Authenticator, Authy or FreeOTP) to get a one time code on every new untrusted connection. You can't choose both option."
         name_label: 'Имя'
         email_label: 'Email'
-        # emailTwoFactor_label: 'Using email (receive a code by email)'
-        # googleTwoFactor_label: 'Using an OTP app (open the app, like Google Authenticator, Authy or FreeOTP, to get a one time code)'
-        # two_factor_code_description_1: You just enabled the OTP two factor authentication, open your OTP app and use that code to get a one time password. It'll disapear after a page reload.
-        # two_factor_code_description_2: 'You can scan that QR Code with your app:'
-        # two_factor_code_description_3: 'Or use that code:'
-        # two_factor_code_description_4: 'Also, save these backup codes in a safe place, you can use them in case you lose access to your OTP app:'
+            # emailTwoFactor_label: 'Using email (receive a code by email)'
+            # googleTwoFactor_label: 'Using an OTP app (open the app, like Google Authenticator, Authy or FreeOTP, to get a one time code)'
+            # table_method: Method
+            # table_state: State
+            # table_action: Action
+            # state_enabled: Enabled
+            # state_disabled: Disabled
+            # action_email: Use email
+            # action_app: Use OTP App
         delete:
             title: "Удалить мой аккаунт (или опасная зона)"
             description: "Если Вы удалите ваш аккаунт, ВСЕ ваши записи, теги и другие данные, будут БЕЗВОЗВРАТНО удалены (операция не может быть отменена после). Затем Вы выйдете из системы."
@@ -160,6 +163,15 @@ config:
                 or: 'Одно правило ИЛИ другое'
                 and: 'Одно правило И другое'
                 matches: 'Тесты, в которых <i> тема </i> соответствует <i> поиску </i> (без учета регистра). Пример: <code> title matches "футбол" </code>'
+    otp:
+        # page_title: Two-factor authentication
+        # app:
+        #     two_factor_code_description_1: You just enabled the OTP two factor authentication, open your OTP app and use that code to get a one time password. It'll disapear after a page reload.
+        #     two_factor_code_description_2: 'You can scan that QR Code with your app:'
+        #     two_factor_code_description_3: 'Also, save these backup codes in a safe place, you can use them in case you lose access to your OTP app:'
+        #     two_factor_code_description_4: 'Test an OTP code from your configured app:'
+        #     cancel: Cancel
+        #     enable: Enable
 
 entry:
     default_title: 'Название записи'

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.th.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.th.yml
@@ -107,6 +107,7 @@ config:
         # two_factor_code_description_1: You just enabled the OTP two factor authentication, open your OTP app and use that code to get a one time password. It'll disapear after a page reload.
         # two_factor_code_description_2: 'You can scan that QR Code with your app:'
         # two_factor_code_description_3: 'Or use that code:'
+        # two_factor_code_description_4: 'Also, save these backup codes in a safe place, you can use them in case you lose access to your OTP app:'
         delete:
             title: ลบบัญชีของฉัน (โซนที่เป็นภัย!)
             description: ถ้าคุณลบบัญชีของคุณIf , รายการทั้งหมดของคุณ, แท็กทั้งหมดของคุณ, หมายเหตุทั้งหมดของคุณและบัญชีของคุณจะถูกลบอย่างถาวร (มันไม่สามารถยกเลิกได้) คุณจะต้องลงชื่อออก

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.th.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.th.yml
@@ -536,7 +536,7 @@ user:
         enabled_label: 'เปิดใช้งาน'
         last_login_label: 'ลงชื้อเข้าใช้ครั้งสุดท้าย'
         # twofactor_email_label: Two factor authentication by email
-        # twofactor_google_label: Two factor authentication by Google
+        # twofactor_google_label: Two factor authentication by OTP app
         save: บันทึก
         delete: ลบ
         delete_confirm: ตุณแน่ใจหรือไม่?

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.th.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.th.yml
@@ -99,11 +99,11 @@ config:
             all: 'ทั้งหมด'
         rss_limit: 'จำนวนไอเทมที่เก็บ'
     form_user:
-        two_factor_description: "การเปิดใช้งาน two factor authentication คือคุณจะต้องได้รับอีเมลกับ code ที่ยังไม่ตรวจสอบในการเชื่อมต่อ"
+        # two_factor_description: "Enabling two factor authentication means you'll receive an email with a code OR need to use an OTP app (like Google Authenticator) to get a one time code on every new untrusted connection. You can't choose both option."
         name_label: 'ชื่อ'
         email_label: 'อีเมล'
-        twoFactorAuthentication_label: 'Two factor authentication'
-        help_twoFactorAuthentication: "ถ้าคุณเปิด 2FA, ในแต่ละช่วงเวลาที่คุณต้องการลงชื่อเข้าใช wallabag, คุณจะต้องได้รับ code จากอีเมล"
+        # emailTwoFactor_label: 'Using email (receive a code by email)'
+        # googleTwoFactor_label: 'Using an OTP app (open the app, like Google Authenticator, to get a one time code)'
         delete:
             title: ลบบัญชีของฉัน (โซนที่เป็นภัย!)
             description: ถ้าคุณลบบัญชีของคุณIf , รายการทั้งหมดของคุณ, แท็กทั้งหมดของคุณ, หมายเหตุทั้งหมดของคุณและบัญชีของคุณจะถูกลบอย่างถาวร (มันไม่สามารถยกเลิกได้) คุณจะต้องลงชื่อออก
@@ -531,7 +531,8 @@ user:
         email_label: 'อีเมล'
         enabled_label: 'เปิดใช้งาน'
         last_login_label: 'ลงชื้อเข้าใช้ครั้งสุดท้าย'
-        twofactor_label: Two factor authentication
+        # twofactor_email_label: Two factor authentication by email
+        # twofactor_google_label: Two factor authentication by Google
         save: บันทึก
         delete: ลบ
         delete_confirm: ตุณแน่ใจหรือไม่?

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.th.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.th.yml
@@ -59,6 +59,7 @@ config:
         password: 'รหัสผ่าน'
         rules: 'การแท็กข้อบังคับ'
         new_user: 'เพิ่มผู้ใช้'
+        reset: 'รีเซ็ตพื้นที่ '
     form:
         save: 'บันทึก'
     form_settings:

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.th.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.th.yml
@@ -102,12 +102,15 @@ config:
         # two_factor_description: "Enabling two factor authentication means you'll receive an email with a code OR need to use an OTP app (like Google Authenticator, Authy or FreeOTP) to get a one time code on every new untrusted connection. You can't choose both option."
         name_label: 'ชื่อ'
         email_label: 'อีเมล'
-        # emailTwoFactor_label: 'Using email (receive a code by email)'
-        # googleTwoFactor_label: 'Using an OTP app (open the app, like Google Authenticator, Authy or FreeOTP, to get a one time code)'
-        # two_factor_code_description_1: You just enabled the OTP two factor authentication, open your OTP app and use that code to get a one time password. It'll disapear after a page reload.
-        # two_factor_code_description_2: 'You can scan that QR Code with your app:'
-        # two_factor_code_description_3: 'Or use that code:'
-        # two_factor_code_description_4: 'Also, save these backup codes in a safe place, you can use them in case you lose access to your OTP app:'
+            # emailTwoFactor_label: 'Using email (receive a code by email)'
+            # googleTwoFactor_label: 'Using an OTP app (open the app, like Google Authenticator, Authy or FreeOTP, to get a one time code)'
+            # table_method: Method
+            # table_state: State
+            # table_action: Action
+            # state_enabled: Enabled
+            # state_disabled: Disabled
+            # action_email: Use email
+            # action_app: Use OTP App
         delete:
             title: ลบบัญชีของฉัน (โซนที่เป็นภัย!)
             description: ถ้าคุณลบบัญชีของคุณIf , รายการทั้งหมดของคุณ, แท็กทั้งหมดของคุณ, หมายเหตุทั้งหมดของคุณและบัญชีของคุณจะถูกลบอย่างถาวร (มันไม่สามารถยกเลิกได้) คุณจะต้องลงชื่อออก
@@ -165,6 +168,15 @@ config:
                 and: 'หนึ่งข้อบังคับและอื่นๆ'
                 matches: 'ทดสอบว่า <i>เรื่อง</i> นี้ตรงกับ <i>การต้นหา</i> (กรณีไม่ทราบ).<br />ตัวอย่าง: <code>หัวข้อที่ตรงกับ "football"</code>'
                 notmatches: 'ทดสอบว่า <i>เรื่อง</i> นี้ไม่ตรงกับ <i>การต้นหา</i> (กรณีไม่ทราบ).<br />ตัวอย่าง: <code>หัวข้อทีไม่ตรงกับ "football"</code>'
+    otp:
+        # page_title: Two-factor authentication
+        # app:
+        #     two_factor_code_description_1: You just enabled the OTP two factor authentication, open your OTP app and use that code to get a one time password. It'll disapear after a page reload.
+        #     two_factor_code_description_2: 'You can scan that QR Code with your app:'
+        #     two_factor_code_description_3: 'Also, save these backup codes in a safe place, you can use them in case you lose access to your OTP app:'
+        #     two_factor_code_description_4: 'Test an OTP code from your configured app:'
+        #     cancel: Cancel
+        #     enable: Enable
 
 entry:
     default_title: 'หัวข้อรายการ'

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.th.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.th.yml
@@ -99,11 +99,14 @@ config:
             all: 'ทั้งหมด'
         rss_limit: 'จำนวนไอเทมที่เก็บ'
     form_user:
-        # two_factor_description: "Enabling two factor authentication means you'll receive an email with a code OR need to use an OTP app (like Google Authenticator) to get a one time code on every new untrusted connection. You can't choose both option."
+        # two_factor_description: "Enabling two factor authentication means you'll receive an email with a code OR need to use an OTP app (like Google Authenticator, Authy or FreeOTP) to get a one time code on every new untrusted connection. You can't choose both option."
         name_label: 'ชื่อ'
         email_label: 'อีเมล'
         # emailTwoFactor_label: 'Using email (receive a code by email)'
-        # googleTwoFactor_label: 'Using an OTP app (open the app, like Google Authenticator, to get a one time code)'
+        # googleTwoFactor_label: 'Using an OTP app (open the app, like Google Authenticator, Authy or FreeOTP, to get a one time code)'
+        # two_factor_code_description_1: You just enabled the OTP two factor authentication, open your OTP app and use that code to get a one time password. It'll disapear after a page reload.
+        # two_factor_code_description_2: 'You can scan that QR Code with your app:'
+        # two_factor_code_description_3: 'Or use that code:'
         delete:
             title: ลบบัญชีของฉัน (โซนที่เป็นภัย!)
             description: ถ้าคุณลบบัญชีของคุณIf , รายการทั้งหมดของคุณ, แท็กทั้งหมดของคุณ, หมายเหตุทั้งหมดของคุณและบัญชีของคุณจะถูกลบอย่างถาวร (มันไม่สามารถยกเลิกได้) คุณจะต้องลงชื่อออก

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.tr.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.tr.yml
@@ -59,6 +59,7 @@ config:
         password: 'Şifre'
         rules: 'Etiketleme kuralları'
         new_user: 'Bir kullanıcı ekle'
+        # reset: 'Reset area'
     form:
         save: 'Kaydet'
     form_settings:

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.tr.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.tr.yml
@@ -99,11 +99,11 @@ config:
             # all: 'All'
         rss_limit: 'RSS içeriğinden talep edilecek makale limiti'
     form_user:
-        two_factor_description: "İki adımlı doğrulamayı aktifleştirdiğinizde, her yeni güvenilmeyen bağlantılarda size e-posta ile bir kod alacaksınız."
+        # two_factor_description: "Enabling two factor authentication means you'll receive an email with a code OR need to use an OTP app (like Google Authenticator) to get a one time code on every new untrusted connection. You can't choose both option."
         name_label: 'İsim'
         email_label: 'E-posta'
-        twoFactorAuthentication_label: 'İki adımlı doğrulama'
-        # help_twoFactorAuthentication: "If you enable 2FA, each time you want to login to wallabag, you'll receive a code by email."
+        # emailTwoFactor_label: 'Using email (receive a code by email)'
+        # googleTwoFactor_label: 'Using an OTP app (open the app, like Google Authenticator, to get a one time code)'
         delete:
             # title: Delete my account (a.k.a danger zone)
             # description: If you remove your account, ALL your articles, ALL your tags, ALL your annotations and your account will be PERMANENTLY removed (it can't be UNDONE). You'll then be logged out.
@@ -531,7 +531,8 @@ user:
         email_label: 'E-posta'
         # enabled_label: 'Enabled'
         # last_login_label: 'Last login'
-        # twofactor_label: Two factor authentication
+        # twofactor_email_label: Two factor authentication by email
+        # twofactor_google_label: Two factor authentication by Google
         # save: Save
         # delete: Delete
         # delete_confirm: Are you sure?

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.tr.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.tr.yml
@@ -107,6 +107,7 @@ config:
         # two_factor_code_description_1: You just enabled the OTP two factor authentication, open your OTP app and use that code to get a one time password. It'll disapear after a page reload.
         # two_factor_code_description_2: 'You can scan that QR Code with your app:'
         # two_factor_code_description_3: 'Or use that code:'
+        # two_factor_code_description_4: 'Also, save these backup codes in a safe place, you can use them in case you lose access to your OTP app:'
         delete:
             # title: Delete my account (a.k.a danger zone)
             # description: If you remove your account, ALL your articles, ALL your tags, ALL your annotations and your account will be PERMANENTLY removed (it can't be UNDONE). You'll then be logged out.

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.tr.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.tr.yml
@@ -536,7 +536,7 @@ user:
         # enabled_label: 'Enabled'
         # last_login_label: 'Last login'
         # twofactor_email_label: Two factor authentication by email
-        # twofactor_google_label: Two factor authentication by Google
+        # twofactor_google_label: Two factor authentication by OTP app
         # save: Save
         # delete: Delete
         # delete_confirm: Are you sure?

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.tr.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.tr.yml
@@ -99,11 +99,14 @@ config:
             # all: 'All'
         rss_limit: 'RSS içeriğinden talep edilecek makale limiti'
     form_user:
-        # two_factor_description: "Enabling two factor authentication means you'll receive an email with a code OR need to use an OTP app (like Google Authenticator) to get a one time code on every new untrusted connection. You can't choose both option."
+        # two_factor_description: "Enabling two factor authentication means you'll receive an email with a code OR need to use an OTP app (like Google Authenticator, Authy or FreeOTP) to get a one time code on every new untrusted connection. You can't choose both option."
         name_label: 'İsim'
         email_label: 'E-posta'
         # emailTwoFactor_label: 'Using email (receive a code by email)'
-        # googleTwoFactor_label: 'Using an OTP app (open the app, like Google Authenticator, to get a one time code)'
+        # googleTwoFactor_label: 'Using an OTP app (open the app, like Google Authenticator, Authy or FreeOTP, to get a one time code)'
+        # two_factor_code_description_1: You just enabled the OTP two factor authentication, open your OTP app and use that code to get a one time password. It'll disapear after a page reload.
+        # two_factor_code_description_2: 'You can scan that QR Code with your app:'
+        # two_factor_code_description_3: 'Or use that code:'
         delete:
             # title: Delete my account (a.k.a danger zone)
             # description: If you remove your account, ALL your articles, ALL your tags, ALL your annotations and your account will be PERMANENTLY removed (it can't be UNDONE). You'll then be logged out.

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.tr.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.tr.yml
@@ -102,12 +102,15 @@ config:
         # two_factor_description: "Enabling two factor authentication means you'll receive an email with a code OR need to use an OTP app (like Google Authenticator, Authy or FreeOTP) to get a one time code on every new untrusted connection. You can't choose both option."
         name_label: 'İsim'
         email_label: 'E-posta'
-        # emailTwoFactor_label: 'Using email (receive a code by email)'
-        # googleTwoFactor_label: 'Using an OTP app (open the app, like Google Authenticator, Authy or FreeOTP, to get a one time code)'
-        # two_factor_code_description_1: You just enabled the OTP two factor authentication, open your OTP app and use that code to get a one time password. It'll disapear after a page reload.
-        # two_factor_code_description_2: 'You can scan that QR Code with your app:'
-        # two_factor_code_description_3: 'Or use that code:'
-        # two_factor_code_description_4: 'Also, save these backup codes in a safe place, you can use them in case you lose access to your OTP app:'
+            # emailTwoFactor_label: 'Using email (receive a code by email)'
+            # googleTwoFactor_label: 'Using an OTP app (open the app, like Google Authenticator, Authy or FreeOTP, to get a one time code)'
+            # table_method: Method
+            # table_state: State
+            # table_action: Action
+            # state_enabled: Enabled
+            # state_disabled: Disabled
+            # action_email: Use email
+            # action_app: Use OTP App
         delete:
             # title: Delete my account (a.k.a danger zone)
             # description: If you remove your account, ALL your articles, ALL your tags, ALL your annotations and your account will be PERMANENTLY removed (it can't be UNDONE). You'll then be logged out.
@@ -165,6 +168,15 @@ config:
                 and: 'Bir kural ve diğeri'
                 # matches: 'Tests that a <i>subject</i> matches a <i>search</i> (case-insensitive).<br />Example: <code>title matches "football"</code>'
                 # notmatches: 'Tests that a <i>subject</i> doesn''t match match a <i>search</i> (case-insensitive).<br />Example: <code>title notmatches "football"</code>'
+    otp:
+        # page_title: Two-factor authentication
+        # app:
+        #     two_factor_code_description_1: You just enabled the OTP two factor authentication, open your OTP app and use that code to get a one time password. It'll disapear after a page reload.
+        #     two_factor_code_description_2: 'You can scan that QR Code with your app:'
+        #     two_factor_code_description_3: 'Also, save these backup codes in a safe place, you can use them in case you lose access to your OTP app:'
+        #     two_factor_code_description_4: 'Test an OTP code from your configured app:'
+        #     cancel: Cancel
+        #     enable: Enable
 
 entry:
     default_title: 'Makalenin başlığı'

--- a/src/Wallabag/CoreBundle/Resources/views/themes/baggy/Config/index.html.twig
+++ b/src/Wallabag/CoreBundle/Resources/views/themes/baggy/Config/index.html.twig
@@ -187,19 +187,22 @@
             </div>
             {% for OtpQrCode in app.session.flashbag.get('OtpQrCode') %}
                 <div class="row">
-                    You just enabled the OTP two factor authentication, open your OTP app and use that code to get a one time password.
+                    {{ 'config.form_user.two_factor_code_description_1'|trans }}
                     <br/>
-                    That code will disapear after a page reload.
+                    {{ 'config.form_user.two_factor_code_description_2'|trans }}
+                    <br/><br/>
+                    <img id="2faQrcode" class="hide-on-med-and-down" />
+                    <script>
+                        document.getElementById('2faQrcode').src = jrQrcode.getQrBase64('{{ OtpQrCode }}');
+                    </script>
+                    <br/><br/>
+                    {{ 'config.form_user.two_factor_code_description_3'|trans }}
                     <br/><br/>
                     <strong>{{ app.user.getGoogleAuthenticatorSecret }}</strong>
                     <br/><br/>
-                    Or you can scan that QR Code with your app:
-                    <br/>
-                    <img id="2faQrcode" class="hide-on-med-and-down" />
-
-                    <script>
-                        document.getElementById('2faQrcode').src = jrQrcode.getQrBase64('{{ OtpQrCode }}');;
-                    </script>
+                    {{ 'config.form_user.two_factor_code_description_4'|trans }}
+                    <br/><br/>
+                    <strong>{{ app.user.getBackupCodes|join("\n")|nl2br }}</strong>
                 </div>
             {% endfor %}
         </fieldset>

--- a/src/Wallabag/CoreBundle/Resources/views/themes/baggy/Config/index.html.twig
+++ b/src/Wallabag/CoreBundle/Resources/views/themes/baggy/Config/index.html.twig
@@ -86,8 +86,7 @@
                 <br/>
                 <img id="androidQrcode" />
                 <script>
-                    const imgBase64 = jrQrcode.getQrBase64('wallabag://{{ app.user.username }}@{{ wallabag_url }}');
-                    document.getElementById('androidQrcode').src = imgBase64;
+                    document.getElementById('androidQrcode').src = jrQrcode.getQrBase64('wallabag://{{ app.user.username }}@{{ wallabag_url }}');
                 </script>
             </div>
         </fieldset>
@@ -186,20 +185,20 @@
                 {{ form_widget(form.user.googleTwoFactor) }}
                 {{ form_errors(form.user.googleTwoFactor) }}
             </div>
-            {% for OTPSecret in app.session.flashbag.get('OTPSecret') %}
+            {% for OtpQrCode in app.session.flashbag.get('OtpQrCode') %}
                 <div class="row">
                     You just enabled the OTP two factor authentication, open your OTP app and use that code to get a one time password.
                     <br/>
                     That code will disapear after a page reload.
                     <br/><br/>
-                    <strong>{{ OTPSecret.code }}</strong>
+                    <strong>{{ app.user.getGoogleAuthenticatorSecret }}</strong>
                     <br/><br/>
                     Or you can scan that QR Code with your app:
                     <br/>
                     <img id="2faQrcode" class="hide-on-med-and-down" />
 
                     <script>
-                        document.getElementById('2faQrcode').src = jrQrcode.getQrBase64('{{ OTPSecret.qrCode }}');;
+                        document.getElementById('2faQrcode').src = jrQrcode.getQrBase64('{{ OtpQrCode }}');;
                     </script>
                 </div>
             {% endfor %}

--- a/src/Wallabag/CoreBundle/Resources/views/themes/baggy/Config/index.html.twig
+++ b/src/Wallabag/CoreBundle/Resources/views/themes/baggy/Config/index.html.twig
@@ -176,42 +176,35 @@
 
         <fieldset class="w500p inline">
             <div class="row">
-                {{ form_label(form.user.twoFactorAuthentication) }}
-                {{ form_errors(form.user.twoFactorAuthentication) }}
-                {{ form_widget(form.user.twoFactorAuthentication) }}
+                {{ form_label(form.user.emailTwoFactor) }}
+                {{ form_errors(form.user.emailTwoFactor) }}
+                {{ form_widget(form.user.emailTwoFactor) }}
             </div>
-            <a href="#" title="{{ 'config.form_user.help_twoFactorAuthentication'|trans }}">
-                <i class="material-icons">live_help</i>
-            </a>
+            <br/>
+            <div class="row">
+                {{ form_label(form.user.googleTwoFactor) }}
+                {{ form_widget(form.user.googleTwoFactor) }}
+                {{ form_errors(form.user.googleTwoFactor) }}
+            </div>
+            {% for OTPSecret in app.session.flashbag.get('OTPSecret') %}
+                <div class="row">
+                    You just enabled the OTP two factor authentication, open your OTP app and use that code to get a one time password.
+                    <br/>
+                    That code will disapear after a page reload.
+                    <br/><br/>
+                    <strong>{{ OTPSecret.code }}</strong>
+                    <br/><br/>
+                    Or you can scan that QR Code with your app:
+                    <br/>
+                    <img id="2faQrcode" class="hide-on-med-and-down" />
+
+                    <script>
+                        document.getElementById('2faQrcode').src = jrQrcode.getQrBase64('{{ OTPSecret.qrCode }}');;
+                    </script>
+                </div>
+            {% endfor %}
         </fieldset>
         {% endif %}
-
-        <h2>{{ 'config.reset.title'|trans }}</h2>
-        <fieldset class="w500p inline">
-            <p>{{ 'config.reset.description'|trans }}</p>
-            <ul>
-                <li>
-                    <a href="{{ path('config_reset', { type: 'annotations'}) }}" onclick="return confirm('{{ 'config.reset.confirm'|trans|escape('js') }}')" class="waves-effect waves-light btn red">
-                        {{ 'config.reset.annotations'|trans }}
-                    </a>
-                </li>
-                <li>
-                    <a href="{{ path('config_reset', { type: 'tags'}) }}" onclick="return confirm('{{ 'config.reset.confirm'|trans|escape('js') }}')" class="waves-effect waves-light btn red">
-                        {{ 'config.reset.tags'|trans }}
-                    </a>
-                </li>
-                <li>
-                    <a href="{{ path('config_reset', { type: 'archived'}) }}" onclick="return confirm('{{ 'config.reset.confirm'|trans|escape('js') }}')" class="waves-effect waves-light btn red">
-                        {{ 'config.reset.archived'|trans }}
-                    </a>
-                </li>
-                <li>
-                    <a href="{{ path('config_reset', { type: 'entries'}) }}" onclick="return confirm('{{ 'config.reset.confirm'|trans|escape('js') }}')" class="waves-effect waves-light btn red">
-                        {{ 'config.reset.entries'|trans }}
-                    </a>
-                </li>
-            </ul>
-        </fieldset>
 
         {{ form_widget(form.user._token) }}
         {{ form_widget(form.user.save) }}
@@ -277,7 +270,7 @@
         {% endfor %}
     </ul>
 
-        {{ form_start(form.new_tagging_rule) }}
+    {{ form_start(form.new_tagging_rule) }}
         {{ form_errors(form.new_tagging_rule) }}
 
         <fieldset class="w500p inline">
@@ -382,4 +375,31 @@
             </table>
         </div>
     </div>
+
+    <h2>{{ 'config.reset.title'|trans }}</h2>
+    <fieldset class="w500p inline">
+        <p>{{ 'config.reset.description'|trans }}</p>
+        <ul>
+            <li>
+                <a href="{{ path('config_reset', { type: 'annotations'}) }}" onclick="return confirm('{{ 'config.reset.confirm'|trans|escape('js') }}')" class="waves-effect waves-light btn red">
+                    {{ 'config.reset.annotations'|trans }}
+                </a>
+            </li>
+            <li>
+                <a href="{{ path('config_reset', { type: 'tags'}) }}" onclick="return confirm('{{ 'config.reset.confirm'|trans|escape('js') }}')" class="waves-effect waves-light btn red">
+                    {{ 'config.reset.tags'|trans }}
+                </a>
+            </li>
+            <li>
+                <a href="{{ path('config_reset', { type: 'archived'}) }}" onclick="return confirm('{{ 'config.reset.confirm'|trans|escape('js') }}')" class="waves-effect waves-light btn red">
+                    {{ 'config.reset.archived'|trans }}
+                </a>
+            </li>
+            <li>
+                <a href="{{ path('config_reset', { type: 'entries'}) }}" onclick="return confirm('{{ 'config.reset.confirm'|trans|escape('js') }}')" class="waves-effect waves-light btn red">
+                    {{ 'config.reset.entries'|trans }}
+                </a>
+            </li>
+        </ul>
+    </fieldset>
 {% endblock %}

--- a/src/Wallabag/CoreBundle/Resources/views/themes/baggy/Config/index.html.twig
+++ b/src/Wallabag/CoreBundle/Resources/views/themes/baggy/Config/index.html.twig
@@ -168,48 +168,41 @@
             </div>
         </fieldset>
 
+        {{ form_widget(form.user.save) }}
+
         {% if twofactor_auth %}
+        <h5>{{ 'config.otp.page_title'|trans }}</h5>
+
         <div class="row">
             {{ 'config.form_user.two_factor_description'|trans }}
         </div>
 
-        <fieldset class="w500p inline">
-            <div class="row">
-                {{ form_label(form.user.emailTwoFactor) }}
-                {{ form_errors(form.user.emailTwoFactor) }}
-                {{ form_widget(form.user.emailTwoFactor) }}
-            </div>
-            <br/>
-            <div class="row">
-                {{ form_label(form.user.googleTwoFactor) }}
-                {{ form_widget(form.user.googleTwoFactor) }}
-                {{ form_errors(form.user.googleTwoFactor) }}
-            </div>
-            {% for OtpQrCode in app.session.flashbag.get('OtpQrCode') %}
-                <div class="row">
-                    {{ 'config.form_user.two_factor_code_description_1'|trans }}
-                    <br/>
-                    {{ 'config.form_user.two_factor_code_description_2'|trans }}
-                    <br/><br/>
-                    <img id="2faQrcode" class="hide-on-med-and-down" />
-                    <script>
-                        document.getElementById('2faQrcode').src = jrQrcode.getQrBase64('{{ OtpQrCode }}');
-                    </script>
-                    <br/><br/>
-                    {{ 'config.form_user.two_factor_code_description_3'|trans }}
-                    <br/><br/>
-                    <strong>{{ app.user.getGoogleAuthenticatorSecret }}</strong>
-                    <br/><br/>
-                    {{ 'config.form_user.two_factor_code_description_4'|trans }}
-                    <br/><br/>
-                    <strong>{{ app.user.getBackupCodes|join("\n")|nl2br }}</strong>
-                </div>
-            {% endfor %}
-        </fieldset>
+        <table>
+            <thead>
+                <tr>
+                    <th>{{ 'config.form_user.two_factor.table_method'|trans }}</th>
+                    <th>{{ 'config.form_user.two_factor.table_state'|trans }}</th>
+                    <th>{{ 'config.form_user.two_factor.table_action'|trans }}</th>
+                </tr>
+            </thead>
+
+            <tbody>
+                <tr>
+                    <td>{{ 'config.form_user.two_factor.emailTwoFactor_label'|trans }}</td>
+                    <td>{% if app.user.isEmailTwoFactor %}<b>{{ 'config.form_user.two_factor.state_enabled'|trans }}</b>{% else %}{{ 'config.form_user.two_factor.state_disabled'|trans }}{% endif %}</td>
+                    <td><a href="{{ path('config_otp_email') }}" class="waves-effect waves-light btn{% if app.user.isEmailTwoFactor %} disabled{% endif %}">{{ 'config.form_user.two_factor.action_email'|trans }}</a></td>
+                </tr>
+                <tr>
+                    <td>{{ 'config.form_user.two_factor.googleTwoFactor_label'|trans }}</td>
+                    <td>{% if app.user.isGoogleTwoFactor %}<b>{{ 'config.form_user.two_factor.state_enabled'|trans }}</b>{% else %}{{ 'config.form_user.two_factor.state_disabled'|trans }}{% endif %}</td>
+                    <td><a href="{{ path('config_otp_app') }}" class="waves-effect waves-light btn{% if app.user.isGoogleTwoFactor %} disabled{% endif %}">{{ 'config.form_user.two_factor.action_app'|trans }}</a></td>
+                </tr>
+            </tbody>
+        </table>
+
         {% endif %}
 
         {{ form_widget(form.user._token) }}
-        {{ form_widget(form.user.save) }}
     </form>
 
     {% if enabled_users > 1 %}

--- a/src/Wallabag/CoreBundle/Resources/views/themes/baggy/Config/otp_app.html.twig
+++ b/src/Wallabag/CoreBundle/Resources/views/themes/baggy/Config/otp_app.html.twig
@@ -20,7 +20,7 @@
         <li>
             <p>{{ 'config.otp.app.two_factor_code_description_3'|trans }}</p>
 
-            <p><strong>{{ app.user.getBackupCodes|join("\n")|nl2br }}</strong></p>
+            <p><strong>{{ backupCodes|join("\n")|nl2br }}</strong></p>
         </li>
         <li>
             <p>{{ 'config.otp.app.two_factor_code_description_4'|trans }}</p>

--- a/src/Wallabag/CoreBundle/Resources/views/themes/baggy/Config/otp_app.html.twig
+++ b/src/Wallabag/CoreBundle/Resources/views/themes/baggy/Config/otp_app.html.twig
@@ -1,0 +1,55 @@
+{% extends "WallabagCoreBundle::layout.html.twig" %}
+
+{% block title %}{{ 'config.page_title'|trans }} > {{ 'config.otp.page_title'|trans }}{% endblock %}
+
+{% block content %}
+    <h5>{{ 'config.otp.page_title'|trans }}</h5>
+
+    <ol>
+        <li>
+            <p>{{ 'config.otp.app.two_factor_code_description_1'|trans }}</p>
+            <p>{{ 'config.otp.app.two_factor_code_description_2'|trans }}</p>
+
+            <p>
+                <img id="2faQrcode" class="hide-on-med-and-down" />
+                <script>
+                    document.getElementById('2faQrcode').src = jrQrcode.getQrBase64('{{ qr_code }}');
+                </script>
+            </p>
+        </li>
+        <li>
+            <p>{{ 'config.otp.app.two_factor_code_description_3'|trans }}</p>
+
+            <p><strong>{{ app.user.getBackupCodes|join("\n")|nl2br }}</strong></p>
+        </li>
+        <li>
+            <p>{{ 'config.otp.app.two_factor_code_description_4'|trans }}</p>
+
+            {% for flashMessage in app.session.flashbag.get("two_factor") %}
+            <div class="card-panel red darken-1 black-text">
+                {{ flashMessage|trans }}
+            </div>
+            {% endfor %}
+
+            <form class="form" action="{{ path("config_otp_app_check") }}" method="post">
+                <div class="card-content">
+                    <div class="row">
+                        <div class="input-field col s12">
+                            <label for="_auth_code">{{ "scheb_two_factor.auth_code"|trans }}</label>
+                            <input id="_auth_code" type="text" autocomplete="off" name="_auth_code" />
+                        </div>
+                    </div>
+                </div>
+                <div class="card-action">
+                    <a href="{{ path('config_otp_app_cancel') }}" class="waves-effect waves-light grey btn">
+                        {{ 'config.otp.app.cancel'|trans }}
+                    </a>
+                    <button class="btn waves-effect waves-light" type="submit" name="send">
+                        {{ 'config.otp.app.enable'|trans }}
+                        <i class="material-icons right">send</i>
+                    </button>
+                </div>
+            </form>
+        </li>
+    </ol>
+{% endblock %}

--- a/src/Wallabag/CoreBundle/Resources/views/themes/material/Config/index.html.twig
+++ b/src/Wallabag/CoreBundle/Resources/views/themes/material/Config/index.html.twig
@@ -112,7 +112,7 @@
                                     <img id="androidQrcode" class="hide-on-med-and-down" />
                                 </div>
                                 <script>
-                                    document.getElementById('androidQrcode').src = jrQrcode.getQrBase64('wallabag://{{ app.user.username }}@{{ wallabag_url }}');;
+                                    document.getElementById('androidQrcode').src = jrQrcode.getQrBase64('wallabag://{{ app.user.username }}@{{ wallabag_url }}');
                                 </script>
                             </div>
 
@@ -220,12 +220,16 @@
                                         <br/><br/>
                                         <img id="2faQrcode" class="hide-on-med-and-down" />
                                         <script>
-                                            document.getElementById('2faQrcode').src = jrQrcode.getQrBase64('{{ OtpQrCode }}');;
+                                            document.getElementById('2faQrcode').src = jrQrcode.getQrBase64('{{ OtpQrCode }}');
                                         </script>
                                         <br/><br/>
                                         {{ 'config.form_user.two_factor_code_description_3'|trans }}
                                         <br/><br/>
                                         <strong>{{ app.user.getGoogleAuthenticatorSecret }}</strong>
+                                        <br/><br/>
+                                        {{ 'config.form_user.two_factor_code_description_4'|trans }}
+                                        <br/><br/>
+                                        <strong>{{ app.user.getBackupCodes|join("\n")|nl2br }}</strong>
                                     </div>
                                 {% endfor %}
                             {% endif %}

--- a/src/Wallabag/CoreBundle/Resources/views/themes/material/Config/index.html.twig
+++ b/src/Wallabag/CoreBundle/Resources/views/themes/material/Config/index.html.twig
@@ -212,20 +212,20 @@
                                     </div>
                                 </div>
 
-                                {% for OTPSecret in app.session.flashbag.get('OTPSecret') %}
+                                {% for OtpQrCode in app.session.flashbag.get('OtpQrCode') %}
                                     <div class="card-panel yellow darken-1 black-text">
                                         You just enabled the OTP two factor authentication, open your OTP app and use that code to get a one time password.
                                         <br/>
                                         That code will disapear after a page reload.
                                         <br/><br/>
-                                        <strong>{{ OTPSecret.code }}</strong>
+                                        <strong>{{ app.user.getGoogleAuthenticatorSecret }}</strong>
                                         <br/><br/>
                                         Or you can scan that QR Code with your app:
                                         <br/>
                                         <img id="2faQrcode" class="hide-on-med-and-down" />
 
                                         <script>
-                                            document.getElementById('2faQrcode').src = jrQrcode.getQrBase64('{{ OTPSecret.qrCode }}');;
+                                            document.getElementById('2faQrcode').src = jrQrcode.getQrBase64('{{ OtpQrCode }}');;
                                         </script>
                                     </div>
                                 {% endfor %}

--- a/src/Wallabag/CoreBundle/Resources/views/themes/material/Config/index.html.twig
+++ b/src/Wallabag/CoreBundle/Resources/views/themes/material/Config/index.html.twig
@@ -196,45 +196,40 @@
                                 </div>
                             </div>
 
-                            {% if twofactor_auth %}
-                                <div class="row">
-                                    {{ 'config.form_user.two_factor_description'|trans }}
-
-                                    <div class="input-field col s11">
-                                        {{ form_widget(form.user.emailTwoFactor) }}
-                                        {{ form_label(form.user.emailTwoFactor) }}
-                                        {{ form_errors(form.user.emailTwoFactor) }}
-                                    </div>
-                                    <div class="input-field col s11">
-                                        {{ form_widget(form.user.googleTwoFactor) }}
-                                        {{ form_label(form.user.googleTwoFactor) }}
-                                        {{ form_errors(form.user.googleTwoFactor) }}
-                                    </div>
-                                </div>
-
-                                {% for OtpQrCode in app.session.flashbag.get('OtpQrCode') %}
-                                    <div class="card-panel yellow darken-1 black-text">
-                                        {{ 'config.form_user.two_factor_code_description_1'|trans }}
-                                        <br/>
-                                        {{ 'config.form_user.two_factor_code_description_2'|trans }}
-                                        <br/><br/>
-                                        <img id="2faQrcode" class="hide-on-med-and-down" />
-                                        <script>
-                                            document.getElementById('2faQrcode').src = jrQrcode.getQrBase64('{{ OtpQrCode }}');
-                                        </script>
-                                        <br/><br/>
-                                        {{ 'config.form_user.two_factor_code_description_3'|trans }}
-                                        <br/><br/>
-                                        <strong>{{ app.user.getGoogleAuthenticatorSecret }}</strong>
-                                        <br/><br/>
-                                        {{ 'config.form_user.two_factor_code_description_4'|trans }}
-                                        <br/><br/>
-                                        <strong>{{ app.user.getBackupCodes|join("\n")|nl2br }}</strong>
-                                    </div>
-                                {% endfor %}
-                            {% endif %}
-
                             {{ form_widget(form.user.save, {'attr': {'class': 'btn waves-effect waves-light'}}) }}
+
+                            {% if twofactor_auth %}
+                                <br/>
+                                <br/>
+                                <div class="row">
+                                    <h5>{{ 'config.otp.page_title'|trans }}</h5>
+
+                                    <p>{{ 'config.form_user.two_factor_description'|trans }}</p>
+
+                                    <table>
+                                        <thead>
+                                            <tr>
+                                                <th>{{ 'config.form_user.two_factor.table_method'|trans }}</th>
+                                                <th>{{ 'config.form_user.two_factor.table_state'|trans }}</th>
+                                                <th>{{ 'config.form_user.two_factor.table_action'|trans }}</th>
+                                            </tr>
+                                        </thead>
+
+                                        <tbody>
+                                            <tr>
+                                                <td>{{ 'config.form_user.two_factor.emailTwoFactor_label'|trans }}</td>
+                                                <td>{% if app.user.isEmailTwoFactor %}<b>{{ 'config.form_user.two_factor.state_enabled'|trans }}</b>{% else %}{{ 'config.form_user.two_factor.state_disabled'|trans }}{% endif %}</td>
+                                                <td><a href="{{ path('config_otp_email') }}" class="waves-effect waves-light btn{% if app.user.isEmailTwoFactor %} disabled{% endif %}">{{ 'config.form_user.two_factor.action_email'|trans }}</a></td>
+                                            </tr>
+                                            <tr>
+                                                <td>{{ 'config.form_user.two_factor.googleTwoFactor_label'|trans }}</td>
+                                                <td>{% if app.user.isGoogleTwoFactor %}<b>{{ 'config.form_user.two_factor.state_enabled'|trans }}</b>{% else %}{{ 'config.form_user.two_factor.state_disabled'|trans }}{% endif %}</td>
+                                                <td><a href="{{ path('config_otp_app') }}" class="waves-effect waves-light btn{% if app.user.isGoogleTwoFactor %} disabled{% endif %}">{{ 'config.form_user.two_factor.action_app'|trans }}</a></td>
+                                            </tr>
+                                        </tbody>
+                                    </table>
+                                </div>
+                            {% endif %}
                             {{ form_widget(form.user._token) }}
                         </form>
                     </div>

--- a/src/Wallabag/CoreBundle/Resources/views/themes/material/Config/index.html.twig
+++ b/src/Wallabag/CoreBundle/Resources/views/themes/material/Config/index.html.twig
@@ -214,19 +214,18 @@
 
                                 {% for OtpQrCode in app.session.flashbag.get('OtpQrCode') %}
                                     <div class="card-panel yellow darken-1 black-text">
-                                        You just enabled the OTP two factor authentication, open your OTP app and use that code to get a one time password.
+                                        {{ 'config.form_user.two_factor_code_description_1'|trans }}
                                         <br/>
-                                        That code will disapear after a page reload.
+                                        {{ 'config.form_user.two_factor_code_description_2'|trans }}
                                         <br/><br/>
-                                        <strong>{{ app.user.getGoogleAuthenticatorSecret }}</strong>
-                                        <br/><br/>
-                                        Or you can scan that QR Code with your app:
-                                        <br/>
                                         <img id="2faQrcode" class="hide-on-med-and-down" />
-
                                         <script>
                                             document.getElementById('2faQrcode').src = jrQrcode.getQrBase64('{{ OtpQrCode }}');;
                                         </script>
+                                        <br/><br/>
+                                        {{ 'config.form_user.two_factor_code_description_3'|trans }}
+                                        <br/><br/>
+                                        <strong>{{ app.user.getGoogleAuthenticatorSecret }}</strong>
                                     </div>
                                 {% endfor %}
                             {% endif %}

--- a/src/Wallabag/CoreBundle/Resources/views/themes/material/Config/index.html.twig
+++ b/src/Wallabag/CoreBundle/Resources/views/themes/material/Config/index.html.twig
@@ -112,8 +112,7 @@
                                     <img id="androidQrcode" class="hide-on-med-and-down" />
                                 </div>
                                 <script>
-                                    const imgBase64 = jrQrcode.getQrBase64('wallabag://{{ app.user.username }}@{{ wallabag_url }}');
-                                    document.getElementById('androidQrcode').src = imgBase64;
+                                    document.getElementById('androidQrcode').src = jrQrcode.getQrBase64('wallabag://{{ app.user.username }}@{{ wallabag_url }}');;
                                 </script>
                             </div>
 
@@ -198,22 +197,38 @@
                             </div>
 
                             {% if twofactor_auth %}
-                            <div class="row">
-                                <div class="input-field col s11">
+                                <div class="row">
                                     {{ 'config.form_user.two_factor_description'|trans }}
 
-                                    <br />
+                                    <div class="input-field col s11">
+                                        {{ form_widget(form.user.emailTwoFactor) }}
+                                        {{ form_label(form.user.emailTwoFactor) }}
+                                        {{ form_errors(form.user.emailTwoFactor) }}
+                                    </div>
+                                    <div class="input-field col s11">
+                                        {{ form_widget(form.user.googleTwoFactor) }}
+                                        {{ form_label(form.user.googleTwoFactor) }}
+                                        {{ form_errors(form.user.googleTwoFactor) }}
+                                    </div>
+                                </div>
 
-                                    {{ form_widget(form.user.twoFactorAuthentication) }}
-                                    {{ form_label(form.user.twoFactorAuthentication) }}
-                                    {{ form_errors(form.user.twoFactorAuthentication) }}
-                                </div>
-                                <div class="input-field col s1">
-                                    <a href="#" class="tooltipped" data-position="left" data-delay="50" data-tooltip="{{ 'config.form_user.help_twoFactorAuthentication'|trans }}">
-                                        <i class="material-icons">live_help</i>
-                                    </a>
-                                </div>
-                            </div>
+                                {% for OTPSecret in app.session.flashbag.get('OTPSecret') %}
+                                    <div class="card-panel yellow darken-1 black-text">
+                                        You just enabled the OTP two factor authentication, open your OTP app and use that code to get a one time password.
+                                        <br/>
+                                        That code will disapear after a page reload.
+                                        <br/><br/>
+                                        <strong>{{ OTPSecret.code }}</strong>
+                                        <br/><br/>
+                                        Or you can scan that QR Code with your app:
+                                        <br/>
+                                        <img id="2faQrcode" class="hide-on-med-and-down" />
+
+                                        <script>
+                                            document.getElementById('2faQrcode').src = jrQrcode.getQrBase64('{{ OTPSecret.qrCode }}');;
+                                        </script>
+                                    </div>
+                                {% endfor %}
                             {% endif %}
 
                             {{ form_widget(form.user.save, {'attr': {'class': 'btn waves-effect waves-light'}}) }}

--- a/src/Wallabag/CoreBundle/Resources/views/themes/material/Config/index.html.twig
+++ b/src/Wallabag/CoreBundle/Resources/views/themes/material/Config/index.html.twig
@@ -16,6 +16,7 @@
                             <li class="tab col s12 m6 l3"><a href="#set3">{{ 'config.tab_menu.user_info'|trans }}</a></li>
                             <li class="tab col s12 m6 l3"><a href="#set4">{{ 'config.tab_menu.password'|trans }}</a></li>
                             <li class="tab col s12 m6 l3"><a href="#set5">{{ 'config.tab_menu.rules'|trans }}</a></li>
+                            <li class="tab col s12 m6 l3"><a href="#set6">{{ 'config.tab_menu.reset'|trans }}</a></li>
                         </ul>
                     </div>
 
@@ -218,37 +219,6 @@
                             {{ form_widget(form.user.save, {'attr': {'class': 'btn waves-effect waves-light'}}) }}
                             {{ form_widget(form.user._token) }}
                         </form>
-
-                        <br /><hr /><br />
-
-                        <div class="row">
-                            <h5>{{ 'config.reset.title'|trans }}</h5>
-                            <p>{{ 'config.reset.description'|trans }}</p>
-                            <a href="{{ path('config_reset', { type: 'annotations'}) }}" onclick="return confirm('{{ 'config.reset.confirm'|trans|escape('js') }}')" class="waves-effect waves-light btn red">
-                                {{ 'config.reset.annotations'|trans }}
-                            </a>
-                            <a href="{{ path('config_reset', { type: 'tags'}) }}" onclick="return confirm('{{ 'config.reset.confirm'|trans|escape('js') }}')" class="waves-effect waves-light btn red">
-                                {{ 'config.reset.tags'|trans }}
-                            </a>
-                            <a href="{{ path('config_reset', { type: 'archived'}) }}" onclick="return confirm('{{ 'config.reset.confirm'|trans|escape('js') }}')" class="waves-effect waves-light btn red">
-                                {{ 'config.reset.archived'|trans }}
-                            </a>
-                            <a href="{{ path('config_reset', { type: 'entries'}) }}" onclick="return confirm('{{ 'config.reset.confirm'|trans|escape('js') }}')" class="waves-effect waves-light btn red">
-                                {{ 'config.reset.entries'|trans }}
-                            </a>
-                        </div>
-
-                        {% if enabled_users > 1 %}
-                            <br /><hr /><br />
-
-                            <div class="row">
-                                <h5>{{ 'config.form_user.delete.title'|trans }}</h5>
-                                <p>{{ 'config.form_user.delete.description'|trans }}</p>
-                                <a href="{{ path('delete_account') }}" onclick="return confirm('{{ 'config.form_user.delete.confirm'|trans|escape('js') }}')" class="waves-effect waves-light btn red delete-account">
-                                    {{ 'config.form_user.delete.button'|trans }}
-                                </a>
-                            </div>
-                        {% endif %}
                     </div>
 
                     <div id="set4" class="col s12">
@@ -421,6 +391,37 @@
                                 </table>
                             </div>
                         </div>
+                    </div>
+
+                    <div id="set6" class="col s12">
+                        <div class="row">
+                            <h5>{{ 'config.reset.title'|trans }}</h5>
+                            <p>{{ 'config.reset.description'|trans }}</p>
+                            <a href="{{ path('config_reset', { type: 'annotations'}) }}" onclick="return confirm('{{ 'config.reset.confirm'|trans|escape('js') }}')" class="waves-effect waves-light btn red">
+                                {{ 'config.reset.annotations'|trans }}
+                            </a>
+                            <a href="{{ path('config_reset', { type: 'tags'}) }}" onclick="return confirm('{{ 'config.reset.confirm'|trans|escape('js') }}')" class="waves-effect waves-light btn red">
+                                {{ 'config.reset.tags'|trans }}
+                            </a>
+                            <a href="{{ path('config_reset', { type: 'archived'}) }}" onclick="return confirm('{{ 'config.reset.confirm'|trans|escape('js') }}')" class="waves-effect waves-light btn red">
+                                {{ 'config.reset.archived'|trans }}
+                            </a>
+                            <a href="{{ path('config_reset', { type: 'entries'}) }}" onclick="return confirm('{{ 'config.reset.confirm'|trans|escape('js') }}')" class="waves-effect waves-light btn red">
+                                {{ 'config.reset.entries'|trans }}
+                            </a>
+                        </div>
+
+                        {% if enabled_users > 1 %}
+                            <br /><hr /><br />
+
+                            <div class="row">
+                                <h5>{{ 'config.form_user.delete.title'|trans }}</h5>
+                                <p>{{ 'config.form_user.delete.description'|trans }}</p>
+                                <a href="{{ path('delete_account') }}" onclick="return confirm('{{ 'config.form_user.delete.confirm'|trans|escape('js') }}')" class="waves-effect waves-light btn red delete-account">
+                                    {{ 'config.form_user.delete.button'|trans }}
+                                </a>
+                            </div>
+                        {% endif %}
                     </div>
                 </div>
 

--- a/src/Wallabag/CoreBundle/Resources/views/themes/material/Config/otp_app.html.twig
+++ b/src/Wallabag/CoreBundle/Resources/views/themes/material/Config/otp_app.html.twig
@@ -24,7 +24,7 @@
                         <li>
                             <p>{{ 'config.otp.app.two_factor_code_description_3'|trans }}</p>
 
-                            <p><strong>{{ app.user.getBackupCodes|join("\n")|nl2br }}</strong></p>
+                            <p><strong>{{ backupCodes|join("\n")|nl2br }}</strong></p>
                         </li>
                         <li>
                             <p>{{ 'config.otp.app.two_factor_code_description_4'|trans }}</p>

--- a/src/Wallabag/CoreBundle/Resources/views/themes/material/Config/otp_app.html.twig
+++ b/src/Wallabag/CoreBundle/Resources/views/themes/material/Config/otp_app.html.twig
@@ -1,0 +1,63 @@
+{% extends "WallabagCoreBundle::layout.html.twig" %}
+
+{% block title %}{{ 'config.page_title'|trans }} > {{ 'config.otp.page_title'|trans }}{% endblock %}
+
+{% block content %}
+    <div class="row">
+        <div class="col s12">
+            <div class="card-panel settings">
+                <div class="row">
+                    <h5>{{ 'config.otp.page_title'|trans }}</h5>
+
+                    <ol>
+                        <li>
+                            <p>{{ 'config.otp.app.two_factor_code_description_1'|trans }}</p>
+                            <p>{{ 'config.otp.app.two_factor_code_description_2'|trans }}</p>
+
+                            <p>
+                                <img id="2faQrcode" class="hide-on-med-and-down" />
+                                <script>
+                                    document.getElementById('2faQrcode').src = jrQrcode.getQrBase64('{{ qr_code }}');
+                                </script>
+                            </p>
+                        </li>
+                        <li>
+                            <p>{{ 'config.otp.app.two_factor_code_description_3'|trans }}</p>
+
+                            <p><strong>{{ app.user.getBackupCodes|join("\n")|nl2br }}</strong></p>
+                        </li>
+                        <li>
+                            <p>{{ 'config.otp.app.two_factor_code_description_4'|trans }}</p>
+
+                            {% for flashMessage in app.session.flashbag.get("two_factor") %}
+                            <div class="card-panel red darken-1 black-text">
+                                {{ flashMessage|trans }}
+                            </div>
+                            {% endfor %}
+
+                            <form class="form" action="{{ path("config_otp_app_check") }}" method="post">
+                                <div class="card-content">
+                                    <div class="row">
+                                        <div class="input-field col s12">
+                                            <label for="_auth_code">{{ "scheb_two_factor.auth_code"|trans }}</label>
+                                            <input id="_auth_code" type="text" autocomplete="off" name="_auth_code" />
+                                        </div>
+                                    </div>
+                                </div>
+                                <div class="card-action">
+                                    <a href="{{ path('config_otp_app_cancel') }}" class="waves-effect waves-light grey btn">
+                                        {{ 'config.otp.app.cancel'|trans }}
+                                    </a>
+                                    <button class="btn waves-effect waves-light" type="submit" name="send">
+                                        {{ 'config.otp.app.enable'|trans }}
+                                        <i class="material-icons right">send</i>
+                                    </button>
+                                </div>
+                            </form>
+                        </li>
+                    </ol>
+                </div>
+            </div>
+        </div>
+    </div>
+{% endblock %}

--- a/src/Wallabag/UserBundle/Controller/ManageController.php
+++ b/src/Wallabag/UserBundle/Controller/ManageController.php
@@ -146,8 +146,6 @@ class ManageController extends Controller
         $form->handleRequest($request);
 
         if ($form->isSubmitted() && $form->isValid()) {
-            $this->get('logger')->info('searching users');
-
             $searchTerm = (isset($request->get('search_user')['term']) ? $request->get('search_user')['term'] : '');
 
             $qb = $em->getRepository('WallabagUserBundle:User')->getQueryBuilderForSearch($searchTerm);

--- a/src/Wallabag/UserBundle/Form/UserType.php
+++ b/src/Wallabag/UserBundle/Form/UserType.php
@@ -35,9 +35,14 @@ class UserType extends AbstractType
                 'required' => false,
                 'label' => 'user.form.enabled_label',
             ])
-            ->add('twoFactorAuthentication', CheckboxType::class, [
+            ->add('emailTwoFactor', CheckboxType::class, [
                 'required' => false,
-                'label' => 'user.form.twofactor_label',
+                'label' => 'user.form.twofactor_email_label',
+            ])
+            ->add('googleTwoFactor', CheckboxType::class, [
+                'required' => false,
+                'label' => 'user.form.twofactor_google_label',
+                'mapped' => false,
             ])
             ->add('save', SubmitType::class, [
                 'label' => 'user.form.save',

--- a/src/Wallabag/UserBundle/Mailer/AuthCodeMailer.php
+++ b/src/Wallabag/UserBundle/Mailer/AuthCodeMailer.php
@@ -78,7 +78,7 @@ class AuthCodeMailer implements AuthCodeMailerInterface
      *
      * @param TwoFactorInterface $user
      */
-    public function sendAuthCode(TwoFactorInterface $user)
+    public function sendAuthCode(TwoFactorInterface $user): void
     {
         $template = $this->twig->loadTemplate('WallabagUserBundle:TwoFactor:email_auth_code.html.twig');
 

--- a/src/Wallabag/UserBundle/Mailer/AuthCodeMailer.php
+++ b/src/Wallabag/UserBundle/Mailer/AuthCodeMailer.php
@@ -97,7 +97,7 @@ class AuthCodeMailer implements AuthCodeMailerInterface
 
         $message = new \Swift_Message();
         $message
-            ->setTo($user->getEmail())
+            ->setTo($user->getEmailAuthRecipient())
             ->setFrom($this->senderEmail, $this->senderName)
             ->setSubject($subject)
             ->setBody($bodyText, 'text/plain')

--- a/src/Wallabag/UserBundle/Resources/views/Authentication/form.html.twig
+++ b/src/Wallabag/UserBundle/Resources/views/Authentication/form.html.twig
@@ -1,7 +1,8 @@
+{# Override `vendor/scheb/two-factor-bundle/Resources/views/Authentication/form.html.twig` #}
 {% extends "WallabagUserBundle::layout.html.twig" %}
 
 {% block fos_user_content %}
-<form class="form" action="" method="post">
+<form class="form" action="{{ path("2fa_login_check") }}" method="post">
     <div class="card-content">
         <div class="row">
 
@@ -9,14 +10,19 @@
             <p class="error">{{ flashMessage|trans }}</p>
             {% endfor %}
 
+            {# Authentication errors #}
+            {% if authenticationError %}
+            <p class="error">{{ authenticationError|trans(authenticationErrorData) }}</p>
+            {% endif %}
+
             <div class="input-field col s12">
                 <label for="_auth_code">{{ "scheb_two_factor.auth_code"|trans }}</label>
-                <input id="_auth_code" type="text" autocomplete="off" name="_auth_code" />
+                <input id="_auth_code" type="text" autocomplete="off" name="{{ authCodeParameterName }}" />
             </div>
 
-            {% if useTrustedOption %}
+            {% if displayTrustedOption %}
             <div class="input-field col s12">
-                <input id="_trusted" type="checkbox" name="_trusted" />
+                <input id="_trusted" type="checkbox" name="{{ trustedParameterName }}" />
                 <label for="_trusted">{{ "scheb_two_factor.trusted"|trans }}</label>
             </div>
             {% endif %}

--- a/src/Wallabag/UserBundle/Resources/views/Manage/edit.html.twig
+++ b/src/Wallabag/UserBundle/Resources/views/Manage/edit.html.twig
@@ -59,12 +59,6 @@
                                         {{ form_label(edit_form.googleTwoFactor) }}
                                         {{ form_errors(edit_form.googleTwoFactor) }}
                                     </div>
-
-                                    {% if user.isGoogleAuthenticatorEnabled %}
-                                    <div class="input-field col s12">
-                                        <p><strong>OTP Secret</strong>: {{ user.googleAuthenticatorSecret }}</p>
-                                    </div>
-                                    {% endif %}
                                 </div>
                                 {% endif %}
 

--- a/src/Wallabag/UserBundle/Resources/views/Manage/edit.html.twig
+++ b/src/Wallabag/UserBundle/Resources/views/Manage/edit.html.twig
@@ -50,10 +50,21 @@
                                 {% if twofactor_auth %}
                                 <div class="row">
                                     <div class="input-field col s12">
-                                        {{ form_widget(edit_form.twoFactorAuthentication) }}
-                                        {{ form_label(edit_form.twoFactorAuthentication) }}
-                                        {{ form_errors(edit_form.twoFactorAuthentication) }}
+                                        {{ form_widget(edit_form.emailTwoFactor) }}
+                                        {{ form_label(edit_form.emailTwoFactor) }}
+                                        {{ form_errors(edit_form.emailTwoFactor) }}
                                     </div>
+                                    <div class="input-field col s12">
+                                        {{ form_widget(edit_form.googleTwoFactor) }}
+                                        {{ form_label(edit_form.googleTwoFactor) }}
+                                        {{ form_errors(edit_form.googleTwoFactor) }}
+                                    </div>
+
+                                    {% if user.isGoogleAuthenticatorEnabled %}
+                                    <div class="input-field col s12">
+                                        <p><strong>OTP Secret</strong>: {{ user.googleAuthenticatorSecret }}</p>
+                                    </div>
+                                    {% endif %}
                                 </div>
                                 {% endif %}
 

--- a/tests/Wallabag/CoreBundle/Command/ShowUserCommandTest.php
+++ b/tests/Wallabag/CoreBundle/Command/ShowUserCommandTest.php
@@ -59,7 +59,8 @@ class ShowUserCommandTest extends WallabagCoreTestCase
         $this->assertContains('Username: admin', $tester->getDisplay());
         $this->assertContains('Email: bigboss@wallabag.org', $tester->getDisplay());
         $this->assertContains('Display name: Big boss', $tester->getDisplay());
-        $this->assertContains('2FA activated: no', $tester->getDisplay());
+        $this->assertContains('2FA (email) activated', $tester->getDisplay());
+        $this->assertContains('2FA (OTP) activated', $tester->getDisplay());
     }
 
     public function testShowUser()

--- a/tests/Wallabag/CoreBundle/Controller/ConfigControllerTest.php
+++ b/tests/Wallabag/CoreBundle/Controller/ConfigControllerTest.php
@@ -297,119 +297,6 @@ class ConfigControllerTest extends WallabagCoreTestCase
         $this->assertContains('flashes.config.notice.user_updated', $alert[0]);
     }
 
-    public function testUserEnable2faEmail()
-    {
-        $this->logInAs('admin');
-        $client = $this->getClient();
-
-        $crawler = $client->request('GET', '/config');
-
-        $this->assertSame(200, $client->getResponse()->getStatusCode());
-
-        $form = $crawler->filter('button[id=update_user_save]')->form();
-
-        $data = [
-            'update_user[emailTwoFactor]' => '1',
-        ];
-
-        $client->submit($form, $data);
-
-        $this->assertSame(302, $client->getResponse()->getStatusCode());
-
-        $crawler = $client->followRedirect();
-
-        $this->assertGreaterThan(1, $alert = $crawler->filter('body')->extract(['_text']));
-        $this->assertContains('flashes.config.notice.user_updated', $alert[0]);
-
-        // restore user
-        $em = $this->getEntityManager();
-        $user = $em
-            ->getRepository('WallabagUserBundle:User')
-            ->findOneByUsername('admin');
-
-        $this->assertTrue($user->isEmailTwoFactor());
-
-        $user->setEmailTwoFactor(false);
-        $em->persist($user);
-        $em->flush();
-    }
-
-    public function testUserEnable2faGoogle()
-    {
-        $this->logInAs('admin');
-        $client = $this->getClient();
-
-        $crawler = $client->request('GET', '/config');
-
-        $this->assertSame(200, $client->getResponse()->getStatusCode());
-
-        $form = $crawler->filter('button[id=update_user_save]')->form();
-
-        $data = [
-            'update_user[googleTwoFactor]' => '1',
-        ];
-
-        $client->submit($form, $data);
-
-        $this->assertSame(302, $client->getResponse()->getStatusCode());
-
-        $crawler = $client->followRedirect();
-
-        $this->assertGreaterThan(1, $alert = $crawler->filter('body')->extract(['_text']));
-        $this->assertContains('flashes.config.notice.user_updated', $alert[0]);
-
-        // restore user
-        $em = $this->getEntityManager();
-        $user = $em
-            ->getRepository('WallabagUserBundle:User')
-            ->findOneByUsername('admin');
-
-        $this->assertTrue($user->isGoogleAuthenticatorEnabled());
-
-        $user->setGoogleAuthenticatorSecret(null);
-        $em->persist($user);
-        $em->flush();
-    }
-
-    public function testUserEnable2faBoth()
-    {
-        $this->logInAs('admin');
-        $client = $this->getClient();
-
-        $crawler = $client->request('GET', '/config');
-
-        $this->assertSame(200, $client->getResponse()->getStatusCode());
-
-        $form = $crawler->filter('button[id=update_user_save]')->form();
-
-        $data = [
-            'update_user[googleTwoFactor]' => '1',
-            'update_user[emailTwoFactor]' => '1',
-        ];
-
-        $client->submit($form, $data);
-
-        $this->assertSame(302, $client->getResponse()->getStatusCode());
-
-        $crawler = $client->followRedirect();
-
-        $this->assertGreaterThan(1, $alert = $crawler->filter('body')->extract(['_text']));
-        $this->assertContains('flashes.config.notice.user_updated', $alert[0]);
-
-        // restore user
-        $em = $this->getEntityManager();
-        $user = $em
-            ->getRepository('WallabagUserBundle:User')
-            ->findOneByUsername('admin');
-
-        $this->assertTrue($user->isGoogleAuthenticatorEnabled());
-        $this->assertFalse($user->isEmailTwoFactor());
-
-        $user->setGoogleAuthenticatorSecret(null);
-        $em->persist($user);
-        $em->flush();
-    }
-
     public function testRssUpdateResetToken()
     {
         $this->logInAs('admin');
@@ -1112,5 +999,86 @@ class ConfigControllerTest extends WallabagCoreTestCase
 
         $this->assertNotSame('yuyuyuyu', $client->getRequest()->getLocale());
         $this->assertNotSame('yuyuyuyu', $client->getContainer()->get('session')->get('_locale'));
+    }
+
+    public function testUserEnable2faEmail()
+    {
+        $this->logInAs('admin');
+        $client = $this->getClient();
+
+        $crawler = $client->request('GET', '/config/otp/email');
+
+        $this->assertSame(302, $client->getResponse()->getStatusCode());
+
+        $crawler = $client->followRedirect();
+
+        $this->assertGreaterThan(1, $alert = $crawler->filter('body')->extract(['_text']));
+        $this->assertContains('flashes.config.notice.otp_enabled', $alert[0]);
+
+        // restore user
+        $em = $this->getEntityManager();
+        $user = $em
+            ->getRepository('WallabagUserBundle:User')
+            ->findOneByUsername('admin');
+
+        $this->assertTrue($user->isEmailTwoFactor());
+
+        $user->setEmailTwoFactor(false);
+        $em->persist($user);
+        $em->flush();
+    }
+
+    public function testUserEnable2faGoogle()
+    {
+        $this->logInAs('admin');
+        $client = $this->getClient();
+
+        $crawler = $client->request('GET', '/config/otp/app');
+
+        $this->assertSame(200, $client->getResponse()->getStatusCode());
+
+        // restore user
+        $em = $this->getEntityManager();
+        $user = $em
+            ->getRepository('WallabagUserBundle:User')
+            ->findOneByUsername('admin');
+
+        $this->assertTrue($user->isGoogleTwoFactor());
+        $this->assertGreaterThan(0, $user->getBackupCodes());
+
+        $user->setGoogleAuthenticatorSecret(false);
+        $user->setBackupCodes(null);
+        $em->persist($user);
+        $em->flush();
+    }
+
+    public function testUserEnable2faGoogleCancel()
+    {
+        $this->logInAs('admin');
+        $client = $this->getClient();
+
+        $crawler = $client->request('GET', '/config/otp/app');
+
+        $this->assertSame(200, $client->getResponse()->getStatusCode());
+
+        // restore user
+        $em = $this->getEntityManager();
+        $user = $em
+            ->getRepository('WallabagUserBundle:User')
+            ->findOneByUsername('admin');
+
+        $this->assertTrue($user->isGoogleTwoFactor());
+        $this->assertGreaterThan(0, $user->getBackupCodes());
+
+        $crawler = $client->request('GET', '/config/otp/app/cancel');
+
+        $this->assertSame(302, $client->getResponse()->getStatusCode());
+
+        $user = $em
+            ->getRepository('WallabagUserBundle:User')
+            ->findOneByUsername('admin');
+
+        $this->assertFalse($user->isGoogleTwoFactor());
+        $this->assertEmpty($user->getBackupCodes());
     }
 }

--- a/tests/Wallabag/CoreBundle/Controller/ConfigControllerTest.php
+++ b/tests/Wallabag/CoreBundle/Controller/ConfigControllerTest.php
@@ -297,6 +297,119 @@ class ConfigControllerTest extends WallabagCoreTestCase
         $this->assertContains('flashes.config.notice.user_updated', $alert[0]);
     }
 
+    public function testUserEnable2faEmail()
+    {
+        $this->logInAs('admin');
+        $client = $this->getClient();
+
+        $crawler = $client->request('GET', '/config');
+
+        $this->assertSame(200, $client->getResponse()->getStatusCode());
+
+        $form = $crawler->filter('button[id=update_user_save]')->form();
+
+        $data = [
+            'update_user[emailTwoFactor]' => '1',
+        ];
+
+        $client->submit($form, $data);
+
+        $this->assertSame(302, $client->getResponse()->getStatusCode());
+
+        $crawler = $client->followRedirect();
+
+        $this->assertGreaterThan(1, $alert = $crawler->filter('body')->extract(['_text']));
+        $this->assertContains('flashes.config.notice.user_updated', $alert[0]);
+
+        // restore user
+        $em = $this->getEntityManager();
+        $user = $em
+            ->getRepository('WallabagUserBundle:User')
+            ->findOneByUsername('admin');
+
+        $this->assertTrue($user->isEmailTwoFactor());
+
+        $user->setEmailTwoFactor(false);
+        $em->persist($user);
+        $em->flush();
+    }
+
+    public function testUserEnable2faGoogle()
+    {
+        $this->logInAs('admin');
+        $client = $this->getClient();
+
+        $crawler = $client->request('GET', '/config');
+
+        $this->assertSame(200, $client->getResponse()->getStatusCode());
+
+        $form = $crawler->filter('button[id=update_user_save]')->form();
+
+        $data = [
+            'update_user[googleTwoFactor]' => '1',
+        ];
+
+        $client->submit($form, $data);
+
+        $this->assertSame(302, $client->getResponse()->getStatusCode());
+
+        $crawler = $client->followRedirect();
+
+        $this->assertGreaterThan(1, $alert = $crawler->filter('body')->extract(['_text']));
+        $this->assertContains('flashes.config.notice.user_updated', $alert[0]);
+
+        // restore user
+        $em = $this->getEntityManager();
+        $user = $em
+            ->getRepository('WallabagUserBundle:User')
+            ->findOneByUsername('admin');
+
+        $this->assertTrue($user->isGoogleAuthenticatorEnabled());
+
+        $user->setGoogleAuthenticatorSecret(null);
+        $em->persist($user);
+        $em->flush();
+    }
+
+    public function testUserEnable2faBoth()
+    {
+        $this->logInAs('admin');
+        $client = $this->getClient();
+
+        $crawler = $client->request('GET', '/config');
+
+        $this->assertSame(200, $client->getResponse()->getStatusCode());
+
+        $form = $crawler->filter('button[id=update_user_save]')->form();
+
+        $data = [
+            'update_user[googleTwoFactor]' => '1',
+            'update_user[emailTwoFactor]' => '1',
+        ];
+
+        $client->submit($form, $data);
+
+        $this->assertSame(302, $client->getResponse()->getStatusCode());
+
+        $crawler = $client->followRedirect();
+
+        $this->assertGreaterThan(1, $alert = $crawler->filter('body')->extract(['_text']));
+        $this->assertContains('flashes.config.notice.user_updated', $alert[0]);
+
+        // restore user
+        $em = $this->getEntityManager();
+        $user = $em
+            ->getRepository('WallabagUserBundle:User')
+            ->findOneByUsername('admin');
+
+        $this->assertTrue($user->isGoogleAuthenticatorEnabled());
+        $this->assertFalse($user->isEmailTwoFactor());
+
+        $user->setGoogleAuthenticatorSecret(null);
+        $em->persist($user);
+        $em->flush();
+    }
+
     public function testRssUpdateResetToken()
     {
         $this->logInAs('admin');

--- a/tests/Wallabag/CoreBundle/Controller/SecurityControllerTest.php
+++ b/tests/Wallabag/CoreBundle/Controller/SecurityControllerTest.php
@@ -26,7 +26,7 @@ class SecurityControllerTest extends WallabagCoreTestCase
         $this->assertContains('config.form_rss.description', $crawler->filter('body')->extract(['_text'])[0]);
     }
 
-    public function testLoginWith2Factor()
+    public function testLoginWith2FactorEmail()
     {
         $client = $this->getClient();
 
@@ -42,7 +42,7 @@ class SecurityControllerTest extends WallabagCoreTestCase
         $user = $em
             ->getRepository('WallabagUserBundle:User')
             ->findOneByUsername('admin');
-        $user->setTwoFactorAuthentication(true);
+        $user->setEmailTwoFactor(true);
         $em->persist($user);
         $em->flush();
 
@@ -54,12 +54,12 @@ class SecurityControllerTest extends WallabagCoreTestCase
         $user = $em
             ->getRepository('WallabagUserBundle:User')
             ->findOneByUsername('admin');
-        $user->setTwoFactorAuthentication(false);
+        $user->setEmailTwoFactor(false);
         $em->persist($user);
         $em->flush();
     }
 
-    public function testTrustedComputer()
+    public function testLoginWith2FactorGoogle()
     {
         $client = $this->getClient();
 
@@ -69,15 +69,27 @@ class SecurityControllerTest extends WallabagCoreTestCase
             return;
         }
 
+        $client->followRedirects();
+
         $em = $client->getContainer()->get('doctrine.orm.entity_manager');
         $user = $em
             ->getRepository('WallabagUserBundle:User')
             ->findOneByUsername('admin');
+        $user->setGoogleAuthenticatorSecret('26LDIHYGHNELOQEM');
+        $em->persist($user);
+        $em->flush();
 
-        $date = new \DateTime();
-        $user->addTrustedComputer('ABCDEF', $date->add(new \DateInterval('P1M')));
-        $this->assertTrue($user->isTrustedComputer('ABCDEF'));
-        $this->assertFalse($user->isTrustedComputer('FEDCBA'));
+        $this->logInAsUsingHttp('admin');
+        $crawler = $client->request('GET', '/config');
+        $this->assertContains('scheb_two_factor.trusted', $crawler->filter('body')->extract(['_text'])[0]);
+
+        // restore user
+        $user = $em
+            ->getRepository('WallabagUserBundle:User')
+            ->findOneByUsername('admin');
+        $user->setGoogleAuthenticatorSecret(null);
+        $em->persist($user);
+        $em->flush();
     }
 
     public function testEnabledRegistration()

--- a/tests/Wallabag/CoreBundle/Helper/ContentProxyTest.php
+++ b/tests/Wallabag/CoreBundle/Helper/ContentProxyTest.php
@@ -163,7 +163,7 @@ class ContentProxyTest extends TestCase
 
         $this->assertSame('http://1.1.1.1', $entry->getUrl());
         $this->assertSame('this is my title', $entry->getTitle());
-        $this->assertContains('this is my content', $entry->getContent());
+        $this->assertContains('content', $entry->getContent());
         $this->assertSame('http://3.3.3.3/cover.jpg', $entry->getPreviewPicture());
         $this->assertSame('text/html', $entry->getMimetype());
         $this->assertSame('fr', $entry->getLanguage());
@@ -205,7 +205,7 @@ class ContentProxyTest extends TestCase
 
         $this->assertSame('http://1.1.1.1', $entry->getUrl());
         $this->assertSame('this is my title', $entry->getTitle());
-        $this->assertContains('this is my content', $entry->getContent());
+        $this->assertContains('content', $entry->getContent());
         $this->assertNull($entry->getPreviewPicture());
         $this->assertSame('text/html', $entry->getMimetype());
         $this->assertSame('fr', $entry->getLanguage());
@@ -247,7 +247,7 @@ class ContentProxyTest extends TestCase
 
         $this->assertSame('http://1.1.1.1', $entry->getUrl());
         $this->assertSame('this is my title', $entry->getTitle());
-        $this->assertContains('this is my content', $entry->getContent());
+        $this->assertContains('content', $entry->getContent());
         $this->assertSame('text/html', $entry->getMimetype());
         $this->assertNull($entry->getLanguage());
         $this->assertSame('200', $entry->getHttpStatus());
@@ -296,7 +296,7 @@ class ContentProxyTest extends TestCase
 
         $this->assertSame('http://1.1.1.1', $entry->getUrl());
         $this->assertSame('this is my title', $entry->getTitle());
-        $this->assertContains('this is my content', $entry->getContent());
+        $this->assertContains('content', $entry->getContent());
         $this->assertNull($entry->getPreviewPicture());
         $this->assertSame('text/html', $entry->getMimetype());
         $this->assertSame('fr', $entry->getLanguage());
@@ -332,7 +332,7 @@ class ContentProxyTest extends TestCase
 
         $this->assertSame('http://1.1.1.1', $entry->getUrl());
         $this->assertSame('this is my title', $entry->getTitle());
-        $this->assertContains('this is my content', $entry->getContent());
+        $this->assertContains('content', $entry->getContent());
         $this->assertSame('text/html', $entry->getMimetype());
         $this->assertSame('fr', $entry->getLanguage());
         $this->assertSame(4.0, $entry->getReadingTime());
@@ -371,7 +371,7 @@ class ContentProxyTest extends TestCase
 
         $this->assertSame('http://1.1.1.1', $entry->getUrl());
         $this->assertSame('this is my title', $entry->getTitle());
-        $this->assertContains('this is my content', $entry->getContent());
+        $this->assertContains('content', $entry->getContent());
         $this->assertSame('text/html', $entry->getMimetype());
         $this->assertSame('fr', $entry->getLanguage());
         $this->assertSame(4.0, $entry->getReadingTime());
@@ -406,7 +406,7 @@ class ContentProxyTest extends TestCase
 
         $this->assertSame('http://1.1.1.1', $entry->getUrl());
         $this->assertSame('this is my title', $entry->getTitle());
-        $this->assertContains('this is my content', $entry->getContent());
+        $this->assertContains('content', $entry->getContent());
         $this->assertSame('text/html', $entry->getMimetype());
         $this->assertSame('fr', $entry->getLanguage());
         $this->assertSame(4.0, $entry->getReadingTime());

--- a/tests/Wallabag/UserBundle/Mailer/AuthCodeMailerTest.php
+++ b/tests/Wallabag/UserBundle/Mailer/AuthCodeMailerTest.php
@@ -33,7 +33,7 @@ TWIG;
     public function testSendEmail()
     {
         $user = new User();
-        $user->setTwoFactorAuthentication(true);
+        $user->setEmailTwoFactor(true);
         $user->setEmailAuthCode(666666);
         $user->setEmail('test@wallabag.io');
         $user->setName('Bob');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Documentation | needed
| Translation   | missing
| CHANGELOG.md  | no
| License       | MIT

Fixes #2822

Moved stuff from the "reset area" to a dedicated tab. Might be better.

<img width="1418" alt="screen 2018-12-02 a 17 37 13" src="https://user-images.githubusercontent.com/62333/49342219-ed160b80-f658-11e8-90de-07d146e8be75.png">

Enable OTP 2FA:
- Update SchebTwoFactorBundle to version 3
- Enable Google 2fa on the bundle
- Disallow ability to use both email and google as 2fa
- use `$this->addFlash` shortcut instead of `$this->get('session')->getFlashBag()->add`
- update admin to be able to enable/reset the 2fa

Here is a gif when enabling OTP app:

![2fa](https://user-images.githubusercontent.com/62333/51414718-abdbab80-1b73-11e9-9c8f-fda6e551bb6e.gif)

- [x] Backup codes
- [ ] Hash backup codes
- [x] Replace "Google Authenticator"
- [x] Ability to test a generated code