### PR TITLE
Added a button to disable 2FA when enabled

### DIFF
--- a/src/Wallabag/CoreBundle/Controller/ConfigController.php
+++ b/src/Wallabag/CoreBundle/Controller/ConfigController.php
@@ -193,6 +193,30 @@ class ConfigController extends Controller
     }
 
     /**
+     * Disable 2FA using email.
+     *
+     * @Route("/config/otp/email/disable", name="disable_otp_email")
+     */
+    public function disableOtpEmailAction()
+    {
+        if (!$this->getParameter('twofactor_auth')) {
+            return $this->createNotFoundException('two_factor not enabled');
+        }
+
+        $user = $this->getUser();
+        $user->setEmailTwoFactor(false);
+
+        $this->container->get('fos_user.user_manager')->updateUser($user, true);
+
+        $this->addFlash(
+            'notice',
+            'flashes.config.notice.otp_disabled'
+        );
+
+        return $this->redirect($this->generateUrl('config') . '#set3');
+    }
+
+    /**
      * Enable 2FA using email.
      *
      * @Route("/config/otp/email", name="config_otp_email")
@@ -214,6 +238,32 @@ class ConfigController extends Controller
         $this->addFlash(
             'notice',
             'flashes.config.notice.otp_enabled'
+        );
+
+        return $this->redirect($this->generateUrl('config') . '#set3');
+    }
+
+    /**
+     * Disable 2FA using OTP app.
+     *
+     * @Route("/config/otp/app/disable", name="disable_otp_app")
+     */
+    public function disableOtpAppAction()
+    {
+        if (!$this->getParameter('twofactor_auth')) {
+            return $this->createNotFoundException('two_factor not enabled');
+        }
+
+        $user = $this->getUser();
+
+        $user->setGoogleAuthenticatorSecret('');
+        $user->setBackupCodes(null);
+
+        $this->container->get('fos_user.user_manager')->updateUser($user, true);
+
+        $this->addFlash(
+            'notice',
+            'flashes.config.notice.otp_disabled'
         );
 
         return $this->redirect($this->generateUrl('config') . '#set3');
@@ -247,6 +297,11 @@ class ConfigController extends Controller
         $user->setBackupCodes($backupCodesHashed);
 
         $this->container->get('fos_user.user_manager')->updateUser($user, true);
+
+        $this->addFlash(
+            'notice',
+            'flashes.config.notice.otp_enabled'
+        );
 
         return $this->render('WallabagCoreBundle:Config:otp_app.html.twig', [
             'backupCodes' => $backupCodes,

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.da.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.da.yml
@@ -613,6 +613,7 @@ flashes:
             # entries_reset: Entries reset
             # archived_reset: Archived entries deleted
             # otp_enabled: Two-factor authentication enabled
+            # otp_disabled: Two-factor authentication disabled
             # tagging_rules_imported: Tagging rules imported
             # tagging_rules_not_imported: Error while importing tagging rules
     entry:

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.de.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.de.yml
@@ -613,6 +613,7 @@ flashes:
             entries_reset: Einträge zurücksetzen
             archived_reset: Archiverte Einträge zurücksetzen
             # otp_enabled: Two-factor authentication enabled
+            # otp_disabled: Two-factor authentication disabled
             # tagging_rules_imported: Tagging rules imported
             # tagging_rules_not_imported: Error while importing tagging rules
     entry:

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.en.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.en.yml
@@ -613,6 +613,7 @@ flashes:
             entries_reset: Entries reset
             archived_reset: Archived entries deleted
             otp_enabled: Two-factor authentication enabled
+            otp_disabled: Two-factor authentication disabled
             tagging_rules_imported: Tagging rules imported
             tagging_rules_not_imported: Error while importing tagging rules
     entry:

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.es.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.es.yml
@@ -613,6 +613,7 @@ flashes:
             entries_reset: Artículos reiniciados
             archived_reset: Artículos archivados borrados
             otp_enabled: Autenticación de dos pasos activada
+            # otp_disabled: Two-factor authentication disabled
             tagging_rules_imported: Reglas de etiquetado importadas
             tagging_rules_not_imported: Un error se ha producico en la importación de las reglas de etiquetado
     entry:

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.fa.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.fa.yml
@@ -613,6 +613,7 @@ flashes:
             # entries_reset: Entries reset
             # archived_reset: Archived entries deleted
             # otp_enabled: Two-factor authentication enabled
+            # otp_disabled: Two-factor authentication disabled
             # tagging_rules_imported: Tagging rules imported
             # tagging_rules_not_imported: Error while importing tagging rules
     entry:

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.fr.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.fr.yml
@@ -614,6 +614,7 @@ flashes:
             entries_reset: "Articles supprimés"
             archived_reset: "Articles archivés supprimés"
             otp_enabled: "Authentification à double-facteur activée"
+            otp_disabled: "Authentification à double-facteur désactivée"
             tagging_rules_imported: Règles bien importées
             tagging_rules_not_imported: Impossible d'importer les règles
     entry:

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.it.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.it.yml
@@ -613,6 +613,7 @@ flashes:
             entries_reset: Reset articoli
             # archived_reset: Archived entries deleted
             # otp_enabled: Two-factor authentication enabled
+            # otp_disabled: Two-factor authentication disabled
             # tagging_rules_imported: Tagging rules imported
             # tagging_rules_not_imported: Error while importing tagging rules
     entry:

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.ja.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.ja.yml
@@ -613,6 +613,7 @@ flashes:
             entries_reset: 記事がリセットされました
             archived_reset: アーカイブ済みの記事がリセットされました
             otp_enabled: 2要素認証が有効化されました
+            # otp_disabled: Two-factor authentication disabled
             tagging_rules_imported: タグ付けルールがインポートされました
             tagging_rules_not_imported: タグ付けルールのインポート中にエラーが発生しました
     entry:

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.oc.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.oc.yml
@@ -613,6 +613,7 @@ flashes:
             entries_reset: Articles levats
             archived_reset: Articles archivat suprimits
             otp_enabled: Autentificacion en dos temps activada
+            # otp_disabled: Two-factor authentication disabled
             tagging_rules_imported: Règlas d’etiquetatge importadas
             tagging_rules_not_imported: Error en important las règlas d’etiquetatge
     entry:

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.pl.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.pl.yml
@@ -613,6 +613,7 @@ flashes:
             entries_reset: Zresetuj wpisy
             archived_reset: Zarchiwizowane wpisy usunięte
             # otp_enabled: Two-factor authentication enabled
+            # otp_disabled: Two-factor authentication disabled
             # tagging_rules_imported: Tagging rules imported
             # tagging_rules_not_imported: Error while importing tagging rules
     entry:

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.pt.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.pt.yml
@@ -613,6 +613,7 @@ flashes:
             entries_reset: Artigos reinicializados
             archived_reset: Artigos arquivados apagados
             otp_enabled: Autenticação de dois fatores ativada
+            # otp_disabled: Two-factor authentication disabled
             tagging_rules_imported: Regras de tags importadas
             tagging_rules_not_imported: Erro ao importar regras de tags
     entry:

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.ro.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.ro.yml
@@ -613,6 +613,7 @@ flashes:
             # entries_reset: Entries reset
             # archived_reset: Archived entries deleted
             # otp_enabled: Two-factor authentication enabled
+            # otp_disabled: Two-factor authentication disabled
             # tagging_rules_imported: Tagging rules imported
             # tagging_rules_not_imported: Error while importing tagging rules
     entry:

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.ru.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.ru.yml
@@ -613,6 +613,7 @@ flashes:
             entries_reset: "Записи сброшены"
             # archived_reset: Archived entries deleted
             # otp_enabled: Two-factor authentication enabled
+            # otp_disabled: Two-factor authentication disabled
             # tagging_rules_imported: Tagging rules imported
             # tagging_rules_not_imported: Error while importing tagging rules
     entry:

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.th.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.th.yml
@@ -613,6 +613,7 @@ flashes:
             entries_reset: รีเซ็ตรายการ
             archived_reset: การลบเอกสารของรายการ
             # otp_enabled: Two-factor authentication enabled
+            # otp_disabled: Two-factor authentication disabled
             # tagging_rules_imported: Tagging rules imported
             # tagging_rules_not_imported: Error while importing tagging rules
     entry:

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.tr.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.tr.yml
@@ -613,6 +613,7 @@ flashes:
             # entries_reset: Entries reset
             # archived_reset: Archived entries deleted
             # otp_enabled: Two-factor authentication enabled
+            # otp_disabled: Two-factor authentication disabled
             # tagging_rules_imported: Tagging rules imported
             # tagging_rules_not_imported: Error while importing tagging rules
     entry:

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.zh.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.zh.yml
@@ -613,6 +613,7 @@ flashes:
             entries_reset: 项目列表已重置
             archived_reset: 所有存档项目已删除
             otp_enabled: 两步验证已启用
+            # otp_disabled: Two-factor authentication disabled
             tagging_rules_imported: 标签规则已导入
             tagging_rules_not_imported: 导入标签规则时发生了错误
     entry:

--- a/src/Wallabag/CoreBundle/Resources/views/themes/baggy/Config/index.html.twig
+++ b/src/Wallabag/CoreBundle/Resources/views/themes/baggy/Config/index.html.twig
@@ -195,12 +195,12 @@
                 <tr>
                     <td>{{ 'config.form_user.two_factor.emailTwoFactor_label'|trans }}</td>
                     <td>{% if app.user.isEmailTwoFactor %}<b>{{ 'config.form_user.two_factor.state_enabled'|trans }}</b>{% else %}{{ 'config.form_user.two_factor.state_disabled'|trans }}{% endif %}</td>
-                    <td><a href="{{ path('config_otp_email') }}" class="waves-effect waves-light btn{% if app.user.isEmailTwoFactor %} disabled{% endif %}">{{ 'config.form_user.two_factor.action_email'|trans }}</a></td>
+                    <td><a href="{{ path('config_otp_email') }}" class="waves-effect waves-light btn{% if app.user.isEmailTwoFactor %} disabled{% endif %}">{{ 'config.form_user.two_factor.action_email'|trans }}</a>  {% if app.user.isEmailTwoFactor %}<a href="{{ path('disable_otp_email') }}" class="waves-effect waves-light btn">Disable</a>{% endif %}</td>
                 </tr>
                 <tr>
                     <td>{{ 'config.form_user.two_factor.googleTwoFactor_label'|trans }}</td>
                     <td>{% if app.user.isGoogleTwoFactor %}<b>{{ 'config.form_user.two_factor.state_enabled'|trans }}</b>{% else %}{{ 'config.form_user.two_factor.state_disabled'|trans }}{% endif %}</td>
-                    <td><a href="{{ path('config_otp_app') }}" class="waves-effect waves-light btn{% if app.user.isGoogleTwoFactor %} disabled{% endif %}">{{ 'config.form_user.two_factor.action_app'|trans }}</a></td>
+                    <td><a href="{{ path('config_otp_app') }}" class="waves-effect waves-light btn{% if app.user.isGoogleTwoFactor %} disabled{% endif %}">{{ 'config.form_user.two_factor.action_app'|trans }}</a> {% if app.user.isGoogleTwoFactor %}<a href="{{ path('disable_otp_app') }}" class="waves-effect waves-light btn">Disable</a>{% endif %}</td>
                 </tr>
             </tbody>
         </table>

--- a/src/Wallabag/CoreBundle/Resources/views/themes/material/Config/index.html.twig
+++ b/src/Wallabag/CoreBundle/Resources/views/themes/material/Config/index.html.twig
@@ -229,12 +229,12 @@
                                             <tr>
                                                 <td>{{ 'config.form_user.two_factor.emailTwoFactor_label'|trans }}</td>
                                                 <td>{% if app.user.isEmailTwoFactor %}<b>{{ 'config.form_user.two_factor.state_enabled'|trans }}</b>{% else %}{{ 'config.form_user.two_factor.state_disabled'|trans }}{% endif %}</td>
-                                                <td><a href="{{ path('config_otp_email') }}" class="waves-effect waves-light btn{% if app.user.isEmailTwoFactor %} disabled{% endif %}">{{ 'config.form_user.two_factor.action_email'|trans }}</a> {% if app.user.isEmailTwoFactor %}<a href="{{ path('disable_otp_email') }}" class="waves-effect waves-light btn">Disable</a>{% endif %}</td>
+                                                <td><a href="{{ path('config_otp_email') }}" class="waves-effect waves-light btn{% if app.user.isEmailTwoFactor %} disabled{% endif %}">{{ 'config.form_user.two_factor.action_email'|trans }}</a> {% if app.user.isEmailTwoFactor %}<a href="{{ path('disable_otp_email') }}" class="waves-effect waves-light btn red">Disable</a>{% endif %}</td>
                                             </tr>
                                             <tr>
                                                 <td>{{ 'config.form_user.two_factor.googleTwoFactor_label'|trans }}</td>
                                                 <td>{% if app.user.isGoogleTwoFactor %}<b>{{ 'config.form_user.two_factor.state_enabled'|trans }}</b>{% else %}{{ 'config.form_user.two_factor.state_disabled'|trans }}{% endif %}</td>
-                                                <td><a href="{{ path('config_otp_app') }}" class="waves-effect waves-light btn{% if app.user.isGoogleTwoFactor %} disabled{% endif %}">{{ 'config.form_user.two_factor.action_app'|trans }}</a> {% if app.user.isGoogleTwoFactor %}<a href="{{ path('disable_otp_app') }}" class="waves-effect waves-light btn">Disable</a>{% endif %}</td>
+                                                <td><a href="{{ path('config_otp_app') }}" class="waves-effect waves-light btn{% if app.user.isGoogleTwoFactor %} disabled{% endif %}">{{ 'config.form_user.two_factor.action_app'|trans }}</a> {% if app.user.isGoogleTwoFactor %}<a href="{{ path('disable_otp_app') }}" class="waves-effect waves-light btn red">Disable</a>{% endif %}</td>
                                             </tr>
                                         </tbody>
                                     </table>

--- a/src/Wallabag/CoreBundle/Resources/views/themes/material/Config/index.html.twig
+++ b/src/Wallabag/CoreBundle/Resources/views/themes/material/Config/index.html.twig
@@ -229,12 +229,12 @@
                                             <tr>
                                                 <td>{{ 'config.form_user.two_factor.emailTwoFactor_label'|trans }}</td>
                                                 <td>{% if app.user.isEmailTwoFactor %}<b>{{ 'config.form_user.two_factor.state_enabled'|trans }}</b>{% else %}{{ 'config.form_user.two_factor.state_disabled'|trans }}{% endif %}</td>
-                                                <td><a href="{{ path('config_otp_email') }}" class="waves-effect waves-light btn{% if app.user.isEmailTwoFactor %} disabled{% endif %}">{{ 'config.form_user.two_factor.action_email'|trans }}</a></td>
+                                                <td><a href="{{ path('config_otp_email') }}" class="waves-effect waves-light btn{% if app.user.isEmailTwoFactor %} disabled{% endif %}">{{ 'config.form_user.two_factor.action_email'|trans }}</a> {% if app.user.isEmailTwoFactor %}<a href="{{ path('disable_otp_email') }}" class="waves-effect waves-light btn">Disable</a>{% endif %}</td>
                                             </tr>
                                             <tr>
                                                 <td>{{ 'config.form_user.two_factor.googleTwoFactor_label'|trans }}</td>
                                                 <td>{% if app.user.isGoogleTwoFactor %}<b>{{ 'config.form_user.two_factor.state_enabled'|trans }}</b>{% else %}{{ 'config.form_user.two_factor.state_disabled'|trans }}{% endif %}</td>
-                                                <td><a href="{{ path('config_otp_app') }}" class="waves-effect waves-light btn{% if app.user.isGoogleTwoFactor %} disabled{% endif %}">{{ 'config.form_user.two_factor.action_app'|trans }}</a></td>
+                                                <td><a href="{{ path('config_otp_app') }}" class="waves-effect waves-light btn{% if app.user.isGoogleTwoFactor %} disabled{% endif %}">{{ 'config.form_user.two_factor.action_app'|trans }}</a> {% if app.user.isGoogleTwoFactor %}<a href="{{ path('disable_otp_app') }}" class="waves-effect waves-light btn">Disable</a>{% endif %}</td>
                                             </tr>
                                         </tbody>
                                     </table>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Documentation | no
| Translation   | yes
| CHANGELOG.md  | no
| License       | MIT

Fixes #4217 

Today we don't ask user password because I think it should be a global feature: for each sensitive action (delete data, delete account, disable 2fa, etc.), we should ask user password. 
