### PR TITLE
Cast client id to avoid PG error

### DIFF
--- a/src/Wallabag/ApiBundle/Entity/Client.php
+++ b/src/Wallabag/ApiBundle/Entity/Client.php
@@ -11,7 +11,7 @@ use Wallabag\UserBundle\Entity\User;
 
 /**
  * @ORM\Table("oauth2_clients")
- * @ORM\Entity
+ * @ORM\Entity(repositoryClass="Wallabag\ApiBundle\Repository\ClientRepository")
  */
 class Client extends BaseClient
 {

--- a/src/Wallabag/ApiBundle/Repository/ClientRepository.php
+++ b/src/Wallabag/ApiBundle/Repository/ClientRepository.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Wallabag\ApiBundle\Repository;
+
+use Doctrine\ORM\EntityRepository;
+
+class ClientRepository extends EntityRepository
+{
+    public function findOneBy(array $criteria, array $orderBy = null)
+    {
+        if (!empty($criteria['id'])) {
+            // cast client id to be an integer to avoid postgres error:
+            // "invalid input syntax for integer"
+            $criteria['id'] = (int) $criteria['id'];
+        }
+
+        return parent::findOneBy($criteria, $orderBy);
+    }
+}

--- a/tests/Wallabag/ApiBundle/Controller/DeveloperControllerTest.php
+++ b/tests/Wallabag/ApiBundle/Controller/DeveloperControllerTest.php
@@ -56,6 +56,20 @@ class DeveloperControllerTest extends WallabagCoreTestCase
         $this->assertArrayHasKey('refresh_token', $data);
     }
 
+    public function testCreateTokenWithBadClientId()
+    {
+        $client = $this->getClient();
+        $client->request('POST', '/oauth/v2/token', [
+            'grant_type' => 'password',
+            'client_id' => '$WALLABAG_CLIENT_ID',
+            'client_secret' => 'secret',
+            'username' => 'admin',
+            'password' => 'mypassword',
+        ]);
+
+        $this->assertSame(400, $client->getResponse()->getStatusCode());
+    }
+
     public function testListingClient()
     {
         $this->logInAs('admin');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Documentation | no
| Translation   | no
| CHANGELOG.md  | no
| License       | MIT

If someone send a malformated client_id when trying to authenticate using the API we got a 500 if wallabag use postgres because the request send a string instead of an integer.

Fixes #3817