### PR TITLE
Drop SimplePie

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -63,7 +63,6 @@
         "nelmio/api-doc-bundle": "^2.13.2",
         "mgargano/simplehtmldom": "~1.5",
         "wallabag/tcpdf": "^6.2.26",
-        "simplepie/simplepie": "~1.5",
         "willdurand/hateoas-bundle": "~1.3",
         "liip/theme-bundle": "^1.4.6",
         "lexik/form-filter-bundle": "^5.0.4",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "883f44eda34a48c8ddabc3294498d996",
+    "content-hash": "c42e1b50f4a2b8a59ca06c5ccb24e6a3",
     "packages": [
         {
             "name": "bdunogier/guzzle-site-authenticator",


### PR DESCRIPTION
It was only used to make an absolute url when downloading images.

The deps is still there (in the `composer.lock`) because Graby use it (not for absolute but for encoding) : https://github.com/j0k3r/graby/blob/84a698f0aba5bc24343741d075d3760a88d90e17/src/Graby.php#L976

Fix https://github.com/wallabag/wallabag/issues/3540