### PR TITLE
Reduce opacity of archived entries on tag view

### DIFF
--- a/app/Resources/static/themes/material/css/cards.scss
+++ b/app/Resources/static/themes/material/css/cards.scss
@@ -293,6 +293,11 @@ a.original:not(.waves-effect) {
   }
 }
 
+.card.archived,
+.card-stacked.archived {
+  opacity: 0.5;
+}
+
 #content .collection .collection-item {
   min-height: 65px;
   height: auto;

--- a/src/Wallabag/CoreBundle/Resources/views/themes/material/Entry/_card_full_image.html.twig
+++ b/src/Wallabag/CoreBundle/Resources/views/themes/material/Entry/_card_full_image.html.twig
@@ -1,4 +1,4 @@
-<div class="card">
+<div class="card{% if currentRoute == 'tag_entries' and entry.isArchived %} archived{% endif %}">
     <div class="card-body">
         <div class="card-fullimage">
             <ul class="card-entry-labels">

--- a/src/Wallabag/CoreBundle/Resources/views/themes/material/Entry/_card_list.html.twig
+++ b/src/Wallabag/CoreBundle/Resources/views/themes/material/Entry/_card_list.html.twig
@@ -1,4 +1,4 @@
-<div class="card-stacked">
+<div class="card-stacked{% if currentRoute == 'tag_entries' and entry.isArchived %} archived{% endif %}">
     {% include "@WallabagCore/themes/material/Entry/Card/_mass_checkbox.html.twig" with {'entry': entry} only %}
     <div class="card-preview">
         <a href="{{ path('view', { 'id': entry.id }) }}">

--- a/src/Wallabag/CoreBundle/Resources/views/themes/material/Entry/_card_preview.html.twig
+++ b/src/Wallabag/CoreBundle/Resources/views/themes/material/Entry/_card_preview.html.twig
@@ -1,4 +1,4 @@
-<div class="card">
+<div class="card{% if currentRoute == 'tag_entries' and entry.isArchived %} archived{% endif %}">
     <div class="card-body">
         <div class="card-image waves-effect waves-block waves-light">
             <ul class="card-entry-labels">

--- a/src/Wallabag/CoreBundle/Resources/views/themes/material/Entry/entries.html.twig
+++ b/src/Wallabag/CoreBundle/Resources/views/themes/material/Entry/entries.html.twig
@@ -57,11 +57,11 @@
         {% for entry in entries %}
             <li id="entry-{{ entry.id|e }}" class="entry col {% if listMode == 0 %}l3 m6{% else %}collection-item{% endif %} s12">
                 {% if listMode == 1 %}
-                    {% include "@WallabagCore/themes/material/Entry/_card_list.html.twig" with {'entry': entry} only %}
+                    {% include "@WallabagCore/themes/material/Entry/_card_list.html.twig" with {'entry': entry, 'currentRoute': currentRoute} only %}
                 {% elseif not entry.previewPicture is null and entry.mimetype starts with 'image/' %}
-                    {% include "@WallabagCore/themes/material/Entry/_card_full_image.html.twig" with {'entry': entry} only %}
+                    {% include "@WallabagCore/themes/material/Entry/_card_full_image.html.twig" with {'entry': entry, 'currentRoute': currentRoute} only %}
                 {% else %}
-                    {% include "@WallabagCore/themes/material/Entry/_card_preview.html.twig" with {'entry': entry} only %}
+                    {% include "@WallabagCore/themes/material/Entry/_card_preview.html.twig" with {'entry': entry, 'currentRoute': currentRoute} only %}
                 {% endif %}
             </li>
         {% endfor %}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | ~
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | 
| Documentation | no
| Translation   | no
| CHANGELOG.md  | no
| License       | MIT

Fixes #4466

This change is only on the `tag_entries` view, setting opacity of archived entries to 0.45:

![2020-07-13-184431_828x398](https://user-images.githubusercontent.com/226063/87331652-9c57db80-c53a-11ea-9635-7e341b5c0b56.png)

![2020-07-13-184446_1282x499](https://user-images.githubusercontent.com/226063/87331662-9feb6280-c53a-11ea-9cc6-6e07e7acfea1.png)
