### PR TITLE
Jump to PHP 7.2+

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@
 !/bin/console
 !/bin/symfony_requirements
 .php_cs.cache
+.phpunit.result.cache
 
 # Parameters
 /app/config/parameters.yml

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,6 @@ if: |
     branch = master
 
 php:
-    - 7.1
     - 7.2
     - 7.3
     - 7.4
@@ -51,7 +50,6 @@ before_install:
     - PHP=$TRAVIS_PHP_VERSION
     - echo "memory_limit=-1" >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
     - phpenv config-rm xdebug.ini || echo "xdebug not available"
-    - composer self-update --no-progress
     # install imagick
     - pear config-set preferred_state beta
     - pecl channel-update pecl.php.net
@@ -71,7 +69,7 @@ before_script:
 script:
     - if [[ $VALIDATE_TRANSLATION_FILE = '' ]]; then ./bin/simple-phpunit -v ; fi;
     # PHPStan needs PHPUnit to be installed and cache app to be generated
-    - if [[ $VALIDATE_TRANSLATION_FILE = '' ]]; then php bin/phpstan analyse src tests --no-progress --level 1 ; fi;
+    - if [[ $CS_FIXER = run ]]; then php bin/phpstan analyse ; fi;
     - if [[ $CS_FIXER = run ]]; then php bin/php-cs-fixer fix --verbose --dry-run ; fi;
     - if [[ $VALIDATE_TRANSLATION_FILE = run ]]; then php bin/console lint:yaml src/Wallabag/CoreBundle/Resources/translations -v ; fi;
     - if [[ $VALIDATE_TRANSLATION_FILE = run ]]; then php bin/console lint:yaml app/Resources/CraueConfigBundle/translations -v ; fi;

--- a/app/AppKernel.php
+++ b/app/AppKernel.php
@@ -30,7 +30,7 @@ class AppKernel extends Kernel
             new KPhoen\RulerZBundle\KPhoenRulerZBundle(),
             new Doctrine\Bundle\MigrationsBundle\DoctrineMigrationsBundle(),
             new Craue\ConfigBundle\CraueConfigBundle(),
-            new WhiteOctober\PagerfantaBundle\WhiteOctoberPagerfantaBundle(),
+            new BabDev\PagerfantaBundle\BabDevPagerfantaBundle(),
             new FOS\JsRoutingBundle\FOSJsRoutingBundle(),
             new BD\GuzzleSiteAuthenticatorBundle\BDGuzzleSiteAuthenticatorBundle(),
             new OldSound\RabbitMqBundle\OldSoundRabbitMqBundle(),

--- a/composer.json
+++ b/composer.json
@@ -3,6 +3,8 @@
     "type": "project",
     "description": "open source self hostable read-it-later web application",
     "keywords": [
+        "poche",
+        "wallabag",
         "read-it-later",
         "read it later"
     ],
@@ -22,7 +24,7 @@
         },
         {
             "name": "Jérémy Benoist",
-            "homepage": "http://www.j0k3r.net",
+            "homepage": "https://www.j0k3r.net",
             "role": "Developer"
         }
     ],
@@ -31,7 +33,7 @@
         "issues": "https://github.com/wallabag/wallabag/issues"
     },
     "require": {
-        "php": ">=7.1.3",
+        "php": ">=7.2.5",
         "ext-ctype": "*",
         "ext-curl": "*",
         "ext-dom": "*",
@@ -47,6 +49,7 @@
         "ext-tidy": "*",
         "ext-tokenizer": "*",
         "ext-xml": "*",
+        "babdev/pagerfanta-bundle": "^2.4",
         "bdunogier/guzzle-site-authenticator": "^1.0.0",
         "craue/config-bundle": "^2.3.0",
         "defuse/php-encryption": "^2.1",
@@ -64,7 +67,7 @@
         "incenteev/composer-parameter-handler": "^2.1",
         "j0k3r/graby": "^2.0",
         "javibravo/simpleue": "^2.0",
-        "jms/serializer-bundle": "~2.2",
+        "jms/serializer-bundle": "~3.6",
         "kphoen/rulerz-bundle": "~0.13",
         "laminas/laminas-code": "^3.4",
         "laminas/laminas-diactoros": "^2.3",
@@ -93,22 +96,22 @@
         "twig/extensions": "^1.5",
         "wallabag/php-mobi": "~1.0",
         "wallabag/phpepub": "^4.0.7.2",
-        "white-october/pagerfanta-bundle": "^1.1",
-        "willdurand/hateoas-bundle": "~1.3"
+        "willdurand/hateoas-bundle": "~2.1"
     },
     "require-dev": {
-        "dama/doctrine-test-bundle": "^5.0",
+        "dama/doctrine-test-bundle": "^6.0",
         "doctrine/doctrine-fixtures-bundle": "~3.0",
         "friendsofphp/php-cs-fixer": "~2.13",
         "guzzlehttp/psr7": "^1.0",
         "m6web/redis-mock": "^5.0",
         "php-http/mock-client": "^1.0",
-        "phpstan/phpstan": "^0.11.0",
-        "phpstan/phpstan-doctrine": "^0.11.0",
-        "phpstan/phpstan-phpunit": "^0.11.0",
-        "phpstan/phpstan-symfony": "^0.11.0",
+        "phpstan/extension-installer": "^1.0",
+        "phpstan/phpstan": "^0.12.0",
+        "phpstan/phpstan-doctrine": "^0.12.0",
+        "phpstan/phpstan-phpunit": "^0.12.0",
+        "phpstan/phpstan-symfony": "^0.12.0",
         "symfony/maker-bundle": "^1.18",
-        "symfony/phpunit-bridge": "~4.3.8"
+        "symfony/phpunit-bridge": "~5.1.1"
     },
     "suggest": {
         "ext-imagick": "To keep GIF animation when downloading image is enabled"
@@ -159,7 +162,7 @@
     "config": {
         "bin-dir": "bin",
         "platform": {
-            "php": "7.1.3"
+            "php": "7.2.5"
         },
         "sort-packages": true
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,82 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "684e23e16257042ea975c6797fc40c26",
+    "content-hash": "7bfe0742fcefa618c3817291f40c799f",
     "packages": [
+        {
+            "name": "babdev/pagerfanta-bundle",
+            "version": "v2.4.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/BabDev/BabDevPagerfantaBundle.git",
+                "reference": "93c041c59d43263ee63ddd3f922045328334bb81"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/BabDev/BabDevPagerfantaBundle/zipball/93c041c59d43263ee63ddd3f922045328334bb81",
+                "reference": "93c041c59d43263ee63ddd3f922045328334bb81",
+                "shasum": ""
+            },
+            "require": {
+                "pagerfanta/pagerfanta": "^2.2.1",
+                "php": "^7.2",
+                "symfony/config": "^3.4 || ^4.4 || ^5.0",
+                "symfony/dependency-injection": "^3.4 || ^4.4 || ^5.0",
+                "symfony/deprecation-contracts": "^2.1",
+                "symfony/http-foundation": "^3.4 || ^4.4 || ^5.0",
+                "symfony/http-kernel": "^3.4 || ^4.4 || ^5.0",
+                "symfony/property-access": "^3.4 || ^4.4 || ^5.0",
+                "symfony/routing": "^3.4 || ^4.4 || ^5.0"
+            },
+            "conflict": {
+                "twig/twig": "<1.34 || >=2.0,<2.4",
+                "white-october/pagerfanta-bundle": "*"
+            },
+            "require-dev": {
+                "doctrine/annotations": "^1.8",
+                "friendsofphp/php-cs-fixer": "^2.16",
+                "matthiasnoback/symfony-dependency-injection-test": "^4.1",
+                "phpunit/phpunit": "^8.5 || ^9.0",
+                "symfony/translation": "^3.4 || ^4.4 || ^5.0",
+                "symfony/twig-bridge": "^3.4 || ^4.4 || ^5.0",
+                "twig/twig": "^1.34 || ^2.4 || ^3.0"
+            },
+            "suggest": {
+                "symfony/translation": "To use the Pagerfanta views with translation support",
+                "twig/twig": "To integrate Pagerfanta with Twig through extensions"
+            },
+            "type": "symfony-bundle",
+            "extra": {
+                "branch-alias": {
+                    "dev-2.x": "2.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "BabDev\\PagerfantaBundle\\": ""
+                },
+                "exclude-from-classmap": [
+                    "Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Bundle integrating Pagerfanta with Symfony",
+            "keywords": [
+                "pagerfanta",
+                "pagination",
+                "symfony"
+            ],
+            "funding": [
+                {
+                    "url": "https://github.com/mbabker",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-06-09T15:42:00+00:00"
+        },
         {
             "name": "bdunogier/guzzle-site-authenticator",
             "version": "1.0.0",
@@ -268,6 +342,16 @@
                 }
             ],
             "description": "Composer plugin that provides efficient querying for installed package versions (no runtime IO)",
+            "funding": [
+                {
+                    "url": "https://packagist.com",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/composer/composer",
+                    "type": "tidelift"
+                }
+            ],
             "time": "2020-04-23T11:49:37+00:00"
         },
         {
@@ -552,6 +636,20 @@
                 "php",
                 "redis",
                 "xcache"
+            ],
+            "funding": [
+                {
+                    "url": "https://www.doctrine-project.org/sponsorship.html",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://www.patreon.com/phpdoctrine",
+                    "type": "patreon"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/doctrine%2Fcache",
+                    "type": "tidelift"
+                }
             ],
             "time": "2020-05-27T16:24:54+00:00"
         },
@@ -1109,33 +1207,38 @@
         },
         {
             "name": "doctrine/inflector",
-            "version": "1.3.1",
+            "version": "1.4.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/inflector.git",
-                "reference": "ec3a55242203ffa6a4b27c58176da97ff0a7aec1"
+                "reference": "4650c8b30c753a76bf44fb2ed00117d6f367490c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/inflector/zipball/ec3a55242203ffa6a4b27c58176da97ff0a7aec1",
-                "reference": "ec3a55242203ffa6a4b27c58176da97ff0a7aec1",
+                "url": "https://api.github.com/repos/doctrine/inflector/zipball/4650c8b30c753a76bf44fb2ed00117d6f367490c",
+                "reference": "4650c8b30c753a76bf44fb2ed00117d6f367490c",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.1"
+                "php": "^7.2 || ^8.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^6.2"
+                "doctrine/coding-standard": "^7.0",
+                "phpstan/phpstan": "^0.11",
+                "phpstan/phpstan-phpunit": "^0.11",
+                "phpstan/phpstan-strict-rules": "^0.11",
+                "phpunit/phpunit": "^7.0 || ^8.0 || ^9.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.3.x-dev"
+                    "dev-master": "2.0.x-dev"
                 }
             },
             "autoload": {
                 "psr-4": {
-                    "Doctrine\\Common\\Inflector\\": "lib/Doctrine/Common/Inflector"
+                    "Doctrine\\Common\\Inflector\\": "lib/Doctrine/Common/Inflector",
+                    "Doctrine\\Inflector\\": "lib/Doctrine/Inflector"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -1164,32 +1267,52 @@
                     "email": "schmittjoh@gmail.com"
                 }
             ],
-            "description": "Common String Manipulations with regard to casing and singular/plural rules.",
-            "homepage": "http://www.doctrine-project.org",
+            "description": "PHP Doctrine Inflector is a small library that can perform string manipulations with regard to upper/lowercase and singular/plural forms of words.",
+            "homepage": "https://www.doctrine-project.org/projects/inflector.html",
             "keywords": [
                 "inflection",
-                "pluralize",
-                "singularize",
-                "string"
+                "inflector",
+                "lowercase",
+                "manipulation",
+                "php",
+                "plural",
+                "singular",
+                "strings",
+                "uppercase",
+                "words"
             ],
-            "time": "2019-10-30T19:59:35+00:00"
+            "funding": [
+                {
+                    "url": "https://www.doctrine-project.org/sponsorship.html",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://www.patreon.com/phpdoctrine",
+                    "type": "patreon"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/doctrine%2Finflector",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-05-29T07:19:59+00:00"
         },
         {
             "name": "doctrine/instantiator",
-            "version": "1.3.0",
+            "version": "1.3.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/instantiator.git",
-                "reference": "ae466f726242e637cebdd526a7d991b9433bacf1"
+                "reference": "f350df0268e904597e3bd9c4685c53e0e333feea"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/ae466f726242e637cebdd526a7d991b9433bacf1",
-                "reference": "ae466f726242e637cebdd526a7d991b9433bacf1",
+                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/f350df0268e904597e3bd9c4685c53e0e333feea",
+                "reference": "f350df0268e904597e3bd9c4685c53e0e333feea",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.1"
+                "php": "^7.1 || ^8.0"
             },
             "require-dev": {
                 "doctrine/coding-standard": "^6.0",
@@ -1228,32 +1351,48 @@
                 "constructor",
                 "instantiate"
             ],
-            "time": "2019-10-21T16:45:58+00:00"
+            "funding": [
+                {
+                    "url": "https://www.doctrine-project.org/sponsorship.html",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://www.patreon.com/phpdoctrine",
+                    "type": "patreon"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/doctrine%2Finstantiator",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-05-29T17:27:14+00:00"
         },
         {
             "name": "doctrine/lexer",
-            "version": "1.0.2",
+            "version": "1.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/lexer.git",
-                "reference": "1febd6c3ef84253d7c815bed85fc622ad207a9f8"
+                "reference": "e864bbf5904cb8f5bb334f99209b48018522f042"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/lexer/zipball/1febd6c3ef84253d7c815bed85fc622ad207a9f8",
-                "reference": "1febd6c3ef84253d7c815bed85fc622ad207a9f8",
+                "url": "https://api.github.com/repos/doctrine/lexer/zipball/e864bbf5904cb8f5bb334f99209b48018522f042",
+                "reference": "e864bbf5904cb8f5bb334f99209b48018522f042",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.2"
+                "php": "^7.2 || ^8.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^4.5"
+                "doctrine/coding-standard": "^6.0",
+                "phpstan/phpstan": "^0.11.8",
+                "phpunit/phpunit": "^8.2"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0.x-dev"
+                    "dev-master": "1.2.x-dev"
                 }
             },
             "autoload": {
@@ -1267,12 +1406,12 @@
             ],
             "authors": [
                 {
-                    "name": "Roman Borschel",
-                    "email": "roman@code-factory.org"
-                },
-                {
                     "name": "Guilherme Blanco",
                     "email": "guilhermeblanco@gmail.com"
+                },
+                {
+                    "name": "Roman Borschel",
+                    "email": "roman@code-factory.org"
                 },
                 {
                     "name": "Johannes Schmitt",
@@ -1288,7 +1427,21 @@
                 "parser",
                 "php"
             ],
-            "time": "2019-06-08T11:03:04+00:00"
+            "funding": [
+                {
+                    "url": "https://www.doctrine-project.org/sponsorship.html",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://www.patreon.com/phpdoctrine",
+                    "type": "patreon"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/doctrine%2Flexer",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-05-25T17:44:05+00:00"
         },
         {
             "name": "doctrine/migrations",
@@ -1526,6 +1679,20 @@
                 "orm",
                 "persistence"
             ],
+            "funding": [
+                {
+                    "url": "https://www.doctrine-project.org/sponsorship.html",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://www.patreon.com/phpdoctrine",
+                    "type": "patreon"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/doctrine%2Fpersistence",
+                    "type": "tidelift"
+                }
+            ],
             "time": "2020-03-21T15:13:52+00:00"
         },
         {
@@ -1663,58 +1830,6 @@
                 "validator"
             ],
             "time": "2020-02-13T22:36:52+00:00"
-        },
-        {
-            "name": "electrolinux/php-html5lib",
-            "version": "0.1.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/electrolinux/php-html5lib.git",
-                "reference": "9f92154993c7ecb120d9f9c0e558660d32846721"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/electrolinux/php-html5lib/zipball/9f92154993c7ecb120d9f9c0e558660d32846721",
-                "reference": "9f92154993c7ecb120d9f9c0e558660d32846721",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.3.2"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-0": {
-                    "HTML5Lib": "src/",
-                    "HTML5Lib\\Tests": "tests/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Multiple users",
-                    "homepage": "https://code.google.com/p/html5lib/",
-                    "role": "Original developers"
-                },
-                {
-                    "name": "Sébastien Lavoie",
-                    "homepage": "http://blog.lavoie.sl",
-                    "role": "Packager"
-                },
-                {
-                    "name": "didier Belot",
-                    "role": "Packager"
-                }
-            ],
-            "description": "A PHP implementations of a HTML parser based on the WHATWG HTML5 specification.",
-            "homepage": "https://github.com/electrolinux/php-html5lib",
-            "keywords": [
-                "HTML5",
-                "php"
-            ],
-            "time": "2013-03-18T18:32:30+00:00"
         },
         {
             "name": "fig/link-util",
@@ -2027,16 +2142,16 @@
         },
         {
             "name": "friendsofsymfony/rest-bundle",
-            "version": "2.7.4",
+            "version": "2.8.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/FriendsOfSymfony/FOSRestBundle.git",
-                "reference": "3d8501dbdfa48811ef942f5f93c358c80d5ad8eb"
+                "reference": "cc53e997761a56f657d2cae2d49e91dd64a7da76"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/FriendsOfSymfony/FOSRestBundle/zipball/3d8501dbdfa48811ef942f5f93c358c80d5ad8eb",
-                "reference": "3d8501dbdfa48811ef942f5f93c358c80d5ad8eb",
+                "url": "https://api.github.com/repos/FriendsOfSymfony/FOSRestBundle/zipball/cc53e997761a56f657d2cae2d49e91dd64a7da76",
+                "reference": "cc53e997761a56f657d2cae2d49e91dd64a7da76",
                 "shasum": ""
             },
             "require": {
@@ -2057,6 +2172,7 @@
                 "willdurand/negotiation": "^2.0"
             },
             "conflict": {
+                "doctrine/inflector": "1.4.0",
                 "jms/serializer": "<1.13.0",
                 "jms/serializer-bundle": "<2.0.0",
                 "sensio/framework-extra-bundle": "<3.0.13"
@@ -2092,6 +2208,7 @@
             "type": "symfony-bundle",
             "extra": {
                 "branch-alias": {
+                    "2.x-dev": "2.8-dev",
                     "dev-master": "2.7-dev"
                 }
             },
@@ -2127,7 +2244,7 @@
             "keywords": [
                 "rest"
             ],
-            "time": "2020-04-23T17:34:09+00:00"
+            "time": "2020-06-03T06:41:50+00:00"
         },
         {
             "name": "friendsofsymfony/user-bundle",
@@ -3914,28 +4031,27 @@
         },
         {
             "name": "j0k3r/php-readability",
-            "version": "1.2.4",
+            "version": "1.2.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/j0k3r/php-readability.git",
-                "reference": "9306996b472fd3d4bc5a7928a301ccce38423793"
+                "reference": "3fa88461a057158d8b06c6e575909d0aa1e822ef"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/j0k3r/php-readability/zipball/9306996b472fd3d4bc5a7928a301ccce38423793",
-                "reference": "9306996b472fd3d4bc5a7928a301ccce38423793",
+                "url": "https://api.github.com/repos/j0k3r/php-readability/zipball/3fa88461a057158d8b06c6e575909d0aa1e822ef",
+                "reference": "3fa88461a057158d8b06c6e575909d0aa1e822ef",
                 "shasum": ""
             },
             "require": {
-                "electrolinux/php-html5lib": "^0.1.0",
                 "ext-mbstring": "*",
+                "masterminds/html5": "^2.7",
                 "php": ">=5.6.0",
                 "psr/log": "^1.0"
             },
             "require-dev": {
                 "friendsofphp/php-cs-fixer": "^2.14",
-                "monolog/monolog": "^1.24",
-                "php-coveralls/php-coveralls": "^2.1",
+                "monolog/monolog": "^1.24|^2.1",
                 "symfony/phpunit-bridge": "^4.2.3"
             },
             "suggest": {
@@ -3953,17 +4069,6 @@
             ],
             "authors": [
                 {
-                    "name": "Keyvan Minoukadeh",
-                    "email": "keyvan@keyvan.net",
-                    "homepage": "http://keyvan.net",
-                    "role": "Developer (ported original JS code to PHP)"
-                },
-                {
-                    "name": "Arc90",
-                    "homepage": "http://arc90.com",
-                    "role": "Developer (original JS version)"
-                },
-                {
                     "name": "Jeremy Benoist",
                     "email": "jeremy.benoist@gmail.com",
                     "homepage": "http://www.j0k3r.net",
@@ -3973,6 +4078,17 @@
                     "name": "DitherSky",
                     "homepage": "https://github.com/Dither",
                     "role": "Developer (https://github.com/Dither/full-text-rss)"
+                },
+                {
+                    "name": "Keyvan Minoukadeh",
+                    "email": "keyvan@keyvan.net",
+                    "homepage": "http://keyvan.net",
+                    "role": "Developer (ported original JS code to PHP)"
+                },
+                {
+                    "name": "Arc90",
+                    "homepage": "http://arc90.com",
+                    "role": "Developer (original JS version)"
                 }
             ],
             "description": "Automatic article extraction from HTML",
@@ -3984,7 +4100,7 @@
                 "extraction",
                 "html"
             ],
-            "time": "2019-06-25T15:15:37+00:00"
+            "time": "2020-06-08T05:59:42+00:00"
         },
         {
             "name": "javibravo/simpleue",
@@ -4146,33 +4262,36 @@
         },
         {
             "name": "jms/metadata",
-            "version": "1.7.0",
+            "version": "2.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/schmittjoh/metadata.git",
-                "reference": "e5854ab1aa643623dc64adde718a8eec32b957a8"
+                "reference": "6eb35fce7142234946d58d13e1aa829e9b78b095"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/schmittjoh/metadata/zipball/e5854ab1aa643623dc64adde718a8eec32b957a8",
-                "reference": "e5854ab1aa643623dc64adde718a8eec32b957a8",
+                "url": "https://api.github.com/repos/schmittjoh/metadata/zipball/6eb35fce7142234946d58d13e1aa829e9b78b095",
+                "reference": "6eb35fce7142234946d58d13e1aa829e9b78b095",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.0"
+                "php": "^7.2"
             },
             "require-dev": {
-                "doctrine/cache": "~1.0",
-                "symfony/cache": "~3.1"
+                "doctrine/cache": "^1.0",
+                "doctrine/coding-standard": "^4.0",
+                "phpunit/phpunit": "^7.0",
+                "symfony/cache": "^3.1|^4.0|^5.0",
+                "symfony/dependency-injection": "^3.1|^4.0|^5.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.5.x-dev"
+                    "dev-master": "2.x-dev"
                 }
             },
             "autoload": {
-                "psr-0": {
+                "psr-4": {
                     "Metadata\\": "src/"
                 }
             },
@@ -4182,12 +4301,12 @@
             ],
             "authors": [
                 {
-                    "name": "Asmir Mustafic",
-                    "email": "goetas@gmail.com"
-                },
-                {
                     "name": "Johannes M. Schmitt",
                     "email": "schmittjoh@gmail.com"
+                },
+                {
+                    "name": "Asmir Mustafic",
+                    "email": "goetas@gmail.com"
                 }
             ],
             "description": "Class/method/property metadata management in PHP",
@@ -4197,100 +4316,66 @@
                 "xml",
                 "yaml"
             ],
-            "time": "2018-10-26T12:40:10+00:00"
-        },
-        {
-            "name": "jms/parser-lib",
-            "version": "1.0.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/schmittjoh/parser-lib.git",
-                "reference": "c509473bc1b4866415627af0e1c6cc8ac97fa51d"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/schmittjoh/parser-lib/zipball/c509473bc1b4866415627af0e1c6cc8ac97fa51d",
-                "reference": "c509473bc1b4866415627af0e1c6cc8ac97fa51d",
-                "shasum": ""
-            },
-            "require": {
-                "phpoption/phpoption": ">=0.9,<2.0-dev"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.0-dev"
-                }
-            },
-            "autoload": {
-                "psr-0": {
-                    "JMS\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "Apache2"
-            ],
-            "description": "A library for easily creating recursive-descent parsers.",
-            "time": "2012-11-18T18:08:43+00:00"
+            "time": "2020-06-06T16:52:59+00:00"
         },
         {
             "name": "jms/serializer",
-            "version": "1.14.1",
+            "version": "3.7.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/schmittjoh/serializer.git",
-                "reference": "ba908d278fff27ec01fb4349f372634ffcd697c0"
+                "reference": "6ae57ed4a2c028051ead47e57005e4866b1c34b1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/schmittjoh/serializer/zipball/ba908d278fff27ec01fb4349f372634ffcd697c0",
-                "reference": "ba908d278fff27ec01fb4349f372634ffcd697c0",
+                "url": "https://api.github.com/repos/schmittjoh/serializer/zipball/6ae57ed4a2c028051ead47e57005e4866b1c34b1",
+                "reference": "6ae57ed4a2c028051ead47e57005e4866b1c34b1",
                 "shasum": ""
             },
             "require": {
                 "doctrine/annotations": "^1.0",
                 "doctrine/instantiator": "^1.0.3",
-                "jms/metadata": "^1.3",
-                "jms/parser-lib": "1.*",
-                "php": "^5.5|^7.0",
-                "phpcollection/phpcollection": "~0.1",
-                "phpoption/phpoption": "^1.1"
+                "hoa/compiler": "^3.17.08.08",
+                "jms/metadata": "^2.0",
+                "php": "^7.2"
             },
             "conflict": {
-                "twig/twig": "<1.12"
+                "hoa/consistency": "<1.17.05.02",
+                "hoa/core": "*",
+                "hoa/iterator": "<2.16.03.15"
             },
             "require-dev": {
+                "doctrine/coding-standard": "^5.0",
                 "doctrine/orm": "~2.1",
                 "doctrine/phpcr-odm": "^1.3|^2.0",
                 "ext-pdo_sqlite": "*",
                 "jackalope/jackalope-doctrine-dbal": "^1.1.5",
-                "phpunit/phpunit": "^4.8|^5.0",
-                "propel/propel1": "~1.7",
+                "ocramius/proxy-manager": "^1.0|^2.0",
+                "phpunit/phpunit": "^8.0||^9.0",
                 "psr/container": "^1.0",
-                "symfony/dependency-injection": "^2.7|^3.3|^4.0",
-                "symfony/expression-language": "^2.6|^3.0",
-                "symfony/filesystem": "^2.1",
-                "symfony/form": "~2.1|^3.0",
-                "symfony/translation": "^2.1|^3.0",
-                "symfony/validator": "^2.2|^3.0",
-                "symfony/yaml": "^2.1|^3.0",
-                "twig/twig": "~1.12|~2.0"
+                "symfony/dependency-injection": "^3.0|^4.0|^5.0",
+                "symfony/expression-language": "^3.0|^4.0|^5.0",
+                "symfony/filesystem": "^3.0|^4.0|^5.0",
+                "symfony/form": "^3.0|^4.0|^5.0",
+                "symfony/translation": "^3.0|^4.0|^5.0",
+                "symfony/validator": "^3.1.9|^4.0|^5.0",
+                "symfony/yaml": "^3.3|^4.0|^5.0",
+                "twig/twig": "~1.34|~2.4"
             },
             "suggest": {
                 "doctrine/cache": "Required if you like to use cache functionality.",
                 "doctrine/collections": "Required if you like to use doctrine collection types as ArrayCollection.",
-                "symfony/yaml": "Required if you'd like to serialize data to YAML format."
+                "symfony/yaml": "Required if you'd like to use the YAML metadata format."
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-1.x": "1.14-dev"
+                    "dev-master": "3.7-dev"
                 }
             },
             "autoload": {
-                "psr-0": {
-                    "JMS\\Serializer": "src/"
+                "psr-4": {
+                    "JMS\\Serializer\\": "src/"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -4316,47 +4401,53 @@
                 "serialization",
                 "xml"
             ],
-            "time": "2020-02-22T20:59:37+00:00"
+            "funding": [
+                {
+                    "url": "https://github.com/goetas",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-05-23T06:09:27+00:00"
         },
         {
             "name": "jms/serializer-bundle",
-            "version": "2.4.4",
+            "version": "3.6.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/schmittjoh/JMSSerializerBundle.git",
-                "reference": "92ee808c64c1c180775a0e57d00e3be0674668fb"
+                "reference": "9986fff4d6c0ab099af0a7149376651e15c9a763"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/schmittjoh/JMSSerializerBundle/zipball/92ee808c64c1c180775a0e57d00e3be0674668fb",
-                "reference": "92ee808c64c1c180775a0e57d00e3be0674668fb",
+                "url": "https://api.github.com/repos/schmittjoh/JMSSerializerBundle/zipball/9986fff4d6c0ab099af0a7149376651e15c9a763",
+                "reference": "9986fff4d6c0ab099af0a7149376651e15c9a763",
                 "shasum": ""
             },
             "require": {
-                "jms/serializer": "^1.10",
-                "php": "^5.4|^7.0",
-                "phpoption/phpoption": "^1.1.0",
-                "symfony/framework-bundle": "~2.3|~3.0|~4.0"
+                "jms/serializer": "^3.0",
+                "php": "^7.2",
+                "symfony/dependency-injection": "^3.3 || ^4.0 || ^5.0",
+                "symfony/framework-bundle": "^3.0 || ^4.0 || ^5.0"
             },
             "require-dev": {
-                "doctrine/orm": "*",
-                "phpunit/phpunit": "^4.8.35|^5.4.3|^6.0",
-                "symfony/expression-language": "~2.6|~3.0|~4.0",
-                "symfony/finder": "^2.3|^3.0|^4.0",
-                "symfony/form": "*",
-                "symfony/stopwatch": "*",
+                "doctrine/orm": "^2.4",
+                "phpunit/phpunit": "^6.0|^7.0",
+                "symfony/expression-language": "^3.0 || ^4.0 || ^5.0",
+                "symfony/finder": "^3.0 || ^4.0 || ^5.0",
+                "symfony/form": "^3.0 || ^4.0 || ^5.0",
+                "symfony/stopwatch": "^3.0 || ^4.0 || ^5.0",
                 "symfony/twig-bundle": "*",
-                "symfony/validator": "*",
-                "symfony/yaml": "*"
+                "symfony/validator": "^3.0 || ^4.0 || ^5.0",
+                "symfony/yaml": "^3.0 || ^4.0 || ^5.0"
             },
             "suggest": {
-                "jms/di-extra-bundle": "Required to get lazy loading (de)serialization visitors, ~1.3",
-                "symfony/finder": "Required for cache warmup, supported versions ^2.3|^3.0|^4.0"
+                "jms/di-extra-bundle": "Required to get lazy loading (de)serialization visitors, ^1.3",
+                "symfony/finder": "Required for cache warmup, supported versions ^3.0|^4.0"
             },
             "type": "symfony-bundle",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.4-dev"
+                    "dev-master": "3.6-dev"
                 }
             },
             "autoload": {
@@ -4373,24 +4464,29 @@
             ],
             "authors": [
                 {
-                    "name": "Asmir Mustafic",
-                    "email": "goetas@gmail.com"
-                },
-                {
                     "name": "Johannes M. Schmitt",
                     "email": "schmittjoh@gmail.com"
+                },
+                {
+                    "name": "Asmir Mustafic",
+                    "email": "goetas@gmail.com"
                 }
             ],
             "description": "Allows you to easily serialize, and deserialize data of any complexity",
             "homepage": "http://jmsyst.com/bundles/JMSSerializerBundle",
             "keywords": [
                 "deserialization",
-                "jaxb",
                 "json",
                 "serialization",
                 "xml"
             ],
-            "time": "2019-03-30T10:26:09+00:00"
+            "funding": [
+                {
+                    "url": "https://github.com/goetas",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-05-23T06:13:14+00:00"
         },
         {
             "name": "kphoen/rulerz",
@@ -4722,6 +4818,12 @@
                 "psr",
                 "psr-7"
             ],
+            "funding": [
+                {
+                    "url": "https://funding.communitybridge.org/projects/laminas-project",
+                    "type": "community_bridge"
+                }
+            ],
             "time": "2020-04-27T17:07:01+00:00"
         },
         {
@@ -4832,6 +4934,12 @@
                 "laminas",
                 "zf"
             ],
+            "funding": [
+                {
+                    "url": "https://funding.communitybridge.org/projects/laminas-project",
+                    "type": "community_bridge"
+                }
+            ],
             "time": "2020-05-20T16:45:56+00:00"
         },
         {
@@ -4886,6 +4994,16 @@
             "keywords": [
                 "JWS",
                 "jwt"
+            ],
+            "funding": [
+                {
+                    "url": "https://github.com/lcobucci",
+                    "type": "github"
+                },
+                {
+                    "url": "https://www.patreon.com/lcobucci",
+                    "type": "patreon"
+                }
             ],
             "time": "2020-05-22T08:21:12+00:00"
         },
@@ -5017,16 +5135,16 @@
         },
         {
             "name": "masterminds/html5",
-            "version": "2.7.0",
+            "version": "2.7.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Masterminds/html5-php.git",
-                "reference": "104443ad663d15981225f99532ba73c2f1d6b6f2"
+                "reference": "a3edfe52f9e7380e498d33157e1330e85386645d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Masterminds/html5-php/zipball/104443ad663d15981225f99532ba73c2f1d6b6f2",
-                "reference": "104443ad663d15981225f99532ba73c2f1d6b6f2",
+                "url": "https://api.github.com/repos/Masterminds/html5-php/zipball/a3edfe52f9e7380e498d33157e1330e85386645d",
+                "reference": "a3edfe52f9e7380e498d33157e1330e85386645d",
                 "shasum": ""
             },
             "require": {
@@ -5080,7 +5198,7 @@
                 "serializer",
                 "xml"
             ],
-            "time": "2019-07-25T07:03:26+00:00"
+            "time": "2020-02-06T11:39:04+00:00"
         },
         {
             "name": "mgargano/simplehtmldom",
@@ -5287,6 +5405,16 @@
                 "logging",
                 "psr-3"
             ],
+            "funding": [
+                {
+                    "url": "https://github.com/Seldaek",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/monolog/monolog",
+                    "type": "tidelift"
+                }
+            ],
             "time": "2020-05-22T07:31:27+00:00"
         },
         {
@@ -5434,33 +5562,34 @@
         },
         {
             "name": "ocramius/proxy-manager",
-            "version": "2.1.1",
+            "version": "2.2.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Ocramius/ProxyManager.git",
-                "reference": "e18ac876b2e4819c76349de8f78ccc8ef1554cd7"
+                "reference": "4d154742e31c35137d5374c998e8f86b54db2e2f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Ocramius/ProxyManager/zipball/e18ac876b2e4819c76349de8f78ccc8ef1554cd7",
-                "reference": "e18ac876b2e4819c76349de8f78ccc8ef1554cd7",
+                "url": "https://api.github.com/repos/Ocramius/ProxyManager/zipball/4d154742e31c35137d5374c998e8f86b54db2e2f",
+                "reference": "4d154742e31c35137d5374c998e8f86b54db2e2f",
                 "shasum": ""
             },
             "require": {
-                "ocramius/package-versions": "^1.1.1",
-                "php": "^7.1.0",
-                "zendframework/zend-code": "^3.1.0"
+                "ocramius/package-versions": "^1.1.3",
+                "php": "^7.2.0",
+                "zendframework/zend-code": "^3.3.0"
             },
             "require-dev": {
-                "couscous/couscous": "^1.5.2",
+                "couscous/couscous": "^1.6.1",
                 "ext-phar": "*",
-                "humbug/humbug": "dev-master@DEV",
-                "nikic/php-parser": "^3.0.4",
+                "humbug/humbug": "1.0.0-RC.0@RC",
+                "nikic/php-parser": "^3.1.1",
+                "padraic/phpunit-accelerator": "dev-master@DEV",
                 "phpbench/phpbench": "^0.12.2",
-                "phpstan/phpstan": "^0.6.4",
-                "phpunit/phpunit": "^5.6.4",
-                "phpunit/phpunit-mock-objects": "^3.4.1",
-                "squizlabs/php_codesniffer": "^2.7.0"
+                "phpstan/phpstan": "dev-master#856eb10a81c1d27c701a83f167dc870fd8f4236a as 0.9.999",
+                "phpstan/phpstan-phpunit": "dev-master#5629c0a1f4a9c417cb1077cf6693ad9753895761",
+                "phpunit/phpunit": "^6.4.3",
+                "squizlabs/php_codesniffer": "^2.9.1"
             },
             "suggest": {
                 "ocramius/generated-hydrator": "To have very fast object to array to object conversion for ghost objects",
@@ -5499,67 +5628,63 @@
                 "proxy pattern",
                 "service proxies"
             ],
-            "time": "2017-05-04T11:12:50+00:00"
+            "time": "2019-08-10T08:37:15+00:00"
         },
         {
             "name": "pagerfanta/pagerfanta",
-            "version": "v2.1.3",
+            "version": "v2.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/BabDev/Pagerfanta.git",
-                "reference": "a53ff01d521648d9dbca19b93ac6bc75a59b0972"
+                "reference": "fd00eb74632fecc0265327e9fe0eddc08c72b238"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/BabDev/Pagerfanta/zipball/a53ff01d521648d9dbca19b93ac6bc75a59b0972",
-                "reference": "a53ff01d521648d9dbca19b93ac6bc75a59b0972",
+                "url": "https://api.github.com/repos/BabDev/Pagerfanta/zipball/fd00eb74632fecc0265327e9fe0eddc08c72b238",
+                "reference": "fd00eb74632fecc0265327e9fe0eddc08c72b238",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.0"
+                "ext-json": "*",
+                "php": "^7.2",
+                "symfony/deprecation-contracts": "^2.1"
             },
             "require-dev": {
-                "doctrine/orm": "~2.3",
-                "doctrine/phpcr-odm": "1.*",
-                "jackalope/jackalope-doctrine-dbal": "1.*",
-                "jmikola/geojson": "~1.0",
-                "mandango/mandango": "~1.0@dev",
-                "mandango/mondator": "~1.0@dev",
-                "phpunit/phpunit": "^6.5",
-                "propel/propel": "~2.0@dev",
-                "propel/propel1": "~1.6",
-                "ruflin/elastica": "~1.3",
-                "solarium/solarium": "~3.1"
+                "doctrine/collections": "^1.4",
+                "doctrine/dbal": "^2.5",
+                "doctrine/orm": "^2.5",
+                "doctrine/phpcr-odm": "^1.3",
+                "friendsofphp/php-cs-fixer": "^2.16.3",
+                "jackalope/jackalope-doctrine-dbal": "^1.3",
+                "mandango/mandango": "^1.0@dev",
+                "phpunit/phpunit": "^8.5 || ^9.0",
+                "propel/propel": "^2.0@dev",
+                "propel/propel1": "^1.7",
+                "ruflin/elastica": "^1.3 || ^2.0 || ^3.0 || ^5.0 || ^6.0",
+                "solarium/solarium": "^2.3 || ^3.0 || ^4.0 || ^5.0"
             },
             "suggest": {
-                "doctrine/mongodb-odm": "To use the DoctrineODMMongoDBAdapter.",
-                "doctrine/orm": "To use the DoctrineORMAdapter.",
-                "doctrine/phpcr-odm": "To use the DoctrineODMPhpcrAdapter. >= 1.1.0",
-                "mandango/mandango": "To use the MandangoAdapter.",
-                "propel/propel": "To use the Propel2Adapter",
-                "propel/propel1": "To use the PropelAdapter",
+                "doctrine/collections": "To use the Doctrine Collection and Selectable adapter.",
+                "doctrine/dbal": "To use the Doctrine DBAL adapters.",
+                "doctrine/mongodb-odm": "To use the Doctrine MongoDB ODM Adapter.",
+                "doctrine/orm": "To use the Doctrine ORM Adapter.",
+                "doctrine/phpcr-odm": "To use the Doctrine PHPCR ODM Adapter.",
                 "solarium/solarium": "To use the SolariumAdapter."
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0.x-dev"
+                    "dev-2.x": "2.x-dev"
                 }
             },
             "autoload": {
                 "psr-4": {
-                    "Pagerfanta\\": "src/Pagerfanta/"
+                    "Pagerfanta\\": "src/"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
                 "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Pablo Díez",
-                    "email": "pablodip@gmail.com"
-                }
             ],
             "description": "Pagination for PHP",
             "keywords": [
@@ -5568,7 +5693,13 @@
                 "paginator",
                 "paging"
             ],
-            "time": "2019-07-17T20:56:16+00:00"
+            "funding": [
+                {
+                    "url": "https://github.com/mbabker",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-06-09T15:25:12+00:00"
         },
         {
             "name": "paragonie/constant_time_encoding",
@@ -5962,16 +6093,16 @@
         },
         {
             "name": "php-http/discovery",
-            "version": "1.7.4",
+            "version": "1.8.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-http/discovery.git",
-                "reference": "82dbef649ccffd8e4f22e1953c3a5265992b83c0"
+                "reference": "10d9019f393773345aedc0dc79e7fd678da874ee"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-http/discovery/zipball/82dbef649ccffd8e4f22e1953c3a5265992b83c0",
-                "reference": "82dbef649ccffd8e4f22e1953c3a5265992b83c0",
+                "url": "https://api.github.com/repos/php-http/discovery/zipball/10d9019f393773345aedc0dc79e7fd678da874ee",
+                "reference": "10d9019f393773345aedc0dc79e7fd678da874ee",
                 "shasum": ""
             },
             "require": {
@@ -6023,7 +6154,7 @@
                 "message",
                 "psr7"
             ],
-            "time": "2020-01-03T11:25:47+00:00"
+            "time": "2020-06-14T10:44:12+00:00"
         },
         {
             "name": "php-http/guzzle5-adapter",
@@ -6147,20 +6278,20 @@
         },
         {
             "name": "php-http/httplug-bundle",
-            "version": "1.16.0",
+            "version": "1.18.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-http/HttplugBundle.git",
-                "reference": "5044b655fcd3a43243383cd692a6bb6cd18af24f"
+                "reference": "027dff799d50f32cb312f383eb631a035d820db2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-http/HttplugBundle/zipball/5044b655fcd3a43243383cd692a6bb6cd18af24f",
-                "reference": "5044b655fcd3a43243383cd692a6bb6cd18af24f",
+                "url": "https://api.github.com/repos/php-http/HttplugBundle/zipball/027dff799d50f32cb312f383eb631a035d820db2",
+                "reference": "027dff799d50f32cb312f383eb631a035d820db2",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.1",
+                "php": "^7.2",
                 "php-http/client-common": "^1.9 || ^2.0",
                 "php-http/client-implementation": "^1.0",
                 "php-http/discovery": "^1.0",
@@ -6170,35 +6301,35 @@
                 "php-http/message-factory": "^1.0.2",
                 "php-http/stopwatch-plugin": "^1.2",
                 "psr/http-message": "^1.0",
-                "symfony/config": "^3.4.20 || ^4.2.1",
-                "symfony/dependency-injection": "^3.4.20 || ^4.2.1",
-                "symfony/event-dispatcher": "^3.4.20 || ^4.2.1",
-                "symfony/http-kernel": "^3.4.20 || ^4.2.1",
-                "symfony/options-resolver": "^3.4.20 || ^4.2.1"
+                "symfony/config": "^3.4.34 || ^4.2.12 || ^5.0",
+                "symfony/dependency-injection": "^3.4.34 || ^4.2.12 || ^5.0",
+                "symfony/event-dispatcher": "^3.4.34 || ^4.2.12 || ^5.0",
+                "symfony/http-kernel": "^3.4.34 || ^4.2.12 || ^5.0",
+                "symfony/options-resolver": "^3.4.34 || ^4.2.12 || ^5.0"
             },
             "conflict": {
                 "php-http/curl-client": "<2.0",
                 "php-http/guzzle6-adapter": "<1.1"
             },
             "require-dev": {
-                "guzzlehttp/psr7": "^1.0",
-                "matthiasnoback/symfony-dependency-injection-test": "^3.0",
+                "matthiasnoback/symfony-dependency-injection-test": "^4.0",
                 "nyholm/nsa": "^1.1",
-                "php-http/cache-plugin": "^1.6",
+                "nyholm/psr7": "^1.2.1",
+                "php-http/cache-plugin": "^1.7",
                 "php-http/guzzle6-adapter": "^1.1.1 || ^2.0.1",
                 "php-http/mock-client": "^1.2",
                 "php-http/promise": "^1.0",
                 "polishsymfonycommunity/symfony-mocker-container": "^1.0",
-                "symfony/browser-kit": "^3.4.20 || ^4.2.1",
-                "symfony/cache": "^3.4.20 || ^4.2.1",
-                "symfony/dom-crawler": "^3.4.20 || ^4.2.1",
-                "symfony/framework-bundle": "^3.4.0 || ^4.2",
-                "symfony/http-foundation": "^3.4.20 || ^4.2.1",
-                "symfony/phpunit-bridge": "^3.4 || ^4.2",
-                "symfony/stopwatch": "^3.4.20 || ^4.2.1",
-                "symfony/twig-bundle": "^3.4.20 || ^4.2.1",
-                "symfony/web-profiler-bundle": "^3.4.20 || ^4.2.1",
-                "twig/twig": "^1.36 || ^2.6"
+                "symfony/browser-kit": "^3.4.34 || ^4.2.12 || ^5.0",
+                "symfony/cache": "^3.4.35 || ~4.2.12 || ^4.3.8 || ^5.0",
+                "symfony/dom-crawler": "^3.4.34 || ^4.2.12 || ^5.0",
+                "symfony/framework-bundle": "^3.4.34 || ^4.2.12 || ^5.0",
+                "symfony/http-foundation": "^3.4.35 || ~4.2.12 || ^4.3.8 || ^5.0",
+                "symfony/phpunit-bridge": "^3.4.34 || ^4.2.12 || ^5.0",
+                "symfony/stopwatch": "^3.4.34 || ^4.2.12 || ^5.0",
+                "symfony/twig-bundle": "^3.4.34 || ^4.2.12 || ^5.0",
+                "symfony/web-profiler-bundle": "^3.4.34 || ^4.2.12 || ^5.0",
+                "twig/twig": "^1.41 || ^2.10 || ^3.0"
             },
             "suggest": {
                 "php-http/cache-plugin": "To configure clients that cache responses",
@@ -6245,7 +6376,7 @@
                 "message",
                 "php-http"
             ],
-            "time": "2019-06-05T12:03:16+00:00"
+            "time": "2020-03-30T07:21:02+00:00"
         },
         {
             "name": "php-http/logger-plugin",
@@ -6528,109 +6659,6 @@
             "time": "2019-11-18T08:10:48+00:00"
         },
         {
-            "name": "phpcollection/phpcollection",
-            "version": "0.5.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/schmittjoh/php-collection.git",
-                "reference": "f2bcff45c0da7c27991bbc1f90f47c4b7fb434a6"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/schmittjoh/php-collection/zipball/f2bcff45c0da7c27991bbc1f90f47c4b7fb434a6",
-                "reference": "f2bcff45c0da7c27991bbc1f90f47c4b7fb434a6",
-                "shasum": ""
-            },
-            "require": {
-                "phpoption/phpoption": "1.*"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "0.4-dev"
-                }
-            },
-            "autoload": {
-                "psr-0": {
-                    "PhpCollection": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "Apache2"
-            ],
-            "authors": [
-                {
-                    "name": "Johannes M. Schmitt",
-                    "email": "schmittjoh@gmail.com"
-                }
-            ],
-            "description": "General-Purpose Collection Library for PHP",
-            "keywords": [
-                "collection",
-                "list",
-                "map",
-                "sequence",
-                "set"
-            ],
-            "time": "2015-05-17T12:39:23+00:00"
-        },
-        {
-            "name": "phpoption/phpoption",
-            "version": "1.7.3",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/schmittjoh/php-option.git",
-                "reference": "4acfd6a4b33a509d8c88f50e5222f734b6aeebae"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/schmittjoh/php-option/zipball/4acfd6a4b33a509d8c88f50e5222f734b6aeebae",
-                "reference": "4acfd6a4b33a509d8c88f50e5222f734b6aeebae",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^5.5.9 || ^7.0 || ^8.0"
-            },
-            "require-dev": {
-                "bamarni/composer-bin-plugin": "^1.3",
-                "phpunit/phpunit": "^4.8.35 || ^5.0 || ^6.0 || ^7.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.7-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "PhpOption\\": "src/PhpOption/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "Apache-2.0"
-            ],
-            "authors": [
-                {
-                    "name": "Johannes M. Schmitt",
-                    "email": "schmittjoh@gmail.com"
-                },
-                {
-                    "name": "Graham Campbell",
-                    "email": "graham@alt-three.com"
-                }
-            ],
-            "description": "Option Type for PHP",
-            "keywords": [
-                "language",
-                "option",
-                "php",
-                "type"
-            ],
-            "time": "2020-03-21T18:07:53+00:00"
-        },
-        {
             "name": "phpseclib/phpseclib",
             "version": "2.0.27",
             "source": {
@@ -6719,6 +6747,20 @@
                 "twofish",
                 "x.509",
                 "x509"
+            ],
+            "funding": [
+                {
+                    "url": "https://github.com/terrafrost",
+                    "type": "github"
+                },
+                {
+                    "url": "https://www.patreon.com/phpseclib",
+                    "type": "patreon"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/phpseclib/phpseclib",
+                    "type": "tidelift"
+                }
             ],
             "time": "2020-04-04T23:17:33+00:00"
         },
@@ -7796,6 +7838,16 @@
                 "logging",
                 "sentry"
             ],
+            "funding": [
+                {
+                    "url": "https://sentry.io/",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://sentry.io/pricing/",
+                    "type": "custom"
+                }
+            ],
             "time": "2020-05-20T20:49:38+00:00"
         },
         {
@@ -7995,31 +8047,41 @@
         },
         {
             "name": "spomky-labs/otphp",
-            "version": "v9.1.4",
+            "version": "v10.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Spomky-Labs/otphp.git",
-                "reference": "48d463cf909320399fe08eab2e1cd18d899d5068"
+                "reference": "f44cce5a9db4b8da410215d992110482c931232f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Spomky-Labs/otphp/zipball/48d463cf909320399fe08eab2e1cd18d899d5068",
-                "reference": "48d463cf909320399fe08eab2e1cd18d899d5068",
+                "url": "https://api.github.com/repos/Spomky-Labs/otphp/zipball/f44cce5a9db4b8da410215d992110482c931232f",
+                "reference": "f44cce5a9db4b8da410215d992110482c931232f",
                 "shasum": ""
             },
             "require": {
-                "beberlei/assert": "^2.4|^3.0",
+                "beberlei/assert": "^3.0",
+                "ext-mbstring": "*",
                 "paragonie/constant_time_encoding": "^2.0",
-                "php": "^7.1"
+                "php": "^7.2|^8.0",
+                "thecodingmachine/safe": "^0.1.14|^1.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^6.0",
-                "satooshi/php-coveralls": "^1.0"
+                "php-coveralls/php-coveralls": "^2.0",
+                "phpstan/phpstan": "^0.12",
+                "phpstan/phpstan-beberlei-assert": "^0.12",
+                "phpstan/phpstan-deprecation-rules": "^0.12",
+                "phpstan/phpstan-phpunit": "^0.12",
+                "phpstan/phpstan-strict-rules": "^0.12",
+                "phpunit/phpunit": "^8.0",
+                "thecodingmachine/phpstan-safe-rule": "^1.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "9.0.x-dev"
+                    "v10.0": "10.0.x-dev",
+                    "v9.0": "9.0.x-dev",
+                    "v8.3": "8.3.x-dev"
                 }
             },
             "autoload": {
@@ -8052,7 +8114,7 @@
                 "otp",
                 "totp"
             ],
-            "time": "2019-03-18T10:08:51+00:00"
+            "time": "2020-01-28T09:24:19+00:00"
         },
         {
             "name": "stof/doctrine-extensions-bundle",
@@ -8182,24 +8244,85 @@
             "time": "2019-11-12T09:31:26+00:00"
         },
         {
-            "name": "symfony/http-client",
-            "version": "v4.4.8",
+            "name": "symfony/deprecation-contracts",
+            "version": "v2.1.2",
             "source": {
                 "type": "git",
-                "url": "https://github.com/symfony/http-client.git",
-                "reference": "88d1745f4095727b8bf0574a0f414331f4ec229c"
+                "url": "https://github.com/symfony/deprecation-contracts.git",
+                "reference": "dd99cb3a0aff6cadd2a8d7d7ed72c2161e218337"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/http-client/zipball/88d1745f4095727b8bf0574a0f414331f4ec229c",
-                "reference": "88d1745f4095727b8bf0574a0f414331f4ec229c",
+                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/dd99cb3a0aff6cadd2a8d7d7ed72c2161e218337",
+                "reference": "dd99cb3a0aff6cadd2a8d7d7ed72c2161e218337",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.1.3",
+                "php": ">=7.1"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.1-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "function.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "A generic function and convention to trigger deprecation notices",
+            "homepage": "https://symfony.com",
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-05-27T08:34:37+00:00"
+        },
+        {
+            "name": "symfony/http-client",
+            "version": "v5.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/http-client.git",
+                "reference": "aae28b613d7a88e529df46e617f046be0236ab54"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/http-client/zipball/aae28b613d7a88e529df46e617f046be0236ab54",
+                "reference": "aae28b613d7a88e529df46e617f046be0236ab54",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2.5",
                 "psr/log": "^1.0",
-                "symfony/http-client-contracts": "^1.1.8|^2",
+                "symfony/http-client-contracts": "^2.1.1",
                 "symfony/polyfill-php73": "^1.11",
+                "symfony/polyfill-php80": "^1.15",
                 "symfony/service-contracts": "^1.0|^2"
             },
             "provide": {
@@ -8209,18 +8332,21 @@
                 "symfony/http-client-implementation": "1.1"
             },
             "require-dev": {
+                "amphp/http-client": "^4.2.1",
+                "amphp/http-tunnel": "^1.0",
+                "amphp/socket": "^1.1",
                 "guzzlehttp/promises": "^1.3.1",
                 "nyholm/psr7": "^1.0",
                 "php-http/httplug": "^1.0|^2.0",
                 "psr/http-client": "^1.0",
-                "symfony/dependency-injection": "^4.3|^5.0",
-                "symfony/http-kernel": "^4.4",
-                "symfony/process": "^4.2|^5.0"
+                "symfony/dependency-injection": "^4.4|^5.0",
+                "symfony/http-kernel": "^4.4|^5.0",
+                "symfony/process": "^4.4|^5.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.4-dev"
+                    "dev-master": "5.1-dev"
                 }
             },
             "autoload": {
@@ -8247,24 +8373,38 @@
             ],
             "description": "Symfony HttpClient component",
             "homepage": "https://symfony.com",
-            "time": "2020-04-12T16:14:02+00:00"
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-06-11T21:20:02+00:00"
         },
         {
             "name": "symfony/http-client-contracts",
-            "version": "v1.1.8",
+            "version": "v2.1.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/http-client-contracts.git",
-                "reference": "088bae75cfa2ec5eb6d33dce17dbd8613150ce6e"
+                "reference": "f8bed25edc964d015bcd87f1fec5734963931910"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/http-client-contracts/zipball/088bae75cfa2ec5eb6d33dce17dbd8613150ce6e",
-                "reference": "088bae75cfa2ec5eb6d33dce17dbd8613150ce6e",
+                "url": "https://api.github.com/repos/symfony/http-client-contracts/zipball/f8bed25edc964d015bcd87f1fec5734963931910",
+                "reference": "f8bed25edc964d015bcd87f1fec5734963931910",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.1.3"
+                "php": ">=7.2.5"
             },
             "suggest": {
                 "symfony/http-client-implementation": ""
@@ -8272,7 +8412,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.1-dev"
+                    "dev-master": "2.1-dev"
                 }
             },
             "autoload": {
@@ -8304,38 +8444,53 @@
                 "interoperability",
                 "standards"
             ],
-            "time": "2019-11-07T12:44:51+00:00"
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-05-25T17:37:45+00:00"
         },
         {
             "name": "symfony/mime",
-            "version": "v4.4.8",
+            "version": "v5.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/mime.git",
-                "reference": "7a583ffb6c7dd5aabb5db920817a3cc39261c517"
+                "reference": "c0c418f05e727606e85b482a8591519c4712cf45"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/mime/zipball/7a583ffb6c7dd5aabb5db920817a3cc39261c517",
-                "reference": "7a583ffb6c7dd5aabb5db920817a3cc39261c517",
+                "url": "https://api.github.com/repos/symfony/mime/zipball/c0c418f05e727606e85b482a8591519c4712cf45",
+                "reference": "c0c418f05e727606e85b482a8591519c4712cf45",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.1.3",
+                "php": ">=7.2.5",
                 "symfony/polyfill-intl-idn": "^1.10",
-                "symfony/polyfill-mbstring": "^1.0"
+                "symfony/polyfill-mbstring": "^1.0",
+                "symfony/polyfill-php80": "^1.15"
             },
             "conflict": {
                 "symfony/mailer": "<4.4"
             },
             "require-dev": {
                 "egulias/email-validator": "^2.1.10",
-                "symfony/dependency-injection": "^3.4|^4.1|^5.0"
+                "symfony/dependency-injection": "^4.4|^5.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.4-dev"
+                    "dev-master": "5.1-dev"
                 }
             },
             "autoload": {
@@ -8366,7 +8521,21 @@
                 "mime",
                 "mime-type"
             ],
-            "time": "2020-04-16T14:49:30+00:00"
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-06-09T15:07:35+00:00"
         },
         {
             "name": "symfony/monolog-bundle",
@@ -8485,6 +8654,20 @@
                 "portable",
                 "shim"
             ],
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
             "time": "2020-05-12T16:14:59+00:00"
         },
         {
@@ -8542,6 +8725,20 @@
                 "ctype",
                 "polyfill",
                 "portable"
+            ],
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
             ],
             "time": "2020-05-12T16:14:59+00:00"
         },
@@ -8602,6 +8799,20 @@
                 "portable",
                 "shim"
             ],
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
             "time": "2020-05-12T16:47:27+00:00"
         },
         {
@@ -8659,6 +8870,20 @@
                 "polyfill",
                 "portable",
                 "shim"
+            ],
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
             ],
             "time": "2020-05-12T16:14:59+00:00"
         },
@@ -8722,6 +8947,20 @@
                 "portable",
                 "shim"
             ],
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
             "time": "2020-05-12T16:47:27+00:00"
         },
         {
@@ -8781,6 +9020,20 @@
                 "portable",
                 "shim"
             ],
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
             "time": "2020-05-12T16:47:27+00:00"
         },
         {
@@ -8836,6 +9089,20 @@
                 "polyfill",
                 "portable",
                 "shim"
+            ],
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
             ],
             "time": "2020-05-12T16:47:27+00:00"
         },
@@ -8896,6 +9163,20 @@
                 "portable",
                 "shim"
             ],
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
             "time": "2020-05-12T16:47:27+00:00"
         },
         {
@@ -8950,6 +9231,20 @@
                 "polyfill",
                 "portable",
                 "shim"
+            ],
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
             ],
             "time": "2020-05-12T16:47:27+00:00"
         },
@@ -9009,6 +9304,96 @@
                 "portable",
                 "shim"
             ],
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-05-12T16:47:27+00:00"
+        },
+        {
+            "name": "symfony/polyfill-php80",
+            "version": "v1.17.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-php80.git",
+                "reference": "5e30b2799bc1ad68f7feb62b60a73743589438dd"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-php80/zipball/5e30b2799bc1ad68f7feb62b60a73743589438dd",
+                "reference": "5e30b2799bc1ad68f7feb62b60a73743589438dd",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.0.8"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.17-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Polyfill\\Php80\\": ""
+                },
+                "files": [
+                    "bootstrap.php"
+                ],
+                "classmap": [
+                    "Resources/stubs"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Ion Bazan",
+                    "email": "ion.bazan@gmail.com"
+                },
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill backporting some PHP 8.0+ features to lower PHP versions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
             "time": "2020-05-12T16:47:27+00:00"
         },
         {
@@ -9060,6 +9445,20 @@
                 "compatibility",
                 "polyfill",
                 "shim"
+            ],
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
             ],
             "time": "2020-05-12T16:14:59+00:00"
         },
@@ -9120,24 +9519,38 @@
                 "portable",
                 "uuid"
             ],
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
             "time": "2020-05-12T16:47:27+00:00"
         },
         {
             "name": "symfony/service-contracts",
-            "version": "v1.1.8",
+            "version": "v2.1.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/service-contracts.git",
-                "reference": "ffc7f5692092df31515df2a5ecf3b7302b3ddacf"
+                "reference": "66a8f0957a3ca54e4f724e49028ab19d75a8918b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/service-contracts/zipball/ffc7f5692092df31515df2a5ecf3b7302b3ddacf",
-                "reference": "ffc7f5692092df31515df2a5ecf3b7302b3ddacf",
+                "url": "https://api.github.com/repos/symfony/service-contracts/zipball/66a8f0957a3ca54e4f724e49028ab19d75a8918b",
+                "reference": "66a8f0957a3ca54e4f724e49028ab19d75a8918b",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.1.3",
+                "php": ">=7.2.5",
                 "psr/container": "^1.0"
             },
             "suggest": {
@@ -9146,7 +9559,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.1-dev"
+                    "dev-master": "2.1-dev"
                 }
             },
             "autoload": {
@@ -9178,7 +9591,21 @@
                 "interoperability",
                 "standards"
             ],
-            "time": "2019-10-14T12:27:06+00:00"
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-05-20T17:43:50+00:00"
         },
         {
             "name": "symfony/swiftmailer-bundle",
@@ -9464,6 +9891,139 @@
             "time": "2020-02-14T14:20:12+00:00"
         },
         {
+            "name": "thecodingmachine/safe",
+            "version": "v1.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/thecodingmachine/safe.git",
+                "reference": "04f9ffae372a9816d4472dfb7bcf6126b623a9df"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/thecodingmachine/safe/zipball/04f9ffae372a9816d4472dfb7bcf6126b623a9df",
+                "reference": "04f9ffae372a9816d4472dfb7bcf6126b623a9df",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2"
+            },
+            "require-dev": {
+                "phpstan/phpstan": "^0.12",
+                "squizlabs/php_codesniffer": "^3.2",
+                "thecodingmachine/phpstan-strict-rules": "^0.12"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "0.1-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Safe\\": [
+                        "lib/",
+                        "generated/"
+                    ]
+                },
+                "files": [
+                    "generated/apache.php",
+                    "generated/apc.php",
+                    "generated/apcu.php",
+                    "generated/array.php",
+                    "generated/bzip2.php",
+                    "generated/classobj.php",
+                    "generated/com.php",
+                    "generated/cubrid.php",
+                    "generated/curl.php",
+                    "generated/datetime.php",
+                    "generated/dir.php",
+                    "generated/eio.php",
+                    "generated/errorfunc.php",
+                    "generated/exec.php",
+                    "generated/fileinfo.php",
+                    "generated/filesystem.php",
+                    "generated/filter.php",
+                    "generated/fpm.php",
+                    "generated/ftp.php",
+                    "generated/funchand.php",
+                    "generated/gmp.php",
+                    "generated/gnupg.php",
+                    "generated/hash.php",
+                    "generated/ibase.php",
+                    "generated/ibmDb2.php",
+                    "generated/iconv.php",
+                    "generated/image.php",
+                    "generated/imap.php",
+                    "generated/info.php",
+                    "generated/ingres-ii.php",
+                    "generated/inotify.php",
+                    "generated/json.php",
+                    "generated/ldap.php",
+                    "generated/libevent.php",
+                    "generated/libxml.php",
+                    "generated/lzf.php",
+                    "generated/mailparse.php",
+                    "generated/mbstring.php",
+                    "generated/misc.php",
+                    "generated/msql.php",
+                    "generated/mssql.php",
+                    "generated/mysql.php",
+                    "generated/mysqli.php",
+                    "generated/mysqlndMs.php",
+                    "generated/mysqlndQc.php",
+                    "generated/network.php",
+                    "generated/oci8.php",
+                    "generated/opcache.php",
+                    "generated/openssl.php",
+                    "generated/outcontrol.php",
+                    "generated/password.php",
+                    "generated/pcntl.php",
+                    "generated/pcre.php",
+                    "generated/pdf.php",
+                    "generated/pgsql.php",
+                    "generated/posix.php",
+                    "generated/ps.php",
+                    "generated/pspell.php",
+                    "generated/readline.php",
+                    "generated/rpminfo.php",
+                    "generated/rrd.php",
+                    "generated/sem.php",
+                    "generated/session.php",
+                    "generated/shmop.php",
+                    "generated/simplexml.php",
+                    "generated/sockets.php",
+                    "generated/sodium.php",
+                    "generated/solr.php",
+                    "generated/spl.php",
+                    "generated/sqlsrv.php",
+                    "generated/ssdeep.php",
+                    "generated/ssh2.php",
+                    "generated/stats.php",
+                    "generated/stream.php",
+                    "generated/strings.php",
+                    "generated/swoole.php",
+                    "generated/uodbc.php",
+                    "generated/uopz.php",
+                    "generated/url.php",
+                    "generated/var.php",
+                    "generated/xdiff.php",
+                    "generated/xml.php",
+                    "generated/xmlrpc.php",
+                    "generated/yaml.php",
+                    "generated/yaz.php",
+                    "generated/zip.php",
+                    "generated/zlib.php",
+                    "lib/special_cases.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "PHP core functions that throw exceptions instead of returning FALSE on error",
+            "time": "2020-05-04T15:25:36+00:00"
+        },
+        {
             "name": "true/punycode",
             "version": "v2.1.1",
             "source": {
@@ -9740,97 +10300,34 @@
             "time": "2020-03-22T16:24:31+00:00"
         },
         {
-            "name": "white-october/pagerfanta-bundle",
-            "version": "v1.3.2",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/whiteoctober/WhiteOctoberPagerfantaBundle.git",
-                "reference": "6df560869b5e09a3acf920890ab40598998b30ae"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/whiteoctober/WhiteOctoberPagerfantaBundle/zipball/6df560869b5e09a3acf920890ab40598998b30ae",
-                "reference": "6df560869b5e09a3acf920890ab40598998b30ae",
-                "shasum": ""
-            },
-            "require": {
-                "pagerfanta/pagerfanta": "^1.1.0|^2.0.0",
-                "php": ">=5.3.3",
-                "symfony/framework-bundle": "~2.3|~3.0|~4.0",
-                "symfony/property-access": "~2.3|~3.0|~4.0",
-                "symfony/translation": "~2.3|~3.0|~4.0",
-                "symfony/twig-bundle": "~2.3|~3.0|~4.0"
-            },
-            "conflict": {
-                "twig/twig": "<1.34|>=2.0,<2.4"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "~3.7|~4.0|^5.0",
-                "symfony/symfony": "~2.3|~3.0|~4.0"
-            },
-            "type": "symfony-bundle",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.0.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "WhiteOctober\\PagerfantaBundle\\": ""
-                },
-                "exclude-from-classmap": [
-                    "Tests/",
-                    "TestsProject/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Pablo Díez",
-                    "email": "pablodip@gmail.com"
-                }
-            ],
-            "description": "Bundle to use Pagerfanta with Symfony2",
-            "keywords": [
-                "page",
-                "paging"
-            ],
-            "abandoned": "babdev/pagerfanta-bundle",
-            "time": "2019-12-02T14:19:37+00:00"
-        },
-        {
             "name": "willdurand/hateoas",
-            "version": "2.12.0",
+            "version": "3.6.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/willdurand/Hateoas.git",
-                "reference": "71b1af62b398dc9a870ac0b16c84bdc23a76a5c5"
+                "reference": "27cfbb4b8497075dba2290cc51b903479385c12a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/willdurand/Hateoas/zipball/71b1af62b398dc9a870ac0b16c84bdc23a76a5c5",
-                "reference": "71b1af62b398dc9a870ac0b16c84bdc23a76a5c5",
+                "url": "https://api.github.com/repos/willdurand/Hateoas/zipball/27cfbb4b8497075dba2290cc51b903479385c12a",
+                "reference": "27cfbb4b8497075dba2290cc51b903479385c12a",
                 "shasum": ""
             },
             "require": {
                 "doctrine/annotations": "~1.0",
-                "doctrine/common": "~2.0",
-                "jms/metadata": "~1.1",
-                "jms/serializer": "^1.7",
-                "php": "^5.5|^7.0",
-                "phpoption/phpoption": ">=1.1.0,<2.0-dev",
-                "symfony/expression-language": "~2.4 || ~3.0 || ~4.0"
+                "jms/metadata": "^2.0",
+                "jms/serializer": "^3.2",
+                "php": "^7.2",
+                "symfony/expression-language": "~3.0 || ~4.0 || ~5.0"
             },
             "require-dev": {
+                "doctrine/coding-standard": "^5.0",
+                "doctrine/persistence": "^1.3.4",
                 "pagerfanta/pagerfanta": "~1.0",
-                "phpunit/phpunit": "~5",
-                "symfony/dependency-injection": "~2.4 || ~3.0 || ~4.0",
-                "symfony/routing": "~2.4 || ~3.0 || ~4.0",
-                "symfony/yaml": "~2.4 || ~3.0 || ~4.0",
-                "twig/twig": "~1.12"
+                "phpunit/phpunit": "^7",
+                "symfony/routing": "~3.0 || ~4.0 || ~5.0",
+                "symfony/yaml": "~3.0 || ~4.0 || ~5.0",
+                "twig/twig": "^1.34 || ^2.0 || ^3.0"
             },
             "suggest": {
                 "symfony/routing": "To use the SymfonyRouteFactory.",
@@ -9840,12 +10337,12 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.12-dev"
+                    "dev-master": "3.0-dev"
                 }
             },
             "autoload": {
-                "psr-0": {
-                    "Hateoas": "src/"
+                "psr-4": {
+                    "Hateoas\\": "src/"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -9854,47 +10351,52 @@
             ],
             "authors": [
                 {
+                    "name": "William Durand",
+                    "email": "william.durand1@gmail.com"
+                },
+                {
                     "name": "Adrien Brault",
                     "email": "adrien.brault@gmail.com"
                 },
                 {
-                    "name": "William DURAND",
-                    "email": "william.durand1@gmail.com"
+                    "name": "Asmir Mustafic",
+                    "email": "goetas@gmail.com"
                 }
             ],
             "description": "A PHP library to support implementing representations for HATEOAS REST web services",
-            "time": "2018-02-23T17:05:31+00:00"
+            "time": "2020-02-19T11:47:03+00:00"
         },
         {
             "name": "willdurand/hateoas-bundle",
-            "version": "1.4.0",
+            "version": "2.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/willdurand/BazingaHateoasBundle.git",
-                "reference": "d1f915fd4f8a7cd43a88a0ce97ffb28abe3a94fa"
+                "reference": "d1653650257a632110374361cba74cb0e0d45580"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/willdurand/BazingaHateoasBundle/zipball/d1f915fd4f8a7cd43a88a0ce97ffb28abe3a94fa",
-                "reference": "d1f915fd4f8a7cd43a88a0ce97ffb28abe3a94fa",
+                "url": "https://api.github.com/repos/willdurand/BazingaHateoasBundle/zipball/d1653650257a632110374361cba74cb0e0d45580",
+                "reference": "d1653650257a632110374361cba74cb0e0d45580",
                 "shasum": ""
             },
             "require": {
-                "jms/serializer-bundle": "~1.0 || ^2.0",
-                "php": ">5.4 |^7.0",
-                "symfony/framework-bundle": "~2.3 || ~3.0 || ~4.0",
-                "willdurand/hateoas": "^2.10.0"
+                "jms/serializer-bundle": "^3.1",
+                "php": "^7.2",
+                "symfony/expression-language": "~3.0 || ~4.0 || ~5.0",
+                "symfony/framework-bundle": "~3.0 || ~4.0 || ~5.0",
+                "willdurand/hateoas": "^3.5"
             },
             "require-dev": {
-                "phpunit/phpunit": "~4.5 || ~5.0",
-                "symfony/expression-language": "~2.4 || ~3.0 || ~4.0",
-                "symfony/stopwatch": "~2.4 || ~3.0 || ~4.0",
-                "twig/twig": "~1.12"
+                "doctrine/coding-standard": "^5.0",
+                "phpunit/phpunit": "^8.4",
+                "symfony/stopwatch": "~3.0 || ~4.0 || ~5.0",
+                "twig/twig": "~1.12|~2.0"
             },
             "type": "symfony-bundle",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.4-dev"
+                    "dev-master": "2.0-dev"
                 }
             },
             "autoload": {
@@ -9908,7 +10410,7 @@
             ],
             "authors": [
                 {
-                    "name": "William DURAND",
+                    "name": "William Durand",
                     "email": "william.durand1@gmail.com"
                 }
             ],
@@ -9917,7 +10419,7 @@
                 "HATEOAS",
                 "rest"
             ],
-            "time": "2018-01-27T13:03:07+00:00"
+            "time": "2019-12-07T14:28:27+00:00"
         },
         {
             "name": "willdurand/jsonp-callback-validator",
@@ -10076,16 +10578,16 @@
         },
         {
             "name": "composer/xdebug-handler",
-            "version": "1.4.1",
+            "version": "1.4.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/composer/xdebug-handler.git",
-                "reference": "1ab9842d69e64fb3a01be6b656501032d1b78cb7"
+                "reference": "fa2aaf99e2087f013a14f7432c1cd2dd7d8f1f51"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/composer/xdebug-handler/zipball/1ab9842d69e64fb3a01be6b656501032d1b78cb7",
-                "reference": "1ab9842d69e64fb3a01be6b656501032d1b78cb7",
+                "url": "https://api.github.com/repos/composer/xdebug-handler/zipball/fa2aaf99e2087f013a14f7432c1cd2dd7d8f1f51",
+                "reference": "fa2aaf99e2087f013a14f7432c1cd2dd7d8f1f51",
                 "shasum": ""
             },
             "require": {
@@ -10116,37 +10618,51 @@
                 "Xdebug",
                 "performance"
             ],
-            "time": "2020-03-01T12:26:26+00:00"
+            "funding": [
+                {
+                    "url": "https://packagist.com",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/composer",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/composer/composer",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-06-04T11:16:35+00:00"
         },
         {
             "name": "dama/doctrine-test-bundle",
-            "version": "v5.0.3",
+            "version": "v6.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/dmaicher/doctrine-test-bundle.git",
-                "reference": "29882b0d1a815f4819126ef714931bb24a31cbaa"
+                "reference": "87e8e8a0587c70ccd0a35c651e2c7bb6d16b9940"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/dmaicher/doctrine-test-bundle/zipball/29882b0d1a815f4819126ef714931bb24a31cbaa",
-                "reference": "29882b0d1a815f4819126ef714931bb24a31cbaa",
+                "url": "https://api.github.com/repos/dmaicher/doctrine-test-bundle/zipball/87e8e8a0587c70ccd0a35c651e2c7bb6d16b9940",
+                "reference": "87e8e8a0587c70ccd0a35c651e2c7bb6d16b9940",
                 "shasum": ""
             },
             "require": {
-                "doctrine/dbal": "~2.5",
-                "doctrine/doctrine-bundle": "~1.4",
-                "php": "^7.1",
-                "symfony/framework-bundle": "~2.7|~3.0|~4.0"
+                "doctrine/dbal": "^2.9",
+                "doctrine/doctrine-bundle": "^1.11 || ^2.0",
+                "php": "^7.2",
+                "symfony/framework-bundle": "^3.4 || ^4.3 || ^5.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "~6.0|~7.0|~8.0",
-                "symfony/phpunit-bridge": "~2.8|~3.0|~4.0",
-                "symfony/yaml": "~2.8|~3.0|~4.0"
+                "phpunit/phpunit": "^7.0 || ^8.0",
+                "symfony/phpunit-bridge": "^4.3 || ^5.0",
+                "symfony/yaml": "^3.4 || ^4.3 || ^5.0"
             },
             "type": "symfony-bundle",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "5.1.x-dev"
+                    "dev-master": "7.0.x-dev"
                 }
             },
             "autoload": {
@@ -10166,43 +10682,42 @@
             ],
             "description": "Symfony bundle to isolate doctrine database tests and improve test performance",
             "keywords": [
-                "Symfony 3",
-                "Symfony 4",
                 "doctrine",
                 "isolation",
                 "performance",
                 "symfony",
-                "symfony 2",
                 "tests"
             ],
-            "time": "2019-03-22T10:34:17+00:00"
+            "time": "2019-10-28T19:15:26+00:00"
         },
         {
             "name": "doctrine/data-fixtures",
-            "version": "1.3.3",
+            "version": "1.4.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/data-fixtures.git",
-                "reference": "f0ee99c64922fc3f863715232b615c478a61b0a3"
+                "reference": "7ebac50901eb4516816ac39100dba1759d843943"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/data-fixtures/zipball/f0ee99c64922fc3f863715232b615c478a61b0a3",
-                "reference": "f0ee99c64922fc3f863715232b615c478a61b0a3",
+                "url": "https://api.github.com/repos/doctrine/data-fixtures/zipball/7ebac50901eb4516816ac39100dba1759d843943",
+                "reference": "7ebac50901eb4516816ac39100dba1759d843943",
                 "shasum": ""
             },
             "require": {
-                "doctrine/common": "~2.2",
-                "php": "^7.1"
+                "doctrine/common": "^2.11",
+                "doctrine/persistence": "^1.3.3",
+                "php": "^7.2 || ^8.0"
             },
             "conflict": {
                 "doctrine/phpcr-odm": "<1.3.0"
             },
             "require-dev": {
                 "alcaeus/mongo-php-adapter": "^1.1",
+                "doctrine/coding-standard": "^6.0",
                 "doctrine/dbal": "^2.5.4",
                 "doctrine/mongodb-odm": "^1.3.0",
-                "doctrine/orm": "^2.5.4",
+                "doctrine/orm": "^2.7.0",
                 "phpunit/phpunit": "^7.0"
             },
             "suggest": {
@@ -10214,7 +10729,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.3.x-dev"
+                    "dev-master": "1.4.x-dev"
                 }
             },
             "autoload": {
@@ -10237,7 +10752,21 @@
             "keywords": [
                 "database"
             ],
-            "time": "2019-10-24T04:52:28+00:00"
+            "funding": [
+                {
+                    "url": "https://www.doctrine-project.org/sponsorship.html",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://www.patreon.com/phpdoctrine",
+                    "type": "patreon"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/doctrine%2Fdata-fixtures",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-05-25T19:45:03+00:00"
         },
         {
             "name": "doctrine/doctrine-fixtures-bundle",
@@ -10304,6 +10833,20 @@
             "keywords": [
                 "Fixture",
                 "persistence"
+            ],
+            "funding": [
+                {
+                    "url": "https://www.doctrine-project.org/sponsorship.html",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://www.patreon.com/phpdoctrine",
+                    "type": "patreon"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/doctrine%2Fdoctrine-fixtures-bundle",
+                    "type": "tidelift"
+                }
             ],
             "time": "2020-04-02T16:40:37+00:00"
         },
@@ -10396,6 +10939,12 @@
                 }
             ],
             "description": "A tool to automatically fix PHP code style",
+            "funding": [
+                {
+                    "url": "https://github.com/keradus",
+                    "type": "github"
+                }
+            ],
             "time": "2020-04-15T18:51:10+00:00"
         },
         {
@@ -10444,552 +10993,17 @@
             "time": "2020-01-08T08:03:01+00:00"
         },
         {
-            "name": "nette/bootstrap",
-            "version": "v3.0.2",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/nette/bootstrap.git",
-                "reference": "67830a65b42abfb906f8e371512d336ebfb5da93"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/nette/bootstrap/zipball/67830a65b42abfb906f8e371512d336ebfb5da93",
-                "reference": "67830a65b42abfb906f8e371512d336ebfb5da93",
-                "shasum": ""
-            },
-            "require": {
-                "nette/di": "^3.0",
-                "nette/utils": "^3.0",
-                "php": ">=7.1"
-            },
-            "conflict": {
-                "tracy/tracy": "<2.6"
-            },
-            "require-dev": {
-                "latte/latte": "^2.2",
-                "nette/application": "^3.0",
-                "nette/caching": "^3.0",
-                "nette/database": "^3.0",
-                "nette/forms": "^3.0",
-                "nette/http": "^3.0",
-                "nette/mail": "^3.0",
-                "nette/robot-loader": "^3.0",
-                "nette/safe-stream": "^2.2",
-                "nette/security": "^3.0",
-                "nette/tester": "^2.0",
-                "phpstan/phpstan-nette": "^0.12",
-                "tracy/tracy": "^2.6"
-            },
-            "suggest": {
-                "nette/robot-loader": "to use Configurator::createRobotLoader()",
-                "tracy/tracy": "to use Configurator::enableTracy()"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "3.0-dev"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause",
-                "GPL-2.0-only",
-                "GPL-3.0-only"
-            ],
-            "authors": [
-                {
-                    "name": "David Grudl",
-                    "homepage": "https://davidgrudl.com"
-                },
-                {
-                    "name": "Nette Community",
-                    "homepage": "https://nette.org/contributors"
-                }
-            ],
-            "description": "🅱 Nette Bootstrap: the simple way to configure and bootstrap your Nette application.",
-            "homepage": "https://nette.org",
-            "keywords": [
-                "bootstrapping",
-                "configurator",
-                "nette"
-            ],
-            "time": "2020-05-26T08:46:23+00:00"
-        },
-        {
-            "name": "nette/di",
-            "version": "v3.0.4",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/nette/di.git",
-                "reference": "34d3e47ebe96229b7671664893a3b1128c102213"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/nette/di/zipball/34d3e47ebe96229b7671664893a3b1128c102213",
-                "reference": "34d3e47ebe96229b7671664893a3b1128c102213",
-                "shasum": ""
-            },
-            "require": {
-                "ext-tokenizer": "*",
-                "nette/neon": "^3.0",
-                "nette/php-generator": "^3.3.3",
-                "nette/robot-loader": "^3.2",
-                "nette/schema": "^1.0",
-                "nette/utils": "^3.1",
-                "php": ">=7.1"
-            },
-            "conflict": {
-                "nette/bootstrap": "<3.0"
-            },
-            "require-dev": {
-                "nette/tester": "^2.2",
-                "phpstan/phpstan": "^0.12",
-                "tracy/tracy": "^2.3"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "3.0-dev"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause",
-                "GPL-2.0-only",
-                "GPL-3.0-only"
-            ],
-            "authors": [
-                {
-                    "name": "David Grudl",
-                    "homepage": "https://davidgrudl.com"
-                },
-                {
-                    "name": "Nette Community",
-                    "homepage": "https://nette.org/contributors"
-                }
-            ],
-            "description": "💎 Nette Dependency Injection Container: Flexible, compiled and full-featured DIC with perfectly usable autowiring and support for all new PHP 7.1 features.",
-            "homepage": "https://nette.org",
-            "keywords": [
-                "compiled",
-                "di",
-                "dic",
-                "factory",
-                "ioc",
-                "nette",
-                "static"
-            ],
-            "time": "2020-05-14T10:29:59+00:00"
-        },
-        {
-            "name": "nette/finder",
-            "version": "v2.5.2",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/nette/finder.git",
-                "reference": "4ad2c298eb8c687dd0e74ae84206a4186eeaed50"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/nette/finder/zipball/4ad2c298eb8c687dd0e74ae84206a4186eeaed50",
-                "reference": "4ad2c298eb8c687dd0e74ae84206a4186eeaed50",
-                "shasum": ""
-            },
-            "require": {
-                "nette/utils": "^2.4 || ^3.0",
-                "php": ">=7.1"
-            },
-            "conflict": {
-                "nette/nette": "<2.2"
-            },
-            "require-dev": {
-                "nette/tester": "^2.0",
-                "phpstan/phpstan": "^0.12",
-                "tracy/tracy": "^2.3"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "2.5-dev"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause",
-                "GPL-2.0",
-                "GPL-3.0"
-            ],
-            "authors": [
-                {
-                    "name": "David Grudl",
-                    "homepage": "https://davidgrudl.com"
-                },
-                {
-                    "name": "Nette Community",
-                    "homepage": "https://nette.org/contributors"
-                }
-            ],
-            "description": "🔍 Nette Finder: find files and directories with an intuitive API.",
-            "homepage": "https://nette.org",
-            "keywords": [
-                "filesystem",
-                "glob",
-                "iterator",
-                "nette"
-            ],
-            "time": "2020-01-03T20:35:40+00:00"
-        },
-        {
-            "name": "nette/neon",
-            "version": "v3.1.2",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/nette/neon.git",
-                "reference": "3c3dcbc6bf6c80dc97b1fc4ba9a22ae67930fc0e"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/nette/neon/zipball/3c3dcbc6bf6c80dc97b1fc4ba9a22ae67930fc0e",
-                "reference": "3c3dcbc6bf6c80dc97b1fc4ba9a22ae67930fc0e",
-                "shasum": ""
-            },
-            "require": {
-                "ext-iconv": "*",
-                "ext-json": "*",
-                "php": ">=7.1"
-            },
-            "require-dev": {
-                "nette/tester": "^2.0",
-                "phpstan/phpstan": "^0.12",
-                "tracy/tracy": "^2.3"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "3.1-dev"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause",
-                "GPL-2.0-only",
-                "GPL-3.0-only"
-            ],
-            "authors": [
-                {
-                    "name": "David Grudl",
-                    "homepage": "https://davidgrudl.com"
-                },
-                {
-                    "name": "Nette Community",
-                    "homepage": "https://nette.org/contributors"
-                }
-            ],
-            "description": "🍸 Nette NEON: encodes and decodes NEON file format.",
-            "homepage": "https://ne-on.org",
-            "keywords": [
-                "export",
-                "import",
-                "neon",
-                "nette",
-                "yaml"
-            ],
-            "time": "2020-03-04T11:47:04+00:00"
-        },
-        {
-            "name": "nette/php-generator",
-            "version": "v3.4.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/nette/php-generator.git",
-                "reference": "ea2c8e8d6439f0a4e3cd3431c572b51a8131539b"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/nette/php-generator/zipball/ea2c8e8d6439f0a4e3cd3431c572b51a8131539b",
-                "reference": "ea2c8e8d6439f0a4e3cd3431c572b51a8131539b",
-                "shasum": ""
-            },
-            "require": {
-                "ext-tokenizer": "*",
-                "nette/utils": "^2.4.2 || ^3.0",
-                "php": ">=7.1"
-            },
-            "require-dev": {
-                "nette/tester": "^2.0",
-                "nikic/php-parser": "^4.4",
-                "phpstan/phpstan": "^0.12",
-                "tracy/tracy": "^2.3"
-            },
-            "suggest": {
-                "nikic/php-parser": "to use ClassType::withBodiesFrom() & GlobalFunction::withBodyFrom()"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "3.4-dev"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause",
-                "GPL-2.0-only",
-                "GPL-3.0-only"
-            ],
-            "authors": [
-                {
-                    "name": "David Grudl",
-                    "homepage": "https://davidgrudl.com"
-                },
-                {
-                    "name": "Nette Community",
-                    "homepage": "https://nette.org/contributors"
-                }
-            ],
-            "description": "🐘 Nette PHP Generator: generates neat PHP code for you. Supports new PHP 7.4 features.",
-            "homepage": "https://nette.org",
-            "keywords": [
-                "code",
-                "nette",
-                "php",
-                "scaffolding"
-            ],
-            "time": "2020-05-26T16:32:45+00:00"
-        },
-        {
-            "name": "nette/robot-loader",
-            "version": "v3.2.3",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/nette/robot-loader.git",
-                "reference": "726c462e73e739e965ec654a667407074cfe83c0"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/nette/robot-loader/zipball/726c462e73e739e965ec654a667407074cfe83c0",
-                "reference": "726c462e73e739e965ec654a667407074cfe83c0",
-                "shasum": ""
-            },
-            "require": {
-                "ext-tokenizer": "*",
-                "nette/finder": "^2.5 || ^3.0",
-                "nette/utils": "^3.0",
-                "php": ">=7.1"
-            },
-            "require-dev": {
-                "nette/tester": "^2.0",
-                "phpstan/phpstan": "^0.12",
-                "tracy/tracy": "^2.3"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "3.2-dev"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause",
-                "GPL-2.0-only",
-                "GPL-3.0-only"
-            ],
-            "authors": [
-                {
-                    "name": "David Grudl",
-                    "homepage": "https://davidgrudl.com"
-                },
-                {
-                    "name": "Nette Community",
-                    "homepage": "https://nette.org/contributors"
-                }
-            ],
-            "description": "🍀 Nette RobotLoader: high performance and comfortable autoloader that will search and autoload classes within your application.",
-            "homepage": "https://nette.org",
-            "keywords": [
-                "autoload",
-                "class",
-                "interface",
-                "nette",
-                "trait"
-            ],
-            "time": "2020-02-28T13:10:07+00:00"
-        },
-        {
-            "name": "nette/schema",
-            "version": "v1.0.2",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/nette/schema.git",
-                "reference": "febf71fb4052c824046f5a33f4f769a6e7fa0cb4"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/nette/schema/zipball/febf71fb4052c824046f5a33f4f769a6e7fa0cb4",
-                "reference": "febf71fb4052c824046f5a33f4f769a6e7fa0cb4",
-                "shasum": ""
-            },
-            "require": {
-                "nette/utils": "^3.1",
-                "php": ">=7.1"
-            },
-            "require-dev": {
-                "nette/tester": "^2.2",
-                "phpstan/phpstan-nette": "^0.12",
-                "tracy/tracy": "^2.3"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": []
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause",
-                "GPL-2.0",
-                "GPL-3.0"
-            ],
-            "authors": [
-                {
-                    "name": "David Grudl",
-                    "homepage": "https://davidgrudl.com"
-                },
-                {
-                    "name": "Nette Community",
-                    "homepage": "https://nette.org/contributors"
-                }
-            ],
-            "description": "📐 Nette Schema: validating data structures against a given Schema.",
-            "homepage": "https://nette.org",
-            "keywords": [
-                "config",
-                "nette"
-            ],
-            "time": "2020-01-06T22:52:48+00:00"
-        },
-        {
-            "name": "nette/utils",
-            "version": "v3.1.2",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/nette/utils.git",
-                "reference": "488f58378bba71767e7831c83f9e0fa808bf83b9"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/nette/utils/zipball/488f58378bba71767e7831c83f9e0fa808bf83b9",
-                "reference": "488f58378bba71767e7831c83f9e0fa808bf83b9",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=7.1"
-            },
-            "require-dev": {
-                "nette/tester": "~2.0",
-                "phpstan/phpstan": "^0.12",
-                "tracy/tracy": "^2.3"
-            },
-            "suggest": {
-                "ext-gd": "to use Image",
-                "ext-iconv": "to use Strings::webalize(), toAscii(), chr() and reverse()",
-                "ext-intl": "to use Strings::webalize(), toAscii(), normalize() and compare()",
-                "ext-json": "to use Nette\\Utils\\Json",
-                "ext-mbstring": "to use Strings::lower() etc...",
-                "ext-tokenizer": "to use Nette\\Utils\\Reflection::getUseStatements()",
-                "ext-xml": "to use Strings::length() etc. when mbstring is not available"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "3.1-dev"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause",
-                "GPL-2.0-only",
-                "GPL-3.0-only"
-            ],
-            "authors": [
-                {
-                    "name": "David Grudl",
-                    "homepage": "https://davidgrudl.com"
-                },
-                {
-                    "name": "Nette Community",
-                    "homepage": "https://nette.org/contributors"
-                }
-            ],
-            "description": "🛠 Nette Utils: lightweight utilities for string & array manipulation, image handling, safe JSON encoding/decoding, validation, slug or strong password generating etc.",
-            "homepage": "https://nette.org",
-            "keywords": [
-                "array",
-                "core",
-                "datetime",
-                "images",
-                "json",
-                "nette",
-                "paginator",
-                "password",
-                "slugify",
-                "string",
-                "unicode",
-                "utf-8",
-                "utility",
-                "validation"
-            ],
-            "time": "2020-05-27T09:58:51+00:00"
-        },
-        {
             "name": "nikic/php-parser",
-            "version": "v4.4.0",
+            "version": "v4.5.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nikic/PHP-Parser.git",
-                "reference": "bd43ec7152eaaab3bd8c6d0aa95ceeb1df8ee120"
+                "reference": "53c2753d756f5adb586dca79c2ec0e2654dd9463"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/bd43ec7152eaaab3bd8c6d0aa95ceeb1df8ee120",
-                "reference": "bd43ec7152eaaab3bd8c6d0aa95ceeb1df8ee120",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/53c2753d756f5adb586dca79c2ec0e2654dd9463",
+                "reference": "53c2753d756f5adb586dca79c2ec0e2654dd9463",
                 "shasum": ""
             },
             "require": {
@@ -11028,7 +11042,7 @@
                 "parser",
                 "php"
             ],
-            "time": "2020-04-10T16:34:50+00:00"
+            "time": "2020-06-03T07:24:19+00:00"
         },
         {
             "name": "php-cs-fixer/diff",
@@ -11142,171 +11156,152 @@
             "time": "2019-11-06T12:49:04+00:00"
         },
         {
-            "name": "phpstan/phpdoc-parser",
-            "version": "0.3.5",
+            "name": "phpstan/extension-installer",
+            "version": "1.0.4",
             "source": {
                 "type": "git",
-                "url": "https://github.com/phpstan/phpdoc-parser.git",
-                "reference": "8c4ef2aefd9788238897b678a985e1d5c8df6db4"
+                "url": "https://github.com/phpstan/extension-installer.git",
+                "reference": "2e041def501d661b806f50000c8a4dccbd4907b4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpdoc-parser/zipball/8c4ef2aefd9788238897b678a985e1d5c8df6db4",
-                "reference": "8c4ef2aefd9788238897b678a985e1d5c8df6db4",
+                "url": "https://api.github.com/repos/phpstan/extension-installer/zipball/2e041def501d661b806f50000c8a4dccbd4907b4",
+                "reference": "2e041def501d661b806f50000c8a4dccbd4907b4",
                 "shasum": ""
             },
             "require": {
-                "php": "~7.1"
+                "composer-plugin-api": "^1.1 || ^2.0",
+                "php": "^7.1",
+                "phpstan/phpstan": ">=0.11.6"
             },
             "require-dev": {
-                "consistence/coding-standard": "^3.5",
-                "jakub-onderka/php-parallel-lint": "^0.9.2",
-                "phing/phing": "^2.16.0",
-                "phpstan/phpstan": "^0.10",
-                "phpunit/phpunit": "^6.3",
-                "slevomat/coding-standard": "^4.7.2",
-                "squizlabs/php_codesniffer": "^3.3.2",
-                "symfony/process": "^3.4 || ^4.0"
+                "composer/composer": "^1.8",
+                "consistence/coding-standard": "^3.8",
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.4.4",
+                "ergebnis/composer-normalize": "^2.0.2",
+                "jakub-onderka/php-parallel-lint": "^1.0",
+                "phing/phing": "^2.16",
+                "phpstan/phpstan-strict-rules": "^0.11",
+                "slevomat/coding-standard": "^5.0.4"
             },
-            "type": "library",
+            "type": "composer-plugin",
             "extra": {
-                "branch-alias": {
-                    "dev-master": "0.3-dev"
-                }
+                "class": "PHPStan\\ExtensionInstaller\\Plugin"
             },
             "autoload": {
                 "psr-4": {
-                    "PHPStan\\PhpDocParser\\": [
-                        "src/"
-                    ]
+                    "PHPStan\\ExtensionInstaller\\": "src/"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
                 "MIT"
             ],
-            "description": "PHPDoc parser with support for nullable, intersection and generic types",
-            "time": "2019-06-07T19:13:52+00:00"
+            "description": "Composer plugin for automatic installation of PHPStan extensions",
+            "time": "2020-03-31T16:00:42+00:00"
         },
         {
             "name": "phpstan/phpstan",
-            "version": "0.11.19",
+            "version": "0.12.29",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan.git",
-                "reference": "63cc502f6957b7f74efbac444b4cf219dcadffd7"
+                "reference": "9771daaf6b95c6313b908d0bcdee0afcd51f838a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/63cc502f6957b7f74efbac444b4cf219dcadffd7",
-                "reference": "63cc502f6957b7f74efbac444b4cf219dcadffd7",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/9771daaf6b95c6313b908d0bcdee0afcd51f838a",
+                "reference": "9771daaf6b95c6313b908d0bcdee0afcd51f838a",
                 "shasum": ""
             },
             "require": {
-                "composer/xdebug-handler": "^1.3.0",
-                "jean85/pretty-package-versions": "^1.0.3",
-                "nette/bootstrap": "^2.4 || ^3.0",
-                "nette/di": "^2.4.7 || ^3.0",
-                "nette/neon": "^2.4.3 || ^3.0",
-                "nette/robot-loader": "^3.0.1",
-                "nette/schema": "^1.0",
-                "nette/utils": "^2.4.5 || ^3.0",
-                "nikic/php-parser": "^4.2.3",
-                "php": "~7.1",
-                "phpstan/phpdoc-parser": "^0.3.5",
-                "symfony/console": "~3.2 || ~4.0",
-                "symfony/finder": "~3.2 || ~4.0"
+                "php": "^7.1"
             },
             "conflict": {
-                "symfony/console": "3.4.16 || 4.1.5"
-            },
-            "require-dev": {
-                "brianium/paratest": "^2.0 || ^3.0",
-                "consistence/coding-standard": "^3.5",
-                "dealerdirect/phpcodesniffer-composer-installer": "^0.4.4",
-                "ext-intl": "*",
-                "ext-mysqli": "*",
-                "ext-simplexml": "*",
-                "ext-soap": "*",
-                "ext-zip": "*",
-                "jakub-onderka/php-parallel-lint": "^1.0",
-                "localheinz/composer-normalize": "^1.1.0",
-                "phing/phing": "^2.16.0",
-                "phpstan/phpstan-deprecation-rules": "^0.11",
-                "phpstan/phpstan-php-parser": "^0.11",
-                "phpstan/phpstan-phpunit": "^0.11",
-                "phpstan/phpstan-strict-rules": "^0.11",
-                "phpunit/phpunit": "^7.5.14 || ^8.0",
-                "slevomat/coding-standard": "^4.7.2",
-                "squizlabs/php_codesniffer": "^3.3.2"
+                "phpstan/phpstan-shim": "*"
             },
             "bin": [
-                "bin/phpstan"
+                "phpstan",
+                "phpstan.phar"
             ],
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "0.11-dev"
+                    "dev-master": "0.12-dev"
                 }
             },
             "autoload": {
-                "psr-4": {
-                    "PHPStan\\": [
-                        "src/"
-                    ]
-                }
+                "files": [
+                    "bootstrap.php"
+                ]
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
                 "MIT"
             ],
             "description": "PHPStan - PHP Static Analysis Tool",
-            "time": "2019-10-22T20:20:22+00:00"
+            "funding": [
+                {
+                    "url": "https://github.com/ondrejmirtes",
+                    "type": "github"
+                },
+                {
+                    "url": "https://www.patreon.com/phpstan",
+                    "type": "patreon"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/phpstan/phpstan",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-06-14T14:10:59+00:00"
         },
         {
             "name": "phpstan/phpstan-doctrine",
-            "version": "0.11.6",
+            "version": "0.12.16",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan-doctrine.git",
-                "reference": "77592865e167b32c7dcb4f39a35210e909a8854c"
+                "reference": "65146e35905478bfb4e2ba078ffca1a16029d4ee"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan-doctrine/zipball/77592865e167b32c7dcb4f39a35210e909a8854c",
-                "reference": "77592865e167b32c7dcb4f39a35210e909a8854c",
+                "url": "https://api.github.com/repos/phpstan/phpstan-doctrine/zipball/65146e35905478bfb4e2ba078ffca1a16029d4ee",
+                "reference": "65146e35905478bfb4e2ba078ffca1a16029d4ee",
                 "shasum": ""
             },
             "require": {
-                "nikic/php-parser": "^4.0",
                 "php": "~7.1",
-                "phpstan/phpdoc-parser": "^0.3",
-                "phpstan/phpstan": "^0.11.7"
+                "phpstan/phpstan": "^0.12.26"
             },
             "conflict": {
                 "doctrine/collections": "<1.0",
                 "doctrine/common": "<2.7",
                 "doctrine/mongodb-odm": "<1.2",
-                "doctrine/orm": "<2.5"
+                "doctrine/orm": "<2.5",
+                "doctrine/persistence": "<1.3"
             },
             "require-dev": {
-                "consistence/coding-standard": "^3.8",
+                "consistence/coding-standard": "^3.0.1",
                 "dealerdirect/phpcodesniffer-composer-installer": "^0.4.4",
                 "doctrine/collections": "^1.0",
-                "doctrine/common": "^2.7",
-                "doctrine/mongodb-odm": "^1.2",
+                "doctrine/common": "^2.7 || ^3.0",
+                "doctrine/mongodb-odm": "^1.3 || ^2.1",
                 "doctrine/orm": "^2.5",
+                "doctrine/persistence": "^1.1 || ^2.0",
+                "ergebnis/composer-normalize": "^2.0.2",
                 "jakub-onderka/php-parallel-lint": "^1.0",
                 "phing/phing": "^2.16.0",
-                "phpstan/phpstan-phpunit": "^0.11",
-                "phpstan/phpstan-strict-rules": "^0.11",
+                "phpstan/phpstan-phpunit": "^0.12",
+                "phpstan/phpstan-strict-rules": "^0.12",
                 "phpunit/phpunit": "^7.0",
-                "slevomat/coding-standard": "^5.0.4"
+                "ramsey/uuid-doctrine": "^1.5.0",
+                "slevomat/coding-standard": "^4.5.2"
             },
             "type": "phpstan-extension",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "0.11-dev"
+                    "dev-master": "0.12-dev"
                 },
                 "phpstan": {
                     "includes": [
@@ -11325,45 +11320,44 @@
                 "MIT"
             ],
             "description": "Doctrine extensions for PHPStan",
-            "time": "2019-09-13T08:40:06+00:00"
+            "time": "2020-06-14T11:03:59+00:00"
         },
         {
             "name": "phpstan/phpstan-phpunit",
-            "version": "0.11.2",
+            "version": "0.12.11",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan-phpunit.git",
-                "reference": "fbf2ad56c3b13189d29655e226c9b1da47c2fad9"
+                "reference": "ab783a8ea634ea23305a8818c4750603e714489b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan-phpunit/zipball/fbf2ad56c3b13189d29655e226c9b1da47c2fad9",
-                "reference": "fbf2ad56c3b13189d29655e226c9b1da47c2fad9",
+                "url": "https://api.github.com/repos/phpstan/phpstan-phpunit/zipball/ab783a8ea634ea23305a8818c4750603e714489b",
+                "reference": "ab783a8ea634ea23305a8818c4750603e714489b",
                 "shasum": ""
             },
             "require": {
-                "nikic/php-parser": "^4.0",
                 "php": "~7.1",
-                "phpstan/phpdoc-parser": "^0.3",
-                "phpstan/phpstan": "^0.11.4"
+                "phpstan/phpstan": "^0.12.20"
             },
             "conflict": {
                 "phpunit/phpunit": "<7.0"
             },
             "require-dev": {
-                "consistence/coding-standard": "^3.0.1",
+                "consistence/coding-standard": "^3.5",
                 "dealerdirect/phpcodesniffer-composer-installer": "^0.4.4",
+                "ergebnis/composer-normalize": "^2.0.2",
                 "jakub-onderka/php-parallel-lint": "^1.0",
                 "phing/phing": "^2.16.0",
-                "phpstan/phpstan-strict-rules": "^0.11",
-                "phpunit/phpunit": "^7.0",
+                "phpstan/phpstan-strict-rules": "^0.12",
+                "phpunit/phpunit": "^7.0 || ^8.0 || ^9.0",
                 "satooshi/php-coveralls": "^1.0",
-                "slevomat/coding-standard": "^4.5.2"
+                "slevomat/coding-standard": "^4.7.2"
             },
             "type": "phpstan-extension",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "0.11-dev"
+                    "dev-master": "0.12-dev"
                 },
                 "phpstan": {
                     "includes": [
@@ -11382,27 +11376,26 @@
                 "MIT"
             ],
             "description": "PHPUnit extensions and rules for PHPStan",
-            "time": "2019-05-17T17:50:16+00:00"
+            "time": "2020-06-01T16:43:31+00:00"
         },
         {
             "name": "phpstan/phpstan-symfony",
-            "version": "0.11.6",
+            "version": "0.12.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan-symfony.git",
-                "reference": "c7be3054c21fd472a52b1c38eb129c3f93776084"
+                "reference": "ba69dcd8e57c1a8580bf190e0554bea0fc37fe2f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan-symfony/zipball/c7be3054c21fd472a52b1c38eb129c3f93776084",
-                "reference": "c7be3054c21fd472a52b1c38eb129c3f93776084",
+                "url": "https://api.github.com/repos/phpstan/phpstan-symfony/zipball/ba69dcd8e57c1a8580bf190e0554bea0fc37fe2f",
+                "reference": "ba69dcd8e57c1a8580bf190e0554bea0fc37fe2f",
                 "shasum": ""
             },
             "require": {
                 "ext-simplexml": "*",
-                "nikic/php-parser": "^4.0",
                 "php": "^7.1",
-                "phpstan/phpstan": "^0.11.7"
+                "phpstan/phpstan": "^0.12"
             },
             "conflict": {
                 "symfony/framework-bundle": "<3.0"
@@ -11410,27 +11403,29 @@
             "require-dev": {
                 "consistence/coding-standard": "^3.0.1",
                 "dealerdirect/phpcodesniffer-composer-installer": "^0.4.4",
+                "ergebnis/composer-normalize": "^2.0.2",
                 "jakub-onderka/php-parallel-lint": "^1.0",
-                "nette/di": "^3.0-stable",
                 "phing/phing": "^2.16.0",
-                "phpstan/phpstan-phpunit": "^0.11",
-                "phpstan/phpstan-strict-rules": "^0.11",
+                "phpstan/phpstan-phpunit": "^0.12",
+                "phpstan/phpstan-strict-rules": "^0.12",
                 "phpunit/phpunit": "^7.0",
                 "slevomat/coding-standard": "^4.5.2",
                 "squizlabs/php_codesniffer": "^3.3.2",
-                "symfony/console": "^3.0 || ^4.0",
-                "symfony/framework-bundle": "^3.0 || ^4.0",
+                "symfony/console": "^4.0",
+                "symfony/framework-bundle": "^4.0",
+                "symfony/http-foundation": "^4.0",
                 "symfony/messenger": "^4.2",
-                "symfony/serializer": "^3.0 || ^4.0"
+                "symfony/serializer": "^4.0"
             },
             "type": "phpstan-extension",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "0.11-dev"
+                    "dev-master": "0.12-dev"
                 },
                 "phpstan": {
                     "includes": [
-                        "extension.neon"
+                        "extension.neon",
+                        "rules.neon"
                     ]
                 }
             },
@@ -11451,7 +11446,7 @@
                 }
             ],
             "description": "Symfony Framework extensions and rules for PHPStan",
-            "time": "2019-05-19T17:40:25+00:00"
+            "time": "2020-04-15T20:26:41+00:00"
         },
         {
             "name": "symfony/maker-bundle",
@@ -11523,26 +11518,26 @@
         },
         {
             "name": "symfony/phpunit-bridge",
-            "version": "v4.3.11",
+            "version": "v5.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/phpunit-bridge.git",
-                "reference": "692a73a2e0b76123150709f5eb7e2ea9bf2bad43"
+                "reference": "de5f0fec631a0cbfe98630b053be1fad7b75aece"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/phpunit-bridge/zipball/692a73a2e0b76123150709f5eb7e2ea9bf2bad43",
-                "reference": "692a73a2e0b76123150709f5eb7e2ea9bf2bad43",
+                "url": "https://api.github.com/repos/symfony/phpunit-bridge/zipball/de5f0fec631a0cbfe98630b053be1fad7b75aece",
+                "reference": "de5f0fec631a0cbfe98630b053be1fad7b75aece",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.5.9"
             },
             "conflict": {
-                "phpunit/phpunit": "<4.8.35|<5.4.3,>=5.0"
+                "phpunit/phpunit": "<4.8.35|<5.4.3,>=5.0|<6.4,>=6.0|9.1.2"
             },
             "suggest": {
-                "symfony/debug": "For tracking deprecated interfaces usages at runtime with DebugClassLoader"
+                "symfony/error-handler": "For tracking deprecated interfaces usages at runtime with DebugClassLoader"
             },
             "bin": [
                 "bin/simple-phpunit"
@@ -11550,7 +11545,7 @@
             "type": "symfony-bridge",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.3-dev"
+                    "dev-master": "5.1-dev"
                 },
                 "thanks": {
                     "name": "phpunit/phpunit",
@@ -11584,7 +11579,21 @@
             ],
             "description": "Symfony PHPUnit Bridge",
             "homepage": "https://symfony.com",
-            "time": "2020-01-31T09:56:21+00:00"
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-06-09T09:56:30+00:00"
         }
     ],
     "aliases": [],
@@ -11595,7 +11604,7 @@
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {
-        "php": ">=7.1.3",
+        "php": ">=7.2.5",
         "ext-ctype": "*",
         "ext-curl": "*",
         "ext-dom": "*",
@@ -11614,6 +11623,7 @@
     },
     "platform-dev": [],
     "platform-overrides": {
-        "php": "7.1.3"
-    }
+        "php": "7.2.5"
+    },
+    "plugin-api-version": "1.1.0"
 }

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,15 +1,14 @@
-includes:
-    - vendor/phpstan/phpstan-phpunit/extension.neon
-    - vendor/phpstan/phpstan-symfony/extension.neon
-    - vendor/phpstan/phpstan-doctrine/extension.neon
-    - vendor/phpstan/phpstan-phpunit/rules.neon
-
 parameters:
+    level: 1
+    paths:
+        - src
+        - tests
+
     symfony:
         container_xml_path: %rootDir%/../../../var/cache/test/appTestDebugProjectContainer.xml
 
     # https://github.com/phpstan/phpstan/issues/694#issuecomment-350724288
     autoload_files:
-        - vendor/bin/.phpunit/phpunit-7.4/vendor/autoload.php
+        - vendor/bin/.phpunit/phpunit-8.3-0/vendor/autoload.php
 
     inferPrivatePropertyTypeFromConstructor: true

--- a/src/Wallabag/AnnotationBundle/DataFixtures/AnnotationFixtures.php
+++ b/src/Wallabag/AnnotationBundle/DataFixtures/AnnotationFixtures.php
@@ -4,7 +4,7 @@ namespace Wallabag\AnnotationBundle\DataFixtures;
 
 use Doctrine\Bundle\FixturesBundle\Fixture;
 use Doctrine\Common\DataFixtures\DependentFixtureInterface;
-use Doctrine\Common\Persistence\ObjectManager;
+use Doctrine\Persistence\ObjectManager;
 use Wallabag\AnnotationBundle\Entity\Annotation;
 use Wallabag\CoreBundle\DataFixtures\EntryFixtures;
 use Wallabag\UserBundle\DataFixtures\UserFixtures;

--- a/src/Wallabag/CoreBundle/DataFixtures/ConfigFixtures.php
+++ b/src/Wallabag/CoreBundle/DataFixtures/ConfigFixtures.php
@@ -4,7 +4,7 @@ namespace Wallabag\CoreBundle\DataFixtures;
 
 use Doctrine\Bundle\FixturesBundle\Fixture;
 use Doctrine\Common\DataFixtures\DependentFixtureInterface;
-use Doctrine\Common\Persistence\ObjectManager;
+use Doctrine\Persistence\ObjectManager;
 use Wallabag\CoreBundle\Entity\Config;
 use Wallabag\UserBundle\DataFixtures\UserFixtures;
 
@@ -13,7 +13,7 @@ class ConfigFixtures extends Fixture implements DependentFixtureInterface
     /**
      * {@inheritdoc}
      */
-    public function load(ObjectManager $manager)
+    public function load(ObjectManager $manager): void
     {
         $adminConfig = new Config($this->getReference('admin-user'));
 

--- a/src/Wallabag/CoreBundle/DataFixtures/EntryFixtures.php
+++ b/src/Wallabag/CoreBundle/DataFixtures/EntryFixtures.php
@@ -4,7 +4,7 @@ namespace Wallabag\CoreBundle\DataFixtures;
 
 use Doctrine\Bundle\FixturesBundle\Fixture;
 use Doctrine\Common\DataFixtures\DependentFixtureInterface;
-use Doctrine\Common\Persistence\ObjectManager;
+use Doctrine\Persistence\ObjectManager;
 use Wallabag\CoreBundle\Entity\Entry;
 use Wallabag\UserBundle\DataFixtures\UserFixtures;
 
@@ -13,7 +13,7 @@ class EntryFixtures extends Fixture implements DependentFixtureInterface
     /**
      * {@inheritdoc}
      */
-    public function load(ObjectManager $manager)
+    public function load(ObjectManager $manager): void
     {
         $entries = [
             'entry1' => [

--- a/src/Wallabag/CoreBundle/DataFixtures/IgnoreOriginInstanceRuleFixtures.php
+++ b/src/Wallabag/CoreBundle/DataFixtures/IgnoreOriginInstanceRuleFixtures.php
@@ -3,7 +3,7 @@
 namespace Wallabag\CoreBundle\DataFixtures;
 
 use Doctrine\Bundle\FixturesBundle\Fixture;
-use Doctrine\Common\Persistence\ObjectManager;
+use Doctrine\Persistence\ObjectManager;
 use Symfony\Component\DependencyInjection\ContainerAwareInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Wallabag\CoreBundle\Entity\IgnoreOriginInstanceRule;
@@ -23,7 +23,7 @@ class IgnoreOriginInstanceRuleFixtures extends Fixture implements ContainerAware
     /**
      * {@inheritdoc}
      */
-    public function load(ObjectManager $manager)
+    public function load(ObjectManager $manager): void
     {
         foreach ($this->container->getParameter('wallabag_core.default_ignore_origin_instance_rules') as $ignore_origin_instance_rule) {
             $newIgnoreOriginInstanceRule = new IgnoreOriginInstanceRule();

--- a/src/Wallabag/CoreBundle/DataFixtures/IgnoreOriginUserRuleFixtures.php
+++ b/src/Wallabag/CoreBundle/DataFixtures/IgnoreOriginUserRuleFixtures.php
@@ -4,7 +4,7 @@ namespace Wallabag\CoreBundle\DataFixtures;
 
 use Doctrine\Bundle\FixturesBundle\Fixture;
 use Doctrine\Common\DataFixtures\DependentFixtureInterface;
-use Doctrine\Common\Persistence\ObjectManager;
+use Doctrine\Persistence\ObjectManager;
 use Wallabag\CoreBundle\Entity\IgnoreOriginUserRule;
 use Wallabag\UserBundle\DataFixtures\UserFixtures;
 
@@ -13,7 +13,7 @@ class IgnoreOriginUserRuleFixtures extends Fixture implements DependentFixtureIn
     /**
      * {@inheritdoc}
      */
-    public function load(ObjectManager $manager)
+    public function load(ObjectManager $manager): void
     {
         $rule = new IgnoreOriginUserRule();
         $rule->setRule('host = "example.fr"');

--- a/src/Wallabag/CoreBundle/DataFixtures/InternalSettingFixtures.php
+++ b/src/Wallabag/CoreBundle/DataFixtures/InternalSettingFixtures.php
@@ -3,7 +3,7 @@
 namespace Wallabag\CoreBundle\DataFixtures;
 
 use Doctrine\Bundle\FixturesBundle\Fixture;
-use Doctrine\Common\Persistence\ObjectManager;
+use Doctrine\Persistence\ObjectManager;
 use Symfony\Component\DependencyInjection\ContainerAwareInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Wallabag\CoreBundle\Entity\InternalSetting;
@@ -23,7 +23,7 @@ class InternalSettingFixtures extends Fixture implements ContainerAwareInterface
     /**
      * {@inheritdoc}
      */
-    public function load(ObjectManager $manager)
+    public function load(ObjectManager $manager): void
     {
         foreach ($this->container->getParameter('wallabag_core.default_internal_settings') as $setting) {
             $newSetting = new InternalSetting();

--- a/src/Wallabag/CoreBundle/DataFixtures/SiteCredentialFixtures.php
+++ b/src/Wallabag/CoreBundle/DataFixtures/SiteCredentialFixtures.php
@@ -4,7 +4,7 @@ namespace Wallabag\CoreBundle\DataFixtures;
 
 use Doctrine\Bundle\FixturesBundle\Fixture;
 use Doctrine\Common\DataFixtures\DependentFixtureInterface;
-use Doctrine\Common\Persistence\ObjectManager;
+use Doctrine\Persistence\ObjectManager;
 use Symfony\Component\DependencyInjection\ContainerAwareInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Wallabag\CoreBundle\Entity\SiteCredential;
@@ -25,7 +25,7 @@ class SiteCredentialFixtures extends Fixture implements DependentFixtureInterfac
     /**
      * {@inheritdoc}
      */
-    public function load(ObjectManager $manager)
+    public function load(ObjectManager $manager): void
     {
         $credential = new SiteCredential($this->getReference('admin-user'));
         $credential->setHost('.super.com');

--- a/src/Wallabag/CoreBundle/DataFixtures/TagFixtures.php
+++ b/src/Wallabag/CoreBundle/DataFixtures/TagFixtures.php
@@ -3,7 +3,7 @@
 namespace Wallabag\CoreBundle\DataFixtures;
 
 use Doctrine\Bundle\FixturesBundle\Fixture;
-use Doctrine\Common\Persistence\ObjectManager;
+use Doctrine\Persistence\ObjectManager;
 use Wallabag\CoreBundle\Entity\Tag;
 
 class TagFixtures extends Fixture
@@ -11,7 +11,7 @@ class TagFixtures extends Fixture
     /**
      * {@inheritdoc}
      */
-    public function load(ObjectManager $manager)
+    public function load(ObjectManager $manager): void
     {
         $tags = [
             'foo-bar-tag' => 'foo bar', //tag used for EntryControllerTest

--- a/src/Wallabag/CoreBundle/DataFixtures/TaggingRuleFixtures.php
+++ b/src/Wallabag/CoreBundle/DataFixtures/TaggingRuleFixtures.php
@@ -4,7 +4,7 @@ namespace Wallabag\CoreBundle\DataFixtures;
 
 use Doctrine\Bundle\FixturesBundle\Fixture;
 use Doctrine\Common\DataFixtures\DependentFixtureInterface;
-use Doctrine\Common\Persistence\ObjectManager;
+use Doctrine\Persistence\ObjectManager;
 use Wallabag\CoreBundle\Entity\TaggingRule;
 
 class TaggingRuleFixtures extends Fixture implements DependentFixtureInterface
@@ -12,7 +12,7 @@ class TaggingRuleFixtures extends Fixture implements DependentFixtureInterface
     /**
      * {@inheritdoc}
      */
-    public function load(ObjectManager $manager)
+    public function load(ObjectManager $manager): void
     {
         $tr1 = new TaggingRule();
         $tr1->setRule('content matches "spurs"');

--- a/src/Wallabag/UserBundle/DataFixtures/UserFixtures.php
+++ b/src/Wallabag/UserBundle/DataFixtures/UserFixtures.php
@@ -3,7 +3,7 @@
 namespace Wallabag\UserBundle\DataFixtures;
 
 use Doctrine\Bundle\FixturesBundle\Fixture;
-use Doctrine\Common\Persistence\ObjectManager;
+use Doctrine\Persistence\ObjectManager;
 use Wallabag\UserBundle\Entity\User;
 
 class UserFixtures extends Fixture

--- a/tests/Wallabag/AnnotationBundle/WallabagAnnotationTestCase.php
+++ b/tests/Wallabag/AnnotationBundle/WallabagAnnotationTestCase.php
@@ -17,7 +17,7 @@ abstract class WallabagAnnotationTestCase extends WebTestCase
      */
     protected $user;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->client = $this->createAuthorizedClient();
     }

--- a/tests/Wallabag/ApiBundle/Controller/DeveloperControllerTest.php
+++ b/tests/Wallabag/ApiBundle/Controller/DeveloperControllerTest.php
@@ -31,7 +31,7 @@ class DeveloperControllerTest extends WallabagCoreTestCase
         $this->assertGreaterThan(\count($nbClients), \count($newNbClients));
 
         $this->assertGreaterThan(1, $alert = $crawler->filter('.settings table strong')->extract(['_text']));
-        $this->assertContains('My app', $alert[0]);
+        $this->assertStringContainsString('My app', $alert[0]);
     }
 
     public function testCreateToken()
@@ -100,7 +100,7 @@ class DeveloperControllerTest extends WallabagCoreTestCase
         // Try to remove an admin's client with a wrong user
         $this->logInAs('bob');
         $client->request('GET', '/developer');
-        $this->assertContains('no_client', $client->getResponse()->getContent());
+        $this->assertStringContainsString('no_client', $client->getResponse()->getContent());
 
         $this->logInAs('bob');
         $client->request('GET', '/developer/client/delete/' . $adminApiClient->getId());

--- a/tests/Wallabag/ApiBundle/Controller/EntryRestControllerTest.php
+++ b/tests/Wallabag/ApiBundle/Controller/EntryRestControllerTest.php
@@ -70,7 +70,7 @@ class EntryRestControllerTest extends WallabagApiTestCase
         $this->assertSame(200, $this->client->getResponse()->getStatusCode());
 
         // epub format got the content type in the content
-        $this->assertContains('application/epub', $this->client->getResponse()->getContent());
+        $this->assertStringContainsString('application/epub', $this->client->getResponse()->getContent());
         $this->assertSame('application/epub+zip', $this->client->getResponse()->headers->get('Content-Type'));
 
         // re-auth client for mobi
@@ -85,7 +85,7 @@ class EntryRestControllerTest extends WallabagApiTestCase
         $client->request('GET', '/api/entries/' . $entry->getId() . '/export.pdf');
         $this->assertSame(200, $client->getResponse()->getStatusCode());
 
-        $this->assertContains('PDF-', $client->getResponse()->getContent());
+        $this->assertStringContainsString('PDF-', $client->getResponse()->getContent());
         $this->assertSame('application/pdf', $client->getResponse()->headers->get('Content-Type'));
 
         // re-auth client for pdf
@@ -93,14 +93,14 @@ class EntryRestControllerTest extends WallabagApiTestCase
         $client->request('GET', '/api/entries/' . $entry->getId() . '/export.txt');
         $this->assertSame(200, $client->getResponse()->getStatusCode());
 
-        $this->assertContains('text/plain', $client->getResponse()->headers->get('Content-Type'));
+        $this->assertStringContainsString('text/plain', $client->getResponse()->headers->get('Content-Type'));
 
         // re-auth client for pdf
         $client = $this->createAuthorizedClient();
         $client->request('GET', '/api/entries/' . $entry->getId() . '/export.csv');
         $this->assertSame(200, $client->getResponse()->getStatusCode());
 
-        $this->assertContains('application/csv', $client->getResponse()->headers->get('Content-Type'));
+        $this->assertStringContainsString('application/csv', $client->getResponse()->headers->get('Content-Type'));
     }
 
     public function testGetOneEntryWrongUser()
@@ -189,13 +189,13 @@ class EntryRestControllerTest extends WallabagApiTestCase
 
         foreach (['self', 'first', 'last'] as $link) {
             $this->assertArrayHasKey('href', $content['_links'][$link]);
-            $this->assertContains('archive=1', $content['_links'][$link]['href']);
-            $this->assertContains('starred=1', $content['_links'][$link]['href']);
-            $this->assertContains('sort=updated', $content['_links'][$link]['href']);
-            $this->assertContains('order=asc', $content['_links'][$link]['href']);
-            $this->assertContains('tags=foo', $content['_links'][$link]['href']);
-            $this->assertContains('since=1443274283', $content['_links'][$link]['href']);
-            $this->assertContains('public=0', $content['_links'][$link]['href']);
+            $this->assertStringContainsString('archive=1', $content['_links'][$link]['href']);
+            $this->assertStringContainsString('starred=1', $content['_links'][$link]['href']);
+            $this->assertStringContainsString('sort=updated', $content['_links'][$link]['href']);
+            $this->assertStringContainsString('order=asc', $content['_links'][$link]['href']);
+            $this->assertStringContainsString('tags=foo', $content['_links'][$link]['href']);
+            $this->assertStringContainsString('since=1443274283', $content['_links'][$link]['href']);
+            $this->assertStringContainsString('public=0', $content['_links'][$link]['href']);
         }
 
         $this->assertSame('application/json', $this->client->getResponse()->headers->get('Content-Type'));
@@ -241,7 +241,7 @@ class EntryRestControllerTest extends WallabagApiTestCase
 
         foreach (['self', 'first', 'last'] as $link) {
             $this->assertArrayHasKey('href', $content['_links'][$link]);
-            $this->assertContains('public=1', $content['_links'][$link]['href']);
+            $this->assertStringContainsString('public=1', $content['_links'][$link]['href']);
         }
 
         $this->assertSame('application/json', $this->client->getResponse()->headers->get('Content-Type'));
@@ -293,8 +293,8 @@ class EntryRestControllerTest extends WallabagApiTestCase
 
         foreach (['self', 'first', 'last'] as $link) {
             $this->assertArrayHasKey('href', $content['_links'][$link]);
-            $this->assertContains('starred=1', $content['_links'][$link]['href']);
-            $this->assertContains('sort=updated', $content['_links'][$link]['href']);
+            $this->assertStringContainsString('starred=1', $content['_links'][$link]['href']);
+            $this->assertStringContainsString('sort=updated', $content['_links'][$link]['href']);
         }
 
         $this->assertSame('application/json', $this->client->getResponse()->headers->get('Content-Type'));
@@ -321,7 +321,7 @@ class EntryRestControllerTest extends WallabagApiTestCase
 
         foreach (['self', 'first', 'last'] as $link) {
             $this->assertArrayHasKey('href', $content['_links'][$link]);
-            $this->assertContains('archive=1', $content['_links'][$link]['href']);
+            $this->assertStringContainsString('archive=1', $content['_links'][$link]['href']);
         }
 
         $this->assertSame('application/json', $this->client->getResponse()->headers->get('Content-Type'));
@@ -351,7 +351,7 @@ class EntryRestControllerTest extends WallabagApiTestCase
 
         foreach (['self', 'first', 'last'] as $link) {
             $this->assertArrayHasKey('href', $content['_links'][$link]);
-            $this->assertContains('tags=' . urlencode('foo,bar'), $content['_links'][$link]['href']);
+            $this->assertStringContainsString('tags=' . urlencode('foo,bar'), $content['_links'][$link]['href']);
         }
 
         $this->assertSame('application/json', $this->client->getResponse()->headers->get('Content-Type'));
@@ -385,7 +385,7 @@ class EntryRestControllerTest extends WallabagApiTestCase
 
         foreach (['self', 'first', 'last'] as $link) {
             $this->assertArrayHasKey('href', $content['_links'][$link]);
-            $this->assertContains('since=1443274283', $content['_links'][$link]['href']);
+            $this->assertStringContainsString('since=1443274283', $content['_links'][$link]['href']);
         }
 
         $this->assertSame('application/json', $this->client->getResponse()->headers->get('Content-Type'));
@@ -413,7 +413,7 @@ class EntryRestControllerTest extends WallabagApiTestCase
 
         foreach (['self', 'first', 'last'] as $link) {
             $this->assertArrayHasKey('href', $content['_links'][$link]);
-            $this->assertContains('since=' . ($future->getTimestamp() + 1000), $content['_links'][$link]['href']);
+            $this->assertStringContainsString('since=' . ($future->getTimestamp() + 1000), $content['_links'][$link]['href']);
         }
 
         $this->assertSame('application/json', $this->client->getResponse()->headers->get('Content-Type'));
@@ -690,7 +690,7 @@ class EntryRestControllerTest extends WallabagApiTestCase
         $this->assertContains('bob', $content['published_by']);
         $this->assertSame('awesome', $content['content']);
         $this->assertFalse($content['is_public'], 'Entry is no more shared');
-        $this->assertContains('2017-03-06', $content['published_at']);
+        $this->assertStringContainsString('2017-03-06', $content['published_at']);
     }
 
     public function testPatchEntryWithoutQuotes()
@@ -1191,7 +1191,7 @@ class EntryRestControllerTest extends WallabagApiTestCase
 
         $content = json_decode($this->client->getResponse()->getContent(), true);
 
-        $this->assertInternalType('int', $content[0]['entry']);
+        $this->assertIsInt($content[0]['entry']);
         $this->assertSame('http://0.0.0.0/entry4', $content[0]['url']);
 
         $entry = $this->client->getContainer()->get('doctrine.orm.entity_manager')
@@ -1263,10 +1263,10 @@ class EntryRestControllerTest extends WallabagApiTestCase
 
         $content = json_decode($this->client->getResponse()->getContent(), true);
 
-        $this->assertInternalType('int', $content[0]['entry']);
+        $this->assertIsInt($content[0]['entry']);
         $this->assertSame('https://www.lemonde.fr/musiques/article/2017/04/23/loin-de-la-politique-le-printemps-de-bourges-retombe-en-enfance_5115862_1654986.html', $content[0]['url']);
 
-        $this->assertInternalType('int', $content[1]['entry']);
+        $this->assertIsInt($content[1]['entry']);
         $this->assertSame('http://0.0.0.0/entry2', $content[1]['url']);
     }
 
@@ -1336,7 +1336,7 @@ class EntryRestControllerTest extends WallabagApiTestCase
         $this->client->request('POST', '/api/entries/lists?urls=' . json_encode($list));
 
         $this->assertSame(400, $this->client->getResponse()->getStatusCode());
-        $this->assertContains('API limit reached', $this->client->getResponse()->getContent());
+        $this->assertStringContainsString('API limit reached', $this->client->getResponse()->getContent());
     }
 
     public function testRePostEntryAndReUsePublishedAt()

--- a/tests/Wallabag/ApiBundle/Controller/SearchRestControllerTest.php
+++ b/tests/Wallabag/ApiBundle/Controller/SearchRestControllerTest.php
@@ -32,7 +32,7 @@ class SearchRestControllerTest extends WallabagApiTestCase
 
         foreach (['self', 'first', 'last'] as $link) {
             $this->assertArrayHasKey('href', $content['_links'][$link]);
-            $this->assertContains('term=entry', $content['_links'][$link]['href']);
+            $this->assertStringContainsString('term=entry', $content['_links'][$link]['href']);
         }
 
         $this->assertSame('application/json', $this->client->getResponse()->headers->get('Content-Type'));
@@ -61,7 +61,7 @@ class SearchRestControllerTest extends WallabagApiTestCase
 
         foreach (['self', 'first', 'last'] as $link) {
             $this->assertArrayHasKey('href', $content['_links'][$link]);
-            $this->assertContains('term=entry', $content['_links'][$link]['href']);
+            $this->assertStringContainsString('term=entry', $content['_links'][$link]['href']);
         }
 
         $this->assertSame('application/json', $this->client->getResponse()->headers->get('Content-Type'));

--- a/tests/Wallabag/ApiBundle/WallabagApiTestCase.php
+++ b/tests/Wallabag/ApiBundle/WallabagApiTestCase.php
@@ -17,7 +17,7 @@ abstract class WallabagApiTestCase extends WebTestCase
      */
     protected $user;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->client = $this->createAuthorizedClient();
     }

--- a/tests/Wallabag/CoreBundle/Command/CleanDuplicatesCommandTest.php
+++ b/tests/Wallabag/CoreBundle/Command/CleanDuplicatesCommandTest.php
@@ -22,8 +22,8 @@ class CleanDuplicatesCommandTest extends WallabagCoreTestCase
             'command' => $command->getName(),
         ]);
 
-        $this->assertContains('Cleaning through 3 user accounts', $tester->getDisplay());
-        $this->assertContains('Finished cleaning. 0 duplicates found in total', $tester->getDisplay());
+        $this->assertStringContainsString('Cleaning through 3 user accounts', $tester->getDisplay());
+        $this->assertStringContainsString('Finished cleaning. 0 duplicates found in total', $tester->getDisplay());
     }
 
     public function testRunCleanDuplicatesCommandWithBadUsername()
@@ -39,7 +39,7 @@ class CleanDuplicatesCommandTest extends WallabagCoreTestCase
             'username' => 'unknown',
         ]);
 
-        $this->assertContains('User "unknown" not found', $tester->getDisplay());
+        $this->assertStringContainsString('User "unknown" not found', $tester->getDisplay());
     }
 
     public function testRunCleanDuplicatesCommandForUser()
@@ -55,7 +55,7 @@ class CleanDuplicatesCommandTest extends WallabagCoreTestCase
             'username' => 'admin',
         ]);
 
-        $this->assertContains('Cleaned 0 duplicates for user admin', $tester->getDisplay());
+        $this->assertStringContainsString('Cleaned 0 duplicates for user admin', $tester->getDisplay());
     }
 
     public function testDuplicate()
@@ -96,7 +96,7 @@ class CleanDuplicatesCommandTest extends WallabagCoreTestCase
             'username' => 'admin',
         ]);
 
-        $this->assertContains('Cleaned 1 duplicates for user admin', $tester->getDisplay());
+        $this->assertStringContainsString('Cleaned 1 duplicates for user admin', $tester->getDisplay());
 
         $nbEntries = $em->getRepository('WallabagCoreBundle:Entry')->findAllByUrlAndUserId($url, $this->getLoggedInUserId());
         $this->assertCount(1, $nbEntries);

--- a/tests/Wallabag/CoreBundle/Command/ExportCommandTest.php
+++ b/tests/Wallabag/CoreBundle/Command/ExportCommandTest.php
@@ -9,12 +9,11 @@ use Wallabag\CoreBundle\Command\ExportCommand;
 
 class ExportCommandTest extends WallabagCoreTestCase
 {
-    /**
-     * @expectedException \Symfony\Component\Console\Exception\RuntimeException
-     * @expectedExceptionMessage Not enough arguments (missing: "username")
-     */
     public function testExportCommandWithoutUsername()
     {
+        $this->expectException(\Symfony\Component\Console\Exception\RuntimeException::class);
+        $this->expectExceptionMessage('Not enough arguments (missing: "username")');
+
         $application = new Application($this->getClient()->getKernel());
         $application->add(new ExportCommand());
 
@@ -39,7 +38,7 @@ class ExportCommandTest extends WallabagCoreTestCase
             'username' => 'unknown',
         ]);
 
-        $this->assertContains('User "unknown" not found', $tester->getDisplay());
+        $this->assertStringContainsString('User "unknown" not found', $tester->getDisplay());
     }
 
     public function testExportCommand()
@@ -55,8 +54,8 @@ class ExportCommandTest extends WallabagCoreTestCase
             'username' => 'admin',
         ]);
 
-        $this->assertContains('Exporting 5 entrie(s) for user admin...', $tester->getDisplay());
-        $this->assertContains('Done', $tester->getDisplay());
+        $this->assertStringContainsString('Exporting 5 entrie(s) for user admin...', $tester->getDisplay());
+        $this->assertStringContainsString('Done', $tester->getDisplay());
         $this->assertFileExists('admin-export.json');
     }
 

--- a/tests/Wallabag/CoreBundle/Command/GenerateUrlHashesCommandTest.php
+++ b/tests/Wallabag/CoreBundle/Command/GenerateUrlHashesCommandTest.php
@@ -22,8 +22,8 @@ class GenerateUrlHashesCommandTest extends WallabagCoreTestCase
             'command' => $command->getName(),
         ]);
 
-        $this->assertContains('Generating hashed urls for "3" users', $tester->getDisplay());
-        $this->assertContains('Finished generated hashed urls', $tester->getDisplay());
+        $this->assertStringContainsString('Generating hashed urls for "3" users', $tester->getDisplay());
+        $this->assertStringContainsString('Finished generated hashed urls', $tester->getDisplay());
     }
 
     public function testRunGenerateUrlHashesCommandWithBadUsername()
@@ -39,7 +39,7 @@ class GenerateUrlHashesCommandTest extends WallabagCoreTestCase
             'username' => 'unknown',
         ]);
 
-        $this->assertContains('User "unknown" not found', $tester->getDisplay());
+        $this->assertStringContainsString('User "unknown" not found', $tester->getDisplay());
     }
 
     public function testRunGenerateUrlHashesCommandForUser()
@@ -55,7 +55,7 @@ class GenerateUrlHashesCommandTest extends WallabagCoreTestCase
             'username' => 'admin',
         ]);
 
-        $this->assertContains('Generated hashed urls for user: admin', $tester->getDisplay());
+        $this->assertStringContainsString('Generated hashed urls for user: admin', $tester->getDisplay());
     }
 
     public function testGenerateUrls()
@@ -85,7 +85,7 @@ class GenerateUrlHashesCommandTest extends WallabagCoreTestCase
             'username' => 'admin',
         ]);
 
-        $this->assertContains('Generated hashed urls for user: admin', $tester->getDisplay());
+        $this->assertStringContainsString('Generated hashed urls for user: admin', $tester->getDisplay());
 
         $entry = $em->getRepository('WallabagCoreBundle:Entry')->findOneByUrl($url);
 

--- a/tests/Wallabag/CoreBundle/Command/InstallCommandTest.php
+++ b/tests/Wallabag/CoreBundle/Command/InstallCommandTest.php
@@ -18,19 +18,19 @@ use Wallabag\CoreBundle\Command\InstallCommand;
 
 class InstallCommandTest extends WallabagCoreTestCase
 {
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass(): void
     {
         // disable doctrine-test-bundle
         StaticDriver::setKeepStaticConnections(false);
     }
 
-    public static function tearDownAfterClass()
+    public static function tearDownAfterClass(): void
     {
         // enable doctrine-test-bundle
         StaticDriver::setKeepStaticConnections(true);
     }
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 
@@ -66,7 +66,7 @@ class InstallCommandTest extends WallabagCoreTestCase
         $this->resetDatabase($this->getClient());
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         $databasePath = getenv('TEST_DATABASE_PATH');
         // Remove variable environnement

--- a/tests/Wallabag/CoreBundle/Command/InstallCommandTest.php
+++ b/tests/Wallabag/CoreBundle/Command/InstallCommandTest.php
@@ -103,10 +103,10 @@ class InstallCommandTest extends WallabagCoreTestCase
             'command' => $command->getName(),
         ]);
 
-        $this->assertContains('Checking system requirements.', $tester->getDisplay());
-        $this->assertContains('Setting up database.', $tester->getDisplay());
-        $this->assertContains('Administration setup.', $tester->getDisplay());
-        $this->assertContains('Config setup.', $tester->getDisplay());
+        $this->assertStringContainsString('Checking system requirements.', $tester->getDisplay());
+        $this->assertStringContainsString('Setting up database.', $tester->getDisplay());
+        $this->assertStringContainsString('Administration setup.', $tester->getDisplay());
+        $this->assertStringContainsString('Config setup.', $tester->getDisplay());
     }
 
     public function testRunInstallCommandWithReset()
@@ -128,14 +128,14 @@ class InstallCommandTest extends WallabagCoreTestCase
             '--reset' => true,
         ]);
 
-        $this->assertContains('Checking system requirements.', $tester->getDisplay());
-        $this->assertContains('Setting up database.', $tester->getDisplay());
-        $this->assertContains('Dropping database, creating database and schema, clearing the cache', $tester->getDisplay());
-        $this->assertContains('Administration setup.', $tester->getDisplay());
-        $this->assertContains('Config setup.', $tester->getDisplay());
+        $this->assertStringContainsString('Checking system requirements.', $tester->getDisplay());
+        $this->assertStringContainsString('Setting up database.', $tester->getDisplay());
+        $this->assertStringContainsString('Dropping database, creating database and schema, clearing the cache', $tester->getDisplay());
+        $this->assertStringContainsString('Administration setup.', $tester->getDisplay());
+        $this->assertStringContainsString('Config setup.', $tester->getDisplay());
 
         // we force to reset everything
-        $this->assertContains('Dropping database, creating database and schema, clearing the cache', $tester->getDisplay());
+        $this->assertStringContainsString('Dropping database, creating database and schema, clearing the cache', $tester->getDisplay());
     }
 
     public function testRunInstallCommandWithDatabaseRemoved()
@@ -174,13 +174,13 @@ class InstallCommandTest extends WallabagCoreTestCase
             'command' => $command->getName(),
         ]);
 
-        $this->assertContains('Checking system requirements.', $tester->getDisplay());
-        $this->assertContains('Setting up database.', $tester->getDisplay());
-        $this->assertContains('Administration setup.', $tester->getDisplay());
-        $this->assertContains('Config setup.', $tester->getDisplay());
+        $this->assertStringContainsString('Checking system requirements.', $tester->getDisplay());
+        $this->assertStringContainsString('Setting up database.', $tester->getDisplay());
+        $this->assertStringContainsString('Administration setup.', $tester->getDisplay());
+        $this->assertStringContainsString('Config setup.', $tester->getDisplay());
 
         // the current database doesn't already exist
-        $this->assertContains('Creating database and schema, clearing the cache', $tester->getDisplay());
+        $this->assertStringContainsString('Creating database and schema, clearing the cache', $tester->getDisplay());
     }
 
     public function testRunInstallCommandChooseResetSchema()
@@ -200,12 +200,12 @@ class InstallCommandTest extends WallabagCoreTestCase
             'command' => $command->getName(),
         ]);
 
-        $this->assertContains('Checking system requirements.', $tester->getDisplay());
-        $this->assertContains('Setting up database.', $tester->getDisplay());
-        $this->assertContains('Administration setup.', $tester->getDisplay());
-        $this->assertContains('Config setup.', $tester->getDisplay());
+        $this->assertStringContainsString('Checking system requirements.', $tester->getDisplay());
+        $this->assertStringContainsString('Setting up database.', $tester->getDisplay());
+        $this->assertStringContainsString('Administration setup.', $tester->getDisplay());
+        $this->assertStringContainsString('Config setup.', $tester->getDisplay());
 
-        $this->assertContains('Dropping schema and creating schema', $tester->getDisplay());
+        $this->assertStringContainsString('Dropping schema and creating schema', $tester->getDisplay());
     }
 
     public function testRunInstallCommandChooseNothing()
@@ -244,12 +244,12 @@ class InstallCommandTest extends WallabagCoreTestCase
             'command' => $command->getName(),
         ]);
 
-        $this->assertContains('Checking system requirements.', $tester->getDisplay());
-        $this->assertContains('Setting up database.', $tester->getDisplay());
-        $this->assertContains('Administration setup.', $tester->getDisplay());
-        $this->assertContains('Config setup.', $tester->getDisplay());
+        $this->assertStringContainsString('Checking system requirements.', $tester->getDisplay());
+        $this->assertStringContainsString('Setting up database.', $tester->getDisplay());
+        $this->assertStringContainsString('Administration setup.', $tester->getDisplay());
+        $this->assertStringContainsString('Config setup.', $tester->getDisplay());
 
-        $this->assertContains('Creating schema', $tester->getDisplay());
+        $this->assertStringContainsString('Creating schema', $tester->getDisplay());
     }
 
     public function testRunInstallCommandNoInteraction()
@@ -266,9 +266,9 @@ class InstallCommandTest extends WallabagCoreTestCase
             'interactive' => false,
         ]);
 
-        $this->assertContains('Checking system requirements.', $tester->getDisplay());
-        $this->assertContains('Setting up database.', $tester->getDisplay());
-        $this->assertContains('Administration setup.', $tester->getDisplay());
-        $this->assertContains('Config setup.', $tester->getDisplay());
+        $this->assertStringContainsString('Checking system requirements.', $tester->getDisplay());
+        $this->assertStringContainsString('Setting up database.', $tester->getDisplay());
+        $this->assertStringContainsString('Administration setup.', $tester->getDisplay());
+        $this->assertStringContainsString('Config setup.', $tester->getDisplay());
     }
 }

--- a/tests/Wallabag/CoreBundle/Command/ListUserCommandTest.php
+++ b/tests/Wallabag/CoreBundle/Command/ListUserCommandTest.php
@@ -21,7 +21,7 @@ class ListUserCommandTest extends WallabagCoreTestCase
             'command' => $command->getName(),
         ]);
 
-        $this->assertContains('3/3 user(s) displayed.', $tester->getDisplay());
+        $this->assertStringContainsString('3/3 user(s) displayed.', $tester->getDisplay());
     }
 
     public function testRunListUserCommandWithLimit()
@@ -37,7 +37,7 @@ class ListUserCommandTest extends WallabagCoreTestCase
             '--limit' => 2,
         ]);
 
-        $this->assertContains('2/3 user(s) displayed.', $tester->getDisplay());
+        $this->assertStringContainsString('2/3 user(s) displayed.', $tester->getDisplay());
     }
 
     public function testRunListUserCommandWithSearch()
@@ -53,7 +53,7 @@ class ListUserCommandTest extends WallabagCoreTestCase
             'search' => 'boss',
         ]);
 
-        $this->assertContains('1/3 (filtered) user(s) displayed.', $tester->getDisplay());
+        $this->assertStringContainsString('1/3 (filtered) user(s) displayed.', $tester->getDisplay());
     }
 
     public function testRunListUserCommandWithSearchAndLimit()
@@ -70,6 +70,6 @@ class ListUserCommandTest extends WallabagCoreTestCase
             '--limit' => 1,
         ]);
 
-        $this->assertContains('1/3 (filtered) user(s) displayed.', $tester->getDisplay());
+        $this->assertStringContainsString('1/3 (filtered) user(s) displayed.', $tester->getDisplay());
     }
 }

--- a/tests/Wallabag/CoreBundle/Command/ReloadEntryCommandTest.php
+++ b/tests/Wallabag/CoreBundle/Command/ReloadEntryCommandTest.php
@@ -70,7 +70,7 @@ class ReloadEntryCommandTest extends WallabagCoreTestCase
             $this->assertNotEmpty($reloadedEntry->getContent());
         }
 
-        $this->assertContains('Done', $tester->getDisplay());
+        $this->assertStringContainsString('Done', $tester->getDisplay());
     }
 
     /**
@@ -98,7 +98,7 @@ class ReloadEntryCommandTest extends WallabagCoreTestCase
         $reloadedBobEntry = $entryRepository->find($this->bobEntry->getId());
         $this->assertEmpty($reloadedBobEntry->getContent());
 
-        $this->assertContains('Done', $tester->getDisplay());
+        $this->assertStringContainsString('Done', $tester->getDisplay());
     }
 
     public function testRunReloadEntryWithoutEntryCommand()
@@ -115,7 +115,7 @@ class ReloadEntryCommandTest extends WallabagCoreTestCase
             'interactive' => false,
         ]);
 
-        $this->assertContains('No entry to reload', $tester->getDisplay());
-        $this->assertNotContains('Done', $tester->getDisplay());
+        $this->assertStringContainsString('No entry to reload', $tester->getDisplay());
+        $this->assertStringNotContainsString('Done', $tester->getDisplay());
     }
 }

--- a/tests/Wallabag/CoreBundle/Command/ReloadEntryCommandTest.php
+++ b/tests/Wallabag/CoreBundle/Command/ReloadEntryCommandTest.php
@@ -22,7 +22,7 @@ class ReloadEntryCommandTest extends WallabagCoreTestCase
      */
     public $bobEntry;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Wallabag/CoreBundle/Command/ShowUserCommandTest.php
+++ b/tests/Wallabag/CoreBundle/Command/ShowUserCommandTest.php
@@ -10,12 +10,11 @@ use Wallabag\UserBundle\Entity\User;
 
 class ShowUserCommandTest extends WallabagCoreTestCase
 {
-    /**
-     * @expectedException \Symfony\Component\Console\Exception\RuntimeException
-     * @expectedExceptionMessage Not enough arguments
-     */
     public function testRunShowUserCommandWithoutUsername()
     {
+        $this->expectException(\Symfony\Component\Console\Exception\RuntimeException::class);
+        $this->expectExceptionMessage('Not enough arguments');
+
         $application = new Application($this->getClient()->getKernel());
         $application->add(new ShowUserCommand());
 
@@ -40,7 +39,7 @@ class ShowUserCommandTest extends WallabagCoreTestCase
             'username' => 'unknown',
         ]);
 
-        $this->assertContains('User "unknown" not found', $tester->getDisplay());
+        $this->assertStringContainsString('User "unknown" not found', $tester->getDisplay());
     }
 
     public function testRunShowUserCommandForUser()
@@ -56,11 +55,11 @@ class ShowUserCommandTest extends WallabagCoreTestCase
             'username' => 'admin',
         ]);
 
-        $this->assertContains('Username: admin', $tester->getDisplay());
-        $this->assertContains('Email: bigboss@wallabag.org', $tester->getDisplay());
-        $this->assertContains('Display name: Big boss', $tester->getDisplay());
-        $this->assertContains('2FA (email) activated', $tester->getDisplay());
-        $this->assertContains('2FA (OTP) activated', $tester->getDisplay());
+        $this->assertStringContainsString('Username: admin', $tester->getDisplay());
+        $this->assertStringContainsString('Email: bigboss@wallabag.org', $tester->getDisplay());
+        $this->assertStringContainsString('Display name: Big boss', $tester->getDisplay());
+        $this->assertStringContainsString('2FA (email) activated', $tester->getDisplay());
+        $this->assertStringContainsString('2FA (OTP) activated', $tester->getDisplay());
     }
 
     public function testShowUser()
@@ -89,6 +88,6 @@ class ShowUserCommandTest extends WallabagCoreTestCase
             'username' => 'admin',
         ]);
 
-        $this->assertContains('Display name: Bug boss', $tester->getDisplay());
+        $this->assertStringContainsString('Display name: Bug boss', $tester->getDisplay());
     }
 }

--- a/tests/Wallabag/CoreBundle/Command/TagAllCommandTest.php
+++ b/tests/Wallabag/CoreBundle/Command/TagAllCommandTest.php
@@ -9,12 +9,11 @@ use Wallabag\CoreBundle\Command\TagAllCommand;
 
 class TagAllCommandTest extends WallabagCoreTestCase
 {
-    /**
-     * @expectedException \Symfony\Component\Console\Exception\RuntimeException
-     * @expectedExceptionMessage Not enough arguments (missing: "username")
-     */
     public function testRunTagAllCommandWithoutUsername()
     {
+        $this->expectException(\Symfony\Component\Console\Exception\RuntimeException::class);
+        $this->expectExceptionMessage('Not enough arguments (missing: "username")');
+
         $application = new Application($this->getClient()->getKernel());
         $application->add(new TagAllCommand());
 
@@ -39,7 +38,7 @@ class TagAllCommandTest extends WallabagCoreTestCase
             'username' => 'unknown',
         ]);
 
-        $this->assertContains('User "unknown" not found', $tester->getDisplay());
+        $this->assertStringContainsString('User "unknown" not found', $tester->getDisplay());
     }
 
     public function testRunTagAllCommand()
@@ -55,7 +54,7 @@ class TagAllCommandTest extends WallabagCoreTestCase
             'username' => 'admin',
         ]);
 
-        $this->assertContains('Tagging entries for user admin...', $tester->getDisplay());
-        $this->assertContains('Done', $tester->getDisplay());
+        $this->assertStringContainsString('Tagging entries for user admin...', $tester->getDisplay());
+        $this->assertStringContainsString('Done', $tester->getDisplay());
     }
 }

--- a/tests/Wallabag/CoreBundle/Controller/ConfigControllerTest.php
+++ b/tests/Wallabag/CoreBundle/Controller/ConfigControllerTest.php
@@ -19,7 +19,7 @@ class ConfigControllerTest extends WallabagCoreTestCase
         $client->request('GET', '/new');
 
         $this->assertSame(302, $client->getResponse()->getStatusCode());
-        $this->assertContains('login', $client->getResponse()->headers->get('location'));
+        $this->assertStringContainsString('login', $client->getResponse()->headers->get('location'));
     }
 
     public function testIndex()
@@ -62,7 +62,7 @@ class ConfigControllerTest extends WallabagCoreTestCase
 
         $crawler = $client->followRedirect();
 
-        $this->assertContains('flashes.config.notice.config_saved', $crawler->filter('body')->extract(['_text'])[0]);
+        $this->assertStringContainsString('flashes.config.notice.config_saved', $crawler->filter('body')->extract(['_text'])[0]);
     }
 
     public function testChangeReadingSpeed()
@@ -141,7 +141,7 @@ class ConfigControllerTest extends WallabagCoreTestCase
         $this->assertSame(200, $client->getResponse()->getStatusCode());
 
         $this->assertGreaterThan(1, $alert = $crawler->filter('body')->extract(['_text']));
-        $this->assertContains('This value should not be blank', $alert[0]);
+        $this->assertStringContainsString('This value should not be blank', $alert[0]);
     }
 
     public function dataForChangePasswordFailed()
@@ -201,7 +201,7 @@ class ConfigControllerTest extends WallabagCoreTestCase
         $this->assertSame(200, $client->getResponse()->getStatusCode());
 
         $this->assertGreaterThan(1, $alert = $crawler->filter('body')->extract(['_text']));
-        $this->assertContains($expectedMessage, $alert[0]);
+        $this->assertStringContainsString($expectedMessage, $alert[0]);
     }
 
     public function testChangePassword()
@@ -227,7 +227,7 @@ class ConfigControllerTest extends WallabagCoreTestCase
 
         $crawler = $client->followRedirect();
 
-        $this->assertContains('flashes.config.notice.password_updated', $crawler->filter('body')->extract(['_text'])[0]);
+        $this->assertStringContainsString('flashes.config.notice.password_updated', $crawler->filter('body')->extract(['_text'])[0]);
     }
 
     public function dataForUserFailed()
@@ -269,7 +269,7 @@ class ConfigControllerTest extends WallabagCoreTestCase
         $this->assertSame(200, $client->getResponse()->getStatusCode());
 
         $this->assertGreaterThan(1, $alert = $crawler->filter('body')->extract(['_text']));
-        $this->assertContains($expectedMessage, $alert[0]);
+        $this->assertStringContainsString($expectedMessage, $alert[0]);
     }
 
     public function testUserUpdate()
@@ -295,7 +295,7 @@ class ConfigControllerTest extends WallabagCoreTestCase
         $crawler = $client->followRedirect();
 
         $this->assertGreaterThan(1, $alert = $crawler->filter('body')->extract(['_text']));
-        $this->assertContains('flashes.config.notice.user_updated', $alert[0]);
+        $this->assertStringContainsString('flashes.config.notice.user_updated', $alert[0]);
     }
 
     public function testFeedUpdateResetToken()
@@ -323,7 +323,7 @@ class ConfigControllerTest extends WallabagCoreTestCase
         $this->assertSame(200, $client->getResponse()->getStatusCode());
 
         $this->assertGreaterThan(1, $body = $crawler->filter('body')->extract(['_text']));
-        $this->assertContains('config.form_feed.no_token', $body[0]);
+        $this->assertStringContainsString('config.form_feed.no_token', $body[0]);
 
         $client->request('GET', '/generate-token');
         $this->assertSame(302, $client->getResponse()->getStatusCode());
@@ -331,7 +331,7 @@ class ConfigControllerTest extends WallabagCoreTestCase
         $crawler = $client->followRedirect();
 
         $this->assertGreaterThan(1, $body = $crawler->filter('body')->extract(['_text']));
-        $this->assertContains('config.form_feed.token_reset', $body[0]);
+        $this->assertStringContainsString('config.form_feed.token_reset', $body[0]);
     }
 
     public function testGenerateTokenAjax()
@@ -389,7 +389,7 @@ class ConfigControllerTest extends WallabagCoreTestCase
 
         $crawler = $client->followRedirect();
 
-        $this->assertContains('flashes.config.notice.feed_updated', $crawler->filter('body')->extract(['_text'])[0]);
+        $this->assertStringContainsString('flashes.config.notice.feed_updated', $crawler->filter('body')->extract(['_text'])[0]);
     }
 
     public function dataForFeedFailed()
@@ -429,7 +429,7 @@ class ConfigControllerTest extends WallabagCoreTestCase
         $this->assertSame(200, $client->getResponse()->getStatusCode());
 
         $this->assertGreaterThan(1, $alert = $crawler->filter('body')->extract(['_text']));
-        $this->assertContains($expectedMessage, $alert[0]);
+        $this->assertStringContainsString($expectedMessage, $alert[0]);
     }
 
     public function testTaggingRuleCreation()
@@ -454,13 +454,13 @@ class ConfigControllerTest extends WallabagCoreTestCase
 
         $crawler = $client->followRedirect();
 
-        $this->assertContains('flashes.config.notice.tagging_rules_updated', $crawler->filter('body')->extract(['_text'])[0]);
+        $this->assertStringContainsString('flashes.config.notice.tagging_rules_updated', $crawler->filter('body')->extract(['_text'])[0]);
 
         $editLink = $crawler->filter('div[id=set5] a.mode_edit')->last()->link();
 
         $crawler = $client->click($editLink);
         $this->assertSame(302, $client->getResponse()->getStatusCode());
-        $this->assertContains('?tagging-rule=', $client->getResponse()->headers->get('location'));
+        $this->assertStringContainsString('?tagging-rule=', $client->getResponse()->headers->get('location'));
 
         $crawler = $client->followRedirect();
 
@@ -477,9 +477,9 @@ class ConfigControllerTest extends WallabagCoreTestCase
 
         $crawler = $client->followRedirect();
 
-        $this->assertContains('flashes.config.notice.tagging_rules_updated', $crawler->filter('body')->extract(['_text'])[0]);
+        $this->assertStringContainsString('flashes.config.notice.tagging_rules_updated', $crawler->filter('body')->extract(['_text'])[0]);
 
-        $this->assertContains('readingTime <= 30', $crawler->filter('body')->extract(['_text'])[0]);
+        $this->assertStringContainsString('readingTime <= 30', $crawler->filter('body')->extract(['_text'])[0]);
 
         $deleteLink = $crawler->filter('div[id=set5] a.delete')->last()->link();
 
@@ -487,7 +487,7 @@ class ConfigControllerTest extends WallabagCoreTestCase
         $this->assertSame(302, $client->getResponse()->getStatusCode());
 
         $crawler = $client->followRedirect();
-        $this->assertContains('flashes.config.notice.tagging_rules_deleted', $crawler->filter('body')->extract(['_text'])[0]);
+        $this->assertStringContainsString('flashes.config.notice.tagging_rules_deleted', $crawler->filter('body')->extract(['_text'])[0]);
     }
 
     public function dataForTaggingRuleFailed()
@@ -537,7 +537,7 @@ class ConfigControllerTest extends WallabagCoreTestCase
         $this->assertGreaterThan(1, $body = $crawler->filter('body')->extract(['_text']));
 
         foreach ($messages as $message) {
-            $this->assertContains($message, $body[0]);
+            $this->assertStringContainsString($message, $body[0]);
         }
     }
 
@@ -561,7 +561,7 @@ class ConfigControllerTest extends WallabagCoreTestCase
 
         $this->assertGreaterThan(1, $body = $crawler->filter('body')->extract(['_text']));
 
-        $this->assertContains('255 characters', $body[0]);
+        $this->assertStringContainsString('255 characters', $body[0]);
     }
 
     public function testDeletingTaggingRuleFromAnOtherUser()
@@ -577,7 +577,7 @@ class ConfigControllerTest extends WallabagCoreTestCase
 
         $this->assertSame(403, $client->getResponse()->getStatusCode());
         $this->assertGreaterThan(1, $body = $crawler->filter('body')->extract(['_text']));
-        $this->assertContains('You can not access this rule', $body[0]);
+        $this->assertStringContainsString('You can not access this rule', $body[0]);
     }
 
     public function testEditingTaggingRuleFromAnOtherUser()
@@ -593,7 +593,7 @@ class ConfigControllerTest extends WallabagCoreTestCase
 
         $this->assertSame(403, $client->getResponse()->getStatusCode());
         $this->assertGreaterThan(1, $body = $crawler->filter('body')->extract(['_text']));
-        $this->assertContains('You can not access this rule', $body[0]);
+        $this->assertStringContainsString('You can not access this rule', $body[0]);
     }
 
     public function testIgnoreOriginRuleCreation()
@@ -617,13 +617,13 @@ class ConfigControllerTest extends WallabagCoreTestCase
 
         $crawler = $client->followRedirect();
 
-        $this->assertContains('flashes.config.notice.ignore_origin_rules_updated', $crawler->filter('body')->extract(['_text'])[0]);
+        $this->assertStringContainsString('flashes.config.notice.ignore_origin_rules_updated', $crawler->filter('body')->extract(['_text'])[0]);
 
         $editLink = $crawler->filter('div[id=set6] a.mode_edit')->last()->link();
 
         $crawler = $client->click($editLink);
         $this->assertSame(302, $client->getResponse()->getStatusCode());
-        $this->assertContains('?ignore-origin-user-rule=', $client->getResponse()->headers->get('location'));
+        $this->assertStringContainsString('?ignore-origin-user-rule=', $client->getResponse()->headers->get('location'));
 
         $crawler = $client->followRedirect();
 
@@ -639,9 +639,9 @@ class ConfigControllerTest extends WallabagCoreTestCase
 
         $crawler = $client->followRedirect();
 
-        $this->assertContains('flashes.config.notice.ignore_origin_rules_updated', $crawler->filter('body')->extract(['_text'])[0]);
+        $this->assertStringContainsString('flashes.config.notice.ignore_origin_rules_updated', $crawler->filter('body')->extract(['_text'])[0]);
 
-        $this->assertContains('host = "example.org"', $crawler->filter('body')->extract(['_text'])[0]);
+        $this->assertStringContainsString('host = "example.org"', $crawler->filter('body')->extract(['_text'])[0]);
 
         $deleteLink = $crawler->filter('div[id=set6] a.delete')->last()->link();
 
@@ -649,7 +649,7 @@ class ConfigControllerTest extends WallabagCoreTestCase
         $this->assertSame(302, $client->getResponse()->getStatusCode());
 
         $crawler = $client->followRedirect();
-        $this->assertContains('flashes.config.notice.ignore_origin_rules_deleted', $crawler->filter('body')->extract(['_text'])[0]);
+        $this->assertStringContainsString('flashes.config.notice.ignore_origin_rules_deleted', $crawler->filter('body')->extract(['_text'])[0]);
     }
 
     public function dataForIgnoreOriginRuleCreationFail()
@@ -697,7 +697,7 @@ class ConfigControllerTest extends WallabagCoreTestCase
         $this->assertGreaterThan(1, $body = $crawler->filter('body')->extract(['_text']));
 
         foreach ($messages as $message) {
-            $this->assertContains($message, $body[0]);
+            $this->assertStringContainsString($message, $body[0]);
         }
     }
 
@@ -714,7 +714,7 @@ class ConfigControllerTest extends WallabagCoreTestCase
 
         $this->assertSame(403, $client->getResponse()->getStatusCode());
         $this->assertGreaterThan(1, $body = $crawler->filter('body')->extract(['_text']));
-        $this->assertContains('You can not access this rule', $body[0]);
+        $this->assertStringContainsString('You can not access this rule', $body[0]);
     }
 
     public function testEditingIgnoreOriginRuleFromAnOtherUser()
@@ -730,7 +730,7 @@ class ConfigControllerTest extends WallabagCoreTestCase
 
         $this->assertSame(403, $client->getResponse()->getStatusCode());
         $this->assertGreaterThan(1, $body = $crawler->filter('body')->extract(['_text']));
-        $this->assertContains('You can not access this rule', $body[0]);
+        $this->assertStringContainsString('You can not access this rule', $body[0]);
     }
 
     public function testDemoMode()
@@ -757,7 +757,7 @@ class ConfigControllerTest extends WallabagCoreTestCase
         $client->submit($form, $data);
 
         $this->assertSame(302, $client->getResponse()->getStatusCode());
-        $this->assertContains('flashes.config.notice.password_not_updated_demo', $client->getContainer()->get('session')->getFlashBag()->get('notice')[0]);
+        $this->assertStringContainsString('flashes.config.notice.password_not_updated_demo', $client->getContainer()->get('session')->getFlashBag()->get('notice')[0]);
 
         $config->set('demo_mode_enabled', 0);
         $config->set('demo_mode_username', 'wallabag');
@@ -771,7 +771,7 @@ class ConfigControllerTest extends WallabagCoreTestCase
         $crawler = $client->request('GET', '/config');
 
         $this->assertGreaterThan(1, $body = $crawler->filter('body')->extract(['_text']));
-        $this->assertContains('config.form_user.delete.button', $body[0]);
+        $this->assertStringContainsString('config.form_user.delete.button', $body[0]);
 
         $em = $client->getContainer()->get('doctrine.orm.entity_manager');
 
@@ -792,7 +792,7 @@ class ConfigControllerTest extends WallabagCoreTestCase
         $crawler = $client->request('GET', '/config');
 
         $this->assertGreaterThan(1, $body = $crawler->filter('body')->extract(['_text']));
-        $this->assertNotContains('config.form_user.delete.button', $body[0]);
+        $this->assertStringNotContainsString('config.form_user.delete.button', $body[0]);
 
         $client->request('GET', '/account/delete');
         $this->assertSame(403, $client->getResponse()->getStatusCode());
@@ -928,7 +928,7 @@ class ConfigControllerTest extends WallabagCoreTestCase
         $crawler = $client->click($crawler->selectLink('config.reset.annotations')->link());
 
         $this->assertSame(302, $client->getResponse()->getStatusCode());
-        $this->assertContains('flashes.config.notice.annotations_reset', $client->getContainer()->get('session')->getFlashBag()->get('notice')[0]);
+        $this->assertStringContainsString('flashes.config.notice.annotations_reset', $client->getContainer()->get('session')->getFlashBag()->get('notice')[0]);
 
         $annotationsReset = $em
             ->getRepository('WallabagAnnotationBundle:Annotation')
@@ -944,7 +944,7 @@ class ConfigControllerTest extends WallabagCoreTestCase
         $crawler = $client->click($crawler->selectLink('config.reset.tags')->link());
 
         $this->assertSame(302, $client->getResponse()->getStatusCode());
-        $this->assertContains('flashes.config.notice.tags_reset', $client->getContainer()->get('session')->getFlashBag()->get('notice')[0]);
+        $this->assertStringContainsString('flashes.config.notice.tags_reset', $client->getContainer()->get('session')->getFlashBag()->get('notice')[0]);
 
         $tagReset = $em
             ->getRepository('WallabagCoreBundle:Tag')
@@ -960,7 +960,7 @@ class ConfigControllerTest extends WallabagCoreTestCase
         $crawler = $client->click($crawler->selectLink('config.reset.entries')->link());
 
         $this->assertSame(302, $client->getResponse()->getStatusCode());
-        $this->assertContains('flashes.config.notice.entries_reset', $client->getContainer()->get('session')->getFlashBag()->get('notice')[0]);
+        $this->assertStringContainsString('flashes.config.notice.entries_reset', $client->getContainer()->get('session')->getFlashBag()->get('notice')[0]);
 
         $entryReset = $em
             ->getRepository('WallabagCoreBundle:Entry')
@@ -1024,7 +1024,7 @@ class ConfigControllerTest extends WallabagCoreTestCase
         $crawler = $client->click($crawler->selectLink('config.reset.archived')->link());
 
         $this->assertSame(302, $client->getResponse()->getStatusCode());
-        $this->assertContains('flashes.config.notice.archived_reset', $client->getContainer()->get('session')->getFlashBag()->get('notice')[0]);
+        $this->assertStringContainsString('flashes.config.notice.archived_reset', $client->getContainer()->get('session')->getFlashBag()->get('notice')[0]);
 
         $entryReset = $em
             ->getRepository('WallabagCoreBundle:Entry')
@@ -1081,7 +1081,7 @@ class ConfigControllerTest extends WallabagCoreTestCase
         $crawler = $client->click($crawler->selectLink('config.reset.entries')->link());
 
         $this->assertSame(302, $client->getResponse()->getStatusCode());
-        $this->assertContains('flashes.config.notice.entries_reset', $client->getContainer()->get('session')->getFlashBag()->get('notice')[0]);
+        $this->assertStringContainsString('flashes.config.notice.entries_reset', $client->getContainer()->get('session')->getFlashBag()->get('notice')[0]);
 
         $entryReset = $em
             ->getRepository('WallabagCoreBundle:Entry')
@@ -1110,14 +1110,14 @@ class ConfigControllerTest extends WallabagCoreTestCase
 
         $client->request('GET', '/unread/list');
 
-        $this->assertNotContains('listmode', $client->getResponse()->getContent());
+        $this->assertStringNotContainsString('listmode', $client->getResponse()->getContent());
 
         $client->request('GET', '/config/view-mode');
         $crawler = $client->followRedirect();
 
         $client->request('GET', '/unread/list');
 
-        $this->assertContains('listmode', $client->getResponse()->getContent());
+        $this->assertStringContainsString('listmode', $client->getResponse()->getContent());
 
         $client->request('GET', '/config/view-mode');
     }
@@ -1169,7 +1169,7 @@ class ConfigControllerTest extends WallabagCoreTestCase
         $crawler = $client->followRedirect();
 
         $this->assertGreaterThan(1, $alert = $crawler->filter('body')->extract(['_text']));
-        $this->assertContains('flashes.config.notice.otp_enabled', $alert[0]);
+        $this->assertStringContainsString('flashes.config.notice.otp_enabled', $alert[0]);
 
         // restore user
         $em = $this->getEntityManager();
@@ -1196,7 +1196,7 @@ class ConfigControllerTest extends WallabagCoreTestCase
         $crawler = $client->followRedirect();
 
         $this->assertGreaterThan(1, $alert = $crawler->filter('body')->extract(['_text']));
-        $this->assertContains('flashes.config.notice.otp_disabled', $alert[0]);
+        $this->assertStringContainsString('flashes.config.notice.otp_disabled', $alert[0]);
 
         // restore user
         $em = $this->getEntityManager();
@@ -1273,7 +1273,7 @@ class ConfigControllerTest extends WallabagCoreTestCase
         $crawler = $client->followRedirect();
 
         $this->assertGreaterThan(1, $alert = $crawler->filter('body')->extract(['_text']));
-        $this->assertContains('flashes.config.notice.otp_disabled', $alert[0]);
+        $this->assertStringContainsString('flashes.config.notice.otp_disabled', $alert[0]);
 
         // restore user
         $em = $this->getEntityManager();

--- a/tests/Wallabag/CoreBundle/Controller/EntryControllerTest.php
+++ b/tests/Wallabag/CoreBundle/Controller/EntryControllerTest.php
@@ -37,7 +37,7 @@ class EntryControllerTest extends WallabagCoreTestCase
         $client->request('GET', '/new');
 
         $this->assertSame(302, $client->getResponse()->getStatusCode());
-        $this->assertContains('login', $client->getResponse()->headers->get('location'));
+        $this->assertStringContainsString('login', $client->getResponse()->headers->get('location'));
     }
 
     /**
@@ -54,7 +54,7 @@ class EntryControllerTest extends WallabagCoreTestCase
 
         $this->assertSame(200, $client->getResponse()->getStatusCode());
         $this->assertGreaterThan(1, $body = $crawler->filter('body')->extract(['_text']));
-        $this->assertContains('quickstart.intro.title', $body[0]);
+        $this->assertStringContainsString('quickstart.intro.title', $body[0]);
 
         // Test if quickstart is disabled when user has 1 entry
         $crawler = $client->request('GET', '/new');
@@ -73,7 +73,7 @@ class EntryControllerTest extends WallabagCoreTestCase
 
         $crawler = $client->request('GET', '/unread/list');
         $this->assertGreaterThan(1, $body = $crawler->filter('body')->extract(['_text']));
-        $this->assertContains('entry.list.number_on_the_page', $body[0]);
+        $this->assertStringContainsString('entry.list.number_on_the_page', $body[0]);
     }
 
     public function testGetNew()
@@ -169,7 +169,7 @@ class EntryControllerTest extends WallabagCoreTestCase
 
         $this->assertInstanceOf('Wallabag\CoreBundle\Entity\Entry', $content);
         $this->assertSame($this->url, $content->getUrl());
-        $this->assertContains('la cryptomonnaie de Facebook', $content->getTitle());
+        $this->assertStringContainsString('la cryptomonnaie de Facebook', $content->getTitle());
         $this->assertSame('fr', $content->getLanguage());
         $this->assertArrayHasKey('x-frame-options', $content->getHeaders());
         $client->getContainer()->get('craue_config')->set('store_article_headers', 0);
@@ -235,7 +235,7 @@ class EntryControllerTest extends WallabagCoreTestCase
         $client->submit($form, $data);
 
         $this->assertSame(302, $client->getResponse()->getStatusCode());
-        $this->assertContains('/view/', $client->getResponse()->getTargetUrl());
+        $this->assertStringContainsString('/view/', $client->getResponse()->getTargetUrl());
     }
 
     /**
@@ -273,7 +273,7 @@ class EntryControllerTest extends WallabagCoreTestCase
         $client->submit($form, $data);
 
         $this->assertSame(302, $client->getResponse()->getStatusCode());
-        $this->assertContains('/view/', $client->getResponse()->getTargetUrl());
+        $this->assertStringContainsString('/view/', $client->getResponse()->getTargetUrl());
     }
 
     /**
@@ -311,7 +311,7 @@ class EntryControllerTest extends WallabagCoreTestCase
         $client->submit($form, $data);
 
         $this->assertSame(302, $client->getResponse()->getStatusCode());
-        $this->assertContains('/view/', $client->getResponse()->getTargetUrl());
+        $this->assertStringContainsString('/view/', $client->getResponse()->getTargetUrl());
     }
 
     /**
@@ -335,7 +335,7 @@ class EntryControllerTest extends WallabagCoreTestCase
         $client->submit($form, $data);
 
         $this->assertSame(302, $client->getResponse()->getStatusCode());
-        $this->assertContains('/', $client->getResponse()->getTargetUrl());
+        $this->assertStringContainsString('/', $client->getResponse()->getTargetUrl());
 
         $em = $client->getContainer()
             ->get('doctrine.orm.entity_manager');
@@ -366,7 +366,7 @@ class EntryControllerTest extends WallabagCoreTestCase
         $client->submit($form, $data);
 
         $this->assertSame(302, $client->getResponse()->getStatusCode());
-        $this->assertContains('/', $client->getResponse()->getTargetUrl());
+        $this->assertStringContainsString('/', $client->getResponse()->getTargetUrl());
 
         $entry = $em
             ->getRepository('WallabagCoreBundle:Entry')
@@ -438,7 +438,7 @@ class EntryControllerTest extends WallabagCoreTestCase
 
         $this->assertSame(200, $client->getResponse()->getStatusCode());
         $this->assertGreaterThan(1, $body = $crawler->filter('body')->extract(['_text']));
-        $this->assertContains($entry->getTitle(), $body[0]);
+        $this->assertStringContainsString($entry->getTitle(), $body[0]);
     }
 
     /**
@@ -538,9 +538,9 @@ class EntryControllerTest extends WallabagCoreTestCase
         $crawler = $client->followRedirect();
 
         $this->assertGreaterThan(1, $title = $crawler->filter('div[id=article] h1')->extract(['_text']));
-        $this->assertContains('My updated title hehe :)', $title[0]);
+        $this->assertStringContainsString('My updated title hehe :)', $title[0]);
         $this->assertGreaterThan(1, $stats = $crawler->filter('div[class="tools grey-text"] ul[class=stats] li a[class="tool grey-text"]')->extract(['_text']));
-        $this->assertContains('example.io', trim($stats[1]));
+        $this->assertStringContainsString('example.io', trim($stats[1]));
     }
 
     public function testEditRemoveOriginUrl()
@@ -572,11 +572,11 @@ class EntryControllerTest extends WallabagCoreTestCase
 
         $title = $crawler->filter('div[id=article] h1')->extract(['_text']);
         $this->assertGreaterThan(1, $title);
-        $this->assertContains('My updated title hehe :)', $title[0]);
+        $this->assertStringContainsString('My updated title hehe :)', $title[0]);
 
         $stats = $crawler->filter('div[class="tools grey-text"] ul[class=stats] li a[class="tool grey-text"]')->extract(['_text']);
         $this->assertCount(1, $stats);
-        $this->assertNotContains('example.io', trim($stats[0]));
+        $this->assertStringNotContainsString('example.io', trim($stats[0]));
     }
 
     public function testToggleArchive()
@@ -896,7 +896,7 @@ class EntryControllerTest extends WallabagCoreTestCase
 
         $client->request('GET', 'unread/list' . $parameters);
 
-        $this->assertContains($parameters, $client->getResponse()->getContent());
+        $this->assertStringContainsString($parameters, $client->getResponse()->getContent());
 
         // reset pagination
         $crawler = $client->request('GET', '/config');
@@ -1045,14 +1045,14 @@ class EntryControllerTest extends WallabagCoreTestCase
         $client->request('GET', $shareUrl);
 
         $this->assertSame(200, $client->getResponse()->getStatusCode());
-        $this->assertContains('max-age=25200', $client->getResponse()->headers->get('cache-control'));
-        $this->assertContains('public', $client->getResponse()->headers->get('cache-control'));
-        $this->assertContains('s-maxage=25200', $client->getResponse()->headers->get('cache-control'));
-        $this->assertNotContains('no-cache', $client->getResponse()->headers->get('cache-control'));
-        $this->assertContains('og:title', $client->getResponse()->getContent());
-        $this->assertContains('og:type', $client->getResponse()->getContent());
-        $this->assertContains('og:url', $client->getResponse()->getContent());
-        $this->assertContains('og:image', $client->getResponse()->getContent());
+        $this->assertStringContainsString('max-age=25200', $client->getResponse()->headers->get('cache-control'));
+        $this->assertStringContainsString('public', $client->getResponse()->headers->get('cache-control'));
+        $this->assertStringContainsString('s-maxage=25200', $client->getResponse()->headers->get('cache-control'));
+        $this->assertStringNotContainsString('no-cache', $client->getResponse()->headers->get('cache-control'));
+        $this->assertStringContainsString('og:title', $client->getResponse()->getContent());
+        $this->assertStringContainsString('og:type', $client->getResponse()->getContent());
+        $this->assertStringContainsString('og:url', $client->getResponse()->getContent());
+        $this->assertStringContainsString('og:image', $client->getResponse()->getContent());
 
         // sharing is now disabled
         $client->getContainer()->get('craue_config')->set('share_public', 0);
@@ -1103,9 +1103,9 @@ class EntryControllerTest extends WallabagCoreTestCase
 
         $this->assertInstanceOf('Wallabag\CoreBundle\Entity\Entry', $entry);
         $this->assertSame($url, $entry->getUrl());
-        $this->assertContains('Judo', $entry->getTitle());
+        $this->assertStringContainsString('Judo', $entry->getTitle());
         // instead of checking for the filename (which might change) check that the image is now local
-        $this->assertContains(rtrim($client->getContainer()->getParameter('domain_name'), '/') . '/assets/images/', $entry->getContent());
+        $this->assertStringContainsString(rtrim($client->getContainer()->getParameter('domain_name'), '/') . '/assets/images/', $entry->getContent());
 
         $client->getContainer()->get('craue_config')->set('download_images_enabled', 0);
     }
@@ -1191,7 +1191,7 @@ class EntryControllerTest extends WallabagCoreTestCase
         $client->request('GET', '/archive/' . $entry->getId());
 
         $this->assertSame(302, $client->getResponse()->getStatusCode());
-        $this->assertContains('/view/' . $entry->getId(), $client->getResponse()->headers->get('location'));
+        $this->assertStringContainsString('/view/' . $entry->getId(), $client->getResponse()->headers->get('location'));
     }
 
     public function testFilterOnHttpStatus()
@@ -1469,7 +1469,7 @@ class EntryControllerTest extends WallabagCoreTestCase
         $crawler = $client->followRedirect();
 
         $this->assertSame(200, $client->getResponse()->getStatusCode());
-        $this->assertContains('flashes.entry.notice.entry_saved', $crawler->filter('body')->extract(['_text'])[0]);
+        $this->assertStringContainsString('flashes.entry.notice.entry_saved', $crawler->filter('body')->extract(['_text'])[0]);
 
         $content = $em
             ->getRepository('WallabagCoreBundle:Entry')
@@ -1555,23 +1555,23 @@ class EntryControllerTest extends WallabagCoreTestCase
 
         $client->request('GET', '/unread/random');
         $this->assertSame(302, $client->getResponse()->getStatusCode());
-        $this->assertContains('/view/', $client->getResponse()->getTargetUrl(), 'Unread random');
+        $this->assertStringContainsString('/view/', $client->getResponse()->getTargetUrl(), 'Unread random');
 
         $client->request('GET', '/starred/random');
         $this->assertSame(302, $client->getResponse()->getStatusCode());
-        $this->assertContains('/view/', $client->getResponse()->getTargetUrl(), 'Starred random');
+        $this->assertStringContainsString('/view/', $client->getResponse()->getTargetUrl(), 'Starred random');
 
         $client->request('GET', '/archive/random');
         $this->assertSame(302, $client->getResponse()->getStatusCode());
-        $this->assertContains('/view/', $client->getResponse()->getTargetUrl(), 'Archive random');
+        $this->assertStringContainsString('/view/', $client->getResponse()->getTargetUrl(), 'Archive random');
 
         $client->request('GET', '/untagged/random');
         $this->assertSame(302, $client->getResponse()->getStatusCode());
-        $this->assertContains('/view/', $client->getResponse()->getTargetUrl(), 'Untagged random');
+        $this->assertStringContainsString('/view/', $client->getResponse()->getTargetUrl(), 'Untagged random');
 
         $client->request('GET', '/all/random');
         $this->assertSame(302, $client->getResponse()->getStatusCode());
-        $this->assertContains('/view/', $client->getResponse()->getTargetUrl(), 'All random');
+        $this->assertStringContainsString('/view/', $client->getResponse()->getTargetUrl(), 'All random');
     }
 
     public function testMass()

--- a/tests/Wallabag/CoreBundle/Controller/ExportControllerTest.php
+++ b/tests/Wallabag/CoreBundle/Controller/ExportControllerTest.php
@@ -17,7 +17,7 @@ class ExportControllerTest extends WallabagCoreTestCase
         $client->request('GET', '/export/unread.csv');
 
         $this->assertSame(302, $client->getResponse()->getStatusCode());
-        $this->assertContains('login', $client->getResponse()->headers->get('location'));
+        $this->assertStringContainsString('login', $client->getResponse()->headers->get('location'));
     }
 
     public function testUnknownCategoryExport()
@@ -186,15 +186,15 @@ class ExportControllerTest extends WallabagCoreTestCase
         // +1 for title line
         $this->assertCount(\count($contentInDB) + 1, $csv);
         $this->assertSame('Title;URL;Content;Tags;"MIME Type";Language;"Creation date"', $csv[0]);
-        $this->assertContains($contentInDB[0]['title'], $csv[1]);
-        $this->assertContains($contentInDB[0]['url'], $csv[1]);
-        $this->assertContains($contentInDB[0]['content'], $csv[1]);
-        $this->assertContains($contentInDB[0]['mimetype'], $csv[1]);
-        $this->assertContains($contentInDB[0]['language'], $csv[1]);
-        $this->assertContains($contentInDB[0]['createdAt']->format('d/m/Y h:i:s'), $csv[1]);
+        $this->assertStringContainsString($contentInDB[0]['title'], $csv[1]);
+        $this->assertStringContainsString($contentInDB[0]['url'], $csv[1]);
+        $this->assertStringContainsString($contentInDB[0]['content'], $csv[1]);
+        $this->assertStringContainsString($contentInDB[0]['mimetype'], $csv[1]);
+        $this->assertStringContainsString($contentInDB[0]['language'], $csv[1]);
+        $this->assertStringContainsString($contentInDB[0]['createdAt']->format('d/m/Y h:i:s'), $csv[1]);
 
         foreach ($contentInDB[0]['tags'] as $tag) {
-            $this->assertContains($tag['label'], $csv[1]);
+            $this->assertStringContainsString($tag['label'], $csv[1]);
         }
     }
 
@@ -300,7 +300,7 @@ class ExportControllerTest extends WallabagCoreTestCase
 
         $content = new \SimpleXMLElement($client->getResponse()->getContent());
         $this->assertGreaterThan(0, $content->count());
-        $this->assertCount($contentInDB, $content);
+        $this->assertCount(\count($contentInDB), $content);
         $this->assertNotEmpty('id', (string) $content->entry[0]->id);
         $this->assertNotEmpty('title', (string) $content->entry[0]->title);
         $this->assertNotEmpty('url', (string) $content->entry[0]->url);

--- a/tests/Wallabag/CoreBundle/Controller/ExportControllerTest.php
+++ b/tests/Wallabag/CoreBundle/Controller/ExportControllerTest.php
@@ -300,7 +300,7 @@ class ExportControllerTest extends WallabagCoreTestCase
 
         $content = new \SimpleXMLElement($client->getResponse()->getContent());
         $this->assertGreaterThan(0, $content->count());
-        $this->assertSame(\count($contentInDB), $content->count());
+        $this->assertCount($contentInDB, $content);
         $this->assertNotEmpty('id', (string) $content->entry[0]->id);
         $this->assertNotEmpty('title', (string) $content->entry[0]->title);
         $this->assertNotEmpty('url', (string) $content->entry[0]->url);

--- a/tests/Wallabag/CoreBundle/Controller/FeedControllerTest.php
+++ b/tests/Wallabag/CoreBundle/Controller/FeedControllerTest.php
@@ -23,8 +23,8 @@ class FeedControllerTest extends WallabagCoreTestCase
         $this->assertSame(1, $xpath->query('/a:feed')->length);
 
         $this->assertSame(1, $xpath->query('/a:feed/a:title')->length);
-        $this->assertContains('favicon.ico', $xpath->query('/a:feed/a:icon')->item(0)->nodeValue);
-        $this->assertContains('logo-square.png', $xpath->query('/a:feed/a:logo')->item(0)->nodeValue);
+        $this->assertStringContainsString('favicon.ico', $xpath->query('/a:feed/a:icon')->item(0)->nodeValue);
+        $this->assertStringContainsString('logo-square.png', $xpath->query('/a:feed/a:logo')->item(0)->nodeValue);
 
         $this->assertSame(1, $xpath->query('/a:feed/a:updated')->length);
 
@@ -42,7 +42,7 @@ class FeedControllerTest extends WallabagCoreTestCase
         }
 
         $this->assertSame(1, $xpath->query('/a:feed/a:link[@rel="self"]')->length);
-        $this->assertContains($type, $xpath->query('/a:feed/a:link[@rel="self"]')->item(0)->getAttribute('href'));
+        $this->assertStringContainsString($type, $xpath->query('/a:feed/a:link[@rel="self"]')->item(0)->getAttribute('href'));
 
         $this->assertSame(1, $xpath->query('/a:feed/a:link[@rel="last"]')->length);
 

--- a/tests/Wallabag/CoreBundle/Controller/IgnoreOriginInstanceRuleControllerTest.php
+++ b/tests/Wallabag/CoreBundle/Controller/IgnoreOriginInstanceRuleControllerTest.php
@@ -17,8 +17,8 @@ class IgnoreOriginInstanceRuleControllerTest extends WallabagCoreTestCase
 
         $body = $crawler->filter('body')->extract(['_text'])[0];
 
-        $this->assertContains('ignore_origin_instance_rule.description', $body);
-        $this->assertContains('ignore_origin_instance_rule.list.create_new_one', $body);
+        $this->assertStringContainsString('ignore_origin_instance_rule.description', $body);
+        $this->assertStringContainsString('ignore_origin_instance_rule.list.create_new_one', $body);
     }
 
     public function testIgnoreOriginInstanceRuleCreationEditionDeletion()
@@ -33,8 +33,8 @@ class IgnoreOriginInstanceRuleControllerTest extends WallabagCoreTestCase
 
         $body = $crawler->filter('body')->extract(['_text'])[0];
 
-        $this->assertContains('ignore_origin_instance_rule.new_ignore_origin_instance_rule', $body);
-        $this->assertContains('ignore_origin_instance_rule.form.back_to_list', $body);
+        $this->assertStringContainsString('ignore_origin_instance_rule.new_ignore_origin_instance_rule', $body);
+        $this->assertStringContainsString('ignore_origin_instance_rule.form.back_to_list', $body);
 
         $form = $crawler->filter('button[id=ignore_origin_instance_rule_save]')->form();
 
@@ -48,7 +48,7 @@ class IgnoreOriginInstanceRuleControllerTest extends WallabagCoreTestCase
 
         $crawler = $client->followRedirect();
 
-        $this->assertContains('flashes.ignore_origin_instance_rule.notice.added', $crawler->filter('body')->extract(['_text'])[0]);
+        $this->assertStringContainsString('flashes.ignore_origin_instance_rule.notice.added', $crawler->filter('body')->extract(['_text'])[0]);
 
         // Edition
         $editLink = $crawler->filter('div[id=content] table a')->last()->link();
@@ -57,12 +57,12 @@ class IgnoreOriginInstanceRuleControllerTest extends WallabagCoreTestCase
 
         $this->assertSame(200, $client->getResponse()->getStatusCode());
 
-        $this->assertContains('foo.example.com', $crawler->filter('form[name=ignore_origin_instance_rule] input[type=text]')->extract(['value'])[0]);
+        $this->assertStringContainsString('foo.example.com', $crawler->filter('form[name=ignore_origin_instance_rule] input[type=text]')->extract(['value'])[0]);
 
         $body = $crawler->filter('body')->extract(['_text'])[0];
 
-        $this->assertContains('ignore_origin_instance_rule.edit_ignore_origin_instance_rule', $body);
-        $this->assertContains('ignore_origin_instance_rule.form.back_to_list', $body);
+        $this->assertStringContainsString('ignore_origin_instance_rule.edit_ignore_origin_instance_rule', $body);
+        $this->assertStringContainsString('ignore_origin_instance_rule.form.back_to_list', $body);
 
         $form = $crawler->filter('button[id=ignore_origin_instance_rule_save]')->form();
 
@@ -76,7 +76,7 @@ class IgnoreOriginInstanceRuleControllerTest extends WallabagCoreTestCase
 
         $crawler = $client->followRedirect();
 
-        $this->assertContains('flashes.ignore_origin_instance_rule.notice.updated', $crawler->filter('body')->extract(['_text'])[0]);
+        $this->assertStringContainsString('flashes.ignore_origin_instance_rule.notice.updated', $crawler->filter('body')->extract(['_text'])[0]);
 
         $editLink = $crawler->filter('div[id=content] table a')->last()->link();
 
@@ -84,7 +84,7 @@ class IgnoreOriginInstanceRuleControllerTest extends WallabagCoreTestCase
 
         $this->assertSame(200, $client->getResponse()->getStatusCode());
 
-        $this->assertContains('bar.example.com', $crawler->filter('form[name=ignore_origin_instance_rule] input[type=text]')->extract(['value'])[0]);
+        $this->assertStringContainsString('bar.example.com', $crawler->filter('form[name=ignore_origin_instance_rule] input[type=text]')->extract(['value'])[0]);
 
         $deleteForm = $crawler->filter('body')->selectButton('ignore_origin_instance_rule.form.delete')->form();
 
@@ -94,7 +94,7 @@ class IgnoreOriginInstanceRuleControllerTest extends WallabagCoreTestCase
 
         $crawler = $client->followRedirect();
 
-        $this->assertContains('flashes.ignore_origin_instance_rule.notice.deleted', $crawler->filter('body')->extract(['_text'])[0]);
+        $this->assertStringContainsString('flashes.ignore_origin_instance_rule.notice.deleted', $crawler->filter('body')->extract(['_text'])[0]);
     }
 
     public function dataForIgnoreOriginInstanceRuleCreationFail()
@@ -142,7 +142,7 @@ class IgnoreOriginInstanceRuleControllerTest extends WallabagCoreTestCase
         $this->assertGreaterThan(1, $body = $crawler->filter('body')->extract(['_text']));
 
         foreach ($messages as $message) {
-            $this->assertContains($message, $body[0]);
+            $this->assertStringContainsString($message, $body[0]);
         }
     }
 }

--- a/tests/Wallabag/CoreBundle/Controller/SecurityControllerTest.php
+++ b/tests/Wallabag/CoreBundle/Controller/SecurityControllerTest.php
@@ -13,7 +13,7 @@ class SecurityControllerTest extends WallabagCoreTestCase
         $client->followRedirects();
 
         $crawler = $client->request('GET', '/config');
-        $this->assertContains('config.form_feed.description', $crawler->filter('body')->extract(['_text'])[0]);
+        $this->assertStringContainsString('config.form_feed.description', $crawler->filter('body')->extract(['_text'])[0]);
     }
 
     public function testLoginWithout2Factor()
@@ -23,7 +23,7 @@ class SecurityControllerTest extends WallabagCoreTestCase
         $client->followRedirects();
 
         $crawler = $client->request('GET', '/config');
-        $this->assertContains('config.form_feed.description', $crawler->filter('body')->extract(['_text'])[0]);
+        $this->assertStringContainsString('config.form_feed.description', $crawler->filter('body')->extract(['_text'])[0]);
     }
 
     public function testLoginWith2FactorEmail()
@@ -48,7 +48,7 @@ class SecurityControllerTest extends WallabagCoreTestCase
 
         $this->logInAsUsingHttp('admin');
         $crawler = $client->request('GET', '/config');
-        $this->assertContains('trusted', $crawler->filter('body')->extract(['_text'])[0]);
+        $this->assertStringContainsString('trusted', $crawler->filter('body')->extract(['_text'])[0]);
 
         // restore user
         $user = $em
@@ -81,7 +81,7 @@ class SecurityControllerTest extends WallabagCoreTestCase
 
         $this->logInAsUsingHttp('admin');
         $crawler = $client->request('GET', '/config');
-        $this->assertContains('trusted', $crawler->filter('body')->extract(['_text'])[0]);
+        $this->assertStringContainsString('trusted', $crawler->filter('body')->extract(['_text'])[0]);
 
         // restore user
         $user = $em
@@ -104,6 +104,6 @@ class SecurityControllerTest extends WallabagCoreTestCase
 
         $client->followRedirects();
         $client->request('GET', '/register');
-        $this->assertContains('registration.submit', $client->getResponse()->getContent());
+        $this->assertStringContainsString('registration.submit', $client->getResponse()->getContent());
     }
 }

--- a/tests/Wallabag/CoreBundle/Controller/SiteCredentialControllerTest.php
+++ b/tests/Wallabag/CoreBundle/Controller/SiteCredentialControllerTest.php
@@ -33,8 +33,8 @@ class SiteCredentialControllerTest extends WallabagCoreTestCase
 
         $body = $crawler->filter('body')->extract(['_text'])[0];
 
-        $this->assertContains('site_credential.description', $body);
-        $this->assertContains('site_credential.list.create_new_one', $body);
+        $this->assertStringContainsString('site_credential.description', $body);
+        $this->assertStringContainsString('site_credential.list.create_new_one', $body);
     }
 
     public function testNewSiteCredential()
@@ -48,8 +48,8 @@ class SiteCredentialControllerTest extends WallabagCoreTestCase
 
         $body = $crawler->filter('body')->extract(['_text'])[0];
 
-        $this->assertContains('site_credential.new_site_credential', $body);
-        $this->assertContains('site_credential.form.back_to_list', $body);
+        $this->assertStringContainsString('site_credential.new_site_credential', $body);
+        $this->assertStringContainsString('site_credential.form.back_to_list', $body);
 
         $form = $crawler->filter('button[id=site_credential_save]')->form();
 
@@ -65,7 +65,7 @@ class SiteCredentialControllerTest extends WallabagCoreTestCase
 
         $crawler = $client->followRedirect();
 
-        $this->assertContains('flashes.site_credential.notice.added', $crawler->filter('body')->extract(['_text'])[0]);
+        $this->assertStringContainsString('flashes.site_credential.notice.added', $crawler->filter('body')->extract(['_text'])[0]);
     }
 
     public function testEditSiteCredential()
@@ -81,8 +81,8 @@ class SiteCredentialControllerTest extends WallabagCoreTestCase
 
         $body = $crawler->filter('body')->extract(['_text'])[0];
 
-        $this->assertContains('site_credential.edit_site_credential', $body);
-        $this->assertContains('site_credential.form.back_to_list', $body);
+        $this->assertStringContainsString('site_credential.edit_site_credential', $body);
+        $this->assertStringContainsString('site_credential.form.back_to_list', $body);
 
         $form = $crawler->filter('button[id=site_credential_save]')->form();
 
@@ -98,7 +98,7 @@ class SiteCredentialControllerTest extends WallabagCoreTestCase
 
         $crawler = $client->followRedirect();
 
-        $this->assertContains('flashes.site_credential.notice.updated', $crawler->filter('body')->extract(['_text'])[0]);
+        $this->assertStringContainsString('flashes.site_credential.notice.updated', $crawler->filter('body')->extract(['_text'])[0]);
     }
 
     public function testEditFromADifferentUserSiteCredential()
@@ -134,7 +134,7 @@ class SiteCredentialControllerTest extends WallabagCoreTestCase
 
         $crawler = $client->followRedirect();
 
-        $this->assertContains('flashes.site_credential.notice.deleted', $crawler->filter('body')->extract(['_text'])[0]);
+        $this->assertStringContainsString('flashes.site_credential.notice.deleted', $crawler->filter('body')->extract(['_text'])[0]);
     }
 
     private function createSiteCredential(Client $client)

--- a/tests/Wallabag/CoreBundle/Controller/TagControllerTest.php
+++ b/tests/Wallabag/CoreBundle/Controller/TagControllerTest.php
@@ -213,7 +213,7 @@ class TagControllerTest extends WallabagCoreTestCase
 
         $crawler = $client->followRedirect();
 
-        $this->assertContains('flashes.tag.notice.tag_renamed', $crawler->filter('body')->extract(['_text'])[0]);
+        $this->assertStringContainsString('flashes.tag.notice.tag_renamed', $crawler->filter('body')->extract(['_text'])[0]);
 
         $freshEntry = $client->getContainer()
             ->get('doctrine.orm.entity_manager')
@@ -277,7 +277,7 @@ class TagControllerTest extends WallabagCoreTestCase
 
         $client->submit($form, $data);
         $this->assertSame(302, $client->getResponse()->getStatusCode());
-        $this->assertNotContains('flashes.tag.notice.tag_renamed', $crawler->filter('body')->extract(['_text'])[0]);
+        $this->assertStringNotContainsString('flashes.tag.notice.tag_renamed', $crawler->filter('body')->extract(['_text'])[0]);
 
         $freshEntry = $client->getContainer()
             ->get('doctrine.orm.entity_manager')
@@ -332,7 +332,7 @@ class TagControllerTest extends WallabagCoreTestCase
 
         $client->submit($form, $data);
         $this->assertSame(302, $client->getResponse()->getStatusCode());
-        $this->assertNotContains('flashes.tag.notice.tag_renamed', $crawler->filter('body')->extract(['_text'])[0]);
+        $this->assertStringNotContainsString('flashes.tag.notice.tag_renamed', $crawler->filter('body')->extract(['_text'])[0]);
 
         $freshEntry = $client->getContainer()
             ->get('doctrine.orm.entity_manager')
@@ -402,7 +402,7 @@ class TagControllerTest extends WallabagCoreTestCase
 
         $client->submit($form, $data);
         $this->assertSame(302, $client->getResponse()->getStatusCode());
-        $this->assertNotContains('flashes.tag.notice.tag_renamed', $crawler->filter('body')->extract(['_text'])[0]);
+        $this->assertStringNotContainsString('flashes.tag.notice.tag_renamed', $crawler->filter('body')->extract(['_text'])[0]);
 
         $freshEntry1 = $client->getContainer()
             ->get('doctrine.orm.entity_manager')

--- a/tests/Wallabag/CoreBundle/Helper/ContentProxyTest.php
+++ b/tests/Wallabag/CoreBundle/Helper/ContentProxyTest.php
@@ -176,7 +176,7 @@ class ContentProxyTest extends TestCase
 
         $this->assertSame('http://1.1.1.1', $entry->getUrl());
         $this->assertSame('this is my title', $entry->getTitle());
-        $this->assertContains('content', $entry->getContent());
+        $this->assertStringContainsString('content', $entry->getContent());
         $this->assertSame('http://3.3.3.3/cover.jpg', $entry->getPreviewPicture());
         $this->assertSame('text/html', $entry->getMimetype());
         $this->assertSame('fr', $entry->getLanguage());
@@ -221,7 +221,7 @@ class ContentProxyTest extends TestCase
 
         $this->assertSame('http://1.1.1.1', $entry->getUrl());
         $this->assertSame('this is my title', $entry->getTitle());
-        $this->assertContains('content', $entry->getContent());
+        $this->assertStringContainsString('content', $entry->getContent());
         $this->assertNull($entry->getPreviewPicture());
         $this->assertSame('text/html', $entry->getMimetype());
         $this->assertSame('fr', $entry->getLanguage());
@@ -357,7 +357,7 @@ class ContentProxyTest extends TestCase
 
         $this->assertSame('http://1.1.1.1', $entry->getUrl());
         $this->assertSame('this is my title', $entry->getTitle());
-        $this->assertContains('content', $entry->getContent());
+        $this->assertStringContainsString('content', $entry->getContent());
         $this->assertSame('text/html', $entry->getMimetype());
         $this->assertNull($entry->getLanguage());
         $this->assertSame('200', $entry->getHttpStatus());
@@ -409,7 +409,7 @@ class ContentProxyTest extends TestCase
 
         $this->assertSame('http://1.1.1.1', $entry->getUrl());
         $this->assertSame('this is my title', $entry->getTitle());
-        $this->assertContains('content', $entry->getContent());
+        $this->assertStringContainsString('content', $entry->getContent());
         $this->assertNull($entry->getPreviewPicture());
         $this->assertSame('text/html', $entry->getMimetype());
         $this->assertSame('fr', $entry->getLanguage());
@@ -449,7 +449,7 @@ class ContentProxyTest extends TestCase
 
         $this->assertSame('http://1.1.1.1', $entry->getUrl());
         $this->assertSame('this is my title', $entry->getTitle());
-        $this->assertContains('content', $entry->getContent());
+        $this->assertStringContainsString('content', $entry->getContent());
         $this->assertSame('text/html', $entry->getMimetype());
         $this->assertSame('fr', $entry->getLanguage());
         $this->assertSame(4.0, $entry->getReadingTime());
@@ -492,7 +492,7 @@ class ContentProxyTest extends TestCase
 
         $this->assertSame('http://1.1.1.1', $entry->getUrl());
         $this->assertSame('this is my title', $entry->getTitle());
-        $this->assertContains('content', $entry->getContent());
+        $this->assertStringContainsString('content', $entry->getContent());
         $this->assertSame('text/html', $entry->getMimetype());
         $this->assertSame('fr', $entry->getLanguage());
         $this->assertSame(4.0, $entry->getReadingTime());
@@ -531,7 +531,7 @@ class ContentProxyTest extends TestCase
 
         $this->assertSame('http://1.1.1.1', $entry->getUrl());
         $this->assertSame('this is my title', $entry->getTitle());
-        $this->assertContains('content', $entry->getContent());
+        $this->assertStringContainsString('content', $entry->getContent());
         $this->assertSame('text/html', $entry->getMimetype());
         $this->assertSame('fr', $entry->getLanguage());
         $this->assertSame(4.0, $entry->getReadingTime());
@@ -541,7 +541,7 @@ class ContentProxyTest extends TestCase
         $records = $handler->getRecords();
 
         $this->assertCount(3, $records);
-        $this->assertContains('Error while defining date', $records[0]['message']);
+        $this->assertStringContainsString('Error while defining date', $records[0]['message']);
     }
 
     public function testTaggerThrowException()
@@ -619,7 +619,7 @@ class ContentProxyTest extends TestCase
 
         $this->assertSame('http://1.1.1.1', $entry->getUrl());
         $this->assertSame('this is my title', $entry->getTitle());
-        $this->assertNotContains($escapedString, $entry->getContent());
+        $this->assertStringNotContainsString($escapedString, $entry->getContent());
         $this->assertSame('http://3.3.3.3/cover.jpg', $entry->getPreviewPicture());
         $this->assertSame('text/html', $entry->getMimetype());
         $this->assertSame('fr', $entry->getLanguage());
@@ -658,7 +658,7 @@ class ContentProxyTest extends TestCase
 
         $this->assertSame('http://1.1.1.1/image.jpg', $entry->getUrl());
         $this->assertSame('this is my title', $entry->getTitle());
-        $this->assertContains('http://1.1.1.1/image.jpg', $entry->getContent());
+        $this->assertStringContainsString('http://1.1.1.1/image.jpg', $entry->getContent());
         $this->assertSame('http://1.1.1.1/image.jpg', $entry->getPreviewPicture());
         $this->assertSame('image/jpeg', $entry->getMimetype());
         $this->assertSame('200', $entry->getHttpStatus());

--- a/tests/Wallabag/CoreBundle/Helper/CryptoProxyTest.php
+++ b/tests/Wallabag/CoreBundle/Helper/CryptoProxyTest.php
@@ -23,18 +23,15 @@ class CryptoProxyTest extends TestCase
 
         $records = $logHandler->getRecords();
         $this->assertCount(2, $records);
-        $this->assertContains('Crypto: crypting value', $records[0]['message']);
-        $this->assertContains('Crypto: decrypting value', $records[1]['message']);
+        $this->assertStringContainsString('Crypto: crypting value', $records[0]['message']);
+        $this->assertStringContainsString('Crypto: decrypting value', $records[1]['message']);
     }
 
-    /**
-     * @expectedException \RuntimeException
-     * @expectedExceptionMessage Decrypt fail
-     *
-     * @return [type] [description]
-     */
     public function testDecryptBadValue()
     {
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Decrypt fail');
+
         $crypto = new CryptoProxy(sys_get_temp_dir() . '/' . uniqid('', true) . '.txt', new NullLogger());
         $crypto->decrypt('badvalue');
     }

--- a/tests/Wallabag/CoreBundle/Helper/DownloadImagesTest.php
+++ b/tests/Wallabag/CoreBundle/Helper/DownloadImagesTest.php
@@ -42,7 +42,7 @@ class DownloadImagesTest extends TestCase
         $res = $download->processHtml(123, $html, $url);
 
         // this the base path of all image (since it's calculated using the entry id: 123)
-        $this->assertContains('http://wallabag.io/assets/images/9/b/9b0ead26/', $res);
+        $this->assertStringContainsString('http://wallabag.io/assets/images/9/b/9b0ead26/', $res);
     }
 
     public function testProcessHtmlWithBadImage()
@@ -56,7 +56,7 @@ class DownloadImagesTest extends TestCase
         $download = new DownloadImages($httpMockClient, sys_get_temp_dir() . '/wallabag_test', 'http://wallabag.io/', $logger);
         $res = $download->processHtml(123, '<div><img src="http://i.imgur.com/T9qgcHc.jpg" /></div>', 'http://imgur.com/gallery/WxtWY');
 
-        $this->assertContains('http://i.imgur.com/T9qgcHc.jpg', $res, 'Image were not replace because of content-type');
+        $this->assertStringContainsString('http://i.imgur.com/T9qgcHc.jpg', $res, 'Image were not replace because of content-type');
     }
 
     public function singleImage()
@@ -83,7 +83,7 @@ class DownloadImagesTest extends TestCase
         $download = new DownloadImages($httpMockClient, sys_get_temp_dir() . '/wallabag_test', 'http://wallabag.io/', $logger);
         $res = $download->processSingleImage(123, 'T9qgcHc.jpg', 'http://imgur.com/gallery/WxtWY');
 
-        $this->assertContains('/assets/images/9/b/9b0ead26/ebe60399.' . $extension, $res);
+        $this->assertStringContainsString('/assets/images/9/b/9b0ead26/ebe60399.' . $extension, $res);
     }
 
     public function testProcessSingleImageWithBadUrl()
@@ -144,8 +144,8 @@ class DownloadImagesTest extends TestCase
             'https://theconversation.com/conversation-avec-gerald-bronner-ce-nest-pas-la-post-verite-qui-nous-menace-mais-lextension-de-notre-credulite-73089'
         );
 
-        $this->assertContains('http://wallabag.io/assets/images/9/b/9b0ead26/', $res, 'Content-Type was empty but data is ok for an image');
-        $this->assertContains('DownloadImages: Checking extension (alternative)', $logHandler->getRecords()[3]['message']);
+        $this->assertStringContainsString('http://wallabag.io/assets/images/9/b/9b0ead26/', $res, 'Content-Type was empty but data is ok for an image');
+        $this->assertStringContainsString('DownloadImages: Checking extension (alternative)', $logHandler->getRecords()[3]['message']);
     }
 
     public function testProcessImageWithSrcset()
@@ -161,7 +161,7 @@ class DownloadImagesTest extends TestCase
         $download = new DownloadImages($httpMockClient, sys_get_temp_dir() . '/wallabag_test', 'http://wallabag.io/', $logger);
         $res = $download->processHtml(123, '<p><img class="alignnone wp-image-1153" src="http://piketty.blog.lemonde.fr/files/2017/10/F1FR-530x375.jpg" alt="" width="628" height="444" srcset="http://piketty.blog.lemonde.fr/files/2017/10/F1FR-530x375.jpg 530w, http://piketty.blog.lemonde.fr/files/2017/10/F1FR-768x543.jpg 768w, http://piketty.blog.lemonde.fr/files/2017/10/F1FR-900x636.jpg 900w" sizes="(max-width: 628px) 100vw, 628px" /></p>', 'http://piketty.blog.lemonde.fr/2017/10/12/budget-2018-la-jeunesse-sacrifiee/');
 
-        $this->assertNotContains('http://piketty.blog.lemonde.fr/', $res, 'Image srcset attribute were not replaced');
+        $this->assertStringNotContainsString('http://piketty.blog.lemonde.fr/', $res, 'Image srcset attribute were not replaced');
     }
 
     public function testProcessImageWithTrickySrcset()
@@ -181,7 +181,7 @@ class DownloadImagesTest extends TestCase
        (min-width: 626px)  calc(100vw - 335px)
                            calc(100vw - 30px)" alt="" /></figure>', 'https://css-tricks.com/the-critical-request/');
 
-        $this->assertNotContains('f_auto,q_auto', $res, 'Image srcset attribute were not replaced');
+        $this->assertStringNotContainsString('f_auto,q_auto', $res, 'Image srcset attribute were not replaced');
     }
 
     public function testProcessImageWithNullPath()

--- a/tests/Wallabag/CoreBundle/Helper/RedirectTest.php
+++ b/tests/Wallabag/CoreBundle/Helper/RedirectTest.php
@@ -20,7 +20,7 @@ class RedirectTest extends TestCase
     /** @var UsernamePasswordToken */
     private $token;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->routerMock = $this->getMockBuilder('Symfony\Component\Routing\Router')
             ->disableOriginalConstructor()

--- a/tests/Wallabag/CoreBundle/Helper/RuleBasedIgnoreOriginProcessorTest.php
+++ b/tests/Wallabag/CoreBundle/Helper/RuleBasedIgnoreOriginProcessorTest.php
@@ -20,7 +20,7 @@ class RuleBasedIgnoreOriginProcessorTest extends TestCase
     private $logger;
     private $handler;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->rulerz = $this->getRulerZMock();
         $this->logger = $this->getLogger();

--- a/tests/Wallabag/CoreBundle/Helper/RuleBasedTaggerTest.php
+++ b/tests/Wallabag/CoreBundle/Helper/RuleBasedTaggerTest.php
@@ -21,7 +21,7 @@ class RuleBasedTaggerTest extends TestCase
     private $logger;
     private $handler;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->rulerz = $this->getRulerZMock();
         $this->tagRepository = $this->getTagRepositoryMock();

--- a/tests/Wallabag/CoreBundle/ParamConverter/UsernameFeedTokenConverterTest.php
+++ b/tests/Wallabag/CoreBundle/ParamConverter/UsernameFeedTokenConverterTest.php
@@ -136,12 +136,11 @@ class UsernameFeedTokenConverterTest extends TestCase
         $this->assertFalse($res);
     }
 
-    /**
-     * @expectedException \Symfony\Component\HttpKernel\Exception\NotFoundHttpException
-     * @expectedExceptionMessage User not found
-     */
     public function testApplyUserNotFound()
     {
+        $this->expectException(\Symfony\Component\HttpKernel\Exception\NotFoundHttpException::class);
+        $this->expectExceptionMessage('User not found');
+
         $repo = $this->getMockBuilder('Wallabag\UserBundle\Repository\UserRepository')
             ->disableOriginalConstructor()
             ->getMock();

--- a/tests/Wallabag/CoreBundle/WallabagCoreTestCase.php
+++ b/tests/Wallabag/CoreBundle/WallabagCoreTestCase.php
@@ -18,7 +18,7 @@ abstract class WallabagCoreTestCase extends WebTestCase
      */
     private $client = null;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Wallabag/ImportBundle/Command/ImportCommandTest.php
+++ b/tests/Wallabag/ImportBundle/Command/ImportCommandTest.php
@@ -9,12 +9,11 @@ use Wallabag\ImportBundle\Command\ImportCommand;
 
 class ImportCommandTest extends WallabagCoreTestCase
 {
-    /**
-     * @expectedException \Symfony\Component\Console\Exception\RuntimeException
-     * @expectedExceptionMessage Not enough arguments
-     */
     public function testRunImportCommandWithoutArguments()
     {
+        $this->expectException(\Symfony\Component\Console\Exception\RuntimeException::class);
+        $this->expectExceptionMessage('Not enough arguments');
+
         $application = new Application($this->getClient()->getKernel());
         $application->add(new ImportCommand());
 
@@ -26,12 +25,11 @@ class ImportCommandTest extends WallabagCoreTestCase
         ]);
     }
 
-    /**
-     * @expectedException \Symfony\Component\Config\Definition\Exception\Exception
-     * @expectedExceptionMessage not found
-     */
     public function testRunImportCommandWithoutFilepath()
     {
+        $this->expectException(\Symfony\Component\Config\Definition\Exception\Exception::class);
+        $this->expectExceptionMessage('not found');
+
         $application = new Application($this->getClient()->getKernel());
         $application->add(new ImportCommand());
 
@@ -45,11 +43,10 @@ class ImportCommandTest extends WallabagCoreTestCase
         ]);
     }
 
-    /**
-     * @expectedException \Doctrine\ORM\NoResultException
-     */
     public function testRunImportCommandWithWrongUsername()
     {
+        $this->expectException(\Doctrine\ORM\NoResultException::class);
+
         $application = new Application($this->getClient()->getKernel());
         $application->add(new ImportCommand());
 
@@ -78,8 +75,8 @@ class ImportCommandTest extends WallabagCoreTestCase
             '--importer' => 'v2',
         ]);
 
-        $this->assertContains('imported', $tester->getDisplay());
-        $this->assertContains('already saved', $tester->getDisplay());
+        $this->assertStringContainsString('imported', $tester->getDisplay());
+        $this->assertStringContainsString('already saved', $tester->getDisplay());
     }
 
     public function testRunImportCommandWithUserId()
@@ -100,7 +97,7 @@ class ImportCommandTest extends WallabagCoreTestCase
             '--importer' => 'v2',
         ]);
 
-        $this->assertContains('imported', $tester->getDisplay());
-        $this->assertContains('already saved', $tester->getDisplay());
+        $this->assertStringContainsString('imported', $tester->getDisplay());
+        $this->assertStringContainsString('already saved', $tester->getDisplay());
     }
 }

--- a/tests/Wallabag/ImportBundle/Command/RedisWorkerCommandTest.php
+++ b/tests/Wallabag/ImportBundle/Command/RedisWorkerCommandTest.php
@@ -10,12 +10,11 @@ use Wallabag\ImportBundle\Command\RedisWorkerCommand;
 
 class RedisWorkerCommandTest extends WallabagCoreTestCase
 {
-    /**
-     * @expectedException \Symfony\Component\Console\Exception\RuntimeException
-     * @expectedExceptionMessage Not enough arguments (missing: "serviceName")
-     */
     public function testRunRedisWorkerCommandWithoutArguments()
     {
+        $this->expectException(\Symfony\Component\Console\Exception\RuntimeException::class);
+        $this->expectExceptionMessage('Not enough arguments (missing: "serviceName")');
+
         $application = new Application($this->getClient()->getKernel());
         $application->add(new RedisWorkerCommand());
 
@@ -27,12 +26,11 @@ class RedisWorkerCommandTest extends WallabagCoreTestCase
         ]);
     }
 
-    /**
-     * @expectedException \Symfony\Component\Config\Definition\Exception\Exception
-     * @expectedExceptionMessage No queue or consumer found for service name
-     */
     public function testRunRedisWorkerCommandWithBadService()
     {
+        $this->expectException(\Symfony\Component\Config\Definition\Exception\Exception::class);
+        $this->expectExceptionMessage('No queue or consumer found for service name');
+
         $application = new Application($this->getClient()->getKernel());
         $application->add(new RedisWorkerCommand());
 
@@ -68,7 +66,7 @@ class RedisWorkerCommandTest extends WallabagCoreTestCase
             '--maxIterations' => 1,
         ]);
 
-        $this->assertContains('Worker started at', $tester->getDisplay());
-        $this->assertContains('Waiting for message', $tester->getDisplay());
+        $this->assertStringContainsString('Worker started at', $tester->getDisplay());
+        $this->assertStringContainsString('Waiting for message', $tester->getDisplay());
     }
 }

--- a/tests/Wallabag/ImportBundle/Controller/ChromeControllerTest.php
+++ b/tests/Wallabag/ImportBundle/Controller/ChromeControllerTest.php
@@ -80,7 +80,7 @@ class ChromeControllerTest extends WallabagCoreTestCase
         $crawler = $client->followRedirect();
 
         $this->assertGreaterThan(1, $body = $crawler->filter('body')->extract(['_text']));
-        $this->assertContains('flashes.import.notice.summary', $body[0]);
+        $this->assertStringContainsString('flashes.import.notice.summary', $body[0]);
 
         $this->assertNotEmpty($client->getContainer()->get('wallabag_core.redis.client')->lpop('wallabag.import.chrome'));
 
@@ -108,7 +108,7 @@ class ChromeControllerTest extends WallabagCoreTestCase
         $crawler = $client->followRedirect();
 
         $this->assertGreaterThan(1, $body = $crawler->filter('body')->extract(['_text']));
-        $this->assertContains('flashes.import.notice.summary', $body[0]);
+        $this->assertStringContainsString('flashes.import.notice.summary', $body[0]);
 
         $content = $client->getContainer()
             ->get('doctrine.orm.entity_manager')
@@ -149,6 +149,6 @@ class ChromeControllerTest extends WallabagCoreTestCase
         $crawler = $client->followRedirect();
 
         $this->assertGreaterThan(1, $body = $crawler->filter('body')->extract(['_text']));
-        $this->assertContains('flashes.import.notice.failed', $body[0]);
+        $this->assertStringContainsString('flashes.import.notice.failed', $body[0]);
     }
 }

--- a/tests/Wallabag/ImportBundle/Controller/ElcuratorControllerTest.php
+++ b/tests/Wallabag/ImportBundle/Controller/ElcuratorControllerTest.php
@@ -81,7 +81,7 @@ class ElcuratorControllerTest extends WallabagCoreTestCase
         $crawler = $client->followRedirect();
 
         $this->assertGreaterThan(1, $body = $crawler->filter('body')->extract(['_text']));
-        $this->assertContains('flashes.import.notice.summary', $body[0]);
+        $this->assertStringContainsString('flashes.import.notice.summary', $body[0]);
 
         $this->assertNotEmpty($client->getContainer()->get('wallabag_core.redis.client')->lpop('wallabag.import.elcurator'));
 
@@ -109,7 +109,7 @@ class ElcuratorControllerTest extends WallabagCoreTestCase
         $crawler = $client->followRedirect();
 
         $this->assertGreaterThan(1, $body = $crawler->filter('body')->extract(['_text']));
-        $this->assertContains('flashes.import.notice.summary', $body[0]);
+        $this->assertStringContainsString('flashes.import.notice.summary', $body[0]);
 
         $content = $client->getContainer()
             ->get('doctrine.orm.entity_manager')

--- a/tests/Wallabag/ImportBundle/Controller/FirefoxControllerTest.php
+++ b/tests/Wallabag/ImportBundle/Controller/FirefoxControllerTest.php
@@ -80,7 +80,7 @@ class FirefoxControllerTest extends WallabagCoreTestCase
         $crawler = $client->followRedirect();
 
         $this->assertGreaterThan(1, $body = $crawler->filter('body')->extract(['_text']));
-        $this->assertContains('flashes.import.notice.summary', $body[0]);
+        $this->assertStringContainsString('flashes.import.notice.summary', $body[0]);
 
         $this->assertNotEmpty($client->getContainer()->get('wallabag_core.redis.client')->lpop('wallabag.import.firefox'));
 
@@ -108,7 +108,7 @@ class FirefoxControllerTest extends WallabagCoreTestCase
         $crawler = $client->followRedirect();
 
         $this->assertGreaterThan(1, $body = $crawler->filter('body')->extract(['_text']));
-        $this->assertContains('flashes.import.notice.summary', $body[0]);
+        $this->assertStringContainsString('flashes.import.notice.summary', $body[0]);
 
         $content = $client->getContainer()
             ->get('doctrine.orm.entity_manager')
@@ -163,6 +163,6 @@ class FirefoxControllerTest extends WallabagCoreTestCase
         $crawler = $client->followRedirect();
 
         $this->assertGreaterThan(1, $body = $crawler->filter('body')->extract(['_text']));
-        $this->assertContains('flashes.import.notice.failed', $body[0]);
+        $this->assertStringContainsString('flashes.import.notice.failed', $body[0]);
     }
 }

--- a/tests/Wallabag/ImportBundle/Controller/ImportControllerTest.php
+++ b/tests/Wallabag/ImportBundle/Controller/ImportControllerTest.php
@@ -13,7 +13,7 @@ class ImportControllerTest extends WallabagCoreTestCase
         $client->request('GET', '/import/');
 
         $this->assertSame(302, $client->getResponse()->getStatusCode());
-        $this->assertContains('login', $client->getResponse()->headers->get('location'));
+        $this->assertStringContainsString('login', $client->getResponse()->headers->get('location'));
     }
 
     public function testImportList()

--- a/tests/Wallabag/ImportBundle/Controller/InstapaperControllerTest.php
+++ b/tests/Wallabag/ImportBundle/Controller/InstapaperControllerTest.php
@@ -80,7 +80,7 @@ class InstapaperControllerTest extends WallabagCoreTestCase
         $crawler = $client->followRedirect();
 
         $this->assertGreaterThan(1, $body = $crawler->filter('body')->extract(['_text']));
-        $this->assertContains('flashes.import.notice.summary', $body[0]);
+        $this->assertStringContainsString('flashes.import.notice.summary', $body[0]);
 
         $this->assertNotEmpty($client->getContainer()->get('wallabag_core.redis.client')->lpop('wallabag.import.instapaper'));
 
@@ -108,7 +108,7 @@ class InstapaperControllerTest extends WallabagCoreTestCase
         $crawler = $client->followRedirect();
 
         $this->assertGreaterThan(1, $body = $crawler->filter('body')->extract(['_text']));
-        $this->assertContains('flashes.import.notice.summary', $body[0]);
+        $this->assertStringContainsString('flashes.import.notice.summary', $body[0]);
 
         $content = $client->getContainer()
             ->get('doctrine.orm.entity_manager')
@@ -183,7 +183,7 @@ class InstapaperControllerTest extends WallabagCoreTestCase
         $this->assertTrue($content2->isArchived());
 
         $this->assertGreaterThan(1, $body = $crawler->filter('body')->extract(['_text']));
-        $this->assertContains('flashes.import.notice.summary', $body[0]);
+        $this->assertStringContainsString('flashes.import.notice.summary', $body[0]);
     }
 
     public function testImportInstapaperWithEmptyFile()
@@ -207,6 +207,6 @@ class InstapaperControllerTest extends WallabagCoreTestCase
         $crawler = $client->followRedirect();
 
         $this->assertGreaterThan(1, $body = $crawler->filter('body')->extract(['_text']));
-        $this->assertContains('flashes.import.notice.failed', $body[0]);
+        $this->assertStringContainsString('flashes.import.notice.failed', $body[0]);
     }
 }

--- a/tests/Wallabag/ImportBundle/Controller/PinboardControllerTest.php
+++ b/tests/Wallabag/ImportBundle/Controller/PinboardControllerTest.php
@@ -80,7 +80,7 @@ class PinboardControllerTest extends WallabagCoreTestCase
         $crawler = $client->followRedirect();
 
         $this->assertGreaterThan(1, $body = $crawler->filter('body')->extract(['_text']));
-        $this->assertContains('flashes.import.notice.summary', $body[0]);
+        $this->assertStringContainsString('flashes.import.notice.summary', $body[0]);
 
         $this->assertNotEmpty($client->getContainer()->get('wallabag_core.redis.client')->lpop('wallabag.import.pinboard'));
 
@@ -116,7 +116,7 @@ class PinboardControllerTest extends WallabagCoreTestCase
             );
 
         $this->assertGreaterThan(1, $body = $crawler->filter('body')->extract(['_text']));
-        $this->assertContains('flashes.import.notice.summary', $body[0]);
+        $this->assertStringContainsString('flashes.import.notice.summary', $body[0]);
 
         $this->assertInstanceOf('Wallabag\CoreBundle\Entity\Entry', $content);
         $this->assertNotEmpty($content->getMimetype(), 'Mimetype for https://ma.ttias.be is ok');
@@ -177,7 +177,7 @@ class PinboardControllerTest extends WallabagCoreTestCase
         $this->assertTrue($content2->isArchived());
 
         $this->assertGreaterThan(1, $body = $crawler->filter('body')->extract(['_text']));
-        $this->assertContains('flashes.import.notice.summary', $body[0]);
+        $this->assertStringContainsString('flashes.import.notice.summary', $body[0]);
     }
 
     public function testImportPinboardWithEmptyFile()
@@ -201,6 +201,6 @@ class PinboardControllerTest extends WallabagCoreTestCase
         $crawler = $client->followRedirect();
 
         $this->assertGreaterThan(1, $body = $crawler->filter('body')->extract(['_text']));
-        $this->assertContains('flashes.import.notice.failed', $body[0]);
+        $this->assertStringContainsString('flashes.import.notice.failed', $body[0]);
     }
 }

--- a/tests/Wallabag/ImportBundle/Controller/PocketControllerTest.php
+++ b/tests/Wallabag/ImportBundle/Controller/PocketControllerTest.php
@@ -77,7 +77,7 @@ class PocketControllerTest extends WallabagCoreTestCase
         $client->request('GET', '/import/pocket/auth');
 
         $this->assertSame(301, $client->getResponse()->getStatusCode());
-        $this->assertContains('getpocket.com/auth/authorize', $client->getResponse()->headers->get('location'));
+        $this->assertStringContainsString('getpocket.com/auth/authorize', $client->getResponse()->headers->get('location'));
     }
 
     public function testImportPocketCallbackWithBadToken()
@@ -99,7 +99,7 @@ class PocketControllerTest extends WallabagCoreTestCase
         $client->request('GET', '/import/pocket/callback');
 
         $this->assertSame(302, $client->getResponse()->getStatusCode());
-        $this->assertContains('/', $client->getResponse()->headers->get('location'), 'Import is ok, redirect to homepage');
+        $this->assertStringContainsString('/', $client->getResponse()->headers->get('location'), 'Import is ok, redirect to homepage');
         $this->assertSame('flashes.import.notice.failed', $client->getContainer()->get('session')->getFlashBag()->peek('notice')[0]);
     }
 
@@ -133,7 +133,7 @@ class PocketControllerTest extends WallabagCoreTestCase
         $client->request('GET', '/import/pocket/callback');
 
         $this->assertSame(302, $client->getResponse()->getStatusCode());
-        $this->assertContains('/', $client->getResponse()->headers->get('location'), 'Import is ok, redirect to homepage');
+        $this->assertStringContainsString('/', $client->getResponse()->headers->get('location'), 'Import is ok, redirect to homepage');
         $this->assertSame('flashes.import.notice.summary', $client->getContainer()->get('session')->getFlashBag()->peek('notice')[0]);
     }
 }

--- a/tests/Wallabag/ImportBundle/Controller/ReadabilityControllerTest.php
+++ b/tests/Wallabag/ImportBundle/Controller/ReadabilityControllerTest.php
@@ -80,7 +80,7 @@ class ReadabilityControllerTest extends WallabagCoreTestCase
         $crawler = $client->followRedirect();
 
         $this->assertGreaterThan(1, $body = $crawler->filter('body')->extract(['_text']));
-        $this->assertContains('flashes.import.notice.summary', $body[0]);
+        $this->assertStringContainsString('flashes.import.notice.summary', $body[0]);
 
         $this->assertNotEmpty($client->getContainer()->get('wallabag_core.redis.client')->lpop('wallabag.import.readability'));
 
@@ -116,7 +116,7 @@ class ReadabilityControllerTest extends WallabagCoreTestCase
             );
 
         $this->assertGreaterThan(1, $body = $crawler->filter('body')->extract(['_text']));
-        $this->assertContains('flashes.import.notice.summary', $body[0]);
+        $this->assertStringContainsString('flashes.import.notice.summary', $body[0]);
 
         $this->assertInstanceOf('Wallabag\CoreBundle\Entity\Entry', $content);
         $this->assertNotEmpty($content->getMimetype(), 'Mimetype for https://www.20minutes.fr is ok');
@@ -175,7 +175,7 @@ class ReadabilityControllerTest extends WallabagCoreTestCase
         $this->assertTrue($content2->isArchived());
 
         $this->assertGreaterThan(1, $body = $crawler->filter('body')->extract(['_text']));
-        $this->assertContains('flashes.import.notice.summary', $body[0]);
+        $this->assertStringContainsString('flashes.import.notice.summary', $body[0]);
     }
 
     public function testImportReadabilityWithEmptyFile()
@@ -199,6 +199,6 @@ class ReadabilityControllerTest extends WallabagCoreTestCase
         $crawler = $client->followRedirect();
 
         $this->assertGreaterThan(1, $body = $crawler->filter('body')->extract(['_text']));
-        $this->assertContains('flashes.import.notice.failed', $body[0]);
+        $this->assertStringContainsString('flashes.import.notice.failed', $body[0]);
     }
 }

--- a/tests/Wallabag/ImportBundle/Controller/WallabagV1ControllerTest.php
+++ b/tests/Wallabag/ImportBundle/Controller/WallabagV1ControllerTest.php
@@ -81,7 +81,7 @@ class WallabagV1ControllerTest extends WallabagCoreTestCase
         $crawler = $client->followRedirect();
 
         $this->assertGreaterThan(1, $body = $crawler->filter('body')->extract(['_text']));
-        $this->assertContains('flashes.import.notice.summary', $body[0]);
+        $this->assertStringContainsString('flashes.import.notice.summary', $body[0]);
 
         $this->assertNotEmpty($client->getContainer()->get('wallabag_core.redis.client')->lpop('wallabag.import.wallabag_v1'));
 
@@ -117,7 +117,7 @@ class WallabagV1ControllerTest extends WallabagCoreTestCase
             );
 
         $this->assertGreaterThan(1, $body = $crawler->filter('body')->extract(['_text']));
-        $this->assertContains('flashes.import.notice.summary', $body[0]);
+        $this->assertStringContainsString('flashes.import.notice.summary', $body[0]);
 
         $this->assertInstanceOf('Wallabag\CoreBundle\Entity\Entry', $content);
         $this->assertEmpty($content->getMimetype(), 'Mimetype for http://www.framablog.org is empty');
@@ -176,7 +176,7 @@ class WallabagV1ControllerTest extends WallabagCoreTestCase
         $this->assertTrue($content2->isArchived());
 
         $this->assertGreaterThan(1, $body = $crawler->filter('body')->extract(['_text']));
-        $this->assertContains('flashes.import.notice.summary', $body[0]);
+        $this->assertStringContainsString('flashes.import.notice.summary', $body[0]);
     }
 
     public function testImportWallabagWithEmptyFile()
@@ -200,6 +200,6 @@ class WallabagV1ControllerTest extends WallabagCoreTestCase
         $crawler = $client->followRedirect();
 
         $this->assertGreaterThan(1, $body = $crawler->filter('body')->extract(['_text']));
-        $this->assertContains('flashes.import.notice.failed', $body[0]);
+        $this->assertStringContainsString('flashes.import.notice.failed', $body[0]);
     }
 }

--- a/tests/Wallabag/ImportBundle/Controller/WallabagV2ControllerTest.php
+++ b/tests/Wallabag/ImportBundle/Controller/WallabagV2ControllerTest.php
@@ -81,7 +81,7 @@ class WallabagV2ControllerTest extends WallabagCoreTestCase
         $crawler = $client->followRedirect();
 
         $this->assertGreaterThan(1, $body = $crawler->filter('body')->extract(['_text']));
-        $this->assertContains('flashes.import.notice.summary', $body[0]);
+        $this->assertStringContainsString('flashes.import.notice.summary', $body[0]);
 
         $this->assertNotEmpty($client->getContainer()->get('wallabag_core.redis.client')->lpop('wallabag.import.wallabag_v2'));
 
@@ -109,7 +109,7 @@ class WallabagV2ControllerTest extends WallabagCoreTestCase
         $crawler = $client->followRedirect();
 
         $this->assertGreaterThan(1, $body = $crawler->filter('body')->extract(['_text']));
-        $this->assertContains('flashes.import.notice.summary', $body[0]);
+        $this->assertStringContainsString('flashes.import.notice.summary', $body[0]);
 
         $content = $client->getContainer()
             ->get('doctrine.orm.entity_manager')
@@ -175,6 +175,6 @@ class WallabagV2ControllerTest extends WallabagCoreTestCase
         $crawler = $client->followRedirect();
 
         $this->assertGreaterThan(1, $body = $crawler->filter('body')->extract(['_text']));
-        $this->assertContains('flashes.import.notice.failed', $body[0]);
+        $this->assertStringContainsString('flashes.import.notice.failed', $body[0]);
     }
 }

--- a/tests/Wallabag/ImportBundle/Import/ChromeImportTest.php
+++ b/tests/Wallabag/ImportBundle/Import/ChromeImportTest.php
@@ -90,7 +90,7 @@ class ChromeImportTest extends TestCase
             ->expects($this->any())
             ->method('persist')
             ->with($this->callback(function ($persistedEntry) {
-                return $persistedEntry->isArchived();
+                return (bool) $persistedEntry->isArchived();
             }));
 
         $res = $chromeImport->setMarkAsRead(true)->import();
@@ -190,7 +190,7 @@ class ChromeImportTest extends TestCase
         $this->assertFalse($res);
 
         $records = $this->logHandler->getRecords();
-        $this->assertContains('Wallabag Browser Import: unable to read file', $records[0]['message']);
+        $this->assertStringContainsString('Wallabag Browser Import: unable to read file', $records[0]['message']);
         $this->assertSame('ERROR', $records[0]['level_name']);
     }
 
@@ -204,7 +204,7 @@ class ChromeImportTest extends TestCase
         $this->assertFalse($res);
 
         $records = $this->logHandler->getRecords();
-        $this->assertContains('Wallabag Browser Import: user is not defined', $records[0]['message']);
+        $this->assertStringContainsString('Wallabag Browser Import: user is not defined', $records[0]['message']);
         $this->assertSame('ERROR', $records[0]['level_name']);
     }
 

--- a/tests/Wallabag/ImportBundle/Import/FirefoxImportTest.php
+++ b/tests/Wallabag/ImportBundle/Import/FirefoxImportTest.php
@@ -90,7 +90,7 @@ class FirefoxImportTest extends TestCase
             ->expects($this->any())
             ->method('persist')
             ->with($this->callback(function ($persistedEntry) {
-                return $persistedEntry->isArchived();
+                return (bool) $persistedEntry->isArchived();
             }));
 
         $res = $firefoxImport->setMarkAsRead(true)->import();
@@ -190,7 +190,7 @@ class FirefoxImportTest extends TestCase
         $this->assertFalse($res);
 
         $records = $this->logHandler->getRecords();
-        $this->assertContains('Wallabag Browser Import: unable to read file', $records[0]['message']);
+        $this->assertStringContainsString('Wallabag Browser Import: unable to read file', $records[0]['message']);
         $this->assertSame('ERROR', $records[0]['level_name']);
     }
 
@@ -204,7 +204,7 @@ class FirefoxImportTest extends TestCase
         $this->assertFalse($res);
 
         $records = $this->logHandler->getRecords();
-        $this->assertContains('Wallabag Browser Import: user is not defined', $records[0]['message']);
+        $this->assertStringContainsString('Wallabag Browser Import: user is not defined', $records[0]['message']);
         $this->assertSame('ERROR', $records[0]['level_name']);
     }
 

--- a/tests/Wallabag/ImportBundle/Import/InstapaperImportTest.php
+++ b/tests/Wallabag/ImportBundle/Import/InstapaperImportTest.php
@@ -91,7 +91,7 @@ class InstapaperImportTest extends TestCase
             ->expects($this->once())
             ->method('persist')
             ->with($this->callback(function ($persistedEntry) {
-                return $persistedEntry->isArchived();
+                return (bool) $persistedEntry->isArchived();
             }));
 
         $res = $instapaperImport->setMarkAsRead(true)->import();
@@ -191,7 +191,7 @@ class InstapaperImportTest extends TestCase
         $this->assertFalse($res);
 
         $records = $this->logHandler->getRecords();
-        $this->assertContains('InstapaperImport: unable to read file', $records[0]['message']);
+        $this->assertStringContainsString('InstapaperImport: unable to read file', $records[0]['message']);
         $this->assertSame('ERROR', $records[0]['level_name']);
     }
 
@@ -205,7 +205,7 @@ class InstapaperImportTest extends TestCase
         $this->assertFalse($res);
 
         $records = $this->logHandler->getRecords();
-        $this->assertContains('InstapaperImport: user is not defined', $records[0]['message']);
+        $this->assertStringContainsString('InstapaperImport: user is not defined', $records[0]['message']);
         $this->assertSame('ERROR', $records[0]['level_name']);
     }
 

--- a/tests/Wallabag/ImportBundle/Import/PocketImportTest.php
+++ b/tests/Wallabag/ImportBundle/Import/PocketImportTest.php
@@ -60,7 +60,7 @@ class PocketImportTest extends TestCase
         $this->assertFalse($code);
 
         $records = $this->logHandler->getRecords();
-        $this->assertContains('PocketImport: Failed to request token', $records[0]['message']);
+        $this->assertStringContainsString('PocketImport: Failed to request token', $records[0]['message']);
         $this->assertSame('ERROR', $records[0]['level_name']);
     }
 
@@ -91,7 +91,7 @@ class PocketImportTest extends TestCase
         $this->assertFalse($res);
 
         $records = $this->logHandler->getRecords();
-        $this->assertContains('PocketImport: Failed to authorize client', $records[0]['message']);
+        $this->assertStringContainsString('PocketImport: Failed to authorize client', $records[0]['message']);
         $this->assertSame('ERROR', $records[0]['level_name']);
     }
 
@@ -204,7 +204,7 @@ JSON
             ->expects($this->any())
             ->method('persist')
             ->with($this->callback(function ($persistedEntry) {
-                return $persistedEntry->isArchived() && $persistedEntry->isStarred();
+                return (bool) $persistedEntry->isArchived() && (bool) $persistedEntry->isStarred();
             }));
 
         $entry = new Entry($this->user);
@@ -295,7 +295,7 @@ JSON
             ->expects($this->any())
             ->method('persist')
             ->with($this->callback(function ($persistedEntry) {
-                return $persistedEntry->isArchived();
+                return (bool) $persistedEntry->isArchived();
             }));
 
         $entry = new Entry($this->user);
@@ -491,7 +491,7 @@ JSON
         $this->assertFalse($res);
 
         $records = $this->logHandler->getRecords();
-        $this->assertContains('PocketImport: Failed to import', $records[0]['message']);
+        $this->assertStringContainsString('PocketImport: Failed to import', $records[0]['message']);
         $this->assertSame('ERROR', $records[0]['level_name']);
     }
 
@@ -511,7 +511,7 @@ JSON
                     }
                 }
             }
-            
+
 JSON
         ));
 

--- a/tests/Wallabag/ImportBundle/Import/ReadabilityImportTest.php
+++ b/tests/Wallabag/ImportBundle/Import/ReadabilityImportTest.php
@@ -90,7 +90,7 @@ class ReadabilityImportTest extends TestCase
             ->expects($this->any())
             ->method('persist')
             ->with($this->callback(function ($persistedEntry) {
-                return $persistedEntry->isArchived();
+                return (bool) $persistedEntry->isArchived();
             }));
 
         $res = $readabilityImport->setMarkAsRead(true)->import();
@@ -190,7 +190,7 @@ class ReadabilityImportTest extends TestCase
         $this->assertFalse($res);
 
         $records = $this->logHandler->getRecords();
-        $this->assertContains('ReadabilityImport: unable to read file', $records[0]['message']);
+        $this->assertStringContainsString('ReadabilityImport: unable to read file', $records[0]['message']);
         $this->assertSame('ERROR', $records[0]['level_name']);
     }
 
@@ -204,7 +204,7 @@ class ReadabilityImportTest extends TestCase
         $this->assertFalse($res);
 
         $records = $this->logHandler->getRecords();
-        $this->assertContains('ReadabilityImport: user is not defined', $records[0]['message']);
+        $this->assertStringContainsString('ReadabilityImport: user is not defined', $records[0]['message']);
         $this->assertSame('ERROR', $records[0]['level_name']);
     }
 

--- a/tests/Wallabag/ImportBundle/Import/WallabagV1ImportTest.php
+++ b/tests/Wallabag/ImportBundle/Import/WallabagV1ImportTest.php
@@ -93,7 +93,7 @@ class WallabagV1ImportTest extends TestCase
             ->expects($this->any())
             ->method('persist')
             ->with($this->callback(function ($persistedEntry) {
-                return $persistedEntry->isArchived();
+                return (bool) $persistedEntry->isArchived();
             }));
 
         $res = $wallabagV1Import->setMarkAsRead(true)->import();
@@ -193,7 +193,7 @@ class WallabagV1ImportTest extends TestCase
         $this->assertFalse($res);
 
         $records = $this->logHandler->getRecords();
-        $this->assertContains('WallabagImport: unable to read file', $records[0]['message']);
+        $this->assertStringContainsString('WallabagImport: unable to read file', $records[0]['message']);
         $this->assertSame('ERROR', $records[0]['level_name']);
     }
 
@@ -207,7 +207,7 @@ class WallabagV1ImportTest extends TestCase
         $this->assertFalse($res);
 
         $records = $this->logHandler->getRecords();
-        $this->assertContains('WallabagImport: user is not defined', $records[0]['message']);
+        $this->assertStringContainsString('WallabagImport: user is not defined', $records[0]['message']);
         $this->assertSame('ERROR', $records[0]['level_name']);
     }
 

--- a/tests/Wallabag/ImportBundle/Import/WallabagV2ImportTest.php
+++ b/tests/Wallabag/ImportBundle/Import/WallabagV2ImportTest.php
@@ -87,7 +87,7 @@ class WallabagV2ImportTest extends TestCase
             ->expects($this->any())
             ->method('persist')
             ->with($this->callback(function ($persistedEntry) {
-                return $persistedEntry->isArchived();
+                return (bool) $persistedEntry->isArchived();
             }));
 
         $res = $wallabagV2Import->setMarkAsRead(true)->import();
@@ -179,7 +179,7 @@ class WallabagV2ImportTest extends TestCase
         $this->assertFalse($res);
 
         $records = $this->logHandler->getRecords();
-        $this->assertContains('WallabagImport: unable to read file', $records[0]['message']);
+        $this->assertStringContainsString('WallabagImport: unable to read file', $records[0]['message']);
         $this->assertSame('ERROR', $records[0]['level_name']);
     }
 
@@ -193,7 +193,7 @@ class WallabagV2ImportTest extends TestCase
         $this->assertFalse($res);
 
         $records = $this->logHandler->getRecords();
-        $this->assertContains('WallabagImport: user is not defined', $records[0]['message']);
+        $this->assertStringContainsString('WallabagImport: user is not defined', $records[0]['message']);
         $this->assertSame('ERROR', $records[0]['level_name']);
     }
 

--- a/tests/Wallabag/UserBundle/Controller/ManageControllerTest.php
+++ b/tests/Wallabag/UserBundle/Controller/ManageControllerTest.php
@@ -13,7 +13,7 @@ class ManageControllerTest extends WallabagCoreTestCase
         $client->request('GET', '/users/list');
 
         $this->assertSame(302, $client->getResponse()->getStatusCode());
-        $this->assertContains('login', $client->getResponse()->headers->get('location'));
+        $this->assertStringContainsString('login', $client->getResponse()->headers->get('location'));
     }
 
     public function testCompleteScenario()

--- a/tests/Wallabag/UserBundle/EventListener/AuthenticationFailureListenerTest.php
+++ b/tests/Wallabag/UserBundle/EventListener/AuthenticationFailureListenerTest.php
@@ -19,7 +19,7 @@ class AuthenticationFailureListenerTest extends TestCase
     private $listener;
     private $dispatcher;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $request = Request::create('/');
         $request->request->set('_username', 'admin');

--- a/tests/Wallabag/UserBundle/EventListener/CreateConfigListenerTest.php
+++ b/tests/Wallabag/UserBundle/EventListener/CreateConfigListenerTest.php
@@ -22,7 +22,7 @@ class CreateConfigListenerTest extends TestCase
     private $request;
     private $response;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $session = new Session(new MockArraySessionStorage());
         $this->em = $this->getMockBuilder('Doctrine\ORM\EntityManager')

--- a/tests/Wallabag/UserBundle/Mailer/AuthCodeMailerTest.php
+++ b/tests/Wallabag/UserBundle/Mailer/AuthCodeMailerTest.php
@@ -57,7 +57,7 @@ TWIG;
         $this->assertArrayHasKey('test@wallabag.io', $msg->getTo());
         $this->assertSame(['nobody@test.io' => 'wallabag test'], $msg->getFrom());
         $this->assertSame('subject', $msg->getSubject());
-        $this->assertContains('text body http://0.0.0.0/support', $msg->toString());
-        $this->assertContains('html body 666666', $msg->toString());
+        $this->assertStringContainsString('text body http://0.0.0.0/support', $msg->toString());
+        $this->assertStringContainsString('html body 666666', $msg->toString());
     }
 }

--- a/tests/Wallabag/UserBundle/Mailer/AuthCodeMailerTest.php
+++ b/tests/Wallabag/UserBundle/Mailer/AuthCodeMailerTest.php
@@ -14,7 +14,7 @@ class AuthCodeMailerTest extends TestCase
     protected $spool;
     protected $twig;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->spool = new CountableMemorySpool();
         $transport = new \Swift_Transport_SpoolTransport(


### PR DESCRIPTION
We already [jumped to PHP 7.1+](https://github.com/wallabag/wallabag/pull/3758) almost 1 year and half ago in the horizon to release the 2.4.0 version (and at that time the 7.1 still has active support).
Sadly, the 2.4.0 is still not released.
We are still working on it but have less time than before.

In the mean time, I think it's best to jump to PHP 7.2+ to avoid having to wait for the next minor version of wallabag (2.5.0).

![image](https://user-images.githubusercontent.com/62333/84654645-d5873680-af0f-11ea-89ff-92d66a7b8b6f.png)
[Support for 7.2 will end in November 2020](https://www.php.net/supported-versions.php).
Which means, we should jump to 7.3 right away but I think it's too fast for most people. Also Symfony still required PHP >=7.2.5 for the current master (the upcoming 5.2.0).

I think it's safe to jump to 7.2+.
It'll eventually allow us to upgrade the Symfony version (to 4.x or 5.x) without forcing (again) people to upgrade their PHP version.

**What you guys think about that?**

<details><summary>Deps summary of the update</summary>
<p>

Updating deps

  - Removing electrolinux/php-html5lib (0.1.0)
  - Updating doctrine/inflector (1.3.1 => 1.4.3)
  - Updating doctrine/lexer (1.0.2 => 1.2.1)
  - Installing symfony/polyfill-php80 (v1.17.0)
  - Updating symfony/service-contracts (v1.1.8 => v2.1.2)
  - Installing symfony/deprecation-contracts (v2.1.2)
  - Updating symfony/mime (v4.4.8 => v5.1.1)
  - Updating friendsofsymfony/rest-bundle (2.7.4 => 2.8.0)
  - Updating doctrine/instantiator (1.3.0 => 1.3.1)
  - Updating ocramius/proxy-manager (2.1.1 => 2.2.3)
  - Updating php-http/discovery (1.7.4 => 1.8.0)
  - Updating symfony/http-client-contracts (v1.1.8 => v2.1.2)
  - Updating symfony/http-client (v4.4.8 => v5.1.1)
  - Updating php-http/httplug-bundle (1.16.0 => 1.18.0)
  - Updating symfony/phpunit-bridge (v4.3.11 => v5.1.1)
  - Updating doctrine/data-fixtures (1.3.3 => 1.4.3)
  - Updating composer/xdebug-handler (1.4.1 => 1.4.2)
  - Updating masterminds/html5 (2.7.0 => 2.7.1)
  - Updating j0k3r/php-readability (1.2.4 => 1.2.5)
  - Updating phpoption/phpoption (1.7.3 => 1.7.4)
  - Updating nikic/php-parser (v4.4.0 => v4.5.0)
  - Installing thecodingmachine/safe (v1.1.1)
  - Updating spomky-labs/otphp (v9.1.4 => v10.0.1)
  - Updating pagerfanta/pagerfanta (v2.1.3 => v2.3.0)

Package white-october/pagerfanta-bundle is abandoned, you should avoid using it. Use babdev/pagerfanta-bundle instead.

  - Removing white-october/pagerfanta-bundle (v1.3.2)
  - Installing babdev/pagerfanta-bundle (v2.4.2)

Upgrading PHPStan to 0.12 and use extension installer

  - Removing phpstan/phpdoc-parser (0.3.5)
  - Removing nette/utils (v3.1.2)
  - Removing nette/schema (v1.0.2)
  - Removing nette/robot-loader (v3.2.3)
  - Removing nette/php-generator (v3.4.0)
  - Removing nette/neon (v3.1.2)
  - Removing nette/finder (v2.5.2)
  - Removing nette/di (v3.0.4)
  - Removing nette/bootstrap (v3.0.2)
  - Updating phpstan/phpstan (0.11.19 => 0.12.29)
  - Updating phpstan/phpstan-doctrine (0.11.6 => 0.12.16)
  - Updating phpstan/phpstan-phpunit (0.11.2 => 0.12.11)
  - Updating phpstan/phpstan-symfony (0.11.6 => 0.12.6)
  - Installing phpstan/extension-installer (1.0.4)

Upgrading jms/serializer-bundle to version 3 (and willdurand/hateoas-bundle to version 2)

  - Removing phpoption/phpoption (1.7.4)
  - Removing phpcollection/phpcollection (0.5.0)
  - Removing jms/parser-lib (1.0.0)
  - Updating jms/metadata (1.7.0 => 2.3.0)
  - Updating jms/serializer (1.14.1 => 3.7.0)
  - Updating jms/serializer-bundle (2.4.4 => 3.6.0)
  - Updating willdurand/hateoas (2.12.0 => 3.6.0)
  - Updating willdurand/hateoas-bundle (1.4.0 => 2.1.0)

Upgrading dama/doctrine-test-bundle to version 6

  - Updating dama/doctrine-test-bundle (v5.0.3 => v6.2.0)
</p>
</details>