### PR TITLE
views: add title to tag li elements, for consistency

### DIFF
--- a/src/Wallabag/CoreBundle/Resources/views/themes/material/Entry/_card_full_image.html.twig
+++ b/src/Wallabag/CoreBundle/Resources/views/themes/material/Entry/_card_full_image.html.twig
@@ -3,7 +3,7 @@
         <div class="card-fullimage">
             <ul class="card-entry-labels">
             {% for tag in entry.tags | slice(0, 3) %}
-                <li><a href="{{ path('tag_entries', {'slug': tag.slug}) }}">{{ tag.label }}</a></li>
+                <li title="{{ tag.label }}"><a href="{{ path('tag_entries', {'slug': tag.slug}) }}">{{ tag.label }}</a></li>
             {% endfor %}
             </ul>
             <a href="{{ path('view', { 'id': entry.id }) }}">

--- a/src/Wallabag/CoreBundle/Resources/views/themes/material/Entry/_card_preview.html.twig
+++ b/src/Wallabag/CoreBundle/Resources/views/themes/material/Entry/_card_preview.html.twig
@@ -3,7 +3,7 @@
         <div class="card-image waves-effect waves-block waves-light">
             <ul class="card-entry-labels">
             {% for tag in entry.tags | slice(0, 3) %}
-                <li><a href="{{ path('tag_entries', {'slug': tag.slug}) }}">{{ tag.label }}</a></li>
+                <li title="{{ tag.label }}"><a href="{{ path('tag_entries', {'slug': tag.slug}) }}">{{ tag.label }}</a></li>
             {% endfor %}
             </ul>
             <a href="{{ path('view', { 'id': entry.id }) }}">
@@ -26,7 +26,7 @@
 
         <ul class="card-entry-labels-hidden">
             {% for tag in entry.tags %}
-                <li><a href="{{ path('tag_entries', {'slug': tag.slug}) }}">{{ tag.label }}</a></li>
+                <li title="{{ tag.label }}"><a href="{{ path('tag_entries', {'slug': tag.slug}) }}">{{ tag.label }}</a></li>
             {% endfor %}
         </ul>
     </div>

--- a/src/Wallabag/CoreBundle/Resources/views/themes/material/Entry/_tags.html.twig
+++ b/src/Wallabag/CoreBundle/Resources/views/themes/material/Entry/_tags.html.twig
@@ -1,7 +1,7 @@
 {% if tags is iterable and tags is not empty %}
     <ul class="tags{{ listClass|default("")}}">
         {% for tag in tags %}
-            <li class="chip">
+            <li class="chip" title="{{ tag.label }}">
                 <a href="{{ path('tag_entries', {'slug': tag.slug}) }}">{{ tag.label }}</a>
                 {% if withRemove is defined and withRemove == true %}
                     <a href="{{ path('remove_tag', { 'entry': entryId, 'tag': tag.id }) }}" onclick="return confirm('{{ 'entry.confirm.delete_tag'|trans|escape('js') }}')">


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes/no
| Documentation | no
| Translation   | no
| CHANGELOG.md  | no
| License       | MIT

This PR is a "hidden" improvement as it does not change the way elements are actually shown.
However, making the `<li>` elements for tags consistent with the tag page will help people doing fun things with custom css (_blog post incoming_).