### PR TITLE
Add a command to clean downloaded images

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -7,8 +7,7 @@ parameters:
     symfony:
         container_xml_path: %rootDir%/../../../var/cache/test/appTestDebugProjectContainer.xml
 
-    # https://github.com/phpstan/phpstan/issues/694#issuecomment-350724288
-    autoload_files:
+    bootstrapFiles:
         - vendor/bin/.phpunit/phpunit-8.3-0/vendor/autoload.php
 
     inferPrivatePropertyTypeFromConstructor: true

--- a/src/Wallabag/CoreBundle/Command/CleanDownloadedImagesCommand.php
+++ b/src/Wallabag/CoreBundle/Command/CleanDownloadedImagesCommand.php
@@ -8,17 +8,9 @@ use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 use Symfony\Component\Finder\Finder;
-use Wallabag\CoreBundle\Helper\DownloadImages;
-use Wallabag\UserBundle\Entity\User;
 
 class CleanDownloadedImagesCommand extends ContainerAwareCommand
 {
-    /** @var SymfonyStyle */
-    protected $io;
-    protected $deleted = 0;
-    /** @var DownloadImages */
-    protected $downloadImages;
-
     protected function configure()
     {
         $this
@@ -34,19 +26,18 @@ class CleanDownloadedImagesCommand extends ContainerAwareCommand
 
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        $this->io = new SymfonyStyle($input, $output);
+        $io = new SymfonyStyle($input, $output);
 
         $dryRun = (bool) $input->getOption('dry-run');
 
-        $users = $this->getContainer()->get('wallabag_user.user_repository')->findAll();
-
-        $this->io->text(sprintf('Cleaning through <info>%d</info> user accounts', \count($users)));
-
         if ($dryRun) {
-            $this->io->text('Dry run mode <info>enabled</info> (no images will be removed)');
+            $io->text('Dry run mode <info>enabled</info> (no images will be removed)');
         }
 
-        $this->downloadImages = $this->getContainer()->get('wallabag_core.entry.download_images');
+        $downloadImages = $this->getContainer()->get('wallabag_core.entry.download_images');
+        $baseFolder = $downloadImages->getBaseFolder();
+
+        $io->text('Retrieve existing images');
 
         // retrieve _existing_ folders in the image folder
         $finder = new Finder();
@@ -54,36 +45,23 @@ class CleanDownloadedImagesCommand extends ContainerAwareCommand
             ->directories()
             ->ignoreDotFiles(true)
             ->depth(2)
-            ->in($this->downloadImages->getBaseFolder());
+            ->in($baseFolder);
 
         $existingPaths = [];
         foreach ($finder as $file) {
             $existingPaths[] = $file->getFilename();
         }
 
-        foreach ($users as $user) {
-            $this->clean($user, $existingPaths, $dryRun);
-        }
+        $io->text(sprintf('  -> <info>%d</info> images found', \count($existingPaths)));
 
-        $this->io->success(sprintf('Finished cleaning. %d deleted images', $this->deleted));
+        $io->text('Retrieve valid folders attached to a user');
 
-        return 0;
-    }
-
-    private function clean(User $user, array $existingPaths, bool $dryRun)
-    {
-        $this->io->text(sprintf('Processing user <info>%s</info>', $user->getUsername()));
-
-        $repo = $this->getContainer()->get('wallabag_core.entry_repository');
-        $baseFolder = $this->downloadImages->getBaseFolder();
-        $entries = $repo->findAllEntriesIdByUserId($user->getId());
-
-        $deletedCount = 0;
+        $entries = $this->getContainer()->get('wallabag_core.entry_repository')->findAllEntriesIdByUserId();
 
         // retrieve _valid_ folders from existing entries
         $validPaths = [];
         foreach ($entries as $entry) {
-            $path = $this->downloadImages->getRelativePath($entry['id']);
+            $path = $downloadImages->getRelativePath($entry['id']);
 
             if (!file_exists($baseFolder . '/' . $path)) {
                 continue;
@@ -92,6 +70,12 @@ class CleanDownloadedImagesCommand extends ContainerAwareCommand
             // only store the hash, not the full path
             $validPaths[] = explode('/', $path)[2];
         }
+
+        $io->text(sprintf('  -> <info>%d</info> folders found', \count($validPaths)));
+
+        $deletedCount = 0;
+
+        $io->text('Remove images');
 
         // check if existing path are valid, if not, remove all images and the folder
         foreach ($existingPaths as $existingPath) {
@@ -106,12 +90,12 @@ class CleanDownloadedImagesCommand extends ContainerAwareCommand
 
                 $deletedCount += \count($files);
 
-                $this->io->text(sprintf('Deleted images in <info>%s</info>: <info>%d</info>', $existingPath, \count($files)));
+                $io->text(sprintf('Deleted images in <info>%s</info>: <info>%d</info>', $existingPath, \count($files)));
             }
         }
 
-        $this->deleted += $deletedCount;
+        $io->success(sprintf('Finished cleaning. %d deleted images', $deletedCount));
 
-        $this->io->text(sprintf('Deleted <info>%d</info> images for user <info>%s</info>', $deletedCount, $user->getUserName()));
+        return 0;
     }
 }

--- a/src/Wallabag/CoreBundle/Command/CleanDownloadedImagesCommand.php
+++ b/src/Wallabag/CoreBundle/Command/CleanDownloadedImagesCommand.php
@@ -1,0 +1,123 @@
+<?php
+
+namespace Wallabag\CoreBundle\Command;
+
+use Doctrine\ORM\NoResultException;
+use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+use Symfony\Component\Finder\Finder;
+use Wallabag\UserBundle\Entity\User;
+
+class CleanDownloadedImagesCommand extends ContainerAwareCommand
+{
+    /** @var SymfonyStyle */
+    protected $io;
+
+    protected $deleted = 0;
+
+    protected function configure()
+    {
+        $this
+            ->setName('wallabag:clean-downloaded-images')
+            ->setDescription('Cleans downloaded images which are no more associated to an entry')
+            ->addArgument(
+                'username',
+                InputArgument::OPTIONAL,
+                'User to clean'
+            );
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $this->io = new SymfonyStyle($input, $output);
+
+        $username = $input->getArgument('username');
+
+        if ($username) {
+            try {
+                $user = $this->getContainer()->get('wallabag_user.user_repository')->findOneByUserName($username);
+                $this->clean($user);
+            } catch (NoResultException $e) {
+                $this->io->error(sprintf('User "%s" not found.', $username));
+
+                return 1;
+            }
+
+            $this->io->success('Finished cleaning.');
+        } else {
+            $users = $this->getContainer()->get('wallabag_user.user_repository')->findAll();
+
+            $this->io->text(sprintf('Cleaning through <info>%d</info> user accounts', \count($users)));
+
+            foreach ($users as $user) {
+                $this->clean($user);
+            }
+            $this->io->success(sprintf('Finished cleaning. %d deleted images', $this->deleted));
+        }
+
+        return 0;
+    }
+
+    private function clean(User $user)
+    {
+        $this->io->text(sprintf('Processing user <info>%s</info>', $user->getUsername()));
+
+        $repo = $this->getContainer()->get('wallabag_core.entry_repository');
+        $downloadImages = $this->getContainer()->get('wallabag_core.entry.download_images');
+        $baseFolder = $downloadImages->getBaseFolder();
+
+        $entries = $repo->findAllEntriesIdByUserId($user->getId());
+
+        $deletedCount = 0;
+
+        // first retrieve _valid_ folders from existing entries
+        $hashToId = [];
+        $validPaths = [];
+        foreach ($entries as $entry) {
+            $path = $downloadImages->getRelativePath($entry['id']);
+
+            if (!file_exists($baseFolder . '/' . $path)) {
+                continue;
+            }
+
+            // only store the hash, not the full path
+            $hash = explode('/', $path)[2];
+            $validPaths[] = $hash;
+            $hashToId[$hash] = $entry['id'];
+        }
+
+        // then retrieve _existing_ folders in the image folder
+        $finder = new Finder();
+        $finder
+            ->directories()
+            ->ignoreDotFiles(true)
+            ->depth(2)
+            ->in($baseFolder);
+
+        $existingPaths = [];
+        foreach ($finder as $file) {
+            $existingPaths[] = $file->getFilename();
+        }
+
+        // check if existing path are valid, if not, remove all images and the folder
+        foreach ($existingPaths as $existingPath) {
+            if (!\in_array($existingPath, $validPaths, true)) {
+                $fullPath = $baseFolder . '/' . $existingPath[0] . '/' . $existingPath[1] . '/' . $existingPath;
+                $res = array_map('unlink', glob($fullPath . '/*.*'));
+
+                rmdir($fullPath);
+
+                $deletedCount += \count($res);
+
+                $this->io->text(sprintf('Deleted images in <info>%s</info>: <info>%d</info>', $existingPath, \count($res)));
+            }
+        }
+
+        $this->deleted += $deletedCount;
+
+        $this->io->text(sprintf('Deleted <info>%d</info> images for user <info>%s</info>', $deletedCount, $user->getUserName()));
+    }
+}

--- a/src/Wallabag/CoreBundle/Helper/DownloadImages.php
+++ b/src/Wallabag/CoreBundle/Helper/DownloadImages.php
@@ -37,6 +37,11 @@ class DownloadImages
         $this->setFolder();
     }
 
+    public function getBaseFolder()
+    {
+        return $this->baseFolder;
+    }
+
     /**
      * Process the html and extract images URLs from it.
      *
@@ -211,6 +216,29 @@ class DownloadImages
     }
 
     /**
+     * Generate the folder where we are going to save images based on the entry url.
+     *
+     * @param int  $entryId      ID of the entry
+     * @param bool $createFolder Should we create the folder for the given id?
+     *
+     * @return string
+     */
+    public function getRelativePath($entryId, $createFolder = true)
+    {
+        $hashId = hash('crc32', $entryId);
+        $relativePath = $hashId[0] . '/' . $hashId[1] . '/' . $hashId;
+        $folderPath = $this->baseFolder . '/' . $relativePath;
+
+        if (!file_exists($folderPath) && $createFolder) {
+            mkdir($folderPath, 0777, true);
+        }
+
+        $this->logger->debug('DownloadImages: Folder used for that Entry id', ['folder' => $folderPath, 'entryId' => $entryId]);
+
+        return $relativePath;
+    }
+
+    /**
      * Get images urls from the srcset image attribute.
      *
      * @return array An array of urls
@@ -252,28 +280,6 @@ class DownloadImages
         if (!file_exists($this->baseFolder)) {
             mkdir($this->baseFolder, 0755, true);
         }
-    }
-
-    /**
-     * Generate the folder where we are going to save images based on the entry url.
-     *
-     * @param int $entryId ID of the entry
-     *
-     * @return string
-     */
-    private function getRelativePath($entryId)
-    {
-        $hashId = hash('crc32', $entryId);
-        $relativePath = $hashId[0] . '/' . $hashId[1] . '/' . $hashId;
-        $folderPath = $this->baseFolder . '/' . $relativePath;
-
-        if (!file_exists($folderPath)) {
-            mkdir($folderPath, 0777, true);
-        }
-
-        $this->logger->debug('DownloadImages: Folder used for that Entry id', ['folder' => $folderPath, 'entryId' => $entryId]);
-
-        return $relativePath;
     }
 
     /**

--- a/src/Wallabag/CoreBundle/Helper/DownloadImages.php
+++ b/src/Wallabag/CoreBundle/Helper/DownloadImages.php
@@ -104,7 +104,7 @@ class DownloadImages
      * @param string $url          Url from where the image were found
      * @param string $relativePath Relative local path to saved the image
      *
-     * @return string Relative url to access the image from the web
+     * @return string|false Relative url to access the image from the web
      */
     public function processSingleImage($entryId, $imagePath, $url, $relativePath = null)
     {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | kind of
| New feature?  | kind of
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Documentation | no
| Translation   | no
| License       | MIT

Fixes #4827

There were a bug in versions prior to 2.4.0 where images weren't properly removed (mostly when coming from the API).
With that command, we'll be able to remove images which aren't associated to any entries.

Like other command you can pass a username to only clean one user.
