### PR TITLE
Check if .git directory exist before making the update

### DIFF
--- a/scripts/require.sh
+++ b/scripts/require.sh
@@ -1,6 +1,6 @@
 #! /usr/bin/env bash
-# File used to check dependencies
 
+# Check for composer
 if [ ! -f composer.phar ]; then
     echo "composer.phar not found, we'll see if composer is installed globally."
     command -v composer >/dev/null 2>&1 || { echo >&2 "wallabag requires composer but it's not installed (see http://doc.wallabag.org/en/master/user/installation.html). Aborting."; exit 1; }

--- a/scripts/update.sh
+++ b/scripts/update.sh
@@ -40,7 +40,7 @@ fi
 # Check for wallabag .git folder
 if [ ! -d .git ]; then
     echo "Can not update because wallabag wasn't installed using git (see https://doc.wallabag.org/en/admin/upgrade.html#upgrade-on-a-shared-hosting). Aborting.";
-    exit 1;
+    exit 2;
 fi
 
 rm -rf var/cache/*

--- a/scripts/update.sh
+++ b/scripts/update.sh
@@ -37,6 +37,12 @@ fi
 
 . "$REQUIRE_FILE"
 
+# Check for wallabag .git folder
+if [ ! -d .git ]; then
+    echo "Can not update because wallabag wasn't installed using git (see https://doc.wallabag.org/en/admin/upgrade.html#upgrade-on-a-shared-hosting). Aborting.";
+    exit 1;
+fi
+
 rm -rf var/cache/*
 git fetch origin
 git fetch --tags


### PR DESCRIPTION
If that folder doesn’t exist, it means the udpate script won’t be able to run because it uses git to retrieve the update.

Tests will fail because of it needs https://github.com/wallabag/wallabag/pull/4008 to be merged.
Related https://github.com/wallabag/wallabag/issues/4007