### PR TITLE
Allow GitHub Actions to run on 2.* branches

### DIFF
--- a/.github/workflows/assets.yml
+++ b/.github/workflows/assets.yml
@@ -2,11 +2,10 @@ name: "Assets"
 
 on:
   pull_request:
-    branches:
-      - master
   push:
     branches:
       - master
+      - 2.*
 
 jobs:
   js:

--- a/.github/workflows/coding-standards.yml
+++ b/.github/workflows/coding-standards.yml
@@ -2,11 +2,10 @@ name: "CS"
 
 on:
   pull_request:
-    branches:
-      - master
   push:
     branches:
       - master
+      - 2.*
 
 jobs:
   coding-standards:

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -2,11 +2,10 @@ name: "CI"
 
 on:
   pull_request:
-    branches:
-      - "master"
   push:
     branches:
-      - "master"
+      - master
+      - 2.*
 
 env:
   PGPASSWORD: wallabagrocks

--- a/.github/workflows/translations.yml
+++ b/.github/workflows/translations.yml
@@ -2,11 +2,10 @@ name: "Translations"
 
 on:
   pull_request:
-    branches:
-      - master
   push:
     branches:
       - master
+      - 2.*
 
 jobs:
   translations:


### PR DESCRIPTION
Since I created the 2.5.0 branch, GA on PR targeting that branch aren't triggered. This should fix this.
