### PR TITLE
dependabot: change schedule to check updates once a month

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,7 +3,7 @@ updates:
 - package-ecosystem: npm
   directory: "/"
   schedule:
-    interval: daily
+    interval: monthly
     time: "04:00"
     timezone: Europe/Paris
   open-pull-requests-limit: 10
@@ -14,7 +14,7 @@ updates:
 - package-ecosystem: composer
   directory: "/"
   schedule:
-    interval: daily
+    interval: monthly
     time: "04:00"
     timezone: Europe/Paris
   open-pull-requests-limit: 10


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | 
| Documentation | no
| Translation   | no
| CHANGELOG.md  | no
| License       | MIT

I don't see value in checking for dependency updates on a daily basis as it makes quite a lot of noise in PR management.
However security updates don't respect the schedule so we will still receive security bumps as soon as they appear.