### PR TITLE
Add build test on PHP 8.0 & 8.1

### DIFF
--- a/.github/workflows/coding-standards.yml
+++ b/.github/workflows/coding-standards.yml
@@ -20,15 +20,15 @@ jobs:
         uses: "shivammathur/setup-php@v2"
         with:
           coverage: "none"
-          php-version: "7.3"
-          tools: cs2pr, pecl, composer:v1
+          php-version: "7.4"
+          tools: cs2pr, pecl, composer:v2
           extensions: pdo, pdo_mysql, pdo_sqlite, pdo_pgsql, curl, imagick, pgsql, gd, tidy
           ini-values: "date.timezone=Europe/Paris"
         env:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: "Install dependencies with Composer"
-        uses: "ramsey/composer-install@v1"
+        uses: "ramsey/composer-install@v2"
         with:
           composer-options: "--optimize-autoloader --prefer-dist"
 

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -32,6 +32,8 @@ jobs:
           - "7.2"
           - "7.3"
           - "7.4"
+          - "8.0"
+          - "8.1"
         database:
           - "sqlite"
           - "mysql"
@@ -48,7 +50,7 @@ jobs:
         with:
           php-version: "${{ matrix.php }}"
           coverage: none
-          tools: pecl, composer:v1
+          tools: pecl, composer:v2
           extensions: json, pdo, pdo_mysql, pdo_sqlite, pdo_pgsql, curl, imagick, pgsql, gd, tidy
           ini-values: "date.timezone=Europe/Paris"
 
@@ -67,7 +69,7 @@ jobs:
           pg_isready -d wallabag_test -h localhost -p 5432 -U wallabag
 
       - name: "Install dependencies with Composer"
-        uses: "ramsey/composer-install@v1"
+        uses: "ramsey/composer-install@v2"
         with:
           composer-options: "--optimize-autoloader --prefer-dist"
 

--- a/.github/workflows/translations.yml
+++ b/.github/workflows/translations.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         php:
-          - "7.3"
+          - "7.4"
 
     steps:
       - name: "Checkout"
@@ -26,14 +26,14 @@ jobs:
         with:
           coverage: "none"
           php-version: "${{ matrix.php }}"
-          tools: pecl, composer:v1
+          tools: pecl, composer:v2
           extensions: pdo, pdo_mysql, pdo_sqlite, pdo_pgsql, curl, imagick, pgsql, gd, tidy
           ini-values: "date.timezone=Europe/Paris"
         env:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: "Install dependencies with Composer"
-        uses: "ramsey/composer-install@v1"
+        uses: "ramsey/composer-install@v2"
         with:
           composer-options: "--optimize-autoloader --prefer-dist"
 

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -8,7 +8,7 @@
 >
 
     <testsuites>
-        <testsuite name="wallabag Test Suite">
+        <testsuite name="wallabag">
             <directory>tests</directory>
         </testsuite>
     </testsuites>

--- a/src/Wallabag/CoreBundle/Doctrine/WallabagMigration.php
+++ b/src/Wallabag/CoreBundle/Doctrine/WallabagMigration.php
@@ -30,6 +30,16 @@ abstract class WallabagMigration extends AbstractMigration implements ContainerA
         $this->container = $container;
     }
 
+    /**
+     * @todo remove when upgrading DoctrineMigration (only needed for PHP 8)
+     *
+     * @see https://github.com/doctrine/DoctrineMigrationsBundle/issues/393
+     */
+    public function isTransactional(): bool
+    {
+        return false;
+    }
+
     protected function getTable($tableName, $unEscaped = false)
     {
         $table = $this->container->getParameter('database_table_prefix') . $tableName;

--- a/src/Wallabag/CoreBundle/Entity/Entry.php
+++ b/src/Wallabag/CoreBundle/Entity/Entry.php
@@ -683,6 +683,19 @@ class Entry
     }
 
     /**
+     * Only used during tests.
+     */
+    public function getTagsLabel(): array
+    {
+        $tags = [];
+        foreach ($this->tags as $tag) {
+            $tags[] = $tag->getLabel();
+        }
+
+        return $tags;
+    }
+
+    /**
      * @VirtualProperty
      * @SerializedName("tags")
      * @Groups({"entries_for_user", "export_all"})

--- a/tests/Wallabag/CoreBundle/Controller/EntryControllerTest.php
+++ b/tests/Wallabag/CoreBundle/Controller/EntryControllerTest.php
@@ -342,7 +342,7 @@ class EntryControllerTest extends WallabagCoreTestCase
         $entry = $em
             ->getRepository('WallabagCoreBundle:Entry')
             ->findOneByUrl($url);
-        $tags = $entry->getTags();
+        $tags = $entry->getTagsLabel();
 
         $this->assertCount(2, $tags);
         $this->assertContains('wallabag', $tags);
@@ -372,7 +372,7 @@ class EntryControllerTest extends WallabagCoreTestCase
             ->getRepository('WallabagCoreBundle:Entry')
             ->findOneByUrl($url);
 
-        $tags = $entry->getTags();
+        $tags = $entry->getTagsLabel();
 
         $this->assertCount(2, $tags);
         $this->assertContains('wallabag', $tags);

--- a/tests/Wallabag/CoreBundle/Controller/TagControllerTest.php
+++ b/tests/Wallabag/CoreBundle/Controller/TagControllerTest.php
@@ -46,7 +46,7 @@ class TagControllerTest extends WallabagCoreTestCase
         // be sure to reload the entry
         $entry = $this->getEntityManager()->getRepository(Entry::class)->find($entry->getId());
         $this->assertCount(1, $entry->getTags());
-        $this->assertContains($this->tagName, $entry->getTags());
+        $this->assertContains($this->tagName, $entry->getTagsLabel());
 
         // tag already exists and already assigned
         $client->submit($form, $data);
@@ -127,7 +127,7 @@ class TagControllerTest extends WallabagCoreTestCase
 
         // re-retrieve the entry to be sure to get fresh data from database (mostly for tags)
         $entry = $this->getEntityManager()->getRepository(Entry::class)->find($entry->getId());
-        $this->assertNotContains($this->tagName, $entry->getTags());
+        $this->assertNotContains($this->tagName, $entry->getTagsLabel());
 
         $client->request('GET', '/remove-tag/' . $entry->getId() . '/' . $tag->getId());
 

--- a/tests/Wallabag/ImportBundle/Controller/ElcuratorControllerTest.php
+++ b/tests/Wallabag/ImportBundle/Controller/ElcuratorControllerTest.php
@@ -125,7 +125,7 @@ class ElcuratorControllerTest extends WallabagCoreTestCase
         $this->assertSame('2015-09-09', $content->getCreatedAt()->format('Y-m-d'));
         $this->assertTrue($content->isStarred(), 'Entry is starred');
 
-        $tags = $content->getTags();
+        $tags = $content->getTagsLabel();
         $this->assertContains('tag1', $tags, 'It includes the "tag1" tag');
         $this->assertContains('tag2', $tags, 'It includes the "tag2" tag');
     }

--- a/tests/Wallabag/ImportBundle/Controller/InstapaperControllerTest.php
+++ b/tests/Wallabag/ImportBundle/Controller/InstapaperControllerTest.php
@@ -123,7 +123,7 @@ class InstapaperControllerTest extends WallabagCoreTestCase
         $this->assertNotEmpty($content->getMimetype(), 'Mimetype for https://www.liberation.fr is ok');
         $this->assertNotEmpty($content->getPreviewPicture(), 'Preview picture for https://www.liberation.fr is ok');
         $this->assertNotEmpty($content->getLanguage(), 'Language for https://www.liberation.fr is ok');
-        $this->assertContains('foot', $content->getTags(), 'It includes the "foot" tag');
+        $this->assertContains('foot', $content->getTagsLabel(), 'It includes the "foot" tag');
         $this->assertCount(1, $content->getTags());
         $this->assertInstanceOf(\DateTime::class, $content->getCreatedAt());
 
@@ -135,8 +135,8 @@ class InstapaperControllerTest extends WallabagCoreTestCase
                 $this->getLoggedInUserId()
             );
 
-        $this->assertContains('foot', $content->getTags());
-        $this->assertContains('test_tag', $content->getTags());
+        $this->assertContains('foot', $content->getTagsLabel());
+        $this->assertContains('test_tag', $content->getTagsLabel());
 
         $this->assertCount(2, $content->getTags());
     }

--- a/tests/Wallabag/ImportBundle/Controller/PinboardControllerTest.php
+++ b/tests/Wallabag/ImportBundle/Controller/PinboardControllerTest.php
@@ -123,7 +123,7 @@ class PinboardControllerTest extends WallabagCoreTestCase
         $this->assertNotEmpty($content->getPreviewPicture(), 'Preview picture for https://ma.ttias.be is ok');
         $this->assertNotEmpty($content->getLanguage(), 'Language for https://ma.ttias.be is ok');
 
-        $tags = $content->getTags();
+        $tags = $content->getTagsLabel();
         $this->assertContains('foot', $tags, 'It includes the "foot" tag');
         $this->assertContains('varnish', $tags, 'It includes the "varnish" tag');
         $this->assertContains('php', $tags, 'It includes the "php" tag');

--- a/tests/Wallabag/ImportBundle/Controller/ReadabilityControllerTest.php
+++ b/tests/Wallabag/ImportBundle/Controller/ReadabilityControllerTest.php
@@ -123,7 +123,7 @@ class ReadabilityControllerTest extends WallabagCoreTestCase
         $this->assertNotEmpty($content->getPreviewPicture(), 'Preview picture for https://www.20minutes.fr is ok');
         $this->assertNotEmpty($content->getLanguage(), 'Language for https://www.20minutes.fr is ok');
 
-        $tags = $content->getTags();
+        $tags = $content->getTagsLabel();
         $this->assertContains('foot', $tags, 'It includes the "foot" tag');
         $this->assertCount(1, $tags);
 

--- a/tests/Wallabag/ImportBundle/Controller/WallabagV1ControllerTest.php
+++ b/tests/Wallabag/ImportBundle/Controller/WallabagV1ControllerTest.php
@@ -124,7 +124,7 @@ class WallabagV1ControllerTest extends WallabagCoreTestCase
         $this->assertSame($content->getPreviewPicture(), 'http://www.framablog.org/public/_img/framablog/wallaby_baby.jpg');
         $this->assertEmpty($content->getLanguage(), 'Language for http://www.framablog.org is empty');
 
-        $tags = $content->getTags();
+        $tags = $content->getTagsLabel();
         $this->assertContains('foot', $tags, 'It includes the "foot" tag');
         $this->assertContains('framabag', $tags, 'It includes the "framabag" tag');
         $this->assertCount(2, $tags);

--- a/tests/Wallabag/ImportBundle/Controller/WallabagV2ControllerTest.php
+++ b/tests/Wallabag/ImportBundle/Controller/WallabagV2ControllerTest.php
@@ -126,7 +126,7 @@ class WallabagV2ControllerTest extends WallabagCoreTestCase
         $this->assertEmpty($content->getPreviewPicture(), 'Preview picture for https://www.liberation.fr is empty');
         $this->assertEmpty($content->getLanguage(), 'Language for https://www.liberation.fr is empty');
 
-        $tags = $content->getTags();
+        $tags = $content->getTagsLabel();
         $this->assertContains('foot', $tags, 'It includes the "foot" tag');
         $this->assertCount(1, $tags);
 
@@ -143,7 +143,7 @@ class WallabagV2ControllerTest extends WallabagCoreTestCase
         $this->assertNotEmpty($content->getPreviewPicture(), 'Preview picture for https://www.mediapart.fr is ok');
         $this->assertNotEmpty($content->getLanguage(), 'Language for https://www.mediapart.fr is ok');
 
-        $tags = $content->getTags();
+        $tags = $content->getTagsLabel();
         $this->assertContains('foot', $tags, 'It includes the "foot" tag');
         $this->assertContains('mediapart', $tags, 'It includes the "mediapart" tag');
         $this->assertContains('blog', $tags, 'It includes the "blog" tag');

--- a/tests/Wallabag/UserBundle/Controller/ManageControllerTest.php
+++ b/tests/Wallabag/UserBundle/Controller/ManageControllerTest.php
@@ -65,7 +65,7 @@ class ManageControllerTest extends WallabagCoreTestCase
         $crawler = $client->followRedirect();
 
         // Check the user has been delete on the list
-        $this->assertNotRegExp('/Foo User/', $client->getResponse()->getContent());
+        $this->assertDoesNotMatchRegularExpression('/Foo User/', $client->getResponse()->getContent());
     }
 
     public function testDeleteDisabledForLoggedUser()


### PR DESCRIPTION
Add `isTransactional` to `WallabagMigration` because PHP 8 behave differently with PDO transaction.
This is a workaround because we can't upgrade Doctrine Migration for now (upper versions have the fix, see https://github.com/doctrine/DoctrineMigrationsBundle/issues/393).

Fix https://github.com/wallabag/wallabag/issues/4987

- Build is now using Composer v2 (instead of v1)
- All actions have been updated to latest version
- Fix bug in PHP 8 were `$entry->getTags()` can't be properly used as a _traversable_ by `assertContains` during tests. Added a custom method `Entry::getTagsLabel()` which return a flatted tag array with only label
- Replace `assertNotRegExp` by `assertDoesNotMatchRegularExpression` because it was deprecated