### PR TITLE
Rework of EPUB/PDF exports

### DIFF
--- a/src/Wallabag/CoreBundle/Controller/ExportController.php
+++ b/src/Wallabag/CoreBundle/Controller/ExportController.php
@@ -58,6 +58,7 @@ class ExportController extends Controller
         $method = ucfirst($category);
         $methodBuilder = 'getBuilderFor' . $method . 'ByUser';
         $repository = $this->get('wallabag_core.entry_repository');
+        $title = $method;
 
         if ('tag_entries' === $category) {
             $tag = $this->get('wallabag_core.tag_repository')->findOneBySlug($request->query->get('tag'));
@@ -66,6 +67,8 @@ class ExportController extends Controller
                 $this->getUser()->getId(),
                 $tag->getId()
             );
+
+            $title = 'Tag ' . $tag->getLabel();
         } else {
             $entries = $repository
                 ->$methodBuilder($this->getUser()->getId())
@@ -76,7 +79,7 @@ class ExportController extends Controller
         try {
             return $this->get('wallabag_core.helper.entries_export')
                 ->setEntries($entries)
-                ->updateTitle($method)
+                ->updateTitle($title)
                 ->updateAuthor($method)
                 ->exportAs($format);
         } catch (\InvalidArgumentException $e) {

--- a/src/Wallabag/CoreBundle/Helper/EntriesExport.php
+++ b/src/Wallabag/CoreBundle/Helper/EntriesExport.php
@@ -223,7 +223,7 @@ class EntriesExport
             [
                 'Content-Description' => 'File Transfer',
                 'Content-type' => 'application/epub+zip',
-                'Content-Disposition' => 'attachment; filename="' . $this->title . '.epub"',
+                'Content-Disposition' => 'attachment; filename="' . $this->getSanitizedFilename() . '.epub"',
                 'Content-Transfer-Encoding' => 'binary',
             ]
         );
@@ -265,9 +265,6 @@ class EntriesExport
         }
         $mobi->setContentProvider($content);
 
-        // the browser inside Kindle Devices doesn't likes special caracters either, we limit to A-z/0-9
-        $this->title = preg_replace('/[^A-Za-z0-9\-]/', '', $this->title);
-
         return Response::create(
             $mobi->toString(),
             200,
@@ -275,7 +272,7 @@ class EntriesExport
                 'Accept-Ranges' => 'bytes',
                 'Content-Description' => 'File Transfer',
                 'Content-type' => 'application/x-mobipocket-ebook',
-                'Content-Disposition' => 'attachment; filename="' . $this->title . '.mobi"',
+                'Content-Disposition' => 'attachment; filename="' . $this->getSanitizedFilename() . '.mobi"',
                 'Content-Transfer-Encoding' => 'binary',
             ]
         );
@@ -348,7 +345,7 @@ class EntriesExport
             [
                 'Content-Description' => 'File Transfer',
                 'Content-type' => 'application/pdf',
-                'Content-Disposition' => 'attachment; filename="' . $this->title . '.pdf"',
+                'Content-Disposition' => 'attachment; filename="' . $this->getSanitizedFilename() . '.pdf"',
                 'Content-Transfer-Encoding' => 'binary',
             ]
         );
@@ -394,7 +391,7 @@ class EntriesExport
             200,
             [
                 'Content-type' => 'application/csv',
-                'Content-Disposition' => 'attachment; filename="' . $this->title . '.csv"',
+                'Content-Disposition' => 'attachment; filename="' . $this->getSanitizedFilename() . '.csv"',
                 'Content-Transfer-Encoding' => 'UTF-8',
             ]
         );
@@ -412,7 +409,7 @@ class EntriesExport
             200,
             [
                 'Content-type' => 'application/json',
-                'Content-Disposition' => 'attachment; filename="' . $this->title . '.json"',
+                'Content-Disposition' => 'attachment; filename="' . $this->getSanitizedFilename() . '.json"',
                 'Content-Transfer-Encoding' => 'UTF-8',
             ]
         );
@@ -430,7 +427,7 @@ class EntriesExport
             200,
             [
                 'Content-type' => 'application/xml',
-                'Content-Disposition' => 'attachment; filename="' . $this->title . '.xml"',
+                'Content-Disposition' => 'attachment; filename="' . $this->getSanitizedFilename() . '.xml"',
                 'Content-Transfer-Encoding' => 'UTF-8',
             ]
         );
@@ -456,7 +453,7 @@ class EntriesExport
             200,
             [
                 'Content-type' => 'text/plain',
-                'Content-Disposition' => 'attachment; filename="' . $this->title . '.txt"',
+                'Content-Disposition' => 'attachment; filename="' . $this->getSanitizedFilename() . '.txt"',
                 'Content-Transfer-Encoding' => 'UTF-8',
             ]
         );
@@ -498,5 +495,16 @@ class EntriesExport
         }
 
         return str_replace('%IMAGE%', '', $info);
+    }
+
+    /**
+     * Return a sanitized version of the title by applying translit iconv
+     * and removing non alphanumeric characters, - and space.
+     *
+     * @return string Sanitized filename
+     */
+    private function getSanitizedFilename()
+    {
+        return preg_replace('/[^A-Za-z0-9\- \']/', '', iconv('utf-8', 'us-ascii//TRANSLIT', $this->title));
     }
 }

--- a/src/Wallabag/CoreBundle/Helper/EntriesExport.php
+++ b/src/Wallabag/CoreBundle/Helper/EntriesExport.php
@@ -173,6 +173,8 @@ class EntriesExport
         }
 
         $entryIds = [];
+        $entryCount = \count($this->entries);
+        $i = 0;
 
         /*
          * Adding actual entries
@@ -180,20 +182,18 @@ class EntriesExport
 
         // set tags as subjects
         foreach ($this->entries as $entry) {
+            ++$i;
             foreach ($entry->getTags() as $tag) {
                 $book->setSubject($tag->getLabel());
             }
-
-            // the reader in Kobo Devices doesn't likes special caracters
-            // in filenames, we limit to A-z/0-9
-            $filename = preg_replace('/[^A-Za-z0-9\-]/', '', $entry->getTitle());
+            $filename = sha1($entry->getTitle());
 
             $titlepage = $content_start . '<h1>' . $entry->getTitle() . '</h1>' . $this->getExportInformation('PHPePub') . $bookEnd;
-            $book->addChapter('Title', 'Title.html', $titlepage, true, EPub::EXTERNAL_REF_ADD);
+            $book->addChapter("Entry {$i} of {$entryCount}", "{$filename}_cover.html", $titlepage, true, EPub::EXTERNAL_REF_ADD);
             $chapter = $content_start . $entry->getContent() . $bookEnd;
-            $book->addChapter($entry->getTitle(), htmlspecialchars($filename) . '.html', $chapter, true, EPub::EXTERNAL_REF_ADD);
 
             $entryIds[] = $entry->getId();
+            $book->addChapter($entry->getTitle(), "{$filename}.html", $chapter, true, EPub::EXTERNAL_REF_ADD);
         }
 
         // Could also be the ISBN number, prefered for published books, or a UUID.

--- a/src/Wallabag/CoreBundle/Helper/EntriesExport.php
+++ b/src/Wallabag/CoreBundle/Helper/EntriesExport.php
@@ -189,10 +189,9 @@ class EntriesExport
             $filename = sha1($entry->getTitle());
 
             $publishedBy = $entry->getPublishedBy();
+            $authors = $this->translator->trans('export.unknown');
             if (!empty($publishedBy)) {
                 $authors = implode(',', $publishedBy);
-            } else {
-                $authors = $this->translator->trans('export.unknown');
             }
 
             $titlepage = $content_start .
@@ -305,10 +304,9 @@ class EntriesExport
             }
 
             $publishedBy = $entry->getPublishedBy();
+            $authors = $this->translator->trans('export.unknown');
             if (!empty($publishedBy)) {
                 $authors = implode(',', $publishedBy);
-            } else {
-                $authors = $this->translator->trans('export.unknown');
             }
 
             $pdf->addPage();

--- a/src/Wallabag/CoreBundle/Helper/EntriesExport.php
+++ b/src/Wallabag/CoreBundle/Helper/EntriesExport.php
@@ -200,8 +200,6 @@ class EntriesExport
         $hash = sha1(sprintf('%s:%s', $this->wallabagUrl, implode(',', $entryIds)));
         $book->setIdentifier(sprintf('urn:wallabag:%s', $hash), EPub::IDENTIFIER_URI);
 
-        $book->buildTOC();
-
         return Response::create(
             $book->getBook(),
             200,

--- a/src/Wallabag/CoreBundle/Helper/EntriesExport.php
+++ b/src/Wallabag/CoreBundle/Helper/EntriesExport.php
@@ -188,13 +188,15 @@ class EntriesExport
             }
             $filename = sha1($entry->getTitle());
 
-            $titlepage = $content_start . '<h1>' . $entry->getTitle() . '</h1>' . $this->getExportInformation('PHPePub') . $bookEnd;
+            $titlepage = $content_start . '<h1>' . $entry->getTitle() . '</h1>' . $bookEnd;
             $book->addChapter("Entry {$i} of {$entryCount}", "{$filename}_cover.html", $titlepage, true, EPub::EXTERNAL_REF_ADD);
             $chapter = $content_start . $entry->getContent() . $bookEnd;
 
             $entryIds[] = $entry->getId();
             $book->addChapter($entry->getTitle(), "{$filename}.html", $chapter, true, EPub::EXTERNAL_REF_ADD);
         }
+
+        $book->addChapter('Notices', 'Cover2.html', $content_start . $this->getExportInformation('PHPePub') . $bookEnd);
 
         // Could also be the ISBN number, prefered for published books, or a UUID.
         $hash = sha1(sprintf('%s:%s', $this->wallabagUrl, implode(',', $entryIds)));

--- a/src/Wallabag/CoreBundle/Helper/EntriesExport.php
+++ b/src/Wallabag/CoreBundle/Helper/EntriesExport.php
@@ -300,14 +300,6 @@ class EntriesExport
         $pdf->SetKeywords('wallabag');
 
         /*
-         * Front page
-         */
-        $pdf->AddPage();
-        $intro = '<h1>' . $this->title . '</h1>' . $this->getExportInformation('tcpdf');
-
-        $pdf->writeHTMLCell(0, 0, '', '', $intro, 0, 1, 0, true, '', true);
-
-        /*
          * Adding actual entries
          */
         foreach ($this->entries as $entry) {
@@ -315,12 +307,37 @@ class EntriesExport
                 $pdf->SetKeywords($tag->getLabel());
             }
 
+            $publishedBy = $entry->getPublishedBy();
+            if (!empty($publishedBy)) {
+                $authors = implode(',', $publishedBy);
+            } else {
+                $authors = $this->translator->trans('export.unknown');
+            }
+
+            $pdf->addPage();
+            $html = '<h1>' . $entry->getTitle() . '</h1>' .
+                '<dl>' .
+                '<dt>' . $this->translator->trans('entry.view.published_by') . '</dt><dd>' . $authors . '</dd>' .
+                '<dt>' . $this->translator->trans('entry.metadata.reading_time') . '</dt><dd>' . $this->translator->trans('entry.metadata.reading_time_minutes_short', ['%readingTime%' => $entry->getReadingTime()]) . '</dd>' .
+                '<dt>' . $this->translator->trans('entry.metadata.added_on') . '</dt><dd>' . $entry->getCreatedAt()->format('Y-m-d') . '</dd>' .
+                '<dt>' . $this->translator->trans('entry.metadata.address') . '</dt><dd><a href="' . $entry->getUrl() . '">' . $entry->getUrl() . '</a></dd>' .
+                '</dl>';
+            $pdf->writeHTMLCell(0, 0, '', '', $html, 0, 1, 0, true, '', true);
+
             $pdf->AddPage();
             $html = '<h1>' . $entry->getTitle() . '</h1>';
             $html .= $entry->getContent();
 
             $pdf->writeHTMLCell(0, 0, '', '', $html, 0, 1, 0, true, '', true);
         }
+
+        /*
+         * Last page
+         */
+        $pdf->AddPage();
+        $html = $this->getExportInformation('tcpdf');
+
+        $pdf->writeHTMLCell(0, 0, '', '', $html, 0, 1, 0, true, '', true);
 
         // set image scale factor
         $pdf->setImageScale(PDF_IMAGE_SCALE_RATIO);

--- a/src/Wallabag/CoreBundle/Helper/EntriesExport.php
+++ b/src/Wallabag/CoreBundle/Helper/EntriesExport.php
@@ -188,7 +188,22 @@ class EntriesExport
             }
             $filename = sha1($entry->getTitle());
 
-            $titlepage = $content_start . '<h1>' . $entry->getTitle() . '</h1>' . $bookEnd;
+            $publishedBy = $entry->getPublishedBy();
+            if (!empty($publishedBy)) {
+                $authors = implode(',', $publishedBy);
+            } else {
+                $authors = $this->translator->trans('export.unknown');
+            }
+
+            $titlepage = $content_start .
+                '<h1>' . $entry->getTitle() . '</h1>' .
+                '<dl>' .
+                '<dt>' . $this->translator->trans('entry.view.published_by') . '</dt><dd>' . $authors . '</dd>' .
+                '<dt>' . $this->translator->trans('entry.metadata.reading_time') . '</dt><dd>' . $this->translator->trans('entry.metadata.reading_time_minutes_short', ['%readingTime%' => $entry->getReadingTime()]) . '</dd>' .
+                '<dt>' . $this->translator->trans('entry.metadata.added_on') . '</dt><dd>' . $entry->getCreatedAt()->format('Y-m-d') . '</dd>' .
+                '<dt>' . $this->translator->trans('entry.metadata.address') . '</dt><dd><a href="' . $entry->getUrl() . '">' . $entry->getUrl() . '</a></dd>' .
+                '</dl>' .
+                $bookEnd;
             $book->addChapter("Entry {$i} of {$entryCount}", "{$filename}_cover.html", $titlepage, true, EPub::EXTERNAL_REF_ADD);
             $chapter = $content_start . $entry->getContent() . $bookEnd;
 

--- a/src/Wallabag/CoreBundle/Helper/EntriesExport.php
+++ b/src/Wallabag/CoreBundle/Helper/EntriesExport.php
@@ -85,7 +85,7 @@ class EntriesExport
     public function updateAuthor($method)
     {
         if ('entry' !== $method) {
-            $this->author = $method . ' authors';
+            $this->author = 'Various authors';
 
             return $this;
         }

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.da.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.da.yml
@@ -253,6 +253,11 @@ entry:
     confirm:
         # delete: "Are you sure you want to remove that article?"
         # delete_tag: "Are you sure you want to remove that tag from that article?"
+    metadata:
+        # reading_time: "Estimated reading time"
+        # reading_time_minutes_short: "%readingTime% min"
+        # address: "Address"
+        # added_on: "Added on"
 
 about:
     page_title: 'Om'
@@ -402,6 +407,7 @@ tag:
 
 # export:
 #     footer_template: '<div style="text-align:center;"><p>Produced by wallabag with %method%</p><p>Please open <a href="https://github.com/wallabag/wallabag/issues">an issue</a> if you have trouble with the display of this E-Book on your device.</p></div>'
+#     unknown: 'Unknown'
 
 import:
     # page_title: 'Import'

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.de.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.de.yml
@@ -253,6 +253,11 @@ entry:
     confirm:
         delete: 'Bist du sicher, dass du diesen Artikel löschen möchtest?'
         delete_tag: 'Bist du sicher, dass du diesen Tag vom Artikel entfernen möchtest?'
+    metadata:
+        # reading_time: "Estimated reading time"
+        # reading_time_minutes_short: "%readingTime% min"
+        # address: "Address"
+        # added_on: "Added on"
 
 about:
     page_title: 'Über'
@@ -402,6 +407,7 @@ tag:
 
 export:
     footer_template: '<div style="text-align:center;"><p>Generiert von wallabag mit Hilfe von %method%</p><p>Bitte öffne <a href="https://github.com/wallabag/wallabag/issues">ein Ticket</a> wenn du ein Problem mit der Darstellung von diesem E-Book auf deinem Gerät hast.</p></div>'
+    # unknown: 'Unknown'
 
 import:
     page_title: 'Importieren'

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.en.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.en.yml
@@ -253,6 +253,11 @@ entry:
     confirm:
         delete: "Are you sure you want to remove that article?"
         delete_tag: "Are you sure you want to remove that tag from that article?"
+    metadata:
+        reading_time: "Estimated reading time"
+        reading_time_minutes_short: "%readingTime% min"
+        address: "Address"
+        added_on: "Added on"
 
 about:
     page_title: 'About'
@@ -402,6 +407,7 @@ tag:
 
 export:
     footer_template: '<div style="text-align:center;"><p>Produced by wallabag with %method%</p><p>Please open <a href="https://github.com/wallabag/wallabag/issues">an issue</a> if you have trouble with the display of this E-Book on your device.</p></div>'
+    unknown: 'Unknown'
 
 import:
     page_title: 'Import'

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.es.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.es.yml
@@ -253,6 +253,11 @@ entry:
     confirm:
         # delete: "Are you sure you want to remove that article?"
         # delete_tag: "Are you sure you want to remove that tag from that article?"
+    metadata:
+        # reading_time: "Estimated reading time"
+        # reading_time_minutes_short: "%readingTime% min"
+        # address: "Address"
+        # added_on: "Added on"
 
 about:
     page_title: 'Acerca de'
@@ -402,6 +407,7 @@ tag:
 
 # export:
 #     footer_template: '<div style="text-align:center;"><p>Produced by wallabag with %method%</p><p>Please open <a href="https://github.com/wallabag/wallabag/issues">an issue</a> if you have trouble with the display of this E-Book on your device.</p></div>'
+#     unknown: 'Unknown'
 
 import:
     page_title: 'Importar'

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.fa.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.fa.yml
@@ -253,6 +253,11 @@ entry:
     confirm:
         # delete: "Are you sure you want to remove that article?"
         # delete_tag: "Are you sure you want to remove that tag from that article?"
+    metadata:
+        # reading_time: "Estimated reading time"
+        # reading_time_minutes_short: "%readingTime% min"
+        # address: "Address"
+        # added_on: "Added on"
 
 about:
     page_title: 'درباره'
@@ -402,6 +407,7 @@ tag:
 
 # export:
 #     footer_template: '<div style="text-align:center;"><p>Produced by wallabag with %method%</p><p>Please open <a href="https://github.com/wallabag/wallabag/issues">an issue</a> if you have trouble with the display of this E-Book on your device.</p></div>'
+#     unknown: 'Unknown'
 
 import:
     page_title: 'درون‌ریزی'

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.fr.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.fr.yml
@@ -253,6 +253,11 @@ entry:
     confirm:
         delete: "Voulez-vous vraiment supprimer cet article ?"
         delete_tag: "Voulez-vous vraiment supprimer ce tag de cet article ?"
+    metadata:
+        reading_time: "Durée de lecture estimée"
+        reading_time_minutes_short: "%readingTime% min"
+        address: "Adresse"
+        added_on: "Ajouté le"
 
 about:
     page_title: "À propos"
@@ -402,6 +407,7 @@ tag:
 
 export:
     footer_template: '<div style="text-align:center;"><p>Généré par wallabag with %method%</p><p>Merci d''ouvrir <a href="https://github.com/wallabag/wallabag/issues">un ticket</a> si vous rencontrez des soucis d''affichage avec ce document sur votre support.</p></div>'
+    unknown: 'Inconnu'
 
 import:
     page_title: "Importer"

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.it.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.it.yml
@@ -253,6 +253,11 @@ entry:
     confirm:
         delete: "Vuoi veramente rimuovere quell'articolo?"
         delete_tag: "Vuoi veramente rimuovere quell'etichetta da quell'articolo?"
+    metadata:
+        # reading_time: "Estimated reading time"
+        # reading_time_minutes_short: "%readingTime% min"
+        # address: "Address"
+        # added_on: "Added on"
 
 about:
     page_title: 'A proposito'
@@ -402,6 +407,7 @@ tag:
 
 # export:
 #     footer_template: '<div style="text-align:center;"><p>Produced by wallabag with %method%</p><p>Please open <a href="https://github.com/wallabag/wallabag/issues">an issue</a> if you have trouble with the display of this E-Book on your device.</p></div>'
+#     unknown: 'Unknown'
 
 import:
     page_title: 'Importa'

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.oc.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.oc.yml
@@ -253,6 +253,11 @@ entry:
     confirm:
         delete: "Sètz segur de voler suprimir aqueste article ?"
         delete_tag: "Sètz segur de voler levar aquesta etiqueta de l'article ?"
+    metadata:
+        # reading_time: "Estimated reading time"
+        # reading_time_minutes_short: "%readingTime% min"
+        # address: "Address"
+        # added_on: "Added on"
 
 about:
     page_title: 'A prepaus'
@@ -402,6 +407,7 @@ tag:
 
 export:
     footer_template: '<div style="text-align:center;"><p>Produch per wallabag amb %method%</p><p>Mercés de dobrir <a href="https://github.com/wallabag/wallabag/issues">una sollicitacion</a> s’avètz de problèmas amb l’afichatge d’aqueste E-Book sus vòstre periferic.</p></div>'
+    # unknown: 'Unknown'
 
 import:
     page_title: 'Importar'

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.pl.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.pl.yml
@@ -253,6 +253,11 @@ entry:
     confirm:
         delete: "Czy jesteś pewien, że chcesz usunąć ten artykuł?"
         delete_tag: "Czy jesteś pewien, że chcesz usunąć ten tag, z tego artykułu?"
+    metadata:
+        # reading_time: "Estimated reading time"
+        # reading_time_minutes_short: "%readingTime% min"
+        # address: "Address"
+        # added_on: "Added on"
 
 about:
     page_title: 'O nas'
@@ -401,7 +406,8 @@ tag:
         placeholder: 'Możesz dodać kilka tagów, oddzielając je przecinkami.'
 
 export:
-     footer_template: '<div style="text-align:center;"><p>Stworzone przez wallabag z %method%</p><p>Proszę zgłoś <a href="https://github.com/wallabag/wallabag/issues">sprawę</a>, jeżeli masz problem z wyświetleniem tego e-booka na swoim urządzeniu.</p></div>'
+    footer_template: '<div style="text-align:center;"><p>Stworzone przez wallabag z %method%</p><p>Proszę zgłoś <a href="https://github.com/wallabag/wallabag/issues">sprawę</a>, jeżeli masz problem z wyświetleniem tego e-booka na swoim urządzeniu.</p></div>'
+    # unknown: 'Unknown'
 
 import:
     page_title: 'Import'

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.pt.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.pt.yml
@@ -253,6 +253,11 @@ entry:
     confirm:
         # delete: "Are you sure you want to remove that article?"
         # delete_tag: "Are you sure you want to remove that tag from that article?"
+    metadata:
+        # reading_time: "Estimated reading time"
+        # reading_time_minutes_short: "%readingTime% min"
+        # address: "Address"
+        # added_on: "Added on"
 
 about:
     page_title: 'Sobre'
@@ -402,6 +407,7 @@ tag:
 
 # export:
 #     footer_template: '<div style="text-align:center;"><p>Produced by wallabag with %method%</p><p>Please open <a href="https://github.com/wallabag/wallabag/issues">an issue</a> if you have trouble with the display of this E-Book on your device.</p></div>'
+#     unknown: 'Unknown'
 
 import:
     page_title: 'Importar'

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.ro.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.ro.yml
@@ -253,6 +253,11 @@ entry:
     confirm:
         # delete: "Are you sure you want to remove that article?"
         # delete_tag: "Are you sure you want to remove that tag from that article?"
+    metadata:
+        # reading_time: "Estimated reading time"
+        # reading_time_minutes_short: "%readingTime% min"
+        # address: "Address"
+        # added_on: "Added on"
 
 about:
     page_title: 'Despre'
@@ -402,6 +407,7 @@ tag:
 
 # export:
 #     footer_template: '<div style="text-align:center;"><p>Produced by wallabag with %method%</p><p>Please open <a href="https://github.com/wallabag/wallabag/issues">an issue</a> if you have trouble with the display of this E-Book on your device.</p></div>'
+#     unknown: 'Unknown'
 
 import:
     # page_title: 'Import'

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.ru.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.ru.yml
@@ -241,6 +241,11 @@ entry:
         save_label: 'Сохранить'
     public:
         shared_by_wallabag: "Запись была опубликована <a href='%wallabag_instance%'>wallabag</a>"
+    metadata:
+        # reading_time: "Estimated reading time"
+        # reading_time_minutes_short: "%readingTime% min"
+        # address: "Address"
+        # added_on: "Added on"
 
 about:
     page_title: 'О'
@@ -387,6 +392,10 @@ tag:
     new:
         add: 'Добавить'
         placeholder: 'Вы можете добавить несколько тегов, разделенных запятой.'
+
+# export:
+#     footer_template: '<div style="text-align:center;"><p>Produced by wallabag with %method%</p><p>Please open <a href="https://github.com/wallabag/wallabag/issues">an issue</a> if you have trouble with the display of this E-Book on your device.</p></div>'
+#     unknown: 'Unknown'
 
 import:
     page_title: 'Импорт'

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.th.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.th.yml
@@ -251,6 +251,11 @@ entry:
     confirm:
         delete: "คุณแน่ใจหรือไม่ว่าคุณต้องการลบบทความนี้?"
         delete_tag: "คุณแน่ใจหรือไม่ว่าคุณต้องการลบแท็กจากบทความนี้?"
+    metadata:
+        # reading_time: "Estimated reading time"
+        # reading_time_minutes_short: "%readingTime% min"
+        # address: "Address"
+        # added_on: "Added on"
 
 about:
     page_title: 'เกี่ยวกับ'
@@ -400,6 +405,7 @@ tag:
 
 export:
     footer_template: '<div style="text-align:center;"><p>ผลิตโดย wallabag กับ %method%</p><p>ให้ทำการเปิด <a href="https://github.com/wallabag/wallabag/issues">ฉบับนี้</a> ถ้าคุณมีข้อบกพร่องif you have trouble with the display of this E-Book on your device.</p></div>'
+    # unknown: 'Unknown'
 
 import:
     page_title: 'นำข้อมูลเช้า'

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.tr.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.tr.yml
@@ -251,6 +251,11 @@ entry:
     confirm:
         # delete: "Are you sure you want to remove that article?"
         # delete_tag: "Are you sure you want to remove that tag from that article?"
+    metadata:
+        # reading_time: "Estimated reading time"
+        # reading_time_minutes_short: "%readingTime% min"
+        # address: "Address"
+        # added_on: "Added on"
 
 about:
     page_title: 'Hakkımızda'
@@ -400,6 +405,7 @@ tag:
 
 # export:
 #     footer_template: '<div style="text-align:center;"><p>Produced by wallabag with %method%</p><p>Please open <a href="https://github.com/wallabag/wallabag/issues">an issue</a> if you have trouble with the display of this E-Book on your device.</p></div>'
+#     unknown: 'Unknown'
 
 import:
     page_title: 'İçe Aktar'

--- a/tests/Wallabag/CoreBundle/Controller/ExportControllerTest.php
+++ b/tests/Wallabag/CoreBundle/Controller/ExportControllerTest.php
@@ -98,7 +98,7 @@ class ExportControllerTest extends WallabagCoreTestCase
 
         $headers = $client->getResponse()->headers;
         $this->assertSame('application/x-mobipocket-ebook', $headers->get('content-type'));
-        $this->assertSame('attachment; filename="' . preg_replace('/[^A-Za-z0-9\-]/', '', $content->getTitle()) . '.mobi"', $headers->get('content-disposition'));
+        $this->assertSame('attachment; filename="' . $this->getSanitizedFilename($content->getTitle()) . '.mobi"', $headers->get('content-disposition'));
         $this->assertSame('binary', $headers->get('content-transfer-encoding'));
     }
 
@@ -126,7 +126,7 @@ class ExportControllerTest extends WallabagCoreTestCase
 
         $headers = $client->getResponse()->headers;
         $this->assertSame('application/pdf', $headers->get('content-type'));
-        $this->assertSame('attachment; filename="Tag_entries articles.pdf"', $headers->get('content-disposition'));
+        $this->assertSame('attachment; filename="Tag foo bar articles.pdf"', $headers->get('content-disposition'));
         $this->assertSame('binary', $headers->get('content-transfer-encoding'));
     }
 
@@ -212,7 +212,7 @@ class ExportControllerTest extends WallabagCoreTestCase
 
         $headers = $client->getResponse()->headers;
         $this->assertSame('application/json', $headers->get('content-type'));
-        $this->assertSame('attachment; filename="' . $contentInDB->getTitle() . '.json"', $headers->get('content-disposition'));
+        $this->assertSame('attachment; filename="' . $this->getSanitizedFilename($contentInDB->getTitle()) . '.json"', $headers->get('content-disposition'));
         $this->assertSame('UTF-8', $headers->get('content-transfer-encoding'));
 
         $content = json_decode($client->getResponse()->getContent(), true);
@@ -280,5 +280,10 @@ class ExportControllerTest extends WallabagCoreTestCase
         $this->assertNotEmpty('domain_name', (string) $content->entry[0]->domain_name);
         $this->assertNotEmpty('created_at', (string) $content->entry[0]->created_at);
         $this->assertNotEmpty('updated_at', (string) $content->entry[0]->updated_at);
+    }
+
+    private function getSanitizedFilename($title)
+    {
+        return preg_replace('/[^A-Za-z0-9\- \']/', '', iconv('utf-8', 'us-ascii//TRANSLIT', $title));
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | -
| Documentation | no
| Translation   | yes
| License       | MIT

Fixes #3603 
Related to #2821 
Completes fix for #3811 

This PR:
- removes the TOC page inserted at the end of an epub export (#3603)
- fixes issue with filenames (_Title.html duplicates_)
- reverts c779373 and moves back phpepub and wallabag notes to the end of the book
- changes title and filename when the export is of type `tag_entries`, appending the related tag (_e.g. `Tag hello-world articles.epub`)
- replaces the "{method} authors" with "Various authors"
- adds metadata on the cover of each entry: reading time, publishers, date of creation and a link to the original article
- sanitizes the name of exported files with iconv translit and replace of `[^a-zA-Z0-9\- ']`

Article's cover metadata added and wallabag notes moved at the end of the PDF export file.

Here are PDF and epub tab export samples:
- pdf: https://framadrop.org/r/QkhQCxNeoM#JK1jhJsYd9k/0bpKxZvPwNrinW7wnnT35dnYzlzcYOM=
- epub: https://framadrop.org/r/oG8ApK9eGg#xLcCYeZIo1ZDYaPj7e4ubxFLPHKBcnS0xqzaAzUbTAI=