### PR TITLE
Update release process and introduce 2.4.1-dev

### DIFF
--- a/RELEASE_PROCESS.md
+++ b/RELEASE_PROCESS.md
@@ -16,25 +16,6 @@ During this documentation, we assume the release is `$LAST_WALLABAG_RELEASE` (li
 
 #### Create a new release on GitHub
 
-- Run these commands to create the tag:
-
-```
-git checkout master
-git pull origin master
-git checkout -b release-$LAST_WALLABAG_RELEASE
-composer up
-```
-
-- Then continue with these commands:
-
-```
-git add composer.lock
-git commit -m "Release wallabag $LAST_WALLABAG_RELEASE"
-git push origin release-$LAST_WALLABAG_RELEASE
-```
-
-- Create a new pull request with this title `Release wallabag $LAST_WALLABAG_RELEASE`. This pull request is used to launch builds on Travis-CI.
-- Once PR is green, merge it and delete the branch.
 - Run this command to create the package:
 
 ```
@@ -42,7 +23,7 @@ make release VERSION=$LAST_WALLABAG_RELEASE
 ```
 
 - [Create the new release on GitHub](https://github.com/wallabag/wallabag/releases/new) by targetting the `master` branch or any appropriate branch (for instance backports). You have to upload the package (generated previously).
-- Update the URL shortener (used on `wllbg.org` to update links like `https://wllbg.org/latest-v2-package` or `http://wllbg.org/latest-v2`)
+- Update nginx config to change the redirect rule for `https://wllbg.org/latest-v2-package` & `http://wllbg.org/latest-v2` (they both redirect to the asset of the GitHub release)
 - Update Dockerfile https://github.com/wallabag/docker (and create a new tag)
 - Update wallabag.org website (downloads, MD5 sum, releases and new blog post)
 - Put the next patch version suffixed with `-dev` in `app/config/wallabag.yml` (`wallabag_core.version`)

--- a/app/config/wallabag.yml
+++ b/app/config/wallabag.yml
@@ -1,5 +1,5 @@
 wallabag_core:
-    version: 2.4.0
+    version: 2.4.1-dev
     paypal_url: "https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=9UBA65LG3FX9Y&lc=gb"
     languages:
         en: 'English'


### PR DESCRIPTION
Small changes in the release process, the `composer.lock` is now inside the repo so we don't need to create a dedicated PR for it.

And jump to 2.4.1-dev 🎉