### PR TITLE
Make dark scroll bar in Chromium-based browsers

### DIFF
--- a/app/Resources/static/themes/material/css/dark_theme.scss
+++ b/app/Resources/static/themes/material/css/dark_theme.scss
@@ -1,4 +1,8 @@
 .dark-theme {
+  :root {
+    color-scheme: dark;
+  }
+    
   body,
   main #content,
   #article,


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Documentation | no
| Translation   | no
| CHANGELOG.md  | no
| License       | MIT

Make a dark scrollbar in Chromium based browsers in a dark theme.