### PR TITLE
TagController: fix duplicated tags when renaming them

### DIFF
--- a/src/Wallabag/CoreBundle/Controller/TagController.php
+++ b/src/Wallabag/CoreBundle/Controller/TagController.php
@@ -151,7 +151,10 @@ class TagController extends Controller
         $form = $this->createForm(RenameTagType::class, new Tag());
         $form->handleRequest($request);
 
-        if ($form->isSubmitted() && $form->isValid()) {
+        if ($form->isSubmitted()
+            && $form->isValid()
+            && $form->get('label')->getData() !== $tag->getLabel()
+           ) {
             $newTagLabel = $form->get('label')->getData();
             $newTag = new Tag();
             $newTag->setLabel($newTagLabel);
@@ -171,12 +174,12 @@ class TagController extends Controller
 
             $em = $this->getDoctrine()->getManager();
             $em->flush();
-        }
 
-        $this->get('session')->getFlashBag()->add(
-            'notice',
-            'flashes.tag.notice.tag_renamed'
-        );
+            $this->get('session')->getFlashBag()->add(
+                'notice',
+                'flashes.tag.notice.tag_renamed'
+            );
+        }
 
         $redirectUrl = $this->get('wallabag_core.helper.redirect')->to($request->headers->get('referer'), '', true);
 

--- a/src/Wallabag/CoreBundle/Controller/TagController.php
+++ b/src/Wallabag/CoreBundle/Controller/TagController.php
@@ -152,6 +152,10 @@ class TagController extends Controller
         $form->handleRequest($request);
 
         if ($form->isSubmitted() && $form->isValid()) {
+            $newTagLabel = $form->get('label')->getData();
+            $newTag = new Tag();
+            $newTag->setLabel($newTagLabel);
+
             $entries = $this->get('wallabag_core.entry_repository')->findAllByTagId(
                 $this->getUser()->getId(),
                 $tag->getId()
@@ -159,7 +163,8 @@ class TagController extends Controller
             foreach ($entries as $entry) {
                 $this->get('wallabag_core.tags_assigner')->assignTagsToEntry(
                     $entry,
-                    $form->get('label')->getData()
+                    $newTagLabel,
+                    [$newTag]
                 );
                 $entry->removeTag($tag);
             }

--- a/tests/Wallabag/CoreBundle/Controller/TagControllerTest.php
+++ b/tests/Wallabag/CoreBundle/Controller/TagControllerTest.php
@@ -304,6 +304,133 @@ class TagControllerTest extends WallabagCoreTestCase
         $this->assertTrue($newTag[0]->hasEntry($freshEntry), 'Tag is still assigned to the entry.');
     }
 
+    public function testRenameTagWithSameLabelDifferentCase()
+    {
+        $tagLabel = 'same label';
+        $newTagLabel = 'saMe labEl';
+        $this->logInAs('admin');
+        $client = $this->getClient();
+
+        $tag = new Tag();
+        $tag->setLabel($tagLabel);
+
+        $entry = new Entry($this->getLoggedInUser());
+        $entry->setUrl('http://0.0.0.0/foobar');
+        $entry->addTag($tag);
+        $this->getEntityManager()->persist($entry);
+
+        $this->getEntityManager()->flush();
+        $this->getEntityManager()->clear();
+
+        // We make a first request to set an history and test redirection after tag deletion
+        $crawler = $client->request('GET', '/tag/list');
+        $form = $crawler->filter('#tag-' . $tag->getId() . ' form')->form();
+
+        $data = [
+            'tag[label]' => $newTagLabel,
+        ];
+
+        $client->submit($form, $data);
+        $this->assertSame(302, $client->getResponse()->getStatusCode());
+        $this->assertNotContains('flashes.tag.notice.tag_renamed', $crawler->filter('body')->extract(['_text'])[0]);
+
+        $freshEntry = $client->getContainer()
+            ->get('doctrine.orm.entity_manager')
+            ->getRepository('WallabagCoreBundle:Entry')
+            ->find($entry->getId());
+
+        $tags = [];
+
+        $tagsFromEntry = $freshEntry->getTags()->toArray();
+        foreach ($tagsFromEntry as $key => $item) {
+            $tags[$key] = $item->getLabel();
+        }
+
+        $this->assertFalse(array_search($newTagLabel, $tags, true));
+
+        $tagFromRepo = $client->getContainer()
+            ->get('doctrine.orm.entity_manager')
+            ->getRepository('WallabagCoreBundle:Tag')
+            ->findByLabel($tagLabel);
+
+        $newTagFromRepo = $client->getContainer()
+            ->get('doctrine.orm.entity_manager')
+            ->getRepository('WallabagCoreBundle:Tag')
+            ->findByLabel($newTagLabel);
+
+        $this->assertCount(0, $newTagFromRepo);
+        $this->assertCount(1, $tagFromRepo);
+
+        $this->assertSame($tag->getId(), $tagFromRepo[0]->getId(), 'Tag is unchanged.');
+
+        $this->assertTrue($tagFromRepo[0]->hasEntry($freshEntry), 'Tag is still assigned to the entry.');
+    }
+
+    public function testRenameTagWithExistingLabel()
+    {
+        $tagLabel = 'existing label';
+        $previousTagLabel = 'previous label';
+        $this->logInAs('admin');
+        $client = $this->getClient();
+
+        $tag = new Tag();
+        $tag->setLabel($tagLabel);
+
+        $previousTag = new Tag();
+        $previousTag->setLabel($previousTagLabel);
+
+        $entry1 = new Entry($this->getLoggedInUser());
+        $entry1->setUrl('http://0.0.0.0/foobar');
+        $entry1->addTag($previousTag);
+        $this->getEntityManager()->persist($entry1);
+
+        $entry2 = new Entry($this->getLoggedInUser());
+        $entry2->setUrl('http://0.0.0.0/baz');
+        $entry2->addTag($tag);
+        $this->getEntityManager()->persist($entry2);
+
+        $this->getEntityManager()->flush();
+        $this->getEntityManager()->clear();
+
+        // We make a first request to set an history and test redirection after tag deletion
+        $crawler = $client->request('GET', '/tag/list');
+        $form = $crawler->filter('#tag-' . $previousTag->getId() . ' form')->form();
+
+        $data = [
+            'tag[label]' => $tagLabel,
+        ];
+
+        $client->submit($form, $data);
+        $this->assertSame(302, $client->getResponse()->getStatusCode());
+        $this->assertNotContains('flashes.tag.notice.tag_renamed', $crawler->filter('body')->extract(['_text'])[0]);
+
+        $freshEntry1 = $client->getContainer()
+            ->get('doctrine.orm.entity_manager')
+            ->getRepository('WallabagCoreBundle:Entry')
+            ->find($entry1->getId());
+
+        $freshEntry2 = $client->getContainer()
+            ->get('doctrine.orm.entity_manager')
+            ->getRepository('WallabagCoreBundle:Entry')
+            ->find($entry2->getId());
+
+        $tagFromRepo = $client->getContainer()
+            ->get('doctrine.orm.entity_manager')
+            ->getRepository('WallabagCoreBundle:Tag')
+            ->findByLabel($tagLabel);
+
+        $previousTagFromRepo = $client->getContainer()
+            ->get('doctrine.orm.entity_manager')
+            ->getRepository('WallabagCoreBundle:Tag')
+            ->findByLabel($previousTagLabel);
+
+        $this->assertCount(1, $tagFromRepo);
+
+        $this->assertTrue($tagFromRepo[0]->hasEntry($freshEntry1));
+        $this->assertTrue($tagFromRepo[0]->hasEntry($freshEntry2), 'Tag is assigned to the entry.');
+        $this->assertFalse($previousTagFromRepo[0]->hasEntry($freshEntry1));
+    }
+
     public function testAddUnicodeTagLabel()
     {
         $this->logInAs('admin');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | 
| Documentation | no
| Translation   | no
| CHANGELOG.md  | no
| License       | MIT

The fix relies on a workaround available on TagsAssigner, see the
AssignTagsToEntry() signature for detail.

I replaced the findOneByLabel in the corresponding test to assert that
there is no duplicate.

Fixes #4216