### PR TITLE
Always hash exists url

### DIFF
--- a/src/Wallabag/ApiBundle/Controller/EntryRestController.php
+++ b/src/Wallabag/ApiBundle/Controller/EntryRestController.php
@@ -848,8 +848,8 @@ class EntryRestController extends WallabagRestController
     /**
      * Return information about the entry if it exist and depending on the id or not.
      *
-     * @param Entry|null $entry
-     * @param bool       $returnId
+     * @param Entry|bool|null $entry
+     * @param bool            $returnId
      *
      * @return bool|int
      */

--- a/src/Wallabag/ApiBundle/Controller/EntryRestController.php
+++ b/src/Wallabag/ApiBundle/Controller/EntryRestController.php
@@ -14,6 +14,7 @@ use Wallabag\CoreBundle\Entity\Entry;
 use Wallabag\CoreBundle\Entity\Tag;
 use Wallabag\CoreBundle\Event\EntryDeletedEvent;
 use Wallabag\CoreBundle\Event\EntrySavedEvent;
+use Wallabag\CoreBundle\Helper\UrlHasher;
 
 class EntryRestController extends WallabagRestController
 {
@@ -56,8 +57,8 @@ class EntryRestController extends WallabagRestController
         }
 
         $urlHashMap = [];
-        foreach($urls as $urlToHash) {
-            $urlHash = hash('sha1', $urlToHash); // XXX: the hash logic would better be in a separate util to avoid duplication with GenerateUrlHashesCommand::generateHashedUrls
+        foreach ($urls as $urlToHash) {
+            $urlHash = UrlHasher::hashUrl($urlToHash);
             $hashedUrls[] = $urlHash;
             $urlHashMap[$urlHash] = $urlToHash;
         }
@@ -77,25 +78,11 @@ class EntryRestController extends WallabagRestController
 
         if (!empty($url) || !empty($hashedUrl)) {
             $hu = array_keys($results)[0];
+
             return $this->sendResponse(['exists' => $results[$hu]]);
         }
-        return $this->sendResponse($results);
-    }
 
-    /**
-     * Replace the hashedUrl keys in $results with the unhashed URL from the
-     * request, as recorded in $urlHashMap.
-     */
-    private function replaceUrlHashes(array $results, array $urlHashMap) {
-        $newResults = [];
-        foreach($results as $hash => $res) {
-            if (isset($urlHashMap[$hash])) {
-                $newResults[$urlHashMap[$hash]] = $res;
-            } else {
-                $newResults[$hash] = $res;
-            }
-        }
-        return $newResults;
+        return $this->sendResponse($results);
     }
 
     /**
@@ -813,6 +800,24 @@ class EntryRestController extends WallabagRestController
         }
 
         return $this->sendResponse($results);
+    }
+
+    /**
+     * Replace the hashedUrl keys in $results with the unhashed URL from the
+     * request, as recorded in $urlHashMap.
+     */
+    private function replaceUrlHashes(array $results, array $urlHashMap)
+    {
+        $newResults = [];
+        foreach ($results as $hash => $res) {
+            if (isset($urlHashMap[$hash])) {
+                $newResults[$urlHashMap[$hash]] = $res;
+            } else {
+                $newResults[$hash] = $res;
+            }
+        }
+
+        return $newResults;
     }
 
     /**

--- a/src/Wallabag/CoreBundle/Command/GenerateUrlHashesCommand.php
+++ b/src/Wallabag/CoreBundle/Command/GenerateUrlHashesCommand.php
@@ -66,9 +66,7 @@ class GenerateUrlHashesCommand extends ContainerAwareCommand
 
         $i = 1;
         foreach ($entries as $entry) {
-            $entry->setHashedUrl(
-                UrlHasher::hashUrl($entry->getUrl())
-            );
+            $entry->setHashedUrl(UrlHasher::hashUrl($entry->getUrl()));
             $em->persist($entry);
 
             if (0 === ($i % 20)) {
@@ -87,7 +85,7 @@ class GenerateUrlHashesCommand extends ContainerAwareCommand
      *
      * @param string $username
      *
-     * @return \Wallabag\UserBundle\Entity\User
+     * @return User
      */
     private function getUser($username)
     {

--- a/src/Wallabag/CoreBundle/Command/GenerateUrlHashesCommand.php
+++ b/src/Wallabag/CoreBundle/Command/GenerateUrlHashesCommand.php
@@ -7,6 +7,7 @@ use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
+use Wallabag\CoreBundle\Helper\UrlHasher;
 use Wallabag\UserBundle\Entity\User;
 
 class GenerateUrlHashesCommand extends ContainerAwareCommand
@@ -65,7 +66,9 @@ class GenerateUrlHashesCommand extends ContainerAwareCommand
 
         $i = 1;
         foreach ($entries as $entry) {
-            $entry->setHashedUrl(hash('sha1', $entry->getUrl()));
+            $entry->setHashedUrl(
+                UrlHasher::hashUrl($entry->getUrl())
+            );
             $em->persist($entry);
 
             if (0 === ($i % 20)) {

--- a/src/Wallabag/CoreBundle/Entity/Entry.php
+++ b/src/Wallabag/CoreBundle/Entity/Entry.php
@@ -13,6 +13,7 @@ use JMS\Serializer\Annotation\XmlRoot;
 use Symfony\Component\Validator\Constraints as Assert;
 use Wallabag\AnnotationBundle\Entity\Annotation;
 use Wallabag\CoreBundle\Helper\EntityTimestampsTrait;
+use Wallabag\CoreBundle\Helper\UrlHasher;
 use Wallabag\UserBundle\Entity\User;
 
 /**
@@ -324,7 +325,7 @@ class Entry
     public function setUrl($url)
     {
         $this->url = $url;
-        $this->hashedUrl = hash('sha1', $url);
+        $this->hashedUrl = UrlHasher::hashUrl($url);
 
         return $this;
     }

--- a/src/Wallabag/CoreBundle/Helper/UrlHasher.php
+++ b/src/Wallabag/CoreBundle/Helper/UrlHasher.php
@@ -7,16 +7,17 @@ namespace Wallabag\CoreBundle\Helper;
  */
 class UrlHasher
 {
-    /** @var string */
-    const ALGORITHM = 'sha1';
-
     /**
-     * @param string $url
+     * Hash the given url using the given algorithm.
+     * Hashed url are faster to be retrieved in the database than the real url.
      *
-     * @return string hashed $url
+     * @param string $url
+     * @param string $algorithm
+     *
+     * @return string
      */
-    public static function hashUrl(string $url)
+    public static function hashUrl(string $url, $algorithm = 'sha1')
     {
-        return hash(static::ALGORITHM, $url);
+        return hash($algorithm, urldecode($url));
     }
 }

--- a/src/Wallabag/CoreBundle/Helper/UrlHasher.php
+++ b/src/Wallabag/CoreBundle/Helper/UrlHasher.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Wallabag\CoreBundle\Helper;
+
+/**
+ * Hash URLs for privacy and performance.
+ */
+class UrlHasher
+{
+    /** @var string */
+    const ALGORITHM = 'sha1';
+
+    /**
+     * @param string $url
+     *
+     * @return string hashed $url
+     */
+    public static function hashUrl(string $url)
+    {
+        return hash(static::ALGORITHM, $url);
+    }
+}

--- a/src/Wallabag/CoreBundle/Repository/EntryRepository.php
+++ b/src/Wallabag/CoreBundle/Repository/EntryRepository.php
@@ -348,17 +348,9 @@ class EntryRepository extends EntityRepository
      */
     public function findByUrlAndUserId($url, $userId)
     {
-        $res = $this->createQueryBuilder('e')
-            ->where('e.url = :url')->setParameter('url', urldecode($url))
-            ->andWhere('e.user = :user_id')->setParameter('user_id', $userId)
-            ->getQuery()
-            ->getResult();
-
-        if (\count($res)) {
-            return current($res);
-        }
-
-        return false;
+        return $this->findByHashedUrlAndUserId(
+            hash('sha1', $url), // XXX: the hash logic would better be in a separate util to avoid duplication with GenerateUrlHashesCommand::generateHashedUrls
+            $userId);
     }
 
     /**

--- a/src/Wallabag/CoreBundle/Repository/EntryRepository.php
+++ b/src/Wallabag/CoreBundle/Repository/EntryRepository.php
@@ -509,32 +509,6 @@ class EntryRepository extends EntityRepository
     }
 
     /**
-     * Inject a UrlHasher.
-     *
-     * @param UrlHasher $hasher
-     */
-    public function setUrlHasher(UrlHasher $hasher)
-    {
-        $this->urlHasher = $hasher;
-    }
-
-    /**
-     * Get the UrlHasher, or create a default one if not injected.
-     *
-     * XXX: the default uses the default hash algorithm
-     *
-     * @return UrlHasher
-     */
-    protected function getUrlHasher()
-    {
-        if (!isset($this->urlHasher)) {
-            $this->setUrlHasher(new UrlHasher());
-        }
-
-        return $this->urlHasher;
-    }
-
-    /**
      * Return a query builder to be used by other getBuilderFor* method.
      *
      * @param int $userId

--- a/src/Wallabag/CoreBundle/Repository/EntryRepository.php
+++ b/src/Wallabag/CoreBundle/Repository/EntryRepository.php
@@ -9,6 +9,7 @@ use Pagerfanta\Adapter\DoctrineORMAdapter;
 use Pagerfanta\Pagerfanta;
 use Wallabag\CoreBundle\Entity\Entry;
 use Wallabag\CoreBundle\Entity\Tag;
+use Wallabag\CoreBundle\Helper\UrlHasher;
 
 class EntryRepository extends EntityRepository
 {
@@ -349,7 +350,7 @@ class EntryRepository extends EntityRepository
     public function findByUrlAndUserId($url, $userId)
     {
         return $this->findByHashedUrlAndUserId(
-            hash('sha1', $url), // XXX: the hash logic would better be in a separate util to avoid duplication with GenerateUrlHashesCommand::generateHashedUrls
+            UrlHasher::hashUrl($url),
             $userId);
     }
 
@@ -504,6 +505,32 @@ class EntryRepository extends EntityRepository
         $randomId = $ids[mt_rand(0, \count($ids) - 1)]['id'];
 
         return $this->find($randomId);
+    }
+
+    /**
+     * Inject a UrlHasher.
+     *
+     * @param UrlHasher $hasher
+     */
+    public function setUrlHasher(UrlHasher $hasher)
+    {
+        $this->urlHasher = $hasher;
+    }
+
+    /**
+     * Get the UrlHasher, or create a default one if not injected.
+     *
+     * XXX: the default uses the default hash algorithm
+     *
+     * @return UrlHasher
+     */
+    protected function getUrlHasher()
+    {
+        if (!isset($this->urlHasher)) {
+            $this->setUrlHasher(new UrlHasher());
+        }
+
+        return $this->urlHasher;
     }
 
     /**

--- a/src/Wallabag/CoreBundle/Repository/EntryRepository.php
+++ b/src/Wallabag/CoreBundle/Repository/EntryRepository.php
@@ -351,7 +351,8 @@ class EntryRepository extends EntityRepository
     {
         return $this->findByHashedUrlAndUserId(
             UrlHasher::hashUrl($url),
-            $userId);
+            $userId
+        );
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Documentation | no
| Translation   | no
| CHANGELOG.md  |no
Fixed tickets |#3919
| License       | MIT

Simplify the logic from #3158 by hashing all the urls from the request,
and only doing a search by hash. This allows to get performance benefits
from the new indexed hash column even when using older clients that do
not hash the URL in the request.
