### PR TITLE
Edit Preview Picture

### DIFF
--- a/src/Wallabag/CoreBundle/Form/Type/EditEntryType.php
+++ b/src/Wallabag/CoreBundle/Form/Type/EditEntryType.php
@@ -30,6 +30,12 @@ class EditEntryType extends AbstractType
                 'label' => 'entry.edit.origin_url_label',
                 'default_protocol' => null,
             ])
+            ->add('preview_picture', UrlType::class, [
+                'required' => false,
+                'property_path' => 'previewPicture',
+                'label' => 'entry.edit.preview_picture_label',
+                'default_protocol' => null,
+            ])
             ->add('save', SubmitType::class, [
                 'label' => 'entry.edit.save_label',
             ])

--- a/src/Wallabag/CoreBundle/Resources/views/themes/material/Entry/edit.html.twig
+++ b/src/Wallabag/CoreBundle/Resources/views/themes/material/Entry/edit.html.twig
@@ -32,6 +32,11 @@
                             {{ form_label(form.origin_url) }}
                             {{ form_widget(form.origin_url) }}
                         </div>
+                        
+                        <div class="input-field s12">
+                            {{ form_label(form.preview_picture) }}
+                            {{ form_widget(form.preview_picture) }}
+                        </div>
                         <br>
 
                         {{ form_widget(form.save, {'attr': {'class': 'btn waves-effect waves-light'}}) }}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Documentation | no
| Translation   | yes
| CHANGELOG.md  | no
| License       | MIT

Edit (also) Preview Picture into Edit page.

![edit-preview-picture](https://user-images.githubusercontent.com/1734343/149147207-6a3d7de6-7c34-497e-a784-ee06447f28cb.png)

## Changes on only 2 files
`src\Wallabag\CoreBundle\Form\Type\EditEntryType.php`
```diff
...
                'default_protocol' => null,
            ])
+            ->add('preview_picture', UrlType::class, [
+                'required' => false,
+                'property_path' => 'previewPicture',
+                'label' => 'entry.edit.preview_picture_label',
+                'default_protocol' => null,
+            ])
            ->add('save', SubmitType::class, [
                'label' => 'entry.edit.save_label',
...
```

`src\Wallabag\CoreBundle\Resources\views\themes\material\Entry\edit.html.twig`
```diff
...
                            {{ form_widget(form.origin_url) }}
                        </div>

+                       <div class="input-field s12">
+                           {{ form_label(form.preview_picture) }}
+                           {{ form_widget(form.preview_picture) }}
+                       </div>
                        <br>

                        {{ form_widget(form.save, {'attr': {'class': 'btn waves-effect waves-light'}}) }}
...
```
