### PR TITLE
Fix myreadspeed links

### DIFF
--- a/src/Wallabag/CoreBundle/Resources/views/themes/baggy/Config/index.html.twig
+++ b/src/Wallabag/CoreBundle/Resources/views/themes/baggy/Config/index.html.twig
@@ -37,7 +37,7 @@
                 {{ form_widget(form.config.reading_speed) }}
                 <p>
                     {{ 'config.form_settings.reading_speed.help_message'|trans }}
-                    <a href="https://github.com/craigmayhew/myreadspeed">myreadspeed</a>
+                    <a href="https://wallabag.github.io/myreadspeed/">myreadspeed</a>
                 </p>
             </div>
             <a href="#" title="{{ 'config.form_settings.help_reading_speed'|trans }}">

--- a/src/Wallabag/CoreBundle/Resources/views/themes/baggy/Config/index.html.twig
+++ b/src/Wallabag/CoreBundle/Resources/views/themes/baggy/Config/index.html.twig
@@ -37,7 +37,7 @@
                 {{ form_widget(form.config.reading_speed) }}
                 <p>
                     {{ 'config.form_settings.reading_speed.help_message'|trans }}
-                    <a href="http://www.myreadspeed.com/calculate/">myreadspeed</a>
+                    <a href="https://github.com/craigmayhew/myreadspeed">myreadspeed</a>
                 </p>
             </div>
             <a href="#" title="{{ 'config.form_settings.help_reading_speed'|trans }}">

--- a/src/Wallabag/CoreBundle/Resources/views/themes/material/Config/index.html.twig
+++ b/src/Wallabag/CoreBundle/Resources/views/themes/material/Config/index.html.twig
@@ -58,7 +58,7 @@
                                     {{ form_label(form.config.reading_speed) }}
                                     <p>
                                         {{ 'config.form_settings.reading_speed.help_message'|trans }}
-                                        <a href="http://www.myreadspeed.com/calculate/">myreadspeed</a>
+                                        <a href="https://github.com/craigmayhew/myreadspeed">myreadspeed</a>
                                     </p>
                                 </div>
                                 <div class="input-field col s1">

--- a/src/Wallabag/CoreBundle/Resources/views/themes/material/Config/index.html.twig
+++ b/src/Wallabag/CoreBundle/Resources/views/themes/material/Config/index.html.twig
@@ -58,7 +58,7 @@
                                     {{ form_label(form.config.reading_speed) }}
                                     <p>
                                         {{ 'config.form_settings.reading_speed.help_message'|trans }}
-                                        <a href="https://github.com/craigmayhew/myreadspeed">myreadspeed</a>
+                                        <a href="https://wallabag.github.io/myreadspeed/">myreadspeed</a>
                                     </p>
                                 </div>
                                 <div class="input-field col s1">


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | **yes**/no
| New feature?  | yes/**no**
| BC breaks?    | yes/**no**
| Deprecations? | yes/**no**
| Tests pass?   | **yes**/no
| Documentation | yes/**no**
| Translation   | yes/**no**
| CHANGELOG.md  | yes/**no**
| License       | MIT

On the configuration section there is a link to `myreadspeed.com`, a website which is no longer available (see craigmayhew/myreadspeed@9e7786c). This PR changes this link for one to the repo where it is located.

I am not sure whether this qualifies as a bug fix or a documentation fix, I marked it as the former.