### PR TITLE
Increase php memory limit PHP Docker

### DIFF
--- a/docker/php/Dockerfile
+++ b/docker/php/Dockerfile
@@ -2,6 +2,7 @@ FROM php:7.2-fpm
 
 # Default timezone. To change it, use the argument in the docker-compose.yml file
 ARG timezone='Europe/Paris'
+ARG memorylimit='512M'
 
 RUN apt-get update && apt-get install -y \
         libmcrypt-dev \
@@ -27,6 +28,7 @@ RUN docker-php-ext-install \
 RUN printf "\n" | pecl install imagick && docker-php-ext-enable imagick
 
 RUN echo "date.timezone="$timezone > /usr/local/etc/php/conf.d/date_timezone.ini
+RUN echo "memory_limit ="$memorylimit > /usr/local/etc/php/conf.d/memory_limit.ini
 
 RUN usermod -u 1000 www-data
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Documentation | no
| Translation   | no
| CHANGELOG.md  | no
| License       | MIT

In order to run tests, increase the php memory limit of PHP docker from 128M to 512M
<!--
Please list the issues your PR fixes using special keywords, see
https://help.github.com/articles/closing-issues-using-keywords/

Fixes #…
-->

<!--
- Please fill in this template according to the PR you're about to submit.
- Replace this comment by a description of what your PR is solving.
-->
