### PR TITLE
Added publication date on epub export

### DIFF
--- a/src/Wallabag/CoreBundle/Helper/EntriesExport.php
+++ b/src/Wallabag/CoreBundle/Helper/EntriesExport.php
@@ -196,10 +196,17 @@ class EntriesExport
                 $authors = implode(',', $publishedBy);
             }
 
+            $publishedAt = $entry->getPublishedAt();
+            $publishedDate = $this->translator->trans('export.unknown');
+            if (!empty($publishedAt)) {
+                $publishedDate = $entry->getPublishedAt()->format('Y-m-d');
+            }
+
             $titlepage = $content_start .
                 '<h1>' . $entry->getTitle() . '</h1>' .
                 '<dl>' .
                 '<dt>' . $this->translator->trans('entry.view.published_by') . '</dt><dd>' . $authors . '</dd>' .
+                '<dt>' . $this->translator->trans('entry.metadata.published_on') . '</dt><dd>' . $publishedDate . '</dd>' .
                 '<dt>' . $this->translator->trans('entry.metadata.reading_time') . '</dt><dd>' . $this->translator->trans('entry.metadata.reading_time_minutes_short', ['%readingTime%' => $entry->getReadingTime()]) . '</dd>' .
                 '<dt>' . $this->translator->trans('entry.metadata.added_on') . '</dt><dd>' . $entry->getCreatedAt()->format('Y-m-d') . '</dd>' .
                 '<dt>' . $this->translator->trans('entry.metadata.address') . '</dt><dd><a href="' . $entry->getUrl() . '">' . $entry->getUrl() . '</a></dd>' .

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.da.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.da.yml
@@ -285,6 +285,7 @@ entry:
         # reading_time_minutes_short: "%readingTime% min"
         # address: "Address"
         # added_on: "Added on"
+        # published_on: "Published on"
 
 about:
     page_title: 'Om'

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.de.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.de.yml
@@ -285,6 +285,7 @@ entry:
         # reading_time_minutes_short: "%readingTime% min"
         # address: "Address"
         # added_on: "Added on"
+        # published_on: "Published on"
 
 about:
     page_title: 'Über'

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.en.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.en.yml
@@ -285,6 +285,7 @@ entry:
         reading_time_minutes_short: "%readingTime% min"
         address: "Address"
         added_on: "Added on"
+        published_on: "Published on"
 
 about:
     page_title: 'About'

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.es.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.es.yml
@@ -285,6 +285,7 @@ entry:
         reading_time_minutes_short: "%readingTime% min"
         address: "Dirección"
         added_on: "Añadido el"
+        # published_on: "Published on"
 
 about:
     page_title: 'Acerca de'

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.fa.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.fa.yml
@@ -285,6 +285,7 @@ entry:
         # reading_time_minutes_short: "%readingTime% min"
         # address: "Address"
         # added_on: "Added on"
+        # published_on: "Published on"
 
 about:
     page_title: 'درباره'

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.fr.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.fr.yml
@@ -285,6 +285,7 @@ entry:
         reading_time_minutes_short: "%readingTime% min"
         address: "Adresse"
         added_on: "Ajouté le"
+        published_on: "Publié le"
 
 about:
     page_title: "À propos"

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.it.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.it.yml
@@ -285,6 +285,7 @@ entry:
         # reading_time_minutes_short: "%readingTime% min"
         # address: "Address"
         # added_on: "Added on"
+        # published_on: "Published on"
 
 about:
     page_title: 'A proposito'

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.ja.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.ja.yml
@@ -285,6 +285,7 @@ entry:
         reading_time_minutes_short: "%readingTime% 分"
         address: "アドレス"
         added_on: "追加日"
+        # published_on: "Published on"
 
 about:
     page_title: 'アプリについて'

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.oc.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.oc.yml
@@ -285,6 +285,7 @@ entry:
         reading_time_minutes_short: "%readingTime% min"
         address: "Adreça"
         added_on: "Ajustat a"
+        # published_on: "Published on"
 
 about:
     page_title: 'A prepaus'

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.pl.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.pl.yml
@@ -285,6 +285,7 @@ entry:
         # reading_time_minutes_short: "%readingTime% min"
         # address: "Address"
         # added_on: "Added on"
+        # published_on: "Published on"
 
 about:
     page_title: 'O nas'

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.pt.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.pt.yml
@@ -285,6 +285,7 @@ entry:
         reading_time_minutes_short: "%readingTime% min"
         address: "Endereço"
         added_on: "Adicionado o"
+        # published_on: "Published on"
 
 about:
     page_title: 'Sobre'

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.ro.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.ro.yml
@@ -285,6 +285,7 @@ entry:
         # reading_time_minutes_short: "%readingTime% min"
         # address: "Address"
         # added_on: "Added on"
+        # published_on: "Published on"
 
 about:
     page_title: 'Despre'

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.ru.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.ru.yml
@@ -285,6 +285,7 @@ entry:
         # reading_time_minutes_short: "%readingTime% min"
         # address: "Address"
         # added_on: "Added on"
+        # published_on: "Published on"
 
 about:
     page_title: 'О'

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.th.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.th.yml
@@ -285,6 +285,7 @@ entry:
         # reading_time_minutes_short: "%readingTime% min"
         # address: "Address"
         # added_on: "Added on"
+        # published_on: "Published on"
 
 about:
     page_title: 'เกี่ยวกับ'

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.tr.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.tr.yml
@@ -285,6 +285,7 @@ entry:
         # reading_time_minutes_short: "%readingTime% min"
         # address: "Address"
         # added_on: "Added on"
+        # published_on: "Published on"
 
 about:
     page_title: 'Hakkımızda'

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.zh.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.zh.yml
@@ -285,6 +285,7 @@ entry:
         reading_time_minutes_short: "%readingTime% 分钟"
         address: "地址"
         added_on: "添加于"
+        # published_on: "Published on"
 
 about:
     page_title: '关于'


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Documentation | no
| Translation   | yes
| CHANGELOG.md  | no
| License       | MIT

I think that publication date is a good improvement on ePub export. (see #2821)