### PR TITLE
Fixed bug when we delete entry via API

### DIFF
--- a/src/Wallabag/ApiBundle/Controller/EntryRestController.php
+++ b/src/Wallabag/ApiBundle/Controller/EntryRestController.php
@@ -239,12 +239,12 @@ class EntryRestController extends WallabagRestController
             $results[$key]['url'] = $url;
 
             if (false !== $entry) {
+                // entry deleted, dispatch event about it!
+                $this->get('event_dispatcher')->dispatch(EntryDeletedEvent::NAME, new EntryDeletedEvent($entry));
+
                 $em = $this->getDoctrine()->getManager();
                 $em->remove($entry);
                 $em->flush();
-
-                // entry deleted, dispatch event about it!
-                $this->get('event_dispatcher')->dispatch(EntryDeletedEvent::NAME, new EntryDeletedEvent($entry));
             }
 
             $results[$key]['entry'] = $entry instanceof Entry ? true : false;
@@ -610,12 +610,12 @@ class EntryRestController extends WallabagRestController
             $response = $this->sendResponse($e);
         }
 
+        // entry deleted, dispatch event about it!
+        $this->get('event_dispatcher')->dispatch(EntryDeletedEvent::NAME, new EntryDeletedEvent($entry));
+
         $em = $this->getDoctrine()->getManager();
         $em->remove($entry);
         $em->flush();
-
-        // entry deleted, dispatch event about it!
-        $this->get('event_dispatcher')->dispatch(EntryDeletedEvent::NAME, new EntryDeletedEvent($entry));
 
         return $response;
     }


### PR DESCRIPTION
Fixes #4291

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Documentation | no
| Translation   | no
| CHANGELOG.md  | no
| License       | MIT

The event was triggered after the entry deletion, so wallabag had no way to find entry data. 