### PR TITLE
Add missing entries in craue_config_setting.

### DIFF
--- a/app/DoctrineMigrations/Version20190129120000.php
+++ b/app/DoctrineMigrations/Version20190129120000.php
@@ -8,54 +8,132 @@ use Wallabag\CoreBundle\Doctrine\WallabagMigration;
 /**
  * Add missing entries in craue_config_setting.
  */
-class Version20190129120000 extends WallabagMigration
+final class Version20190129120000 extends WallabagMigration
 {
-    var $settings = array(
-        array("name" => "carrot", "value" => "1", "section" => "entry"),
-        array("name" => "share_diaspora", "value" => "1", "section" => "entry"),
-        array("name" => "diaspora_url", "value" => "http://diasporapod.com", "section" => "entry"),
-        array("name" => "share_shaarli", "value" => "1", "section" => "entry"),
-        array("name" => "shaarli_url", "value" => "http://myshaarli.com", "section" => "entry"),
-        array("name" => "share_mail", "value" => "1", "section" => "entry"),
-        array("name" => "share_twitter", "value" => "1", "section" => "entry"),
-        array("name" => "show_printlink", "value" => "1", "section" => "entry"),
-        array("name" => "export_epub", "value" => "1", "section" => "export"),
-        array("name" => "export_mobi", "value" => "1", "section" => "export"),
-        array("name" => "export_pdf", "value" => "1", "section" => "export"),
-        array("name" => "export_csv", "value" => "1", "section" => "export"),
-        array("name" => "export_json", "value" => "1", "section" => "export"),
-        array("name" => "export_txt", "value" => "1", "section" => "export"),
-        array("name" => "export_xml", "value" => "1", "section" => "export"),
-        array("name" => "piwik_enabled", "value" => "0", "section" => "analytics"),
-        array("name" => "piwik_host", "value" => "v2.wallabag.org", "section" => "analytics"),
-        array("name" => "piwik_site_id", "value" => "1", "section" => "analytics"),
-        array("name" => "demo_mode_enabled", "value" => "0", "section" => "misc"),
-        array("name" => "demo_mode_username", "value" => "wallabag", "section" => "misc"),
-        array("name" => "wallabag_support_url", "value" => "https://www.wallabag.org/pages/support.html", "section" => "misc"),
-    );
+    private $settings = [
+        [
+            'name' => 'carrot',
+            'value' => '1',
+            'section' => 'entry',
+        ],
+        [
+            'name' => 'share_diaspora',
+            'value' => '1',
+            'section' => 'entry',
+        ],
+        [
+            'name' => 'diaspora_url',
+            'value' => 'http://diasporapod.com',
+            'section' => 'entry',
+        ],
+        [
+            'name' => 'share_shaarli',
+            'value' => '1',
+            'section' => 'entry',
+        ],
+        [
+            'name' => 'shaarli_url',
+            'value' => 'http://myshaarli.com',
+            'section' => 'entry',
+        ],
+        [
+            'name' => 'share_mail',
+            'value' => '1',
+            'section' => 'entry',
+        ],
+        [
+            'name' => 'share_twitter',
+            'value' => '1',
+            'section' => 'entry',
+        ],
+        [
+            'name' => 'show_printlink',
+            'value' => '1',
+            'section' => 'entry',
+        ],
+        [
+            'name' => 'export_epub',
+            'value' => '1',
+            'section' => 'export',
+        ],
+        [
+            'name' => 'export_mobi',
+            'value' => '1',
+            'section' => 'export',
+        ],
+        [
+            'name' => 'export_pdf',
+            'value' => '1',
+            'section' => 'export',
+        ],
+        [
+            'name' => 'export_csv',
+            'value' => '1',
+            'section' => 'export',
+        ],
+        [
+            'name' => 'export_json',
+            'value' => '1',
+            'section' => 'export',
+        ],
+        [
+            'name' => 'export_txt',
+            'value' => '1',
+            'section' => 'export',
+        ],
+        [
+            'name' => 'export_xml',
+            'value' => '1',
+            'section' => 'export',
+        ],
+        [
+            'name' => 'piwik_enabled',
+            'value' => '0',
+            'section' => 'analytics',
+        ],
+        [
+            'name' => 'piwik_host',
+            'value' => 'v2.wallabag.org',
+            'section' => 'analytics',
+        ],
+        [
+            'name' => 'piwik_site_id',
+            'value' => '1',
+            'section' => 'analytics',
+        ],
+        [
+            'name' => 'demo_mode_enabled',
+            'value' => '0',
+            'section' => 'misc',
+        ],
+        [
+            'name' => 'demo_mode_username',
+            'value' => 'wallabag',
+            'section' => 'misc',
+        ],
+        [
+            'name' => 'wallabag_support_url',
+            'value' => 'https://www.wallabag.org/pages/support.html',
+            'section' => 'misc',
+        ],
+    ];
 
     /**
      * @param Schema $schema
      */
     public function up(Schema $schema)
     {
-        $piwikEnabled = $this->container
-            ->get('doctrine.orm.default_entity_manager')
-            ->getConnection()
-            ->fetchArray('SELECT * FROM ' . $this->getTable('craue_config_setting') . " WHERE name = 'piwik_enabled'");
-
-        $this->skipIf(false !== $piwikEnabled, 'It seems that you already played this migration, or user the wallabag:install command.');
-
         foreach ($this->settings as $setting) {
-            $this->addSql("
-                INSERT INTO " . $this->getTable('craue_config_setting') . "
-                    (name, value, section)
-                    VALUES (
-                        '" . $setting['name'] . "',
-                        '" . $setting['value'] . "',
-                        '" . $setting['section'] . "'
-                    );
-            ");
+            $settingEnabled = $this->container
+                ->get('doctrine.orm.default_entity_manager')
+                ->getConnection()
+                ->fetchArray('SELECT * FROM ' . $this->getTable('craue_config_setting') . " WHERE name = '" . $setting['name'] . "'");
+
+            if (false !== $settingEnabled) {
+                continue;
+            }
+
+            $this->addSql('INSERT INTO ' . $this->getTable('craue_config_setting') . " (name, value, section) VALUES ('" . $setting['name'] . "', '" . $setting['value'] . "', '" . $setting['section'] . "');");
         }
     }
 
@@ -65,8 +143,8 @@ class Version20190129120000 extends WallabagMigration
     public function down(Schema $schema)
     {
         foreach ($this->settings as $setting) {
-            $this->addSql("
-                DELETE FROM " . $this->getTable('craue_config_setting') . "
+            $this->addSql('
+                DELETE FROM ' . $this->getTable('craue_config_setting') . "
                 WHERE name = '" . $setting['name'] . "';
             ");
         }

--- a/app/DoctrineMigrations/Version20190129120000.php
+++ b/app/DoctrineMigrations/Version20190129120000.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace Application\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Wallabag\CoreBundle\Doctrine\WallabagMigration;
+
+/**
+ * Add missing entries in craue_config_setting.
+ */
+class Version20190129120000 extends WallabagMigration
+{
+    var $settings = array(
+        array("name" => "carrot", "value" => "1", "section" => "entry"),
+        array("name" => "share_diaspora", "value" => "1", "section" => "entry"),
+        array("name" => "diaspora_url", "value" => "http://diasporapod.com", "section" => "entry"),
+        array("name" => "share_shaarli", "value" => "1", "section" => "entry"),
+        array("name" => "shaarli_url", "value" => "http://myshaarli.com", "section" => "entry"),
+        array("name" => "share_mail", "value" => "1", "section" => "entry"),
+        array("name" => "share_twitter", "value" => "1", "section" => "entry"),
+        array("name" => "show_printlink", "value" => "1", "section" => "entry"),
+        array("name" => "export_epub", "value" => "1", "section" => "export"),
+        array("name" => "export_mobi", "value" => "1", "section" => "export"),
+        array("name" => "export_pdf", "value" => "1", "section" => "export"),
+        array("name" => "export_csv", "value" => "1", "section" => "export"),
+        array("name" => "export_json", "value" => "1", "section" => "export"),
+        array("name" => "export_txt", "value" => "1", "section" => "export"),
+        array("name" => "export_xml", "value" => "1", "section" => "export"),
+        array("name" => "piwik_enabled", "value" => "0", "section" => "analytics"),
+        array("name" => "piwik_host", "value" => "v2.wallabag.org", "section" => "analytics"),
+        array("name" => "piwik_site_id", "value" => "1", "section" => "analytics"),
+        array("name" => "demo_mode_enabled", "value" => "0", "section" => "misc"),
+        array("name" => "demo_mode_username", "value" => "wallabag", "section" => "misc"),
+        array("name" => "wallabag_support_url", "value" => "https://www.wallabag.org/pages/support.html", "section" => "misc"),
+    );
+
+    /**
+     * @param Schema $schema
+     */
+    public function up(Schema $schema)
+    {
+        $piwikEnabled = $this->container
+            ->get('doctrine.orm.default_entity_manager')
+            ->getConnection()
+            ->fetchArray('SELECT * FROM ' . $this->getTable('craue_config_setting') . " WHERE name = 'piwik_enabled'");
+
+        $this->skipIf(false !== $piwikEnabled, 'It seems that you already played this migration, or user the wallabag:install command.');
+
+        foreach ($this->settings as $setting) {
+            $this->addSql("
+                INSERT INTO " . $this->getTable('craue_config_setting') . "
+                    (name, value, section)
+                    VALUES (
+                        '" . $setting['name'] . "',
+                        '" . $setting['value'] . "',
+                        '" . $setting['section'] . "'
+                    );
+            ");
+        }
+    }
+
+    /**
+     * @param Schema $schema
+     */
+    public function down(Schema $schema)
+    {
+        foreach ($this->settings as $setting) {
+            $this->addSql("
+                DELETE FROM " . $this->getTable('craue_config_setting') . "
+                WHERE name = '" . $setting['name'] . "';
+            ");
+        }
+    }
+}

--- a/app/DoctrineMigrations/Version20190129120000.php
+++ b/app/DoctrineMigrations/Version20190129120000.php
@@ -142,11 +142,6 @@ final class Version20190129120000 extends WallabagMigration
      */
     public function down(Schema $schema)
     {
-        foreach ($this->settings as $setting) {
-            $this->addSql('
-                DELETE FROM ' . $this->getTable('craue_config_setting') . "
-                WHERE name = '" . $setting['name'] . "';
-            ");
-        }
+        $this->skipIf(true, 'These settings are required and should not be removed.');
     }
 }


### PR DESCRIPTION
During `wallabag:install`, the `craue_config_setting` table is populated (see https://github.com/wallabag/wallabag/blob/master/src/Wallabag/CoreBundle/Command/InstallCommand.php#L280-L285) with some default entries that are needed for wallabag to function. On a shared hosting however, this command cannot be run so wallabag crashes because of the missing entries (with this error: https://github.com/wallabag/wallabag/issues/3662).
Only some of these entries were created by the migration scripts. This adds the missing entries as part of a migration, to allow shared hosting users to have a complete database. I took the entries from https://github.com/wallabag/wallabag/blob/master/app/config/wallabag.yml#L32-L164, except those that were already added by a previous migration.
I ran the tests but they were not testing for this issue. I however also tested on a new VM and this fixed the issue.
It may now be possible to remove the setting `wallabag_core.default_internal_settings` from config/wallabag.yml (and the code that uses it), unless it is useful to be able to override those before install.
Fixes https://github.com/wallabag/wallabag/issues/3662.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | don't know what that means
| Deprecations? | no
| Tests pass?   | not all, but same as on `master`
| Documentation | no
| Translation   | no
| CHANGELOG.md  | don't know what that means
| License       | MIT

<!--
Please list the issues your PR fixes using special keywords, see
https://help.github.com/articles/closing-issues-using-keywords/

Fixes #…
-->

<!--
- Please fill in this template according to the PR you're about to submit.
- Replace this comment by a description of what your PR is solving.
-->
