### PR TITLE
api/entries: add parameter detail to exclude or include content in response

### DIFF
--- a/src/Wallabag/ApiBundle/Controller/EntryRestController.php
+++ b/src/Wallabag/ApiBundle/Controller/EntryRestController.php
@@ -103,6 +103,7 @@ class EntryRestController extends WallabagRestController
      *          {"name"="tags", "dataType"="string", "required"=false, "format"="api,rest", "description"="a list of tags url encoded. Will returns entries that matches ALL tags."},
      *          {"name"="since", "dataType"="integer", "required"=false, "format"="default '0'", "description"="The timestamp since when you want entries updated."},
      *          {"name"="public", "dataType"="integer", "required"=false, "format"="1 or 0, all entries by default", "description"="filter by entries with a public link"},
+     *          {"name"="detail", "dataType"="string", "required"=false, "format"="metadata or full, metadata by default", "description"="include content field if 'full'. 'full' by default for backward compatibility."},
      *       }
      * )
      *
@@ -121,6 +122,7 @@ class EntryRestController extends WallabagRestController
         $perPage = (int) $request->query->get('perPage', 30);
         $tags = \is_array($request->query->get('tags')) ? '' : (string) $request->query->get('tags', '');
         $since = $request->query->get('since', 0);
+        $detail = strtolower($request->query->get('detail', 'full'));
 
         try {
             /** @var \Pagerfanta\Pagerfanta $pager */
@@ -132,7 +134,8 @@ class EntryRestController extends WallabagRestController
                 $sort,
                 $order,
                 $since,
-                $tags
+                $tags,
+                $detail
             );
         } catch (\Exception $e) {
             throw new BadRequestHttpException($e->getMessage());
@@ -156,6 +159,7 @@ class EntryRestController extends WallabagRestController
                     'perPage' => $perPage,
                     'tags' => $tags,
                     'since' => $since,
+                    'detail' => $detail,
                 ],
                 true
             )

--- a/tests/Wallabag/ApiBundle/Controller/EntryRestControllerTest.php
+++ b/tests/Wallabag/ApiBundle/Controller/EntryRestControllerTest.php
@@ -133,6 +133,27 @@ class EntryRestControllerTest extends WallabagApiTestCase
         $this->assertSame(1, $content['page']);
         $this->assertGreaterThanOrEqual(1, $content['pages']);
 
+        $this->assertNotNull($content['_embedded']['items'][0]['content']);
+
+        $this->assertSame('application/json', $this->client->getResponse()->headers->get('Content-Type'));
+    }
+
+    public function testGetEntriesDetailMetadata()
+    {
+        $this->client->request('GET', '/api/entries?detail=metadata');
+
+        $this->assertSame(200, $this->client->getResponse()->getStatusCode());
+
+        $content = json_decode($this->client->getResponse()->getContent(), true);
+
+        $this->assertGreaterThanOrEqual(1, \count($content));
+        $this->assertNotEmpty($content['_embedded']['items']);
+        $this->assertGreaterThanOrEqual(1, $content['total']);
+        $this->assertSame(1, $content['page']);
+        $this->assertGreaterThanOrEqual(1, $content['pages']);
+
+        $this->assertNull($content['_embedded']['items'][0]['content']);
+
         $this->assertSame('application/json', $this->client->getResponse()->headers->get('Content-Type'));
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | _sort of_
| BC breaks?    | no
| Deprecations? | _maybe?_
| Tests pass?   | yes
| Documentation | no
| Translation   | no
| CHANGELOG.md  | no
| License       | MIT

`detail=metadata` will nullify the `content` field of entries in order to
make smaller responses.

`detail=full` keeps the former behavior, it sends the content of entries.
It's the default, for backward compatibility.

Fixes #2817

With this change, calls to `/api/entries?detail=metadata` will return `Entry` objects with `content: null`. Are you ok with that @wallabag/core?