### PR TITLE
 Add ability to match many domains for credentials

### DIFF
--- a/src/Wallabag/CoreBundle/DataFixtures/ORM/LoadSiteCredentialData.php
+++ b/src/Wallabag/CoreBundle/DataFixtures/ORM/LoadSiteCredentialData.php
@@ -5,19 +5,38 @@ namespace Wallabag\CoreBundle\DataFixtures\ORM;
 use Doctrine\Common\DataFixtures\AbstractFixture;
 use Doctrine\Common\DataFixtures\OrderedFixtureInterface;
 use Doctrine\Common\Persistence\ObjectManager;
+use Symfony\Component\DependencyInjection\ContainerAwareInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 use Wallabag\CoreBundle\Entity\SiteCredential;
 
-class LoadSiteCredentialData extends AbstractFixture implements OrderedFixtureInterface
+class LoadSiteCredentialData extends AbstractFixture implements OrderedFixtureInterface, ContainerAwareInterface
 {
+    /**
+     * @var ContainerInterface
+     */
+    private $container;
+
+    public function setContainer(ContainerInterface $container = null)
+    {
+        $this->container = $container;
+    }
+
     /**
      * {@inheritdoc}
      */
     public function load(ObjectManager $manager)
     {
         $credential = new SiteCredential($this->getReference('admin-user'));
-        $credential->setHost('example.com');
-        $credential->setUsername('foo');
-        $credential->setPassword('bar');
+        $credential->setHost('.super.com');
+        $credential->setUsername($this->container->get('wallabag_core.helper.crypto_proxy')->crypt('.super'));
+        $credential->setPassword($this->container->get('wallabag_core.helper.crypto_proxy')->crypt('bar'));
+
+        $manager->persist($credential);
+
+        $credential = new SiteCredential($this->getReference('admin-user'));
+        $credential->setHost('paywall.example.com');
+        $credential->setUsername($this->container->get('wallabag_core.helper.crypto_proxy')->crypt('paywall.example'));
+        $credential->setPassword($this->container->get('wallabag_core.helper.crypto_proxy')->crypt('bar'));
 
         $manager->persist($credential);
 

--- a/src/Wallabag/CoreBundle/GuzzleSiteAuthenticator/GrabySiteConfigBuilder.php
+++ b/src/Wallabag/CoreBundle/GuzzleSiteAuthenticator/GrabySiteConfigBuilder.php
@@ -64,7 +64,17 @@ class GrabySiteConfigBuilder implements SiteConfigBuilder
 
         $credentials = null;
         if ($this->currentUser) {
-            $credentials = $this->credentialRepository->findOneByHostAndUser($host, $this->currentUser->getId());
+            $hosts = [$host];
+            // will try to see for a host without the first subdomain (fr.example.org & .example.org)
+            $split = explode('.', $host);
+
+            if (\count($split) > 1) {
+                // remove first subdomain
+                array_shift($split);
+                $hosts[] = '.' . implode('.', $split);
+            }
+
+            $credentials = $this->credentialRepository->findOneByHostsAndUser($hosts, $this->currentUser->getId());
         }
 
         if (null === $credentials) {

--- a/src/Wallabag/CoreBundle/GuzzleSiteAuthenticator/GrabySiteConfigBuilder.php
+++ b/src/Wallabag/CoreBundle/GuzzleSiteAuthenticator/GrabySiteConfigBuilder.php
@@ -62,20 +62,23 @@ class GrabySiteConfigBuilder implements SiteConfigBuilder
             $host = substr($host, 4);
         }
 
-        $credentials = null;
-        if ($this->currentUser) {
-            $hosts = [$host];
-            // will try to see for a host without the first subdomain (fr.example.org & .example.org)
-            $split = explode('.', $host);
+        if (!$this->currentUser) {
+            $this->logger->debug('Auth: no current user defined.');
 
-            if (\count($split) > 1) {
-                // remove first subdomain
-                array_shift($split);
-                $hosts[] = '.' . implode('.', $split);
-            }
-
-            $credentials = $this->credentialRepository->findOneByHostsAndUser($hosts, $this->currentUser->getId());
+            return false;
         }
+
+        $hosts = [$host];
+        // will try to see for a host without the first subdomain (fr.example.org & .example.org)
+        $split = explode('.', $host);
+
+        if (\count($split) > 1) {
+            // remove first subdomain
+            array_shift($split);
+            $hosts[] = '.' . implode('.', $split);
+        }
+
+        $credentials = $this->credentialRepository->findOneByHostsAndUser($hosts, $this->currentUser->getId());
 
         if (null === $credentials) {
             $this->logger->debug('Auth: no credentials available for host.', ['host' => $host]);

--- a/src/Wallabag/CoreBundle/Repository/SiteCredentialRepository.php
+++ b/src/Wallabag/CoreBundle/Repository/SiteCredentialRepository.php
@@ -19,16 +19,16 @@ class SiteCredentialRepository extends \Doctrine\ORM\EntityRepository
     /**
      * Retrieve one username/password for the given host and userId.
      *
-     * @param string $host
-     * @param int    $userId
+     * @param array $hosts  An array of host to look for
+     * @param int   $userId
      *
      * @return array|null
      */
-    public function findOneByHostAndUser($host, $userId)
+    public function findOneByHostsAndUser($hosts, $userId)
     {
         $res = $this->createQueryBuilder('s')
             ->select('s.username', 's.password')
-            ->where('s.host = :hostname')->setParameter('hostname', $host)
+            ->where('s.host IN (:hosts)')->setParameter('hosts', $hosts)
             ->andWhere('s.user = :userId')->setParameter('userId', $userId)
             ->setMaxResults(1)
             ->getQuery()

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.da.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.da.yml
@@ -550,7 +550,7 @@ site_credential:
     #     create_new_one: Create a new credential
     # form:
     #     username_label: 'Username'
-    #     host_label: 'Host'
+    #     host_label: 'Host (subdomain.example.org, .example.org, etc.)'
     #     password_label: 'Password'
     #     save: Save
     #     delete: Delete

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.de.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.de.yml
@@ -550,7 +550,7 @@ site_credential:
         create_new_one: 'Einen neuen Seitenzugang anlegen'
     form:
         username_label: 'Benutzername'
-        host_label: 'Host'
+        host_label: 'Host (subdomain.example.org, .example.org, etc.)'
         password_label: 'Passwort'
         save: 'Speichern'
         delete: 'Löschen'

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.en.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.en.yml
@@ -550,7 +550,7 @@ site_credential:
         create_new_one: Create a new credential
     form:
         username_label: 'Username'
-        host_label: 'Host'
+        host_label: 'Host (subdomain.example.org, .example.org, etc.)'
         password_label: 'Password'
         save: Save
         delete: Delete

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.es.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.es.yml
@@ -550,7 +550,7 @@ site_credential:
     #     create_new_one: Create a new credential
     # form:
     #     username_label: 'Username'
-    #     host_label: 'Host'
+    #     host_label: 'Host (subdomain.example.org, .example.org, etc.)'
     #     password_label: 'Password'
     #     save: Save
     #     delete: Delete

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.fa.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.fa.yml
@@ -550,7 +550,7 @@ site_credential:
     #     create_new_one: Create a new credential
     # form:
     #     username_label: 'Username'
-    #     host_label: 'Host'
+    #     host_label: 'Host (subdomain.example.org, .example.org, etc.)'
     #     password_label: 'Password'
     #     save: Save
     #     delete: Delete

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.fr.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.fr.yml
@@ -550,7 +550,7 @@ site_credential:
         create_new_one: Créer un nouvel accès à un site
     form:
         username_label: 'Identifiant'
-        host_label: 'Domaine'
+        host_label: 'Domaine (subdomain.example.org, .example.org, etc.)'
         password_label: 'Mot de passe'
         save: "Sauvegarder"
         delete: "Supprimer"

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.it.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.it.yml
@@ -550,7 +550,7 @@ site_credential:
     #     create_new_one: Create a new credential
     # form:
     #     username_label: 'Username'
-    #     host_label: 'Host'
+    #     host_label: 'Host (subdomain.example.org, .example.org, etc.)'
     #     password_label: 'Password'
     #     save: Save
     #     delete: Delete

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.oc.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.oc.yml
@@ -550,7 +550,7 @@ site_credential:
          create_new_one: Crear un novèl identificant
     form:
         username_label: "Nom d'utilizaire"
-        host_label: 'Òste'
+        host_label: 'Òste (subdomain.example.org, .example.org, etc.)'
         password_label: 'Senhal'
         save: 'Enregistrar'
         delete: 'Suprimir'

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.pl.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.pl.yml
@@ -550,7 +550,7 @@ site_credential:
         create_new_one: Stwórz nowe poświadczenie
     form:
         username_label: 'Nazwa użytkownika'
-        host_label: 'Host'
+        host_label: 'Host (subdomain.example.org, .example.org, etc.)'
         password_label: 'Hasło'
         save: Zapisz
         delete: Usuń

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.pt.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.pt.yml
@@ -550,7 +550,7 @@ site_credential:
         # create_new_one: Create a new credential
     form:
         # username_label: 'Username'
-        # host_label: 'Host'
+        # host_label: 'Host (subdomain.example.org, .example.org, etc.)'
         # password_label: 'Password'
         save: 'Salvar'
         delete: 'Apagar'

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.ro.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.ro.yml
@@ -550,7 +550,7 @@ site_credential:
     #     create_new_one: Create a new credential
     # form:
     #     username_label: 'Username'
-    #     host_label: 'Host'
+    #     host_label: 'Host (subdomain.example.org, .example.org, etc.)'
     #     password_label: 'Password'
     #     save: Save
     #     delete: Delete

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.th.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.th.yml
@@ -548,7 +548,7 @@ site_credential:
         create_new_one: สร้างข้อมูลส่วนตัวใหม่
     form:
         username_label: 'ชื่อผู้ใช้'
-        host_label: 'โฮส'
+        host_label: 'โฮส (subdomain.example.org, .example.org, etc.)'
         password_label: 'รหัสผ่าน'
         save: บันทึก
         delete: ลบ

--- a/tests/Wallabag/CoreBundle/Controller/EntryControllerTest.php
+++ b/tests/Wallabag/CoreBundle/Controller/EntryControllerTest.php
@@ -166,7 +166,7 @@ class EntryControllerTest extends WallabagCoreTestCase
         $this->assertSame($this->url, $content->getUrl());
         $this->assertContains('Google', $content->getTitle());
         $this->assertSame('fr', $content->getLanguage());
-        $this->assertSame('2016-04-07 19:01:35', $content->getPublishedAt()->format('Y-m-d H:i:s'));
+        $this->assertSame('2015-03-28 11:43:19', $content->getPublishedAt()->format('Y-m-d H:i:s'));
         $this->assertArrayHasKey('x-frame-options', $content->getHeaders());
         $client->getContainer()->get('craue_config')->set('store_article_headers', 0);
     }

--- a/tests/Wallabag/CoreBundle/GuzzleSiteAuthenticator/GrabySiteConfigBuilderTest.php
+++ b/tests/Wallabag/CoreBundle/GuzzleSiteAuthenticator/GrabySiteConfigBuilderTest.php
@@ -24,7 +24,7 @@ class GrabySiteConfigBuilderTest extends TestCase
 
         $grabySiteConfig = new GrabySiteConfig();
         $grabySiteConfig->requires_login = true;
-        $grabySiteConfig->login_uri = 'http://www.example.com/login';
+        $grabySiteConfig->login_uri = 'http://api.example.com/login';
         $grabySiteConfig->login_username_field = 'login';
         $grabySiteConfig->login_password_field = 'password';
         $grabySiteConfig->login_extra_fields = ['field=value'];
@@ -32,7 +32,7 @@ class GrabySiteConfigBuilderTest extends TestCase
 
         $grabyConfigBuilderMock
             ->method('buildForHost')
-            ->with('example.com')
+            ->with('api.example.com')
             ->will($this->returnValue($grabySiteConfig));
 
         $logger = new Logger('foo');
@@ -43,8 +43,8 @@ class GrabySiteConfigBuilderTest extends TestCase
             ->disableOriginalConstructor()
             ->getMock();
         $siteCrentialRepo->expects($this->once())
-            ->method('findOneByHostAndUser')
-            ->with('example.com', 1)
+            ->method('findOneByHostsAndUser')
+            ->with(['api.example.com', '.example.com'], 1)
             ->willReturn(['username' => 'foo', 'password' => 'bar']);
 
         $user = $this->getMockBuilder('Wallabag\UserBundle\Entity\User')
@@ -66,11 +66,11 @@ class GrabySiteConfigBuilderTest extends TestCase
             $logger
         );
 
-        $config = $this->builder->buildForHost('www.example.com');
+        $config = $this->builder->buildForHost('api.example.com');
 
-        $this->assertSame('example.com', $config->getHost());
+        $this->assertSame('api.example.com', $config->getHost());
         $this->assertTrue($config->requiresLogin());
-        $this->assertSame('http://www.example.com/login', $config->getLoginUri());
+        $this->assertSame('http://api.example.com/login', $config->getLoginUri());
         $this->assertSame('login', $config->getUsernameField());
         $this->assertSame('password', $config->getPasswordField());
         $this->assertSame(['field' => 'value'], $config->getExtraFields());
@@ -103,8 +103,8 @@ class GrabySiteConfigBuilderTest extends TestCase
             ->disableOriginalConstructor()
             ->getMock();
         $siteCrentialRepo->expects($this->once())
-            ->method('findOneByHostAndUser')
-            ->with('unknown.com', 1)
+            ->method('findOneByHostsAndUser')
+            ->with(['unknown.com', '.com'], 1)
             ->willReturn(null);
 
         $user = $this->getMockBuilder('Wallabag\UserBundle\Entity\User')


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | kind of
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Documentation | maybe?
| Translation   | no
| CHANGELOG.md  | yes/no
| License       | MIT

Fixes #3936

Add ability to match many domains for credentials  …
Instead of fetching one domain, we use the same method as in site config (to retrieve the matching file) and handle api.example.org, example.org, .org (yes the last one isn’t useful).
If one of these match, we got it and use it.