### PR TITLE
Force default_protocol to generate an url input

### DIFF
--- a/src/Wallabag/ApiBundle/Form/Type/ClientType.php
+++ b/src/Wallabag/ApiBundle/Form/Type/ClientType.php
@@ -20,6 +20,7 @@ class ClientType extends AbstractType
                 'required' => false,
                 'label' => 'developer.client.form.redirect_uris_label',
                 'property_path' => 'redirectUris',
+                'default_protocol' => null,
             ])
             ->add('save', SubmitType::class, ['label' => 'developer.client.form.save_label'])
         ;

--- a/src/Wallabag/CoreBundle/Form/Type/EditEntryType.php
+++ b/src/Wallabag/CoreBundle/Form/Type/EditEntryType.php
@@ -22,11 +22,13 @@ class EditEntryType extends AbstractType
                 'disabled' => true,
                 'required' => false,
                 'label' => 'entry.edit.url_label',
+                'default_protocol' => null,
             ])
             ->add('origin_url', UrlType::class, [
                 'required' => false,
                 'property_path' => 'originUrl',
                 'label' => 'entry.edit.origin_url_label',
+                'default_protocol' => null,
             ])
             ->add('save', SubmitType::class, [
                 'label' => 'entry.edit.save_label',

--- a/src/Wallabag/CoreBundle/Form/Type/NewEntryType.php
+++ b/src/Wallabag/CoreBundle/Form/Type/NewEntryType.php
@@ -15,6 +15,7 @@ class NewEntryType extends AbstractType
             ->add('url', UrlType::class, [
                 'required' => true,
                 'label' => 'entry.new.form_new.url_label',
+                'default_protocol' => null,
             ])
         ;
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Documentation | no
| Translation   | no
| CHANGELOG.md  | no
| License       | MIT

Related to https://github.com/symfony/symfony/issues/29690

For an `UrlType` the `default_protocol` value is `http` which now result in converting the url input into a text input.
Forcing `default_protocol` to null will let the input type as url.