### PR TITLE
Preview picture: use the 1st pic retrieved if no og:image set

### DIFF
--- a/src/Wallabag/CoreBundle/Helper/DownloadImages.php
+++ b/src/Wallabag/CoreBundle/Helper/DownloadImages.php
@@ -31,6 +31,25 @@ class DownloadImages
     }
 
     /**
+     * Process the html and extract images URLs from it.
+     *
+     * @param string $html
+     *
+     * @return string[]
+     */
+    public static function extractImagesUrlsFromHtml($html)
+    {
+        $crawler = new Crawler($html);
+        $imagesCrawler = $crawler
+            ->filterXpath('//img');
+        $imagesUrls = $imagesCrawler
+            ->extract(['src']);
+        $imagesSrcsetUrls = self::getSrcsetUrls($imagesCrawler);
+
+        return array_unique(array_merge($imagesUrls, $imagesSrcsetUrls));
+    }
+
+    /**
      * Process the html and extract image from it, save them to local and return the updated html.
      *
      * @param int    $entryId ID of the entry
@@ -41,13 +60,7 @@ class DownloadImages
      */
     public function processHtml($entryId, $html, $url)
     {
-        $crawler = new Crawler($html);
-        $imagesCrawler = $crawler
-            ->filterXpath('//img');
-        $imagesUrls = $imagesCrawler
-            ->extract(['src']);
-        $imagesSrcsetUrls = $this->getSrcsetUrls($imagesCrawler);
-        $imagesUrls = array_unique(array_merge($imagesUrls, $imagesSrcsetUrls));
+        $imagesUrls = self::extractImagesUrlsFromHtml($html);
 
         $relativePath = $this->getRelativePath($entryId);
 
@@ -199,7 +212,7 @@ class DownloadImages
      *
      * @return array An array of urls
      */
-    private function getSrcsetUrls(Crawler $imagesCrawler)
+    private static function getSrcsetUrls(Crawler $imagesCrawler)
     {
         $urls = [];
         $iterator = $imagesCrawler

--- a/tests/Wallabag/CoreBundle/Helper/ContentProxyTest.php
+++ b/tests/Wallabag/CoreBundle/Helper/ContentProxyTest.php
@@ -499,7 +499,7 @@ class ContentProxyTest extends TestCase
 
         $records = $handler->getRecords();
 
-        $this->assertCount(1, $records);
+        $this->assertCount(3, $records);
         $this->assertContains('Error while defining date', $records[0]['message']);
     }
 

--- a/tests/Wallabag/CoreBundle/Helper/ContentProxyTest.php
+++ b/tests/Wallabag/CoreBundle/Helper/ContentProxyTest.php
@@ -214,6 +214,90 @@ class ContentProxyTest extends TestCase
         $this->assertSame('1.1.1.1', $entry->getDomainName());
     }
 
+    public function testWithContentAndContentImage()
+    {
+        $tagger = $this->getTaggerMock();
+        $tagger->expects($this->once())
+            ->method('tag');
+
+        $graby = $this->getMockBuilder('Graby\Graby')
+            ->setMethods(['fetchContent'])
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $graby->expects($this->any())
+            ->method('fetchContent')
+            ->willReturn([
+                'html' => "<h1>Test</h1><p><img src='http://3.3.3.3/cover.jpg'/></p>",
+                'title' => 'this is my title',
+                'url' => 'http://1.1.1.1',
+                'content_type' => 'text/html',
+                'language' => 'fr',
+                'status' => '200',
+                'open_graph' => [
+                    'og_title' => 'my OG title',
+                    'og_description' => 'OG desc',
+                    'og_image' => null,
+                ],
+            ]);
+
+        $proxy = new ContentProxy($graby, $tagger, $this->getValidator(), $this->getLogger(), $this->fetchingErrorMessage);
+        $entry = new Entry(new User());
+        $proxy->updateEntry($entry, 'http://0.0.0.0');
+
+        $this->assertSame('http://1.1.1.1', $entry->getUrl());
+        $this->assertSame('this is my title', $entry->getTitle());
+        $this->assertSame("<h1>Test</h1><p><img src='http://3.3.3.3/cover.jpg'/></p>", $entry->getContent());
+        $this->assertSame('http://3.3.3.3/cover.jpg', $entry->getPreviewPicture());
+        $this->assertSame('text/html', $entry->getMimetype());
+        $this->assertSame('fr', $entry->getLanguage());
+        $this->assertSame('200', $entry->getHttpStatus());
+        $this->assertSame(0.0, $entry->getReadingTime());
+        $this->assertSame('1.1.1.1', $entry->getDomainName());
+    }
+
+    public function testWithContentImageAndOgImage()
+    {
+        $tagger = $this->getTaggerMock();
+        $tagger->expects($this->once())
+            ->method('tag');
+
+        $graby = $this->getMockBuilder('Graby\Graby')
+            ->setMethods(['fetchContent'])
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $graby->expects($this->any())
+            ->method('fetchContent')
+            ->willReturn([
+                'html' => "<h1>Test</h1><p><img src='http://3.3.3.3/nevermind.jpg'/></p>",
+                'title' => 'this is my title',
+                'url' => 'http://1.1.1.1',
+                'content_type' => 'text/html',
+                'language' => 'fr',
+                'status' => '200',
+                'open_graph' => [
+                    'og_title' => 'my OG title',
+                    'og_description' => 'OG desc',
+                    'og_image' => 'http://3.3.3.3/cover.jpg',
+                ],
+            ]);
+
+        $proxy = new ContentProxy($graby, $tagger, $this->getValidator(), $this->getLogger(), $this->fetchingErrorMessage);
+        $entry = new Entry(new User());
+        $proxy->updateEntry($entry, 'http://0.0.0.0');
+
+        $this->assertSame('http://1.1.1.1', $entry->getUrl());
+        $this->assertSame('this is my title', $entry->getTitle());
+        $this->assertSame("<h1>Test</h1><p><img src='http://3.3.3.3/nevermind.jpg'/></p>", $entry->getContent());
+        $this->assertSame('http://3.3.3.3/cover.jpg', $entry->getPreviewPicture());
+        $this->assertSame('text/html', $entry->getMimetype());
+        $this->assertSame('fr', $entry->getLanguage());
+        $this->assertSame('200', $entry->getHttpStatus());
+        $this->assertSame(0.0, $entry->getReadingTime());
+        $this->assertSame('1.1.1.1', $entry->getDomainName());
+    }
+
     public function testWithContentAndBadLanguage()
     {
         $tagger = $this->getTaggerMock();

--- a/tests/Wallabag/ImportBundle/Controller/WallabagV1ControllerTest.php
+++ b/tests/Wallabag/ImportBundle/Controller/WallabagV1ControllerTest.php
@@ -121,7 +121,7 @@ class WallabagV1ControllerTest extends WallabagCoreTestCase
 
         $this->assertInstanceOf('Wallabag\CoreBundle\Entity\Entry', $content);
         $this->assertEmpty($content->getMimetype(), 'Mimetype for http://www.framablog.org is empty');
-        $this->assertEmpty($content->getPreviewPicture(), 'Preview picture for http://www.framablog.org is empty');
+        $this->assertSame($content->getPreviewPicture(), 'http://www.framablog.org/public/_img/framablog/wallaby_baby.jpg');
         $this->assertEmpty($content->getLanguage(), 'Language for http://www.framablog.org is empty');
 
         $tags = $content->getTags();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Documentation | no
| Translation   | no
| CHANGELOG.md  | no
| License       | MIT

I'd like to have a preview picture for every link I add to my wallabag. Currently only pictures set as `og:image` are used for the preview picture (unless the link is an image).

This MR parses the content to find the first picture in the content and use it as a preview (unless there already is a preview picture).

I'd like that to be added to the core but maybe you'd prefer if it required an activation from the user (a new boolean)? That's why I did not edit the tests that check there are no preview pictures for some links: I am waiting for your feedback.
