### PR TITLE
wallabag is now translated using Weblate

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
+<img src="https://raw.githubusercontent.com/wallabag/logo/master/_default/typo-horizontal/png/sm/logo-typo-horizontal-black-no-bg-no-border-sm.png" align="right" />
+
 [![Build Status](https://api.travis-ci.org/wallabag/wallabag.svg?branch=master)](https://travis-ci.org/wallabag/wallabag)
 [![Scrutinizer Code Quality](https://scrutinizer-ci.com/g/wallabag/wallabag/badges/quality-score.png?b=master)](https://scrutinizer-ci.com/g/wallabag/wallabag/?branch=master)
 [![Gitter](https://badges.gitter.im/gitterHQ/gitter.svg)](https://gitter.im/wallabag/wallabag)
+[![Translation status](https://hosted.weblate.org/widgets/wallabag/-/svg-badge.svg)](https://hosted.weblate.org/engage/wallabag/?utm_source=widget)
 
 # What is wallabag?
 wallabag is a self-hostable PHP application allowing you to not miss any content anymore.
@@ -10,14 +13,12 @@ More information on our website: [wallabag.org](https://wallabag.org).
 
 If you do not have your own server, consider [the wallabag.it hosting solution](https://wallabag.it).
 
-![wallabag logo](https://raw.githubusercontent.com/wallabag/logo/master/_default/typo-horizontal/png/sm/logo-typo-horizontal-black-no-bg-no-border-sm.png)
-
 # Install wallabag
 Please read [the documentation to see the wallabag requirements](https://doc.wallabag.org/en/admin/installation/requirements.html).
 
 Then you can install wallabag by executing the following commands:
 
-```
+```bash
 git clone https://github.com/wallabag/wallabag.git
 cd wallabag && make install
 ```
@@ -28,6 +29,10 @@ Now, [configure a virtual host](https://doc.wallabag.org/en/admin/installation/v
 [![Install Wallabag with YunoHost](https://install-app.yunohost.org/install-with-yunohost.png)](https://install-app.yunohost.org/?app=wallabag2)
 
 Wallabag app for [YunoHost](https://yunohost.org). See [here](https://github.com/YunoHost-Apps/wallabag2_ynh)
+
+# Translate wallabag
+
+[wallabag](https://hosted.weblate.org/projects/wallabag/) is being translated using [Weblate](https://weblate.org/), a web tool designed to ease translating for both developers and translators. Feel free to help us [translate wallabag](https://hosted.weblate.org/projects/wallabag/)!
 
 # License
 Copyright © 2013-current Nicolas Lœuillet <nicolas@loeuillet.org>


### PR DESCRIPTION
Rewamp the readme logo & add a short text explaining how wallabag is translated now.
Also add the weblate badge.