### PR TITLE
epub: fix exception when articles have the same title

### DIFF
--- a/src/Wallabag/CoreBundle/Helper/EntriesExport.php
+++ b/src/Wallabag/CoreBundle/Helper/EntriesExport.php
@@ -188,7 +188,7 @@ class EntriesExport
             foreach ($entry->getTags() as $tag) {
                 $book->setSubject($tag->getLabel());
             }
-            $filename = sha1($entry->getTitle());
+            $filename = sha1(sprintf('%s:%s', $entry->getUrl(), $entry->getTitle()));
 
             $publishedBy = $entry->getPublishedBy();
             $authors = $this->translator->trans('export.unknown');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | -
| Documentation | no
| Translation   | no
| CHANGELOG.md  | no
| License       | MIT

This commit fixes an exception occurring when exporting as epub several
articles with the same title. The chapter filename is now derived from
title and url.

Fixes #3642