### PR TITLE
💄 Add untagged list link to filter menu

### DIFF
--- a/src/Wallabag/CoreBundle/Controller/EntryController.php
+++ b/src/Wallabag/CoreBundle/Controller/EntryController.php
@@ -567,6 +567,9 @@ class EntryController extends Controller
             }
         }
 
+        $nbEntriesUntagged = $this->get('wallabag_core.entry_repository')
+            ->countUntaggedEntriesByUser($this->getUser()->getId());
+
         return $this->render(
             'WallabagCoreBundle:Entry:entries.html.twig', [
                 'form' => $form->createView(),
@@ -574,6 +577,7 @@ class EntryController extends Controller
                 'currentPage' => $page,
                 'searchTerm' => $searchTerm,
                 'isFiltered' => $form->isSubmitted(),
+                'nbEntriesUntagged' => $nbEntriesUntagged,
             ]
         );
     }

--- a/src/Wallabag/CoreBundle/Resources/views/themes/baggy/Entry/entries.html.twig
+++ b/src/Wallabag/CoreBundle/Resources/views/themes/baggy/Entry/entries.html.twig
@@ -117,6 +117,12 @@
             <a href="javascript: void(null);" id="filter-form-close" class="close-button--popup close-button">&times;</a>
 
             <div id="filter-status" class="filter-group">
+                {% if currentRoute != 'untagged' and nbEntriesUntagged != 0 %}
+                    <div class="">
+                        <a href="{{ path('untagged') }}">{{ 'tag.list.see_untagged_entries'|trans }} ({{nbEntriesUntagged}})</a>
+                    </div>
+                {% endif %}
+
                 <div class="">
                     <label>{{ 'entry.filters.status_label'|trans }}</label>
                 </div>

--- a/src/Wallabag/CoreBundle/Resources/views/themes/material/Entry/entries.html.twig
+++ b/src/Wallabag/CoreBundle/Resources/views/themes/material/Entry/entries.html.twig
@@ -83,6 +83,12 @@
             <h4 class="center">{{ 'entry.filters.title'|trans }}</h4>
 
             <div class="row">
+                {% if currentRoute != 'untagged' and nbEntriesUntagged != 0 %}
+                    <div class="col s12 center-align">
+                        <a href="{{ path('untagged') }}">{{ 'tag.list.see_untagged_entries'|trans }} ({{nbEntriesUntagged}})</a>
+                    </div>
+                {% endif %}
+
                 <div class="col s12">
                     <label>{{ 'entry.filters.status_label'|trans }}</label>
                 </div>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | no
| Documentation | no
| Translation   | no
| CHANGELOG.md  | no
| License       | MIT

Fix #3804

Add untagged list link to filter menu. Doesn’t display if on http://your-wallabag/untagged/list or if there is no untagged entry.

![Screenshot_2019-10-09 Articles non lus – wallabag(1)](https://user-images.githubusercontent.com/922350/66495067-f19d2300-eab8-11e9-9ea0-b864b9a7b55e.png)
![Screenshot_2019-10-09 Articles non lus – wallabag](https://user-images.githubusercontent.com/922350/66495069-f235b980-eab8-11e9-9850-8670347576e6.png)

(I use dark reader extension on Firefox)