### PR TITLE
Symfony upgraded to v3.4.24

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -44,7 +44,7 @@
         "ext-tokenizer": "*",
         "ext-pdo": "*",
         "ext-tidy": "*",
-        "symfony/symfony": "~3.3.13",
+        "symfony/symfony": "3.4.*",
         "doctrine/orm": "^2.5.12",
         "doctrine/doctrine-bundle": "^1.8.0",
         "doctrine/doctrine-cache-bundle": "^1.3.2",


### PR DESCRIPTION
Hi there,
I encountered an issue yesterday with the last PHP 7.2.17 version. It was like a process throttle that ended with a max execution time error. I upgraded the Symfony version from v3.3.18 to v3.4.24 and everything seems to be working again.
The v3.3.18 was released in August 1, 2018 so I think it's a good move to upgrade anyway.
Have a nice day.