### PR TITLE
Removed hardcoded database version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,6 @@ matrix:
           env: CS_FIXER=run VALIDATE_TRANSLATION_FILE=run ASSETS=build DB=sqlite
     allow_failures:
         - php: nightly
-        - php: 7.3
 
 # exclude v1 branches
 branches:
@@ -56,7 +55,6 @@ before_script:
     # xdebug isn't enable for PHP 7.1
     - if [[ ! $PHP = hhvm* ]]; then phpenv config-rm xdebug.ini || echo "xdebug not available"; fi
     - composer self-update --no-progress
-    - if [[ $DB = pgsql ]]; then psql -c 'create database wallabag_test;' -U postgres; fi;
 
 script:
     - travis_wait bash composer install -o --no-interaction --no-progress --prefer-dist

--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -54,7 +54,6 @@ doctrine:
         charset: "%database_charset%"
         path: "%database_path%"
         unix_socket: "%database_socket%"
-        server_version: 5.6
 
     orm:
         auto_generate_proxy_classes: "%kernel.debug%"


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Documentation | no
| Translation   | no
| CHANGELOG.md  | no
| License       | MIT

Since https://github.com/doctrine/dbal/pull/2671 the bug with the database server version can be closed.

I've tried to install wallabag on PG 11.1 & MySQL 5.7 and it worked great.

Fixes #3739