### PR TITLE
Fix broken 2 factor auth logo image

### DIFF
--- a/src/Wallabag/UserBundle/Resources/views/TwoFactor/email_auth_code.html.twig
+++ b/src/Wallabag/UserBundle/Resources/views/TwoFactor/email_auth_code.html.twig
@@ -74,7 +74,7 @@
 
                 <table cellpadding="0" cellspacing="0" border="0" align="center" id="card">
                     <tr>
-                        <td style="padding: 20px;" width="96px" valign="top"><img class="image_fix" src="{{ absolute_url(asset('wallassets/themes/_global/img/logo-other_themes.png')) }}" alt="logo" title="{{ wallabag_url }}" style="width: 96px; height: 96px;" /></td>
+                        <td style="padding: 20px;" width="96px" valign="top"><img class="image_fix" src="{{ absolute_url(asset('wallassets/themes/_global/img/logo-square.svg')) }}" alt="logo" title="{{ wallabag_url }}" style="width: 96px; height: 96px;" /></td>
                         <td style="padding: 20px; padding-left: 0;" valign="top" id="cell_desc">
                             <h1>wallabag</h1>
                             <h5>{{ "auth_code.on"|trans({}, 'wallabag_user') }} {{ wallabag_url }}</h5>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Documentation | no
| Translation   | no
| CHANGELOG.md  | no
| License       | MIT

In 2 factor auth emails, the log image is broken:

![screen shot 2019-01-31 at 22 16 50](https://user-images.githubusercontent.com/557391/52085926-f7477e00-25a5-11e9-8163-ab1f598f7e99.png)

This is because the img points to the non-existing `logo-other_themes.png`. Here is swapped for `logo-square.png`, but there are other options at https://github.com/wallabag/wallabag/tree/master/web/wallassets/themes/_global/img, including https://github.com/wallabag/wallabag/blob/master/web/wallassets/themes/_global/img/logo-w.png

![](https://github.com/wallabag/wallabag/blob/master/web/wallassets/themes/_global/img/logo-w.png)


![](https://github.com/wallabag/wallabag/blob/master/web/wallassets/themes/_global/img/logo-w.png)


![](https://github.com/wallabag/wallabag/blob/master/web/wallassets/themes/_global/img/logo-w.png)