### PR TITLE
✨ Allow custom styles system wide

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,6 @@ app/Resources/build/
 admin-export.json
 specialexport.json
 /data/site-credentials-secret-key.txt
+
+# Custom CSS file
+web/custom.css

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -10,14 +10,14 @@ help: ## Display this help menu
 clean: ## Clear the application cache
 	rm -rf var/cache/*
 
-install: ## Install wallabag with the latest version
+install: customcss ## Install wallabag with the latest version
 	@./scripts/install.sh $(ENV)
 
 update: ## Update the wallabag installation to the latest version
 	@./scripts/update.sh $(ENV)
 
 dev: ENV=dev
-dev: build ## Install the latest dev version
+dev: build customcss ## Install the latest dev version
 	@./scripts/dev.sh
 
 run: ## Run the wallabag built-in server
@@ -26,6 +26,9 @@ run: ## Run the wallabag built-in server
 build: ## Run webpack
 	@npm install
 	@npm run build:$(ENV)
+
+customcss:
+	@touch web/custom.css
 
 prepare: clean ## Prepare database for testsuite
 ifdef DB

--- a/src/Wallabag/CoreBundle/Resources/views/base.html.twig
+++ b/src/Wallabag/CoreBundle/Resources/views/base.html.twig
@@ -43,6 +43,7 @@
 
             {% block css %}
             {% endblock %}
+            <link rel="stylesheet" href="{{ asset('custom.css') }}">
             {% block scripts %}
             <script src="{{ asset('bundles/fosjsrouting/js/router.js') }}"></script>
             <script src="{{ path('fos_js_routing_js', { callback: 'fos.Router.setData' }) }}"></script>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | no
| Documentation | yes
| Translation   | no
| CHANGELOG.md  | no
| License       | MIT

Should fix #4060

- add a setting called `custom_css` in `app/config/parameters.yml`, available for twig
- when set to true, Wallabag calls http://your-wallabag/custom.css on every page
- put a file named `custom.css` in `web/` directory: it will be used by Wallabag.

![Screenshot_2019-10-09 Articles non lus – wallabag(2)](https://user-images.githubusercontent.com/922350/66502191-15fefc80-eac5-11e9-9ca8-6038ff7253e6.png)

The green sidebar of the screenshot is created by `custom.css`.