### PR TITLE
Ensure ENV is well defined when using make

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -3,12 +3,9 @@ TMP_FOLDER=/tmp
 RELEASE_FOLDER=wllbg-release
 
 # ensure the ENV variable is well defined
-ifeq ($(origin ENV), prod)
-	# all good ("prod" is a valid env)
-else ifeq ($(origin ENV), dev)
-	# all good ("dev" is a valid env)
-else ifeq ($(origin ENV), test)
-	# all good ("test" is a valid env)
+AVAILABLE_ENV := prod dev test
+ifneq ($(filter $(ENV),$(AVAILABLE_ENV)),)
+	# all good
 else
 	# not good, force it to "prod"
 	override ENV = prod

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -2,7 +2,17 @@ SHELL=bash
 TMP_FOLDER=/tmp
 RELEASE_FOLDER=wllbg-release
 
-ENV ?= prod
+# ensure the ENV variable is well defined
+ifeq ($(origin ENV), prod)
+	# all good ("prod" is a valid env)
+else ifeq ($(origin ENV), dev)
+	# all good ("dev" is a valid env)
+else ifeq ($(origin ENV), test)
+	# all good ("test" is a valid env)
+else
+	# not good, force it to "prod"
+	override ENV = prod
+endif
 
 help: ## Display this help menu
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'


### PR DESCRIPTION
This command should fail before calling other commands (which will fail to because the environment is wrong):

```bash
ENV=toto make install
```

Fix #4246

~~If anyone has a better idea on how to achieve that without multiple `if` condition, it'll be great!~~