### PR TITLE
Fix PHP warning

### DIFF
--- a/src/Wallabag/CoreBundle/Helper/ContentProxy.php
+++ b/src/Wallabag/CoreBundle/Helper/ContentProxy.php
@@ -256,18 +256,17 @@ class ContentProxy
             $entry->setTitle($content['open_graph']['og_title']);
         }
 
-        $html = $content['html'];
-        if (false === $html) {
-            $html = $this->fetchingErrorMessage;
+        if (empty($content['html'])) {
+            $content['html'] = $this->fetchingErrorMessage;
 
             if (!empty($content['open_graph']['og_description'])) {
-                $html .= '<p><i>But we found a short description: </i></p>';
-                $html .= $content['open_graph']['og_description'];
+                $content['html'] .= '<p><i>But we found a short description: </i></p>';
+                $content['html'] .= $content['open_graph']['og_description'];
             }
         }
 
-        $entry->setContent($html);
-        $entry->setReadingTime(Utils::getReadingTime($html));
+        $entry->setContent($content['html']);
+        $entry->setReadingTime(Utils::getReadingTime($content['html']));
 
         if (!empty($content['status'])) {
             $entry->setHttpStatus($content['status']);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Documentation | no
| Translation   | no
| License       | MIT

Looks like sometimes (usually from import) the `html` key isn’t available.