### PR TITLE
Fixed default value for reading speed

### DIFF
--- a/app/config/wallabag.yml
+++ b/app/config/wallabag.yml
@@ -20,7 +20,7 @@ wallabag_core:
     theme: material
     language: '%locale%'
     rss_limit: 50
-    reading_speed: 1
+    reading_speed: 200
     cache_lifetime: 10
     action_mark_as_read: 1
     list_mode: 0

--- a/src/Wallabag/CoreBundle/DependencyInjection/Configuration.php
+++ b/src/Wallabag/CoreBundle/DependencyInjection/Configuration.php
@@ -30,7 +30,7 @@ class Configuration implements ConfigurationInterface
                     ->defaultValue(50)
                 ->end()
                 ->integerNode('reading_speed')
-                    ->defaultValue(1)
+                    ->defaultValue(200)
                 ->end()
                 ->scalarNode('version')
                 ->end()

--- a/tests/Wallabag/CoreBundle/Controller/ConfigControllerTest.php
+++ b/tests/Wallabag/CoreBundle/Controller/ConfigControllerTest.php
@@ -695,7 +695,7 @@ class ConfigControllerTest extends WallabagCoreTestCase
 
         $config->setTheme('material');
         $config->setItemsPerPage(30);
-        $config->setReadingSpeed(1);
+        $config->setReadingSpeed(200);
         $config->setLanguage('en');
         $config->setPocketConsumerKey('xxxxx');
 

--- a/tests/Wallabag/CoreBundle/Helper/RedirectTest.php
+++ b/tests/Wallabag/CoreBundle/Helper/RedirectTest.php
@@ -42,7 +42,7 @@ class RedirectTest extends TestCase
         $config = new Config($user);
         $config->setTheme('material');
         $config->setItemsPerPage(30);
-        $config->setReadingSpeed(1);
+        $config->setReadingSpeed(200);
         $config->setLanguage('en');
         $config->setPocketConsumerKey('xxxxx');
         $config->setActionMarkAsRead(Config::REDIRECT_TO_CURRENT_PAGE);

--- a/tests/Wallabag/UserBundle/EventListener/CreateConfigListenerTest.php
+++ b/tests/Wallabag/UserBundle/EventListener/CreateConfigListenerTest.php
@@ -64,7 +64,7 @@ class CreateConfigListenerTest extends TestCase
         $config->setItemsPerPage(20);
         $config->setFeedLimit(50);
         $config->setLanguage('fr');
-        $config->setReadingSpeed(1);
+        $config->setReadingSpeed(200);
 
         $this->em->expects($this->once())
             ->method('persist')


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Documentation | no
| Translation   | no
| CHANGELOG.md  | no
| License       | MIT

When you install wallabag from scratch, the default value for `reading_speed` was still `1.0`, but it has changed in #4053. 