### PR TITLE
material: restore missing export and filter buttons on tags view

### DIFF
--- a/src/Wallabag/CoreBundle/Resources/views/themes/material/layout.html.twig
+++ b/src/Wallabag/CoreBundle/Resources/views/themes/material/layout.html.twig
@@ -92,6 +92,7 @@
                             <i class="material-icons">casino</i>
                         </a>
                     </li>
+                    {% endif %}
                     <li id="button_filters">
                         <a class="nav-panel-menu button-collapse-right tooltipped js-filters-action" data-position="bottom" data-delay="50" data-tooltip="{{ 'menu.top.filter_entries'|trans }}" href="#" data-activates="filters">
                             <i class="material-icons">filter_list</i>
@@ -102,7 +103,6 @@
                             <i class="material-icons">file_download</i>
                         </a>
                     </li>
-                    {% endif %}
                     <li class="bold">
                         <a class="wave-effect tooltipped dropdown-button" data-beloworigin="true" data-constrainwidth="false" data-activates="dropdown-account" data-position="bottom" data-delay="50" data-tooltip="{{ 'menu.top.account'|trans }}" href="#" id="news_menu">
                             <i class="material-icons" id="news_link">account_circle</i>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes/no
| Documentation | no
| Translation   | no
| CHANGELOG.md  | no
| License       | MIT

The commit d9a68f6ced3f510e5a52d5f857ca9c19aed8924b introduced a change
in the way export and filter buttons are showed. It ended in hiding
them on the tag-related pages, preventing users to export entries for a
given tag.