### PR TITLE
Check user credentials using imap authentication

### DIFF
--- a/app/AppKernel.php
+++ b/app/AppKernel.php
@@ -36,6 +36,7 @@ class AppKernel extends Kernel
             new OldSound\RabbitMqBundle\OldSoundRabbitMqBundle(),
             new Http\HttplugBundle\HttplugBundle(),
             new Sentry\SentryBundle\SentryBundle(),
+            new Seb\AuthenticatorBundle\SebAuthenticatorBundle(),
 
             // wallabag bundles
             new Wallabag\CoreBundle\WallabagCoreBundle(),

--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -411,3 +411,15 @@ httplug:
 # define custom entity so we can override length attribute to fix utf8mb4 issue
 craue_config:
     entity_name: Wallabag\CoreBundle\Entity\InternalSetting
+
+seb_authenticator:
+    guards:
+        local_accounts:
+            form_login: ~
+            local_credentials: ~
+            bad_credentials: 'try_next'
+        imap_accounts:
+            form_login: ~
+            imap_credentials:
+                mailbox: "%seb_authenticator_imap_mailbox%"
+            missing_user: 'create'

--- a/app/config/parameters.yml.dist
+++ b/app/config/parameters.yml.dist
@@ -55,6 +55,9 @@ parameters:
 
     rss_limit: 50
 
+    # Authenticator
+    seb_authenticator_imap_mailbox: '{127.0.0.1:143/imap}'
+
     # RabbitMQ processing
     rabbitmq_host: localhost
     rabbitmq_port: 5672

--- a/app/config/security.yml
+++ b/app/config/security.yml
@@ -41,9 +41,11 @@ security:
         secured_area:
             logout_on_user_change: true
             pattern: ^/
-            form_login:
-                provider: fos_userbundle
-                csrf_token_generator: security.csrf.token_manager
+            guard:
+                authenticators:
+                    - seb_authenticator.guards.local_accounts
+                    - seb_authenticator.guards.imap_accounts
+            entry_point: seb_authenticator.guards.local_accounts
 
             anonymous: true
             remember_me:

--- a/app/config/services.yml
+++ b/app/config/services.yml
@@ -45,3 +45,7 @@ services:
             - 'craue_config'
             - 0
             - '%kernel.cache_dir%'
+
+    seb_user_manager:
+        class: Wallabag\UserBundle\Security\FOSUserManagerBridge
+        autowire: true

--- a/composer.json
+++ b/composer.json
@@ -84,6 +84,7 @@
         "pragmarx/recovery": "^0.1.0",
         "predis/predis": "^1.1.3",
         "scheb/two-factor-bundle": "^4.11.0",
+        "seb/authenticator-bundle": "^0.0.2",
         "sensio/distribution-bundle": "^5.0",
         "sensio/framework-extra-bundle": "^5.2",
         "sentry/sentry-symfony": "3.2.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "e26891992eaad86a76d88a80c9716352",
+    "content-hash": "3f83c9443244c443f58e3ab1a9c57f37",
     "packages": [
         {
             "name": "babdev/pagerfanta-bundle",
@@ -7691,6 +7691,50 @@
             "time": "2020-09-21T13:24:40+00:00"
         },
         {
+            "name": "seb/authenticator-bundle",
+            "version": "0.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/exeba/SebAuthenticatorBundle.git",
+                "reference": "4173e9af156d9f30311be00f82abe33dcde976c3"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/exeba/SebAuthenticatorBundle/zipball/4173e9af156d9f30311be00f82abe33dcde976c3",
+                "reference": "4173e9af156d9f30311be00f82abe33dcde976c3",
+                "shasum": ""
+            },
+            "require": {
+                "ext-imap": "*",
+                "php": "^7.1",
+                "symfony/security-bundle": "^3.0 || ^4.0 || ^5.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Seb\\AuthenticatorBundle\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastiano Degan",
+                    "email": "sebdeg87@gmail.com"
+                }
+            ],
+            "description": "Symfony SebAuthenticatorBundle",
+            "keywords": [
+                "user authentication"
+            ],
+            "time": "2020-10-03T14:07:49+00:00"
+        },
+        {
             "name": "sensio/distribution-bundle",
             "version": "v5.0.25",
             "source": {
@@ -10429,6 +10473,7 @@
                 "i18n",
                 "text"
             ],
+            "abandoned": true,
             "time": "2018-12-05T18:34:18+00:00"
         },
         {

--- a/src/Wallabag/UserBundle/Security/FOSUserManagerBridge.php
+++ b/src/Wallabag/UserBundle/Security/FOSUserManagerBridge.php
@@ -1,0 +1,55 @@
+<?php
+
+
+namespace Wallabag\UserBundle\Security;
+
+
+use Doctrine\ORM\EntityManagerInterface;
+use FOS\UserBundle\Event\UserEvent;
+use FOS\UserBundle\FOSUserEvents;
+use FOS\UserBundle\Model\UserManagerInterface as FOSUserManagerInterface;
+use Seb\AuthenticatorBundle\Security\UserManagerInterface;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Symfony\Component\Security\Core\User\UserInterface;
+
+class FOSUserManagerBridge implements UserManagerInterface
+{
+
+    private $userManager;
+    private $entityManager;
+    private $eventDispatcher;
+
+    public function __construct(FOSUserManagerInterface $userManager,
+            EntityManagerInterface $entityManager,
+            EventDispatcherInterface $eventDispatcher)
+    {
+        $this->userManager = $userManager;
+        $this->entityManager = $entityManager;
+        $this->eventDispatcher = $eventDispatcher;
+    }
+
+    public function createUser($credentials)
+    {
+        $user = $this->userManager->createUser();
+        $user->setEnabled(true);
+        $user->setUsername($credentials['username']);
+        $user->setEmail($credentials['username']);
+        // Password cannot be null, any value is
+        // ok as long as its not a real password hash
+        $user->setPassword('IMAP_AUTH');
+
+        return $user;
+    }
+
+    public function persistUser(UserInterface $user)
+    {
+        if ($this->entityManager->contains($user)) {
+            // Noting to do, user is already persisted
+            return;
+        }
+
+        $this->userManager->updateUser($user);
+        $this->eventDispatcher->dispatch(FOSUserEvents::USER_CREATED, new UserEvent($user));
+        $this->userManager->reloadUser($user);
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes/no
| Documentation | no
| Translation   | no
| CHANGELOG.md  | no
| License       | MIT

This commit allows me to authenticate users using an imap server, the same way it is done in Owncloud with the External User Backends app.

This is the updated login workflow:
  1) Submit credentials
  2) Local user exists -> 3), else 4)
  3) Local password match -> Success, else -> 4)
  4) Imap server refuses credentials -> Fail, else 5)
  5) Create user if needed
  6) Success

In principle it could be extended with other authentication methods.
If you think this is interesting, I'd be happy to work on it.
