### PR TITLE
Remove preview picture from share view page for #1875

### DIFF
--- a/src/Wallabag/CoreBundle/Resources/views/themes/common/Entry/share.html.twig
+++ b/src/Wallabag/CoreBundle/Resources/views/themes/common/Entry/share.html.twig
@@ -29,9 +29,6 @@
             <h1>{{ entry.title|e|raw }}</h1>
             <a href="{{ entry.url|e }}" target="_blank" rel="noopener" title="{{ 'entry.view.original_article'|trans }} : {{ entry.title|e|raw }}" class="tool">{{ entry.domainName|removeWww }}</a>
             <p class="shared-by">{{ "entry.public.shared_by_wallabag"|trans({'%wallabag_instance%': url('homepage'), '%username%': entry.user.username})|raw }}.</p>
-            {% if entry.previewPicture is not null %}
-                <img class="preview" src="{{ entry.previewPicture }}" alt="{{ entry.title|striptags|e('html_attr') }}" />
-            {% endif %}
         </header>
         <article class="block">
             {{ entry.content | raw }}


### PR DESCRIPTION
Essentially, same as commit 038fccd for single entry views. From that commit:
> Showing the preview picture usually leads to showing a duplicate
> image, and frequently leads to showing duplicate images directly
> adjacent to each other.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes/no
| Documentation | no
| Translation   | no
| CHANGELOG.md  | yes/no
| License       | MIT

<!--
Please list the issues your PR fixes using special keywords, see
https://help.github.com/articles/closing-issues-using-keywords/

Fixes #…
-->

<!--
- Please fill in this template according to the PR you're about to submit.
- Replace this comment by a description of what your PR is solving.
-->
