### PR TITLE
Edit Entry Content

### DIFF
--- a/src/Wallabag/CoreBundle/Form/Type/EditEntryType.php
+++ b/src/Wallabag/CoreBundle/Form/Type/EditEntryType.php
@@ -33,7 +33,7 @@ class EditEntryType extends AbstractType
             ])
             ->add('content', TextareaType::class, [
                 'required' => true,
-                'label' => 'Content',
+                'label' => 'entry.edit.content_label',
                 'attr' => [ 'style' => 'height: 20em; padding: 10px' ]
             ])
             ->add('save', SubmitType::class, [

--- a/src/Wallabag/CoreBundle/Form/Type/EditEntryType.php
+++ b/src/Wallabag/CoreBundle/Form/Type/EditEntryType.php
@@ -8,6 +8,7 @@ use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\Extension\Core\Type\UrlType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Form\Extension\Core\Type\TextareaType;
 
 class EditEntryType extends AbstractType
 {
@@ -29,6 +30,11 @@ class EditEntryType extends AbstractType
                 'property_path' => 'originUrl',
                 'label' => 'entry.edit.origin_url_label',
                 'default_protocol' => null,
+            ])
+            ->add('content', TextareaType::class, [
+                'required' => true,
+                'label' => 'Content',
+                'attr' => [ 'style' => 'height: 20em; padding: 10px' ]
             ])
             ->add('save', SubmitType::class, [
                 'label' => 'entry.edit.save_label',

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.cs.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.cs.yml
@@ -92,6 +92,7 @@ entry:
         shared_by_wallabag: Tento článek již sdílel %username% s <a href='%wallabag_instance%'>wallabagem</a>
     edit:
         save_label: Uložit
+        content_label: Obsah
         origin_url_label: Původní URL (kde jste danou položku našli)
         url_label: URL
         title_label: Název

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.da.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.da.yml
@@ -118,6 +118,7 @@ entry:
             url_label: Url
     edit:
         url_label: 'Url'
+        content_label: 'Indhold'
         save_label: 'Gem'
 about:
     page_title: 'Om'

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.de.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.de.yml
@@ -319,6 +319,7 @@ entry:
         page_title: Eintrag bearbeiten
         title_label: Titel
         url_label: URL
+        content_label: Inhalt
         save_label: Speichern
         origin_url_label: Herkunfts-URL (von wo aus Sie diesen Eintrag gefunden haben)
     public:

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.el.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.el.yml
@@ -367,6 +367,7 @@ entry:
         shared_by_wallabag: Αυτό το άρθρο κοινοποιήθηκε από %username% με <a href='%wallabag_instance%'>wallabag</a>
     edit:
         save_label: Αποθήκευση
+        content_label: Περιεχόμενο
         origin_url_label: URL προέλευσης (απ' όπου βρήκατε την καταχώριση)
         url_label: URL
         title_label: Τίτλος

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.en.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.en.yml
@@ -304,6 +304,7 @@ entry:
         title_label: Title
         url_label: Url
         origin_url_label: Origin url (from where you found that entry)
+        content_label: Content
         save_label: Save
     public:
         shared_by_wallabag: This article has been shared by %username% with <a href='%wallabag_instance%'>wallabag</a>

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.es.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.es.yml
@@ -299,6 +299,7 @@ entry:
         page_title: 'Editar un artículo'
         title_label: 'Título'
         url_label: 'URL'
+        content_label: 'Contenido'
         save_label: 'Guardar'
         origin_url_label: URL original (de donde encontraste el artículo)
     public:

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.fa.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.fa.yml
@@ -174,6 +174,7 @@ entry:
         page_title: ویرایش مقاله
         title_label: عنوان
         url_label: نشانی
+        content_label: محتوا
         save_label: ذخیره
 about:
     page_title: درباره

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.fr.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.fr.yml
@@ -304,6 +304,7 @@ entry:
         title_label: Titre
         url_label: Adresse
         origin_url_label: Adresse d'origine (d'où vous avez trouvé cet article)
+        content_label: Contenu
         save_label: Enregistrer
     public:
         shared_by_wallabag: Cet article a été partagé par %username% avec <a href="%wallabag_instance%">wallabag</a>

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.gl.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.gl.yml
@@ -93,6 +93,7 @@ entry:
         shared_by_wallabag: Este artigo foi compartido por %username% con <a href='%wallabag_instance%'>wallabag</a>
     edit:
         save_label: Gardar
+        content_label: Contido
         origin_url_label: Url de orixe (o lugar onde atopaches a entrada)
         url_label: Url
         title_label: Título

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.hr.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.hr.yml
@@ -546,6 +546,7 @@ entry:
         save_label: Spremi
         page_title: Uredi jedan zapis
         origin_url_label: URL izvora (mjesto gdje je taj zapis pronađen)
+        content_label: Sadržaj
     new:
         placeholder: http://website.com
         form_new:

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.hu.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.hu.yml
@@ -243,6 +243,7 @@ entry:
         title_label: Cím
         url_label: Url
         origin_url_label: Eredeti url-je (ahol ezt a bejegyzést találta)
+        content_label: Tartalma
         save_label: Mentés
     public:
         shared_by_wallabag: Ezt a cikket %username% osztotta meg <a href='%wallabag_instance%'>wallabag</a> használatával

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.it.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.it.yml
@@ -260,6 +260,7 @@ entry:
         url_label: Url
         save_label: Salva
         origin_url_label: URL di origine (da dove hai trovato quella voce)
+        content_label: Contenuto
     public:
         shared_by_wallabag: Questo articolo è stato condiviso da %username% con <a href='%wallabag_instance%'>wallabag</a>
     confirm:

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.ja.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.ja.yml
@@ -317,6 +317,7 @@ entry:
         title_label: タイトル
         origin_url_label: オリジナルURL（この記事を見つけた場所）
         url_label: URL
+        content_label: コンテンツ
         save_label: 保存
     metadata:
         added_on: タイムスタンプ

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.ko.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.ko.yml
@@ -207,6 +207,7 @@ entry:
         save_label: 저장
         url_label: Url
         title_label: 제목
+        content_label: 콘텐츠
     new:
         page_title: 새 문서 저장
         form_new:

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.nb.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.nb.yml
@@ -582,6 +582,7 @@ entry:
         delete: Er du sikker på at du vil fjerne artikkelen?
     edit:
         save_label: Lagre
+        content_label: Innhold
         origin_url_label: Opprinnelig nettadresse (der du fant oppføringen)
         url_label: Nettadresse
         title_label: Tittel

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.nl.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.nl.yml
@@ -642,6 +642,7 @@ entry:
         shared_by_wallabag: Dit artikel is gedeeld door %username% met <a href='%wallabag_instance%'>wallabag</a>
     edit:
         save_label: Opslaan
+        content_label: Inhoud
         origin_url_label: Oorspronkelijke url (waar je dit item gevonden hebt)
         url_label: Url
         title_label: Titel

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.oc.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.oc.yml
@@ -260,6 +260,7 @@ entry:
         title_label: Títol
         url_label: Url
         origin_url_label: Url d’origina (ont avètz trobat aqueste article)
+        content_label: Contengut
         save_label: Enregistrar
     public:
         shared_by_wallabag: Aqueste article es estat partejat per <a href='%wallabag_instance%'>wallabag</a>

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.pl.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.pl.yml
@@ -290,6 +290,7 @@ entry:
         title_label: Tytuł
         url_label: Adres URL
         origin_url_label: Oryginalny url (gdzie znalazłeś ten wpis)
+        content_label: Zawartość
         save_label: Zapisz
     public:
         shared_by_wallabag: Ten artykuł został udostępniony przez <a href='%wallabag_instance%'>wallabag</a>

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.pt.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.pt.yml
@@ -202,6 +202,7 @@ entry:
         page_title: 'Editar uma entrada'
         title_label: 'Título'
         url_label: 'Url'
+        content_label: 'Conteúdo'
         save_label: 'Salvar'
     public:
         shared_by_wallabag: "Este artigo foi compartilhado pelo <a href='%wallabag_instance%'>wallabag</a>"

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.ro.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.ro.yml
@@ -119,6 +119,7 @@ entry:
             url_label: Url
     edit:
         url_label: 'Url'
+        content_label: 'Conţinut'
         save_label: 'Salvează'
 about:
     page_title: 'Despre'

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.ru.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.ru.yml
@@ -320,6 +320,7 @@ entry:
         title_label: 'Название'
         url_label: 'URL-адрес'
         is_public_label: 'Публичная'
+        content_label: 'Содержимое'
         save_label: 'Сохранить'
         origin_url_label: Исходный URL (откуда вы нашли эту запись)
     public:

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.th.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.th.yml
@@ -236,6 +236,7 @@ entry:
         page_title: 'แก้ไขรายการ'
         title_label: 'หัวข้อ'
         url_label: 'Url'
+        content_label: 'เนื้อหา'
         save_label: 'บันทึก'
     public:
         shared_by_wallabag: "บทความนี้จะมีการแชร์โดย %username% กับ <a href='%wallabag_instance%'>wallabag</a>"

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.tr.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.tr.yml
@@ -308,6 +308,7 @@ entry:
         page_title: Makaleyi düzenle
         title_label: Başlık
         url_label: Url
+        content_label: Oçeriği
         save_label: Kaydet
         origin_url_label: Orijinal URL (makaleyi nereden buldunuz)
     page_titles:

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.uk.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.uk.yml
@@ -282,6 +282,7 @@ entry:
         title_label: Заголовок
         url_label: Адреса
         origin_url_label: Початкова адреса (там де ви знайшли статтю)
+        content_label: Вміст
         save_label: Зберегти
     public:
         shared_by_wallabag: ''

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.zh.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.zh.yml
@@ -320,6 +320,7 @@ entry:
         title_label: '标题'
         url_label: '链接'
         origin_url_label: '原始链接（你发现这篇文章的地方）'
+        content_label: '内容'
         save_label: '保存'
     public:
         shared_by_wallabag: "这篇文章由 %username% 于 <a href='%wallabag_instance%'>wallabag</a> 分享"

--- a/src/Wallabag/CoreBundle/Resources/views/themes/material/Entry/edit.html.twig
+++ b/src/Wallabag/CoreBundle/Resources/views/themes/material/Entry/edit.html.twig
@@ -2,6 +2,20 @@
 
 {% block title %}{{ 'entry.edit.page_title'|trans }}{% endblock %}
 
+{% block scripts %}
+
+    {{parent()}}
+
+    <script src="https://cdn.tiny.cloud/1/no-api-key/tinymce/5/tinymce.min.js" referrerpolicy="origin"></script>
+
+    <script type="text/javascript">
+        tinymce.init({
+            selector: '#entry_content'
+        });
+    </script>
+
+{% endblock %}
+
 {% block content %}
 
     <div class="row">
@@ -31,6 +45,12 @@
                         <div class="input-field s12">
                             {{ form_label(form.origin_url) }}
                             {{ form_widget(form.origin_url) }}
+                        </div>
+                        <br>
+
+                        <div class="input-field s12">
+                            {{ form_label(form.content) }}
+                            {{ form_widget(form.content) }}
                         </div>
                         <br>
 

--- a/src/Wallabag/CoreBundle/Resources/views/themes/material/Entry/edit.html.twig
+++ b/src/Wallabag/CoreBundle/Resources/views/themes/material/Entry/edit.html.twig
@@ -10,7 +10,9 @@
 
     <script type="text/javascript">
         tinymce.init({
-            selector: '#entry_content'
+            selector: '#entry_content',
+            toolbar: 'undo redo styleselect bold italic alignleft aligncenter alignright bullist numlist outdent indent code',
+			plugins: 'code'
         });
     </script>
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Documentation | no
| Translation   | yes
| CHANGELOG.md  | no
| License       | MIT

Edit (also) content into Edit page, using [TinyMCE ](https://github.com/tinymce/tinymce) script.
Both WYSIWYG and RAW HTML editor.

Resolves #2321

![wallabag-edit-content-1](https://user-images.githubusercontent.com/1734343/148641293-2448401e-0a53-4c15-b21d-ea60580c95d1.png)

![wallabag-edit-content-2](https://user-images.githubusercontent.com/1734343/148638483-0c307f2f-3b42-48c8-b55a-db0ee8a48441.png)

## Extremely simple changes on only 2 files
`src\Wallabag\CoreBundle\Form\Type\EditEntryType.php`
```diff
...
use Symfony\Component\Form\FormBuilderInterface;
use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Form\Extension\Core\Type\TextareaType;

class EditEntryType extends AbstractType
{
...

...
                'default_protocol' => null,
            ])
+           ->add('content', TextareaType::class, [
+               'required' => true,
+               'label' => 'entry.edit.content_label',
+               'attr' => [ 'style' => 'height: 20em; padding: 10px' ]
+           ])
            ->add('save', SubmitType::class, [
                'label' => 'entry.edit.save_label',
...
```

`src\Wallabag\CoreBundle\Resources\views\themes\material\Entry\edit.html.twig`
```diff
...
{% block title %}{{ 'entry.edit.page_title'|trans }}{% endblock %}

+{% block scripts %}
+
+    {{parent()}}
+
+    <script src="https://cdn.tiny.cloud/1/no-api-key/tinymce/5/tinymce.min.js" referrerpolicy="origin"></script>
+
+    <script type="text/javascript">
+        tinymce.init({
+            selector: '#entry_content',
+            toolbar: 'undo redo styleselect bold italic alignleft aligncenter alignright bullist numlist outdent indent code',
+            plugins: 'code'
+        });
+    </script>
+
+{% endblock %}

{% block content %}
...

...
                            {{ form_widget(form.origin_url) }}
                        </div>
                        <br>

+                       <div class="input-field s12">
+                           {{ form_label(form.content) }}
+                           {{ form_widget(form.content) }}
+                       </div>
                        <br>

                        {{ form_widget(form.save, {'attr': {'class': 'btn waves-effect waves-light'}}) }}
...
```

Use a local copy of tinymce.min.js script for more speed
`<script src="/js/tinymce/5/tinymce.min.js"></script>`