### PR TITLE
Make RSS feed entry links valid and accessible

### DIFF
--- a/src/Wallabag/CoreBundle/Resources/views/themes/common/Entry/entries.xml.twig
+++ b/src/Wallabag/CoreBundle/Resources/views/themes/common/Entry/entries.xml.twig
@@ -31,9 +31,11 @@
     {% for entry in entries %}
     <entry>
         <title><![CDATA[{{ entry.title|e }}]]></title>
+        <link href="{{ entry.url }}"/>
         <link rel="alternate" type="text/html"
               href="{{ url('view', {'id': entry.id}) }}"/>
-        <link rel="via">{{ entry.url }}</link>
+        <link rel="via"
+              href="{{ entry.url }}"/>
         <id>wallabag:{{ domainName | removeScheme | removeWww }}:{{ user }}:entry:{{ entry.id }}</id>
         <updated>{{ entry.updatedAt|date('c') }}</updated>
         <published>{{ entry.createdAt|date('c') }}</published>


### PR DESCRIPTION
According to the ATOM spec link elements must have a href:
https://validator.w3.org/feed/docs/atom.html

Also most feed readers (TinyTiny, Feedly, Thunderbird) prefer link elements in
this order:

- plain
- with attribute rel=alternate
- with attribute rel=via

As the content is work of the entry author, link to it by default. Not to the
wallabag instance entry.

This also makes it possible to share links with people who don't have access to
the wallabag instance via the RSS feed.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Documentation | no
| Translation   | no
| CHANGELOG.md  | no
| License       | MIT

