### PR TITLE
Allow optional --ignore-root-warning

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -5,9 +5,17 @@
 IGNORE_ROOT_ARG="--ignore-root-warning"
 IGNORE_ROOT=0
 
-if [ "$1" == "$IGNORE_ROOT_ARG" ]; then
-    IGNORE_ROOT=1
-fi
+while :; do
+    case $1 in
+        $IGNORE_ROOT_ARG) IGNORE_ROOT=1
+        ;;
+        *[a-zA-Z]) ENV=$1
+        ;;
+        *) break
+        ;;
+    esac
+    shift
+done
 
 # Abort running this script if root
 if [ "$IGNORE_ROOT" -eq 0 ] && [ "$EUID" == "0" ]; then
@@ -22,7 +30,6 @@ DIR="${BASH_SOURCE}"
 if [ ! -d "$DIR" ]; then DIR="$PWD/scripts"; fi
 . "$DIR/require.sh"
 
-ENV=$1
 TAG=$(git describe --tags $(git rev-list --tags --max-count=1))
 
 git checkout $TAG

--- a/scripts/update.sh
+++ b/scripts/update.sh
@@ -5,9 +5,17 @@
 IGNORE_ROOT_ARG="--ignore-root-warning"
 IGNORE_ROOT=0
 
-if [ "$1" == "$IGNORE_ROOT_ARG" ]; then
-    IGNORE_ROOT=1
-fi
+while :; do
+    case $1 in
+        $IGNORE_ROOT_ARG) IGNORE_ROOT=1
+        ;;
+        *[a-zA-Z]) ENV=$1
+        ;;
+        *) break
+        ;;
+    esac
+    shift
+done
 
 # Abort running this script if root
 if [ "$IGNORE_ROOT" -eq 0 ] && [ "$EUID" == "0" ]; then
@@ -24,8 +32,6 @@ COMPOSER_COMMAND='composer'
 DIR="${BASH_SOURCE}"
 if [ ! -d "$DIR" ]; then DIR="$PWD/scripts"; fi
 . "$DIR/require.sh"
-
-ENV=$1
 
 rm -rf var/cache/*
 git fetch origin


### PR DESCRIPTION
Now both
```
./install prod --ignore-root-warning
./install --ignore-root-warning prod
```
will work

$1 was both used for the environment and the root flag

Fixes wallabag/wallabag#3884

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| License       | MIT
