### PR TITLE
Added random button on article view

### DIFF
--- a/src/Wallabag/CoreBundle/Resources/views/themes/material/Entry/entry.html.twig
+++ b/src/Wallabag/CoreBundle/Resources/views/themes/material/Entry/entry.html.twig
@@ -216,6 +216,13 @@
         </li>
         {% endif %}
 
+        <li class="bold border-top border-bottom">
+            <a class="waves-effect collapsible-header" title="{{ 'menu.top.random_entry'|trans }}" href="{{ path('random_entry', { 'type': 'all' }) }}">
+                <i class="material-icons small">casino</i>
+                <span>{{ 'menu.top.random_entry'|trans }}</span>
+            </a>
+        </li>
+
         <li class="bold">
             <a class="waves-effect collapsible-header">
                 <i class="material-icons small">file_download</i>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Documentation | no
| Translation   | no
| CHANGELOG.md  | no
| License       | MIT

Should fix #5112. 

The random research will be done on all the articles. Because we don't know the current context: if we are on "starred" articles, we click on the random buttom, we have a random article inside the favorite ones. But, when we are on the article view, we don't know where we were before. 