### PR TITLE
Enable PHPStan

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -67,6 +67,8 @@ script:
     - make fixtures
 
     - if [[ $VALIDATE_TRANSLATION_FILE = '' ]]; then SYMFONY_PHPUNIT_VERSION=6.5 ./bin/simple-phpunit -v ; fi;
+    # PHPStan needs PHPUnit to be installed and cache app to be generated
+    - if [[ $VALIDATE_TRANSLATION_FILE = '' ]]; then php bin/phpstan analyse src tests --no-progress --level 1 ; fi;
     - if [[ $CS_FIXER = run ]]; then php bin/php-cs-fixer fix --verbose --dry-run ; fi;
     - if [[ $VALIDATE_TRANSLATION_FILE = run ]]; then php bin/console lint:yaml src/Wallabag/CoreBundle/Resources/translations -v ; fi;
     - if [[ $VALIDATE_TRANSLATION_FILE = run ]]; then php bin/console lint:yaml app/Resources/CraueConfigBundle/translations -v ; fi;

--- a/app/DoctrineMigrations/Version20190117131816.php
+++ b/app/DoctrineMigrations/Version20190117131816.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Application\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Wallabag\CoreBundle\Doctrine\WallabagMigration;
+
+/**
+ * Add updated_at fields to site_credential table.
+ */
+final class Version20190117131816 extends WallabagMigration
+{
+    public function up(Schema $schema): void
+    {
+        $siteCredentialTable = $schema->getTable($this->getTable('site_credential'));
+
+        $this->skipIf($siteCredentialTable->hasColumn('updated_at'), 'It seems that you already played this migration.');
+
+        $siteCredentialTable->addColumn('updated_at', 'datetime', [
+            'notnull' => false,
+        ]);
+    }
+
+    public function down(Schema $schema): void
+    {
+        $siteCredentialTable = $schema->getTable($this->getTable('site_credential'));
+
+        $this->skipIf(!$siteCredentialTable->hasColumn('updated_at'), 'It seems that you already played this migration.');
+
+        $siteCredentialTable->dropColumn('updated_at');
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -92,7 +92,11 @@
         "symfony/phpunit-bridge": "^4.2",
         "friendsofphp/php-cs-fixer": "~2.13",
         "m6web/redis-mock": "^4.1",
-        "dama/doctrine-test-bundle": "^5.0"
+        "dama/doctrine-test-bundle": "^5.0",
+        "phpstan/phpstan": "^0.11.0",
+        "phpstan/phpstan-phpunit": "^0.11.0",
+        "phpstan/phpstan-symfony": "^0.11.0",
+        "phpstan/phpstan-doctrine": "^0.11.0"
     },
     "scripts": {
         "post-cmd": [

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,0 +1,13 @@
+includes:
+    - vendor/phpstan/phpstan-phpunit/extension.neon
+    - vendor/phpstan/phpstan-symfony/extension.neon
+    - vendor/phpstan/phpstan-doctrine/extension.neon
+    - vendor/phpstan/phpstan-phpunit/rules.neon
+
+parameters:
+    symfony:
+        container_xml_path: %rootDir%/../../../var/cache/test/appTestDebugProjectContainer.xml
+
+    # https://github.com/phpstan/phpstan/issues/694#issuecomment-350724288
+    autoload_files:
+        - vendor/bin/.phpunit/phpunit-6.5/vendor/autoload.php

--- a/src/Wallabag/CoreBundle/Command/InstallCommand.php
+++ b/src/Wallabag/CoreBundle/Command/InstallCommand.php
@@ -94,8 +94,9 @@ class InstallCommand extends ContainerAwareCommand
         $status = '<info>OK!</info>';
         $help = '';
 
+        $conn = $this->getContainer()->get('doctrine')->getManager()->getConnection();
+
         try {
-            $conn = $this->getContainer()->get('doctrine')->getManager()->getConnection();
             $conn->connect();
         } catch (\Exception $e) {
             if (false === strpos($e->getMessage(), 'Unknown database')

--- a/src/Wallabag/CoreBundle/Entity/SiteCredential.php
+++ b/src/Wallabag/CoreBundle/Entity/SiteCredential.php
@@ -60,6 +60,13 @@ class SiteCredential
     private $createdAt;
 
     /**
+     * @var \DateTime
+     *
+     * @ORM\Column(name="updated_at", type="datetime")
+     */
+    private $updatedAt;
+
+    /**
      * @ORM\ManyToOne(targetEntity="Wallabag\UserBundle\Entity\User", inversedBy="siteCredentials")
      */
     private $user;
@@ -176,6 +183,16 @@ class SiteCredential
     public function getCreatedAt()
     {
         return $this->createdAt;
+    }
+
+    /**
+     * Get updatedAt.
+     *
+     * @return \DateTime
+     */
+    public function getUpdatedAt()
+    {
+        return $this->updatedAt;
     }
 
     /**

--- a/src/Wallabag/CoreBundle/Helper/RuleBasedTagger.php
+++ b/src/Wallabag/CoreBundle/Helper/RuleBasedTagger.php
@@ -6,6 +6,7 @@ use Psr\Log\LoggerInterface;
 use RulerZ\RulerZ;
 use Wallabag\CoreBundle\Entity\Entry;
 use Wallabag\CoreBundle\Entity\Tag;
+use Wallabag\CoreBundle\Entity\TaggingRule;
 use Wallabag\CoreBundle\Repository\EntryRepository;
 use Wallabag\CoreBundle\Repository\TagRepository;
 use Wallabag\UserBundle\Entity\User;

--- a/tests/Wallabag/AnnotationBundle/Controller/AnnotationControllerTest.php
+++ b/tests/Wallabag/AnnotationBundle/Controller/AnnotationControllerTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Tests\AnnotationBundle\Controller;
+namespace Tests\Wallabag\AnnotationBundle\Controller;
 
 use Tests\Wallabag\AnnotationBundle\WallabagAnnotationTestCase;
 use Wallabag\AnnotationBundle\Entity\Annotation;

--- a/tests/Wallabag/ApiBundle/Controller/EntryRestControllerTest.php
+++ b/tests/Wallabag/ApiBundle/Controller/EntryRestControllerTest.php
@@ -794,7 +794,7 @@ class EntryRestControllerTest extends WallabagApiTestCase
         $content = json_decode($this->client->getResponse()->getContent(), true);
 
         $this->assertArrayHasKey('tags', $content);
-        $this->assertSame($nbTags + 3, \count($content['tags']));
+        $this->assertCount($nbTags + 3, $content['tags']);
 
         $entryDB = $this->client->getContainer()
             ->get('doctrine.orm.entity_manager')
@@ -834,7 +834,7 @@ class EntryRestControllerTest extends WallabagApiTestCase
         $content = json_decode($this->client->getResponse()->getContent(), true);
 
         $this->assertArrayHasKey('tags', $content);
-        $this->assertSame($nbTags - 1, \count($content['tags']));
+        $this->assertCount($nbTags - 1, $content['tags']);
     }
 
     public function testSaveIsArchivedAfterPost()

--- a/tests/Wallabag/CoreBundle/Controller/ConfigControllerTest.php
+++ b/tests/Wallabag/CoreBundle/Controller/ConfigControllerTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace tests\Wallabag\CoreBundle\Controller;
+namespace Tests\Wallabag\CoreBundle\Controller;
 
 use Tests\Wallabag\CoreBundle\WallabagCoreTestCase;
 use Wallabag\AnnotationBundle\Entity\Annotation;

--- a/tests/Wallabag/CoreBundle/Controller/EntryControllerTest.php
+++ b/tests/Wallabag/CoreBundle/Controller/EntryControllerTest.php
@@ -522,9 +522,12 @@ class EntryControllerTest extends WallabagCoreTestCase
 
         $crawler = $client->followRedirect();
 
-        $this->assertGreaterThan(1, $title = $crawler->filter('div[id=article] h1')->extract(['_text']));
+        $title = $crawler->filter('div[id=article] h1')->extract(['_text']);
+        $this->assertGreaterThan(1, $title);
         $this->assertContains('My updated title hehe :)', $title[0]);
-        $this->assertSame(1, \count($stats = $crawler->filter('div[class=tools] ul[class=stats] li a[class=tool]')->extract(['_text'])));
+
+        $stats = $crawler->filter('div[class=tools] ul[class=stats] li a[class=tool]')->extract(['_text']);
+        $this->assertCount(1, $stats);
         $this->assertNotContains('example.io', trim($stats[0]));
     }
 
@@ -1326,10 +1329,6 @@ class EntryControllerTest extends WallabagCoreTestCase
             'zh_CN' => [
                 'http://www.hao123.com/shequ?__noscript__-=1',
                 'zh_CN',
-            ],
-            'ru' => [
-                'https://www.kp.ru/daily/26879.7/3921982/',
-                'ru',
             ],
             'pt_BR' => [
                 'https://politica.estadao.com.br/noticias/eleicoes,campanha-catatonica,70002491983',

--- a/tests/Wallabag/CoreBundle/Controller/ExportControllerTest.php
+++ b/tests/Wallabag/CoreBundle/Controller/ExportControllerTest.php
@@ -180,7 +180,7 @@ class ExportControllerTest extends WallabagCoreTestCase
 
         $this->assertGreaterThan(1, $csv);
         // +1 for title line
-        $this->assertSame(\count($contentInDB) + 1, \count($csv));
+        $this->assertCount(\count($contentInDB) + 1, $csv);
         $this->assertSame('Title;URL;Content;Tags;"MIME Type";Language;"Creation date"', $csv[0]);
         $this->assertContains($contentInDB[0]['title'], $csv[1]);
         $this->assertContains($contentInDB[0]['url'], $csv[1]);

--- a/tests/Wallabag/CoreBundle/Controller/RssControllerTest.php
+++ b/tests/Wallabag/CoreBundle/Controller/RssControllerTest.php
@@ -11,7 +11,7 @@ class RssControllerTest extends WallabagCoreTestCase
         $doc = new \DOMDocument();
         $doc->loadXML($xml);
 
-        $xpath = new \DOMXpath($doc);
+        $xpath = new \DOMXPath($doc);
 
         if (null === $nb) {
             $this->assertGreaterThan(0, $xpath->query('//item')->length);

--- a/tests/Wallabag/CoreBundle/Helper/RedirectTest.php
+++ b/tests/Wallabag/CoreBundle/Helper/RedirectTest.php
@@ -17,6 +17,9 @@ class RedirectTest extends TestCase
     /** @var Redirect */
     private $redirect;
 
+    /** @var UsernamePasswordToken */
+    private $token;
+
     public function setUp()
     {
         $this->routerMock = $this->getMockBuilder('Symfony\Component\Routing\Router')

--- a/tests/Wallabag/CoreBundle/ParamConverter/UsernameRssTokenConverterTest.php
+++ b/tests/Wallabag/CoreBundle/ParamConverter/UsernameRssTokenConverterTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Tests\Wallabag\CoreBundle\Command;
+namespace Tests\Wallabag\CoreBundle\ParamConverter;
 
 use PHPUnit\Framework\TestCase;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\ParamConverter;

--- a/tests/Wallabag/ImportBundle/Consumer/AMQPEntryConsumerTest.php
+++ b/tests/Wallabag/ImportBundle/Consumer/AMQPEntryConsumerTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Tests\Wallabag\ImportBundle\Consumer\AMQP;
+namespace Tests\Wallabag\ImportBundle\Consumer;
 
 use PhpAmqpLib\Message\AMQPMessage;
 use PHPUnit\Framework\TestCase;

--- a/tests/Wallabag/ImportBundle/Consumer/RedisEntryConsumerTest.php
+++ b/tests/Wallabag/ImportBundle/Consumer/RedisEntryConsumerTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Tests\Wallabag\ImportBundle\Consumer\AMQP;
+namespace Tests\Wallabag\ImportBundle\Consumer;
 
 use PHPUnit\Framework\TestCase;
 use Wallabag\CoreBundle\Entity\Entry;

--- a/tests/Wallabag/ImportBundle/Controller/ChromeControllerTest.php
+++ b/tests/Wallabag/ImportBundle/Controller/ChromeControllerTest.php
@@ -121,7 +121,7 @@ class ChromeControllerTest extends WallabagCoreTestCase
         $this->assertInstanceOf('Wallabag\CoreBundle\Entity\Entry', $content);
         $this->assertNotEmpty($content->getPreviewPicture(), 'Preview picture for http://www.usinenouvelle.com is ok');
         $this->assertNotEmpty($content->getLanguage(), 'Language for http://www.usinenouvelle.com is ok');
-        $this->assertSame(1, \count($content->getTags()));
+        $this->assertCount(1, $content->getTags());
 
         $createdAt = $content->getCreatedAt();
         $this->assertSame('2011', $createdAt->format('Y'));

--- a/tests/Wallabag/ImportBundle/Controller/FirefoxControllerTest.php
+++ b/tests/Wallabag/ImportBundle/Controller/FirefoxControllerTest.php
@@ -122,7 +122,7 @@ class FirefoxControllerTest extends WallabagCoreTestCase
         $this->assertNotEmpty($content->getMimetype(), 'Mimetype for http://lexpansion.lexpress.fr is ok');
         $this->assertNotEmpty($content->getPreviewPicture(), 'Preview picture for http://lexpansion.lexpress.fr is ok');
         $this->assertNotEmpty($content->getLanguage(), 'Language for http://lexpansion.lexpress.fr is ok');
-        $this->assertSame(3, \count($content->getTags()));
+        $this->assertCount(3, $content->getTags());
 
         $content = $client->getContainer()
             ->get('doctrine.orm.entity_manager')

--- a/tests/Wallabag/ImportBundle/Controller/InstapaperControllerTest.php
+++ b/tests/Wallabag/ImportBundle/Controller/InstapaperControllerTest.php
@@ -124,7 +124,7 @@ class InstapaperControllerTest extends WallabagCoreTestCase
         $this->assertNotEmpty($content->getPreviewPicture(), 'Preview picture for https://www.liberation.fr is ok');
         $this->assertNotEmpty($content->getLanguage(), 'Language for https://www.liberation.fr is ok');
         $this->assertContains('foot', $content->getTags(), 'It includes the "foot" tag');
-        $this->assertSame(1, \count($content->getTags()));
+        $this->assertCount(1, $content->getTags());
         $this->assertInstanceOf(\DateTime::class, $content->getCreatedAt());
 
         $content = $client->getContainer()
@@ -138,7 +138,7 @@ class InstapaperControllerTest extends WallabagCoreTestCase
         $this->assertContains('foot', $content->getTags());
         $this->assertContains('test_tag', $content->getTags());
 
-        $this->assertSame(2, \count($content->getTags()));
+        $this->assertCount(2, $content->getTags());
     }
 
     public function testImportInstapaperWithFileAndMarkAllAsRead()

--- a/tests/Wallabag/ImportBundle/Controller/PinboardControllerTest.php
+++ b/tests/Wallabag/ImportBundle/Controller/PinboardControllerTest.php
@@ -127,7 +127,7 @@ class PinboardControllerTest extends WallabagCoreTestCase
         $this->assertContains('foot', $tags, 'It includes the "foot" tag');
         $this->assertContains('varnish', $tags, 'It includes the "varnish" tag');
         $this->assertContains('php', $tags, 'It includes the "php" tag');
-        $this->assertSame(3, \count($tags));
+        $this->assertCount(3, $tags);
 
         $this->assertInstanceOf(\DateTime::class, $content->getCreatedAt());
         $this->assertSame('2016-10-26', $content->getCreatedAt()->format('Y-m-d'));

--- a/tests/Wallabag/ImportBundle/Controller/ReadabilityControllerTest.php
+++ b/tests/Wallabag/ImportBundle/Controller/ReadabilityControllerTest.php
@@ -125,7 +125,7 @@ class ReadabilityControllerTest extends WallabagCoreTestCase
 
         $tags = $content->getTags();
         $this->assertContains('foot', $tags, 'It includes the "foot" tag');
-        $this->assertSame(1, \count($tags));
+        $this->assertCount(1, $tags);
 
         $this->assertInstanceOf(\DateTime::class, $content->getCreatedAt());
         $this->assertSame('2016-09-08', $content->getCreatedAt()->format('Y-m-d'));

--- a/tests/Wallabag/ImportBundle/Controller/WallabagV1ControllerTest.php
+++ b/tests/Wallabag/ImportBundle/Controller/WallabagV1ControllerTest.php
@@ -127,7 +127,7 @@ class WallabagV1ControllerTest extends WallabagCoreTestCase
         $tags = $content->getTags();
         $this->assertContains('foot', $tags, 'It includes the "foot" tag');
         $this->assertContains('framabag', $tags, 'It includes the "framabag" tag');
-        $this->assertSame(2, \count($tags));
+        $this->assertCount(2, $tags);
 
         $this->assertInstanceOf(\DateTime::class, $content->getCreatedAt());
     }

--- a/tests/Wallabag/ImportBundle/Controller/WallabagV2ControllerTest.php
+++ b/tests/Wallabag/ImportBundle/Controller/WallabagV2ControllerTest.php
@@ -128,7 +128,7 @@ class WallabagV2ControllerTest extends WallabagCoreTestCase
 
         $tags = $content->getTags();
         $this->assertContains('foot', $tags, 'It includes the "foot" tag');
-        $this->assertSame(1, \count($tags));
+        $this->assertCount(1, $tags);
 
         $content = $client->getContainer()
             ->get('doctrine.orm.entity_manager')
@@ -147,7 +147,7 @@ class WallabagV2ControllerTest extends WallabagCoreTestCase
         $this->assertContains('foot', $tags, 'It includes the "foot" tag');
         $this->assertContains('mediapart', $tags, 'It includes the "mediapart" tag');
         $this->assertContains('blog', $tags, 'It includes the "blog" tag');
-        $this->assertSame(3, \count($tags));
+        $this->assertCount(3, $tags);
 
         $this->assertInstanceOf(\DateTime::class, $content->getCreatedAt());
         $this->assertSame('2016-09-08', $content->getCreatedAt()->format('Y-m-d'));

--- a/tests/Wallabag/UserBundle/Controller/ManageControllerTest.php
+++ b/tests/Wallabag/UserBundle/Controller/ManageControllerTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Wallabag\UserBundle\Tests\Controller;
+namespace Tests\Wallabag\UserBundle\Controller;
 
 use Tests\Wallabag\CoreBundle\WallabagCoreTestCase;
 

--- a/tests/Wallabag/UserBundle/Mailer/AuthCodeMailerTest.php
+++ b/tests/Wallabag/UserBundle/Mailer/AuthCodeMailerTest.php
@@ -6,22 +6,6 @@ use PHPUnit\Framework\TestCase;
 use Wallabag\UserBundle\Entity\User;
 use Wallabag\UserBundle\Mailer\AuthCodeMailer;
 
-/**
- * @see https://www.pmg.com/blog/integration-testing-swift-mailer/
- */
-final class CountableMemorySpool extends \Swift_MemorySpool implements \Countable
-{
-    public function count()
-    {
-        return \count($this->messages);
-    }
-
-    public function getMessages()
-    {
-        return $this->messages;
-    }
-}
-
 class AuthCodeMailerTest extends TestCase
 {
     protected $mailer;

--- a/tests/Wallabag/UserBundle/Mailer/CountableMemorySpool.php
+++ b/tests/Wallabag/UserBundle/Mailer/CountableMemorySpool.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Tests\Wallabag\UserBundle\Mailer;
+
+/**
+ * @see https://www.pmg.com/blog/integration-testing-swift-mailer/
+ */
+final class CountableMemorySpool extends \Swift_MemorySpool implements \Countable
+{
+    public function count()
+    {
+        return \count($this->messages);
+    }
+
+    public function getMessages()
+    {
+        return $this->messages;
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | kind of
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Documentation | no
| Translation   | no
| CHANGELOG.md  | no
| License       | MIT

The idea is to use it more and more and reach the higher level we could.
I fixed most of from the lowest level.

phpstan will run on travis on the same build as cs-fixer

- Fix error for level 0 & 1 (level 7 has 699 errors...)
- Add `updated_at` to site_credential (so the `timestamps()` method applies correctly)
