### PR TITLE
Add a new config "use_source" to handle new ATOM format

### DIFF
--- a/app/DoctrineMigrations/Version20201223222955.php
+++ b/app/DoctrineMigrations/Version20201223222955.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Application\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Wallabag\CoreBundle\Doctrine\WallabagMigration;
+
+final class Version20201223222955 extends WallabagMigration
+{
+    const NEW_FIELD = 'feed_use_source';
+
+    public function up(Schema $schema): void
+    {
+        $configTable = $schema->getTable($this->getTable('config'));
+
+        $this->skipIf($configTable->hasColumn(self::NEW_FIELD), 'It seems that you already played this migration.');
+
+        $configTable->addColumn(self::NEW_FIELD, 'boolean', ['notnull' => true, 'default' => 0]);
+    }
+
+    public function down(Schema $schema): void
+    {
+        $configTable = $schema->getTable($this->getTable('config'));
+
+        $this->skipIf(!$configTable->hasColumn(self::NEW_FIELD), 'It seems that you already played this migration.');
+
+        $configTable->dropColumn(self::NEW_FIELD);
+    }
+}

--- a/src/Wallabag/CoreBundle/Controller/FeedController.php
+++ b/src/Wallabag/CoreBundle/Controller/FeedController.php
@@ -134,6 +134,7 @@ class FeedController extends Controller
                 'domainName' => $this->getParameter('domain_name'),
                 'version' => $this->getParameter('wallabag_core.version'),
                 'tag' => $tag->getSlug(),
+                'isFeedUseSource' => $user->getConfig()->isFeedUseSource(),
             ],
             new Response('', 200, ['Content-Type' => 'application/atom+xml'])
         );
@@ -199,6 +200,7 @@ class FeedController extends Controller
             'user' => $user->getUsername(),
             'domainName' => $this->getParameter('domain_name'),
             'version' => $this->getParameter('wallabag_core.version'),
+            'isFeedUseSource' => $user->getConfig()->isFeedUseSource(),
         ],
         new Response('', 200, ['Content-Type' => 'application/atom+xml'])
         );

--- a/src/Wallabag/CoreBundle/Entity/Config.php
+++ b/src/Wallabag/CoreBundle/Entity/Config.php
@@ -81,6 +81,15 @@ class Config
     private $feedLimit;
 
     /**
+     * If true, will return source article as <link rel="alternate"> in ATOM feed.
+     *
+     * @var bool
+     *
+     * @ORM\Column(name="feed_use_source", type="boolean", nullable=false)
+     */
+    private $feedUseSource = false;
+
+    /**
      * @var float
      *
      * @ORM\Column(name="reading_speed", type="float", nullable=true)
@@ -287,6 +296,16 @@ class Config
     public function getFeedLimit()
     {
         return $this->feedLimit;
+    }
+
+    public function isFeedUseSource(): bool
+    {
+        return $this->feedUseSource;
+    }
+
+    public function setFeedUseSource(bool $feedUseSource): void
+    {
+        $this->feedUseSource = $feedUseSource;
     }
 
     /**

--- a/src/Wallabag/CoreBundle/Form/Type/FeedType.php
+++ b/src/Wallabag/CoreBundle/Form/Type/FeedType.php
@@ -3,6 +3,7 @@
 namespace Wallabag\CoreBundle\Form\Type;
 
 use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
 use Symfony\Component\Form\Extension\Core\Type\SubmitType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
@@ -12,6 +13,11 @@ class FeedType extends AbstractType
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
         $builder
+            ->add('feed_use_source', CheckboxType::class, [
+                'label' => 'config.form_feed.feed_use_source',
+                'property_path' => 'feedUseSource',
+                'required' => false,
+            ])
             ->add('feed_limit', null, [
                 'label' => 'config.form_feed.feed_limit',
                 'property_path' => 'feedLimit',

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.en.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.en.yml
@@ -103,6 +103,7 @@ config:
             archive: 'Archived'
             all: 'All'
         feed_limit: 'Number of items in the feed'
+        feed_use_source: 'Return source url by default into ATOM feed instead of wallabag uri'
     form_user:
         two_factor_description: Enabling two factor authentication means you'll receive an email with a code on every new untrusted connection.
         login_label: 'Login (can not be changed)'

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.fr.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.fr.yml
@@ -103,6 +103,7 @@ config:
             archive: "Lus"
             all: "Tous"
         feed_limit: "Nombre d’articles dans le flux"
+        feed_use_source: "Retourne l'URL de l'article source par défaut dans le flux ATOM à la place de l'url wallabag"
     form_user:
         two_factor_description: Activer l’authentification à deux facteurs signifie que vous allez recevoir un code par courriel à chaque nouvelle connexion non approuvée.
         name_label: Nom

--- a/src/Wallabag/CoreBundle/Resources/views/themes/common/Entry/entries.xml.twig
+++ b/src/Wallabag/CoreBundle/Resources/views/themes/common/Entry/entries.xml.twig
@@ -31,9 +31,12 @@
     {% for entry in entries %}
     <entry>
         <title><![CDATA[{{ entry.title|e }}]]></title>
-        <link rel="alternate" type="text/html"
-              href="{{ url('view', {'id': entry.id}) }}"/>
-        <link rel="via">{{ entry.url }}</link>
+        {% if isFeedUseSource %}
+            <link rel="alternate" type="text/html" href="{{ entry.url }}"/>
+        {%  else %}
+            <link rel="alternate" type="text/html" href="{{ url('view', {'id': entry.id}) }}"/>
+            <link rel="via" href="{{ entry.url }}" />
+        {% endif -%}
         <id>wallabag:{{ domainName | removeScheme | removeWww }}:{{ user }}:entry:{{ entry.id }}</id>
         <updated>{{ entry.updatedAt|date('c') }}</updated>
         <published>{{ entry.createdAt|date('c') }}</published>

--- a/src/Wallabag/CoreBundle/Resources/views/themes/material/Config/index.html.twig
+++ b/src/Wallabag/CoreBundle/Resources/views/themes/material/Config/index.html.twig
@@ -173,6 +173,14 @@
                                 </div>
                             </div>
 
+                            <div class="row">
+                                <div class="input-field col s12 with-checkbox">
+                                    {{ form_widget(form.feed.feed_use_source) }}
+                                    {{ form_label(form.feed.feed_use_source) }}
+                                    {{ form_errors(form.feed.feed_use_source) }}
+                                </div>
+                            </div>
+
                             {{ form_widget(form.feed.save, {'attr': {'class': 'btn waves-effect waves-light'}}) }}
                             {{ form_rest(form.feed) }}
                         </form>
@@ -548,7 +556,7 @@
                             </div>
                         </div>
                     </div>
-                    
+
                     <div id="set7" class="col s12">
                         <div class="row">
                             <h5>{{ 'config.reset.title'|trans }}</h5>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Documentation | no
| Translation   | no
| CHANGELOG.md  | no
| License       | MIT

When set to true, ATOM feed will return article source url instead of Wallabag Uri

Fix #4871
