### PR TITLE
Fixed query to fetch URL to hash

### DIFF
--- a/src/Wallabag/CoreBundle/Repository/EntryRepository.php
+++ b/src/Wallabag/CoreBundle/Repository/EntryRepository.php
@@ -378,7 +378,9 @@ class EntryRepository extends EntityRepository
     {
         return $this->createQueryBuilder('e')
             ->where('e.hashedUrl = :empty')->setParameter('empty', '')
+            ->orWhere('e.hashedUrl is null')
             ->andWhere('e.user = :user_id')->setParameter('user_id', $userId)
+            ->andWhere('e.url is not null')
             ->getQuery()
             ->getResult();
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Documentation | no
| Translation   | no
| CHANGELOG.md  | no
| License       | MIT

My query was buggy: we also need to find URL where hashedUrl is null and where url is not null (I had this case on wallabag.it)