### PR TITLE
Replace wallabag's fork of tcpdf with the original one, PHP 7.4 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,8 +39,6 @@ matrix:
     include:
         - php: 7.3
           env: CS_FIXER=run VALIDATE_TRANSLATION_FILE=run ASSETS=build DB=sqlite
-    allow_failures:
-        - php: 7.4
 
 # exclude v1 branches
 branches:

--- a/composer.json
+++ b/composer.json
@@ -63,7 +63,7 @@
         "jms/serializer-bundle": "~2.2",
         "nelmio/api-doc-bundle": "^2.13.2",
         "mgargano/simplehtmldom": "~1.5",
-        "wallabag/tcpdf": "^6.2.26",
+        "tecnickcom/tcpdf": "^6.3.0",
         "willdurand/hateoas-bundle": "~1.3",
         "liip/theme-bundle": "^1.4.6",
         "lexik/form-filter-bundle": "^5.0.4",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "60ce056a3ba44dfa4e039261a2326ae9",
+    "content-hash": "934e7fcdcc82a110216efe0a9364ba2c",
     "packages": [
         {
             "name": "bdunogier/guzzle-site-authenticator",
@@ -9165,6 +9165,68 @@
             "time": "2020-03-30T06:25:29+00:00"
         },
         {
+            "name": "tecnickcom/tcpdf",
+            "version": "6.3.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/tecnickcom/TCPDF.git",
+                "reference": "19a535eaa7fb1c1cac499109deeb1a7a201b4549"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/tecnickcom/TCPDF/zipball/19a535eaa7fb1c1cac499109deeb1a7a201b4549",
+                "reference": "19a535eaa7fb1c1cac499109deeb1a7a201b4549",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "config",
+                    "include",
+                    "tcpdf.php",
+                    "tcpdf_parser.php",
+                    "tcpdf_import.php",
+                    "tcpdf_barcodes_1d.php",
+                    "tcpdf_barcodes_2d.php",
+                    "include/tcpdf_colors.php",
+                    "include/tcpdf_filters.php",
+                    "include/tcpdf_font_data.php",
+                    "include/tcpdf_fonts.php",
+                    "include/tcpdf_images.php",
+                    "include/tcpdf_static.php",
+                    "include/barcodes/datamatrix.php",
+                    "include/barcodes/pdf417.php",
+                    "include/barcodes/qrcode.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "LGPL-3.0-only"
+            ],
+            "authors": [
+                {
+                    "name": "Nicola Asuni",
+                    "email": "info@tecnick.com",
+                    "role": "lead"
+                }
+            ],
+            "description": "TCPDF is a PHP class for generating PDF documents and barcodes.",
+            "homepage": "http://www.tcpdf.org/",
+            "keywords": [
+                "PDFD32000-2008",
+                "TCPDF",
+                "barcodes",
+                "datamatrix",
+                "pdf",
+                "pdf417",
+                "qrcode"
+            ],
+            "time": "2020-02-14T14:20:12+00:00"
+        },
+        {
             "name": "true/punycode",
             "version": "v2.1.1",
             "source": {
@@ -9439,78 +9501,6 @@
                 "epub"
             ],
             "time": "2020-03-22T16:24:31+00:00"
-        },
-        {
-            "name": "wallabag/tcpdf",
-            "version": "6.2.26",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/wallabag/TCPDF.git",
-                "reference": "bf590f0604bcef1ae6fa3145649cf997f3564477"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/wallabag/TCPDF/zipball/bf590f0604bcef1ae6fa3145649cf997f3564477",
-                "reference": "bf590f0604bcef1ae6fa3145649cf997f3564477",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.3.0"
-            },
-            "replace": {
-                "tecnickcom/tcpdf": "6.2.*"
-            },
-            "type": "library",
-            "autoload": {
-                "classmap": [
-                    "fonts",
-                    "config",
-                    "include",
-                    "tcpdf.php",
-                    "tcpdf_parser.php",
-                    "tcpdf_import.php",
-                    "tcpdf_barcodes_1d.php",
-                    "tcpdf_barcodes_2d.php",
-                    "include/tcpdf_colors.php",
-                    "include/tcpdf_filters.php",
-                    "include/tcpdf_font_data.php",
-                    "include/tcpdf_fonts.php",
-                    "include/tcpdf_images.php",
-                    "include/tcpdf_static.php",
-                    "include/barcodes/datamatrix.php",
-                    "include/barcodes/pdf417.php",
-                    "include/barcodes/qrcode.php"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "LGPL-3.0"
-            ],
-            "authors": [
-                {
-                    "name": "Nicola Asuni",
-                    "email": "info@tecnick.com",
-                    "homepage": "http://nicolaasuni.tecnick.com",
-                    "role": "Main developer"
-                },
-                {
-                    "name": "wallabag/core",
-                    "homepage": "https://www.wallabag.org",
-                    "role": "Developers"
-                }
-            ],
-            "description": "Keeping a working 6.2.x TCPDF version.",
-            "homepage": "https://www.wallabag.org/",
-            "keywords": [
-                "PDFD32000-2008",
-                "TCPDF",
-                "barcodes",
-                "datamatrix",
-                "pdf",
-                "pdf417",
-                "qrcode"
-            ],
-            "time": "2018-10-25T06:56:14+00:00"
         },
         {
             "name": "white-october/pagerfanta-bundle",

--- a/src/Wallabag/ImportBundle/Controller/PocketController.php
+++ b/src/Wallabag/ImportBundle/Controller/PocketController.php
@@ -47,8 +47,12 @@ class PocketController extends Controller
             return $this->redirect($this->generateUrl('import_pocket'));
         }
 
+        $form = $request->request->get('form');
+
         $this->get('session')->set('import.pocket.code', $requestToken);
-        $this->get('session')->set('mark_as_read', $request->request->get('form')['mark_as_read']);
+        if (null !== $form && \array_key_exists('mark_as_read', $form)) {
+            $this->get('session')->set('mark_as_read', $form['mark_as_read']);
+        }
 
         return $this->redirect(
             'https://getpocket.com/auth/authorize?request_token=' . $requestToken . '&redirect_uri=' . $this->generateUrl('import_pocket_callback', [], UrlGeneratorInterface::ABSOLUTE_URL),
@@ -80,11 +84,11 @@ class PocketController extends Controller
         if (true === $pocket->setMarkAsRead($markAsRead)->import()) {
             $summary = $pocket->getSummary();
             $message = $this->get('translator')->trans('flashes.import.notice.summary', [
-                '%imported%' => $summary['imported'],
-                '%skipped%' => $summary['skipped'],
+                '%imported%' => null !== $summary && \array_key_exists('imported', $summary) ? $summary['imported'] : 0,
+                '%skipped%' => null !== $summary && \array_key_exists('skipped', $summary) ? $summary['skipped'] : 0,
             ]);
 
-            if (0 < $summary['queued']) {
+            if (null !== $summary && \array_key_exists('queued', $summary) && 0 < $summary['queued']) {
                 $message = $this->get('translator')->trans('flashes.import.notice.summary_with_queue', [
                     '%queued%' => $summary['queued'],
                 ]);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | ~
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Documentation | no
| Translation   | no
| CHANGELOG.md  | no
| License       | MIT

This PR replaces our fork of TCPDF with the original version and fixes some issues seen with PHP 7.4.

Note: I currently use the `master` version of Graby to run the tests, we may need to release a new version to include the change for the TCPDF dependency. (cc @j0k3r)