### PR TITLE
Add ability to define lifetime token for the API

### DIFF
--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -195,7 +195,8 @@ fos_oauth_server:
     service:
         user_provider: fos_user.user_provider.username_email
         options:
-            refresh_token_lifetime: 1209600
+            refresh_token_lifetime: "%fos_oauth_server_refresh_token_lifetime%"
+            access_token_lifetime: "%fos_oauth_server_access_token_lifetime%"
 
 scheb_two_factor:
     trusted_device:

--- a/app/config/parameters.yml.dist
+++ b/app/config/parameters.yml.dist
@@ -46,6 +46,11 @@ parameters:
     fosuser_registration: true
     fosuser_confirmation: true
 
+    # how long the access token should live in seconds for the API
+    fos_oauth_server_access_token_lifetime: 3600
+    # how long the refresh token should life in seconds for the API
+    fos_oauth_server_refresh_token_lifetime: 1209600
+
     from_email: no-reply@wallabag.org
 
     rss_limit: 50


### PR DESCRIPTION
It'll allow admin of a wallabag instance to define its own lifetime for the refresh token and the access token.
The default value are the recommended one from the wallabag team.

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Documentation | https://github.com/wallabag/doc/pull/121
| Translation   | no
| CHANGELOG.md  | no
| License       | MIT

Fix #4292