### PR TITLE
Add a new endpoint to retrieve information from the wallabag instance

### DIFF
--- a/app/config/security.yml
+++ b/app/config/security.yml
@@ -57,9 +57,7 @@ security:
                 target: /
 
     access_control:
-        - { path: ^/api/doc, roles: IS_AUTHENTICATED_ANONYMOUSLY }
-        - { path: ^/api/version, roles: IS_AUTHENTICATED_ANONYMOUSLY }
-        - { path: ^/api/user, roles: IS_AUTHENTICATED_ANONYMOUSLY }
+        - { path: ^/api/(doc|version|info|user), roles: IS_AUTHENTICATED_ANONYMOUSLY }
         - { path: ^/login, roles: IS_AUTHENTICATED_ANONYMOUSLY }
         - { path: ^/register, role: IS_AUTHENTICATED_ANONYMOUSLY }
         - { path: ^/resetting, role: IS_AUTHENTICATED_ANONYMOUSLY }

--- a/src/Wallabag/ApiBundle/Controller/WallabagRestController.php
+++ b/src/Wallabag/ApiBundle/Controller/WallabagRestController.php
@@ -14,6 +14,8 @@ class WallabagRestController extends FOSRestController
      *
      * @ApiDoc()
      *
+     * @deprecated Should use info endpoint instead
+     *
      * @return JsonResponse
      */
     public function getVersionAction()
@@ -22,6 +24,24 @@ class WallabagRestController extends FOSRestController
         $json = $this->get('jms_serializer')->serialize($version, 'json');
 
         return (new JsonResponse())->setJson($json);
+    }
+
+    /**
+     * Retrieve information about the wallabag instance.
+     *
+     * @ApiDoc()
+     *
+     * @return JsonResponse
+     */
+    public function getInfoAction()
+    {
+        $info = [
+            'appname' => 'wallabag',
+            'version' => $this->container->getParameter('wallabag_core.version'),
+            'allowed_registration' => $this->container->getParameter('wallabag_user.registration_enabled'),
+        ];
+
+        return (new JsonResponse())->setJson($this->get('jms_serializer')->serialize($info, 'json'));
     }
 
     protected function validateAuthentication()

--- a/tests/Wallabag/ApiBundle/Controller/WallabagRestControllerTest.php
+++ b/tests/Wallabag/ApiBundle/Controller/WallabagRestControllerTest.php
@@ -18,4 +18,21 @@ class WallabagRestControllerTest extends WallabagApiTestCase
 
         $this->assertSame($client->getContainer()->getParameter('wallabag_core.version'), $content);
     }
+
+    public function testGetInfo()
+    {
+        // create a new client instead of using $this->client to be sure client isn't authenticated
+        $client = static::createClient();
+        $client->request('GET', '/api/info');
+
+        $this->assertSame(200, $client->getResponse()->getStatusCode());
+
+        $content = json_decode($client->getResponse()->getContent(), true);
+
+        $this->assertArrayHasKey('appname', $content);
+        $this->assertArrayHasKey('version', $content);
+        $this->assertArrayHasKey('allowed_registration', $content);
+
+        $this->assertSame('wallabag', $content['appname']);
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | yes
| Tests pass?   | yes
| Documentation | no
| Translation   | no
| CHANGELOG.md  | no
| License       | MIT

Useful for api client which required some information.
We might add more inside them in the future.

The endpoint /api/version should be avoided now as it contains not so much information rather the version.


Fixes #3808