### PR TITLE
Add support of expect parameter to change return object when deleting entry

### DIFF
--- a/src/Wallabag/ApiBundle/Controller/EntryRestController.php
+++ b/src/Wallabag/ApiBundle/Controller/EntryRestController.php
@@ -570,18 +570,31 @@ class EntryRestController extends WallabagRestController
      * @ApiDoc(
      *      requirements={
      *          {"name"="entry", "dataType"="integer", "requirement"="\w+", "description"="The entry ID"}
+     *      },
+     *      parameters={
+     *          {"name"="expect", "dataType"="string", "required"=false, "format"="id or entry", "description"="Only returns the id instead of the deleted entry's full entity if 'id' is specified. Default to entry"},
      *      }
      * )
      *
      * @return JsonResponse
      */
-    public function deleteEntriesAction(Entry $entry)
+    public function deleteEntriesAction(Entry $entry, Request $request)
     {
+        $expect = $request->query->get('expect', 'entry');
+        if (!\in_array($expect, ['id', 'entry'], true)) {
+            throw new BadRequestHttpException(sprintf("expect: 'id' or 'entry' expected, %s given", $expect));
+        }
         $this->validateAuthentication();
         $this->validateUserAccess($entry->getUser()->getId());
 
-        // We copy $entry to keep id in returned object
-        $e = $entry;
+        $response = $this->sendResponse([
+            'id' => $entry->getId(),
+        ]);
+        // We clone $entry to keep id in returned object
+        if ('entry' === $expect) {
+            $e = clone $entry;
+            $response = $this->sendResponse($e);
+        }
 
         $em = $this->getDoctrine()->getManager();
         $em->remove($entry);
@@ -590,7 +603,7 @@ class EntryRestController extends WallabagRestController
         // entry deleted, dispatch event about it!
         $this->get('event_dispatcher')->dispatch(EntryDeletedEvent::NAME, new EntryDeletedEvent($entry));
 
-        return $this->sendResponse($e);
+        return $response;
     }
 
     /**

--- a/tests/Wallabag/ApiBundle/Controller/EntryRestControllerTest.php
+++ b/tests/Wallabag/ApiBundle/Controller/EntryRestControllerTest.php
@@ -426,9 +426,10 @@ class EntryRestControllerTest extends WallabagApiTestCase
         $this->assertSame($e['id'], $content['id']);
 
         // We'll try to delete this entry again
-        $this->client->request('DELETE', '/api/entries/' . $e['id'] . '.json');
+        $client = $this->createAuthorizedClient();
+        $client->request('DELETE', '/api/entries/' . $e['id'] . '.json');
 
-        $this->assertSame(404, $this->client->getResponse()->getStatusCode());
+        $this->assertSame(404, $client->getResponse()->getStatusCode());
     }
 
     public function testDeleteEntryExpectId()
@@ -453,9 +454,17 @@ class EntryRestControllerTest extends WallabagApiTestCase
         $this->assertArrayNotHasKey('url', $content);
 
         // We'll try to delete this entry again
-        $this->client->request('DELETE', '/api/entries/' . $id . '.json');
+        $client = $this->createAuthorizedClient();
+        $client->request('DELETE', '/api/entries/' . $id . '.json');
 
-        $this->assertSame(404, $this->client->getResponse()->getStatusCode());
+        $this->assertSame(404, $client->getResponse()->getStatusCode());
+    }
+
+    public function testDeleteEntryExpectBadRequest()
+    {
+        $this->client->request('DELETE', '/api/entries/1.json?expect=badrequest');
+
+        $this->assertSame(400, $this->client->getResponse()->getStatusCode());
     }
 
     public function testPostEntry()

--- a/tests/Wallabag/ApiBundle/Controller/EntryRestControllerTest.php
+++ b/tests/Wallabag/ApiBundle/Controller/EntryRestControllerTest.php
@@ -431,18 +431,29 @@ class EntryRestControllerTest extends WallabagApiTestCase
         $this->assertSame(404, $this->client->getResponse()->getStatusCode());
     }
 
-        $this->client->request('DELETE', '/api/entries/' . $entry->getId() . '.json');
+    public function testDeleteEntryExpectId()
+    {
+        $em = $this->client->getContainer()->get('doctrine.orm.entity_manager');
+        $entry = new Entry($em->getReference(User::class, 1));
+        $entry->setUrl('http://0.0.0.0/test-delete-entry-id');
+        $em->persist($entry);
+        $em->flush();
+
+        $em->clear();
+
+        $id = $entry->getId();
+
+        $this->client->request('DELETE', '/api/entries/' . $id . '.json?expect=id');
 
         $this->assertSame(200, $this->client->getResponse()->getStatusCode());
 
         $content = json_decode($this->client->getResponse()->getContent(), true);
 
-        $this->assertSame($entry->getTitle(), $content['title']);
-        $this->assertSame($entry->getUrl(), $content['url']);
-        $this->assertSame($entry->getId(), $content['id']);
+        $this->assertSame($id, $content['id']);
+        $this->assertArrayNotHasKey('url', $content);
 
         // We'll try to delete this entry again
-        $this->client->request('DELETE', '/api/entries/' . $entry->getId() . '.json');
+        $this->client->request('DELETE', '/api/entries/' . $id . '.json');
 
         $this->assertSame(404, $this->client->getResponse()->getStatusCode());
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Documentation | no
| Translation   | no
| CHANGELOG.md  | no
| License       | MIT

Fixes #3711

This PR fixes a test, the clone and add a new `expect` parameter to the `delete entry` call. When specifying `?expect=id` the API will return the id of the removed entry instead of returning the whole object.
By default, `expect` is set to `entry` which is the current behavior.

Fixes https://github.com/wallabag/android-app/issues/646