### PR TITLE
Update composer.json to add php-tidy (ext-tidy)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -43,6 +43,7 @@
         "ext-iconv": "*",
         "ext-tokenizer": "*",
         "ext-pdo": "*",
+        "ext-tidy": "*",
         "symfony/symfony": "~3.3.13",
         "doctrine/orm": "^2.5.12",
         "doctrine/doctrine-bundle": "^1.8.0",


### PR DESCRIPTION
Fixes #3844 for wallabag 2.3.7.

Easiest. PR. Ever. 😉 