### PR TITLE
Fix read & starred status in Pocket import

### DIFF
--- a/src/Wallabag/ImportBundle/Import/PocketImport.php
+++ b/src/Wallabag/ImportBundle/Import/PocketImport.php
@@ -206,10 +206,10 @@ class PocketImport extends AbstractImport
         $this->fetchContent($entry, $url);
 
         // 0, 1, 2 - 1 if the item is archived - 2 if the item should be deleted
-        $entry->setArchived(1 === $importedEntry['status'] || $this->markAsRead);
+        $entry->setArchived(1 == $importedEntry['status'] || $this->markAsRead);
 
         // 0 or 1 - 1 If the item is starred
-        $entry->setStarred(1 === $importedEntry['favorite']);
+        $entry->setStarred(1 == $importedEntry['favorite']);
 
         $title = 'Untitled';
         if (isset($importedEntry['resolved_title']) && '' !== $importedEntry['resolved_title']) {

--- a/src/Wallabag/ImportBundle/Import/PocketImport.php
+++ b/src/Wallabag/ImportBundle/Import/PocketImport.php
@@ -206,10 +206,10 @@ class PocketImport extends AbstractImport
         $this->fetchContent($entry, $url);
 
         // 0, 1, 2 - 1 if the item is archived - 2 if the item should be deleted
-        $entry->setArchived(1 == $importedEntry['status'] || $this->markAsRead);
+        $entry->setArchived(1 === (int) $importedEntry['status'] || $this->markAsRead);
 
-        // 0 or 1 - 1 If the item is starred
-        $entry->setStarred(1 == $importedEntry['favorite']);
+        // 0 or 1 - 1 if the item is starred
+        $entry->setStarred(1 === (int) $importedEntry['favorite']);
 
         $title = 'Untitled';
         if (isset($importedEntry['resolved_title']) && '' !== $importedEntry['resolved_title']) {

--- a/tests/Wallabag/ImportBundle/Import/PocketImportTest.php
+++ b/tests/Wallabag/ImportBundle/Import/PocketImportTest.php
@@ -226,6 +226,13 @@ class PocketImportTest extends TestCase
             ->method('getRepository')
             ->willReturn($entryRepo);
 
+        $this->em
+            ->expects($this->any())
+            ->method('persist')
+            ->with($this->callback(function ($persistedEntry) {
+                return $persistedEntry->isArchived() && $persistedEntry->isStarred();
+            }));
+
         $entry = new Entry($this->user);
 
         $this->contentProxy


### PR DESCRIPTION
Would be nice to do a test for this given that a lot of it is already there, just need more assertions but haven't found the time yet so thought it would be good to at least get a fix out.