### PR TITLE
Fix link to composer installation requirements

### DIFF
--- a/scripts/require.sh
+++ b/scripts/require.sh
@@ -3,7 +3,7 @@
 # Check for composer
 if [ ! -f composer.phar ]; then
     echo "composer.phar not found, we'll see if composer is installed globally."
-    command -v composer >/dev/null 2>&1 || { echo >&2 "wallabag requires composer but it's not installed (see http://doc.wallabag.org/en/master/user/installation.html). Aborting."; exit 1; }
+    command -v composer >/dev/null 2>&1 || { echo >&2 "wallabag requires composer but it's not installed (see https://doc.wallabag.org/en/admin/installation/requirements.html). Aborting."; exit 1; }
 else
     COMPOSER_COMMAND='./composer.phar'
 fi


### PR DESCRIPTION
The current link 404s and the link to https://doc.wallabag.org/en/admin/installation/installation.html does not give enough context about `composer` so I've linked to the requirements page instead.

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | n/a
| Documentation | yes
| Translation   | no
| CHANGELOG.md  | no
| License       | MIT

<!--
Please list the issues your PR fixes using special keywords, see
https://help.github.com/articles/closing-issues-using-keywords/

Fixes #…
-->

<!--
- Please fill in this template according to the PR you're about to submit.
- Replace this comment by a description of what your PR is solving.
-->
