### PR TITLE
Add environment variables to control scripts/dev.sh behavior

### DIFF
--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -13,5 +13,8 @@ fi
 . "$REQUIRE_FILE"
 
 $COMPOSER_COMMAND install
-php bin/console wallabag:install
-php bin/console server:run
+if [ -z "$SKIP_WALLABAG_INITIALIZATION" ]
+then
+    php bin/console wallabag:install
+fi
+php bin/console server:run $HOST


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | no
| Documentation | no
| Translation   | no
| CHANGELOG.md  | no
| License       | MIT

As I develop in a virtual machine, I need to make the built-in server listen to 0.0.0.0 instead of 127.0.0.1. I added the `HOST` environment variable to be able to do so:
```
export HOST=0.0.0.0:8000
make dev
```

As it’s quite painful to answer to questions about wiping the database and creating a new superuser each time I run `make dev`, I added a `SKIP_WALLABAG_INITIALIZATION` environment variable to skip the `wallabag:install`.