### PR TITLE
Remove FOSUserBundle

### DIFF
--- a/app/AppKernel.php
+++ b/app/AppKernel.php
@@ -17,7 +17,6 @@ class AppKernel extends Kernel
             new Doctrine\Bundle\DoctrineBundle\DoctrineBundle(),
             new Sensio\Bundle\FrameworkExtraBundle\SensioFrameworkExtraBundle(),
             new FOS\RestBundle\FOSRestBundle(),
-            new FOS\UserBundle\FOSUserBundle(),
             new JMS\SerializerBundle\JMSSerializerBundle(),
             new Nelmio\ApiDocBundle\NelmioApiDocBundle(),
             new Nelmio\CorsBundle\NelmioCorsBundle(),

--- a/app/config/routing.yml
+++ b/app/config/routing.yml
@@ -38,9 +38,6 @@ homepage:
     requirements:
         page: \d+
 
-fos_user:
-    resource: "@FOSUserBundle/Resources/config/routing/all.xml"
-
 fos_oauth_server_token:
     resource: "@FOSOAuthServerBundle/Resources/config/routing/token.xml"
 

--- a/composer.json
+++ b/composer.json
@@ -60,7 +60,6 @@
         "friendsofsymfony/jsrouting-bundle": "^2.2",
         "friendsofsymfony/oauth-server-bundle": "^1.5",
         "friendsofsymfony/rest-bundle": "~2.1",
-        "friendsofsymfony/user-bundle": "2.0.*",
         "guzzlehttp/guzzle": "^5.3.1",
         "html2text/html2text": "^4.1",
         "incenteev/composer-parameter-handler": "^2.1",

--- a/src/Wallabag/UserBundle/WallabagUserBundle.php
+++ b/src/Wallabag/UserBundle/WallabagUserBundle.php
@@ -6,8 +6,4 @@ use Symfony\Component\HttpKernel\Bundle\Bundle;
 
 class WallabagUserBundle extends Bundle
 {
-    public function getParent()
-    {
-        return 'FOSUserBundle';
-    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | 
| Documentation | no
| Translation   | 
| CHANGELOG.md  | no
| License       | MIT

FOSUserBundle does not seem to be maintained anymore, thus we need to replace it with in-house user management in order to migrate to Symfony 4+.