### PR TITLE
Fixed search on homepage

### DIFF
--- a/src/Wallabag/CoreBundle/Repository/EntryRepository.php
+++ b/src/Wallabag/CoreBundle/Repository/EntryRepository.php
@@ -88,7 +88,7 @@ class EntryRepository extends EntityRepository
 
         if ('starred' === $currentRoute) {
             $qb->andWhere('e.isStarred = true');
-        } elseif ('unread' === $currentRoute) {
+        } elseif ('unread' === $currentRoute || 'homepage' === $currentRoute) {
             $qb->andWhere('e.isArchived = false');
         } elseif ('archive' === $currentRoute) {
             $qb->andWhere('e.isArchived = true');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Documentation | no
| Translation   | no
| CHANGELOG.md  | no
| License       | MIT

When we are on `https://mywallabag/`, we are on the `homepage` current page, which is the unread view. This page needs to react as the unread page (`https://mywallabag/unread/list`).

This issue fixes a bug when we research articles. The search was done on all articles: it needs to be done on unread articles only. 