### PR TITLE
migrations: fix mysql migration for an edge case

### DIFF
--- a/app/DoctrineMigrations/Version20190510141130.php
+++ b/app/DoctrineMigrations/Version20190510141130.php
@@ -64,8 +64,10 @@ final class Version20190510141130 extends WallabagMigration
                 $this->addSql('ALTER TABLE ' . $this->getTable('oauth2_access_tokens') . ' DROP FOREIGN KEY FK_368A4209A76ED395');
                 $this->addSql('ALTER TABLE ' . $this->getTable('oauth2_access_tokens') . ' ADD CONSTRAINT FK_368A4209A76ED395 FOREIGN KEY (user_id) REFERENCES ' . $this->getTable('user') . ' (id) ON DELETE CASCADE');
 
-                $this->addSql('ALTER TABLE ' . $this->getTable('oauth2_clients') . ' DROP FOREIGN KEY IDX_user_oauth_client');
-                $this->addSql('ALTER TABLE ' . $this->getTable('oauth2_clients') . ' ADD CONSTRAINT FK_635D765EA76ED395 FOREIGN KEY (user_id) REFERENCES ' . $this->getTable('user') . ' (id)');
+                if ($schema->getTable($this->getTable('oauth2_clients'))->hasForeignKey('IDX_user_oauth_client')) {
+                    $this->addSql('ALTER TABLE ' . $this->getTable('oauth2_clients') . ' DROP FOREIGN KEY IDX_user_oauth_client');
+                    $this->addSql('ALTER TABLE ' . $this->getTable('oauth2_clients') . ' ADD CONSTRAINT FK_635D765EA76ED395 FOREIGN KEY (user_id) REFERENCES ' . $this->getTable('user') . ' (id)');
+                }
 
                 $this->addSql('ALTER TABLE ' . $this->getTable('oauth2_refresh_tokens') . ' DROP FOREIGN KEY FK_20C9FB24A76ED395');
                 $this->addSql('ALTER TABLE ' . $this->getTable('oauth2_refresh_tokens') . ' ADD CONSTRAINT FK_20C9FB24A76ED395 FOREIGN KEY (user_id) REFERENCES ' . $this->getTable('user') . ' (id) ON DELETE CASCADE');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | ~
| Documentation | no
| Translation   | no
| CHANGELOG.md  | no
| License       | MIT

Fixes #4826

In an unspecified case the schema state was not consistent with the
expected migration plans. This fix ignores two statements by checking
if a foreign key is here or not.

This issue may have been caused by a rewrite of an old migration,
probably through 4acbeb93717612f361627f7d4b946fcb4477823c

I've also checked several migration paths with SQLite and PostgreSQL and did not encounter further issues.