### PR TITLE
Use a custom cookiejar to avoid error when the cookie is badly saved

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -1470,16 +1470,16 @@
         },
         {
             "name": "egulias/email-validator",
-            "version": "2.1.9",
+            "version": "2.1.10",
             "source": {
                 "type": "git",
                 "url": "https://github.com/egulias/EmailValidator.git",
-                "reference": "128cc721d771ec2c46ce59698f4ca42b73f71b25"
+                "reference": "a6c8d7101b19a451c1707b1b79bbbc56e4bdb7ec"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/egulias/EmailValidator/zipball/128cc721d771ec2c46ce59698f4ca42b73f71b25",
-                "reference": "128cc721d771ec2c46ce59698f4ca42b73f71b25",
+                "url": "https://api.github.com/repos/egulias/EmailValidator/zipball/a6c8d7101b19a451c1707b1b79bbbc56e4bdb7ec",
+                "reference": "a6c8d7101b19a451c1707b1b79bbbc56e4bdb7ec",
                 "shasum": ""
             },
             "require": {
@@ -1489,7 +1489,8 @@
             "require-dev": {
                 "dominicsayers/isemail": "dev-master",
                 "phpunit/phpunit": "^4.8.35||^5.7||^6.0",
-                "satooshi/php-coveralls": "^1.0.1"
+                "satooshi/php-coveralls": "^1.0.1",
+                "symfony/phpunit-bridge": "^4.4@dev"
             },
             "suggest": {
                 "ext-intl": "PHP Internationalization Libraries are required to use the SpoofChecking validation"
@@ -1523,7 +1524,7 @@
                 "validation",
                 "validator"
             ],
-            "time": "2019-06-23T10:14:27+00:00"
+            "time": "2019-07-19T20:52:08+00:00"
         },
         {
             "name": "electrolinux/php-html5lib",
@@ -3673,16 +3674,16 @@
         },
         {
             "name": "j0k3r/graby-site-config",
-            "version": "1.0.86",
+            "version": "1.0.88",
             "source": {
                 "type": "git",
                 "url": "https://github.com/j0k3r/graby-site-config.git",
-                "reference": "9c0ae4ee74e737c6ccf913da9bcb169850d38a30"
+                "reference": "b485a36c31736b8834ebf62f42bd97fb333eefa7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/j0k3r/graby-site-config/zipball/9c0ae4ee74e737c6ccf913da9bcb169850d38a30",
-                "reference": "9c0ae4ee74e737c6ccf913da9bcb169850d38a30",
+                "url": "https://api.github.com/repos/j0k3r/graby-site-config/zipball/b485a36c31736b8834ebf62f42bd97fb333eefa7",
+                "reference": "b485a36c31736b8834ebf62f42bd97fb333eefa7",
                 "shasum": ""
             },
             "require": {
@@ -3709,7 +3710,7 @@
                 }
             ],
             "description": "Graby site config files",
-            "time": "2019-06-25T10:46:50+00:00"
+            "time": "2019-07-23T15:40:40+00:00"
         },
         {
             "name": "j0k3r/httplug-ssrf-plugin",
@@ -5162,16 +5163,16 @@
         },
         {
             "name": "pagerfanta/pagerfanta",
-            "version": "v2.1.2",
+            "version": "v2.1.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/whiteoctober/Pagerfanta.git",
-                "reference": "45a85ad426316ae37f2d007022e5b4c95bc3aef4"
+                "reference": "a53ff01d521648d9dbca19b93ac6bc75a59b0972"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/whiteoctober/Pagerfanta/zipball/45a85ad426316ae37f2d007022e5b4c95bc3aef4",
-                "reference": "45a85ad426316ae37f2d007022e5b4c95bc3aef4",
+                "url": "https://api.github.com/repos/whiteoctober/Pagerfanta/zipball/a53ff01d521648d9dbca19b93ac6bc75a59b0972",
+                "reference": "a53ff01d521648d9dbca19b93ac6bc75a59b0972",
                 "shasum": ""
             },
             "require": {
@@ -5227,7 +5228,7 @@
                 "paginator",
                 "paging"
             ],
-            "time": "2019-04-02T08:50:39+00:00"
+            "time": "2019-07-17T20:56:16+00:00"
         },
         {
             "name": "paragonie/random_compat",
@@ -7016,16 +7017,16 @@
         },
         {
             "name": "scheb/two-factor-bundle",
-            "version": "v3.19.1",
+            "version": "v3.21.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/scheb/two-factor-bundle.git",
-                "reference": "634b9b40ea0b6769f274ac994067f08012d96c44"
+                "reference": "94cc6f2e0fd8a7b683246d95fcad9b15ca828fc6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/scheb/two-factor-bundle/zipball/634b9b40ea0b6769f274ac994067f08012d96c44",
-                "reference": "634b9b40ea0b6769f274ac994067f08012d96c44",
+                "url": "https://api.github.com/repos/scheb/two-factor-bundle/zipball/94cc6f2e0fd8a7b683246d95fcad9b15ca828fc6",
+                "reference": "94cc6f2e0fd8a7b683246d95fcad9b15ca828fc6",
                 "shasum": ""
             },
             "require": {
@@ -7074,7 +7075,7 @@
                 "two-factor",
                 "two-step"
             ],
-            "time": "2019-07-01T19:12:43+00:00"
+            "time": "2019-07-12T16:11:05+00:00"
         },
         {
             "name": "sensio/distribution-bundle",
@@ -7203,7 +7204,7 @@
         },
         {
             "name": "sensiolabs/security-checker",
-            "version": "v6.0.1",
+            "version": "v6.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sensiolabs/security-checker.git",
@@ -8076,7 +8077,7 @@
                 },
                 {
                     "name": "Gert de Pagter",
-                    "email": "BackEndTea@gmail.com"
+                    "email": "backendtea@gmail.com"
                 }
             ],
             "description": "Symfony polyfill for ctype functions",
@@ -9436,16 +9437,16 @@
         },
         {
             "name": "zendframework/zend-diactoros",
-            "version": "2.1.2",
+            "version": "2.1.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/zendframework/zend-diactoros.git",
-                "reference": "37bf68b428850ee26ed7c3be6c26236dd95a95f1"
+                "reference": "279723778c40164bcf984a2df12ff2c6ec5e61c1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/zendframework/zend-diactoros/zipball/37bf68b428850ee26ed7c3be6c26236dd95a95f1",
-                "reference": "37bf68b428850ee26ed7c3be6c26236dd95a95f1",
+                "url": "https://api.github.com/repos/zendframework/zend-diactoros/zipball/279723778c40164bcf984a2df12ff2c6ec5e61c1",
+                "reference": "279723778c40164bcf984a2df12ff2c6ec5e61c1",
                 "shasum": ""
             },
             "require": {
@@ -9498,7 +9499,7 @@
                 "psr",
                 "psr-7"
             ],
-            "time": "2019-04-29T21:11:00+00:00"
+            "time": "2019-07-10T16:13:25+00:00"
         },
         {
             "name": "zendframework/zend-eventmanager",
@@ -9723,16 +9724,16 @@
         },
         {
             "name": "doctrine/data-fixtures",
-            "version": "v1.3.1",
+            "version": "v1.3.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/data-fixtures.git",
-                "reference": "3a1e2c3c600e615a2dffe56d4ca0875cc5233e0a"
+                "reference": "09b16943b27f3d80d63988d100ff256148c2f78b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/data-fixtures/zipball/3a1e2c3c600e615a2dffe56d4ca0875cc5233e0a",
-                "reference": "3a1e2c3c600e615a2dffe56d4ca0875cc5233e0a",
+                "url": "https://api.github.com/repos/doctrine/data-fixtures/zipball/09b16943b27f3d80d63988d100ff256148c2f78b",
+                "reference": "09b16943b27f3d80d63988d100ff256148c2f78b",
                 "shasum": ""
             },
             "require": {
@@ -9779,7 +9780,7 @@
             "keywords": [
                 "database"
             ],
-            "time": "2018-03-20T09:06:36+00:00"
+            "time": "2019-07-10T18:30:35+00:00"
         },
         {
             "name": "doctrine/doctrine-fixtures-bundle",

--- a/src/Wallabag/CoreBundle/Helper/FileCookieJar.php
+++ b/src/Wallabag/CoreBundle/Helper/FileCookieJar.php
@@ -5,6 +5,7 @@ namespace Wallabag\CoreBundle\Helper;
 use GuzzleHttp\Cookie\FileCookieJar as BaseFileCookieJar;
 use GuzzleHttp\Cookie\SetCookie;
 use GuzzleHttp\Utils;
+use Psr\Log\LoggerInterface;
 
 /**
  * Overidden Cookie behavior to:
@@ -13,6 +14,19 @@ use GuzzleHttp\Utils;
  */
 class FileCookieJar extends BaseFileCookieJar
 {
+    private $logger;
+
+    /**
+     * @param LoggerInterface $logger     Only used to log info when something goes wrong
+     * @param string          $cookieFile File to store the cookie data
+     */
+    public function __construct(LoggerInterface $logger, $cookieFile)
+    {
+        parent::__construct($cookieFile);
+
+        $this->logger = $logger;
+    }
+
     /**
      * Saves the cookies to a file.
      *
@@ -57,6 +71,11 @@ class FileCookieJar extends BaseFileCookieJar
         try {
             $data = Utils::jsonDecode($json, true);
         } catch (\InvalidArgumentException $e) {
+            $this->logger->error('JSON inside the cookie is broken', [
+                'json' => $json,
+                'error_msg' => $e->getMessage(),
+            ]);
+
             // cookie file is invalid, just ignore the exception and it'll reset the whole cookie file
             $data = '';
         }

--- a/src/Wallabag/CoreBundle/Helper/FileCookieJar.php
+++ b/src/Wallabag/CoreBundle/Helper/FileCookieJar.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace Wallabag\CoreBundle\Helper;
+
+use GuzzleHttp\Cookie\FileCookieJar as BaseFileCookieJar;
+use GuzzleHttp\Cookie\SetCookie;
+use GuzzleHttp\Utils;
+
+/**
+ * Overidden Cookie behavior to:
+ *     - fix multiple concurrent writes (see https://github.com/guzzle/guzzle/pull/1884)
+ *     - ignore error when the cookie file is malformatted (resulting in clearing it).
+ */
+class FileCookieJar extends BaseFileCookieJar
+{
+    /**
+     * Saves the cookies to a file.
+     *
+     * @param string $filename File to save
+     *
+     * @throws \RuntimeException if the file cannot be found or created
+     */
+    public function save($filename)
+    {
+        $json = [];
+        foreach ($this as $cookie) {
+            if ($cookie->getExpires() && !$cookie->getDiscard()) {
+                $json[] = $cookie->toArray();
+            }
+        }
+
+        if (false === file_put_contents($filename, json_encode($json), LOCK_EX)) {
+            // @codeCoverageIgnoreStart
+            throw new \RuntimeException("Unable to save file {$filename}");
+            // @codeCoverageIgnoreEnd
+        }
+    }
+
+    /**
+     * Load cookies from a JSON formatted file.
+     *
+     * Old cookies are kept unless overwritten by newly loaded ones.
+     *
+     * @param string $filename cookie file to load
+     *
+     * @throws \RuntimeException if the file cannot be loaded
+     */
+    public function load($filename)
+    {
+        $json = file_get_contents($filename);
+        if (false === $json) {
+            // @codeCoverageIgnoreStart
+            throw new \RuntimeException("Unable to load file {$filename}");
+            // @codeCoverageIgnoreEnd
+        }
+
+        try {
+            $data = Utils::jsonDecode($json, true);
+        } catch (\InvalidArgumentException $e) {
+            // cookie file is invalid, just ignore the exception and it'll reset the whole cookie file
+            $data = '';
+        }
+
+        if (\is_array($data)) {
+            foreach (Utils::jsonDecode($json, true) as $cookie) {
+                $this->setCookie(new SetCookie($cookie));
+            }
+        } elseif (\strlen($data)) {
+            throw new \RuntimeException("Invalid cookie file: {$filename}");
+        }
+    }
+}

--- a/src/Wallabag/CoreBundle/Resources/config/services.yml
+++ b/src/Wallabag/CoreBundle/Resources/config/services.yml
@@ -83,7 +83,9 @@ services:
 
     wallabag_core.guzzle.cookie_jar:
         class: Wallabag\CoreBundle\Helper\FileCookieJar
-        arguments: ["%kernel.cache_dir%/cookiejar.json"]
+        arguments:
+            - "@logger"
+            - "%kernel.cache_dir%/cookiejar.json"
 
     wallabag_core.content_proxy:
         class: Wallabag\CoreBundle\Helper\ContentProxy

--- a/src/Wallabag/CoreBundle/Resources/config/services.yml
+++ b/src/Wallabag/CoreBundle/Resources/config/services.yml
@@ -82,7 +82,7 @@ services:
             - ["addSubscriber", ["@bd_guzzle_site_authenticator.authenticator_subscriber"]]
 
     wallabag_core.guzzle.cookie_jar:
-        class: GuzzleHttp\Cookie\FileCookieJar
+        class: Wallabag\CoreBundle\Helper\FileCookieJar
         arguments: ["%kernel.cache_dir%/cookiejar.json"]
 
     wallabag_core.content_proxy:


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Documentation | no
| Translation   | no
| License       | MIT

It happens sometimes on wallabag.it, the json inside the cookie is badly saved and the json isn't valid. It generates an exception and avoid people to use the api and import contents.

To fix that, we use a dedicated `FileCookieJar`, which extends the default one from Guzzle to fix these issues:
- line 31: add the `LOCK_EX`
- line 56/61: add a try catch when parsing the json from the cookie

Also updated deps