### PR TITLE
Article content paste/edit

### DIFF
--- a/app/AppKernel.php
+++ b/app/AppKernel.php
@@ -25,6 +25,7 @@ class AppKernel extends Kernel
             new Bazinga\Bundle\HateoasBundle\BazingaHateoasBundle(),
             new Lexik\Bundle\FormFilterBundle\LexikFormFilterBundle(),
             new FOS\OAuthServerBundle\FOSOAuthServerBundle(),
+            new FOS\CKEditorBundle\FOSCKEditorBundle(),
             new Stof\DoctrineExtensionsBundle\StofDoctrineExtensionsBundle(),
             new Scheb\TwoFactorBundle\SchebTwoFactorBundle(),
             new KPhoen\RulerZBundle\KPhoenRulerZBundle(),

--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -393,3 +393,51 @@ httplug:
                           'X-Accept': 'application/json'
     discovery:
         client: false
+
+fos_ck_editor:
+    default_config: default
+    configs:
+        default:
+            toolbar: basic
+        article_editor:
+            toolbar:
+                - name: 'basicstyles'
+                  items:
+                    - 'Bold'
+                    - 'Italic'
+                    - 'Underline'
+                    - 'Strike'
+                    - 'Subscript'
+                    - 'Superscript'
+                    - '-'
+                    - 'RemoveFormat'
+                - name: 'paragraph'
+                  items:
+                    - 'NumberedList'
+                    - 'BulletedList'
+                    - '-'
+                    - 'Outdent'
+                    - 'Indent'
+                    - '-'
+                    - 'Blockquote'
+                    - 'CreateDiv'
+                    - '-'
+                    - 'JustifyLeft'
+                    - 'JustifyCenter'
+                    - 'JustifyRight'
+                    - 'JustifyBlock'
+                - name: 'links'
+                  items:
+                    - 'Link'
+                    - 'Unlink'
+                    - 'Anchor'
+                - '/'
+                - name: 'styles'
+                  items:
+                    - 'Format'
+                    - 'Font'
+                    - 'FontSize'
+                - '/'
+                - name: 'document'
+                  items:
+                    - 'Source'

--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -40,6 +40,7 @@ twig:
     strict_variables: "%kernel.debug%"
     form_themes:
         - "LexikFormFilterBundle:Form:form_div_layout.html.twig"
+        - "@FOSCKEditor/Form/ckeditor_widget.html.twig"
     exception_controller: wallabag_core.exception_controller:showAction
 
 # Doctrine Configuration

--- a/composer.json
+++ b/composer.json
@@ -70,6 +70,7 @@
         "php-http/guzzle5-adapter": "^2.0",
         "friendsofsymfony/user-bundle": "2.0.*",
         "friendsofsymfony/oauth-server-bundle": "^1.5",
+        "friendsofsymfony/ckeditor-bundle": "^1.2",
         "stof/doctrine-extensions-bundle": "^1.2",
         "scheb/two-factor-bundle": "^4.4",
         "grandt/phpepub": "dev-master",
@@ -115,6 +116,7 @@
             "Incenteev\\ParameterHandler\\ScriptHandler::buildParameters",
             "Sensio\\Bundle\\DistributionBundle\\Composer\\ScriptHandler::buildBootstrap",
             "Sensio\\Bundle\\DistributionBundle\\Composer\\ScriptHandler::clearCache",
+            "FOS\\CKEditorBundle\\Composer\\CKEditorScriptHandler::install",
             "Sensio\\Bundle\\DistributionBundle\\Composer\\ScriptHandler::installAssets",
             "Sensio\\Bundle\\DistributionBundle\\Composer\\ScriptHandler::installRequirementsFile"
         ],

--- a/composer.lock
+++ b/composer.lock
@@ -1737,6 +1737,86 @@
             "time": "2019-05-09T11:53:40+00:00"
         },
         {
+            "name": "friendsofsymfony/ckeditor-bundle",
+            "version": "1.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/FriendsOfSymfony/FOSCKEditorBundle.git",
+                "reference": "7d428b16154a7136e1dd4c11062573afa1bfb3df"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/FriendsOfSymfony/FOSCKEditorBundle/zipball/7d428b16154a7136e1dd4c11062573afa1bfb3df",
+                "reference": "7d428b16154a7136e1dd4c11062573afa1bfb3df",
+                "shasum": ""
+            },
+            "require": {
+                "ext-zip": "*",
+                "php": "^5.6 || ^7.0",
+                "symfony/asset": "^2.7 || ^3.0 || ^4.0",
+                "symfony/config": "^2.7 || ^3.0 || ^4.0",
+                "symfony/dependency-injection": "^2.7 || ^3.0 || ^4.0",
+                "symfony/expression-language": "^2.7 || ^3.0 || ^4.0",
+                "symfony/form": "^2.7 || ^3.0 || ^4.0",
+                "symfony/framework-bundle": "^2.7 || ^3.0 || ^4.0",
+                "symfony/http-foundation": "^2.7 || ^3.0 || ^4.0",
+                "symfony/http-kernel": "^2.7 || ^3.0 || ^4.0",
+                "symfony/options-resolver": "^2.7 || ^3.0 || ^4.0",
+                "symfony/property-access": "^2.7 || ^3.0 || ^4.0",
+                "symfony/routing": "^2.7 || ^3.0 || ^4.0"
+            },
+            "conflict": {
+                "sebastian/environment": "<1.3.4",
+                "sebastian/exporter": "<2.0.0"
+            },
+            "require-dev": {
+                "composer/composer": "^1.0",
+                "friendsofphp/php-cs-fixer": "^2.0",
+                "matthiasnoback/symfony-dependency-injection-test": "^1.0 || ^2.0",
+                "phpunit/phpunit": "^5.0 || ^6.0",
+                "sensio/distribution-bundle": "^3.0.12 || ^4.0 || ^5.0",
+                "symfony/console": "^2.7 || ^3.0 || ^4.0",
+                "symfony/phpunit-bridge": "^4.0",
+                "symfony/templating": "^2.7 || ^3.0 || ^4.0",
+                "symfony/twig-bridge": "^2.7 || ^3.0 || ^4.0",
+                "symfony/yaml": "^2.7 || ^3.0 || ^4.0",
+                "twig/twig": "^1.34 || ^2.0"
+            },
+            "suggest": {
+                "egeloen/form-extra-bundle": "Allows to load CKEditor asynchronously"
+            },
+            "type": "symfony-bundle",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "FOS\\CKEditorBundle\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Eric GELOEN",
+                    "email": "geloen.eric@gmail.com"
+                },
+                {
+                    "name": "FriendsOfSymfony Community",
+                    "homepage": "https://github.com/FriendsOfSymfony/FOSCKEditorBundle/graphs/contributors"
+                }
+            ],
+            "description": "Provides a CKEditor integration for your Symfony project.",
+            "keywords": [
+                "CKEditor"
+            ],
+            "time": "2018-10-03T20:51:58+00:00"
+        },
+        {
             "name": "friendsofsymfony/jsrouting-bundle",
             "version": "2.3.1",
             "source": {

--- a/src/Wallabag/CoreBundle/Form/Type/EditEntryType.php
+++ b/src/Wallabag/CoreBundle/Form/Type/EditEntryType.php
@@ -2,6 +2,7 @@
 
 namespace Wallabag\CoreBundle\Form\Type;
 
+use FOS\CKEditorBundle\Form\Type\CKEditorType;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\SubmitType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
@@ -29,6 +30,10 @@ class EditEntryType extends AbstractType
                 'property_path' => 'originUrl',
                 'label' => 'entry.edit.origin_url_label',
                 'default_protocol' => null,
+            ])
+            ->add('content', CKEditorType::class, [
+                'label' => 'entry.edit.content_label',
+                'config_name' => 'article_editor',
             ])
             ->add('save', SubmitType::class, [
                 'label' => 'entry.edit.save_label',

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.en.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.en.yml
@@ -244,6 +244,7 @@ entry:
             set_as_starred: 'Toggle starred'
             view_original_article: 'Original article'
             re_fetch_content: 'Re-fetch content'
+            edit_content: 'Edit content'
             delete: 'Delete'
             add_a_tag: 'Add a tag'
             share_content: 'Share'

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.en.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.en.yml
@@ -275,6 +275,7 @@ entry:
         url_label: 'Url'
         origin_url_label: 'Origin url (from where you found that entry)'
         save_label: 'Save'
+        content_label: 'Body'
     public:
         shared_by_wallabag: "This article has been shared by %username% with <a href='%wallabag_instance%'>wallabag</a>"
     confirm:

--- a/src/Wallabag/CoreBundle/Resources/views/themes/material/Entry/edit.html.twig
+++ b/src/Wallabag/CoreBundle/Resources/views/themes/material/Entry/edit.html.twig
@@ -32,6 +32,11 @@
                             {{ form_label(form.origin_url) }}
                             {{ form_widget(form.origin_url) }}
                         </div>
+
+                        <div class="s12">
+                            {{ form_label(form.content) }}
+                            {{ form_widget(form.content, {'attr': {'style': 'height:20em; resize:vertical;'}}) }}
+                        </div>
                         <br>
 
                         {{ form_widget(form.save, {'attr': {'class': 'btn waves-effect waves-light'}}) }}

--- a/src/Wallabag/CoreBundle/Resources/views/themes/material/Entry/entry.html.twig
+++ b/src/Wallabag/CoreBundle/Resources/views/themes/material/Entry/entry.html.twig
@@ -61,6 +61,14 @@
             <div class="collapsible-body"></div>
         </li>
 
+        <li class="bold">
+            <a class="waves-effect collapsible-header" title="{{ 'entry.view.left_menu.edit_content'|trans }}" href="{{ path('edit', { 'id': entry.id }) }}" id="edit">
+                <i class="material-icons small">edit</i>
+                <span>{{ 'entry.view.left_menu.edit_content'|trans }}</span>
+            </a>
+            <div class="collapsible-body"></div>
+        </li>
+
         {% set markAsReadLabel = 'entry.view.left_menu.set_as_unread' %}
         {% if entry.isArchived == 0 %}
             {% set markAsReadLabel = 'entry.view.left_menu.set_as_read' %}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Documentation | no
| Translation   | no
| CHANGELOG.md  | no
| License       | MIT

Resolves #2229 
Relates to #3648

Hi, I'd been wanting the ability to correct miss-import and paste in articles that the scraper was failing, for a while.  Since I came across others asking for this I thought I'd have another look and it was quite easy to implement.

I've added a content editor to the edit page, linked from and Edit button in the article itself.  This has required adding a dependency, so I'm submitting this for feedback on license and implementation before I do any more changes; for example, I haven't provided translations or another theme.

Using the Material theme, the editor can be accessed from an article's side menu.  Content can be highlighted and copied from any web page and pasted into the WYSIWYG editor, which preserves the formatting.  Is there anything I need to specifically have it strip out; urls or linked images for example?