### PR TITLE
Avoid overlapping images when downloading them

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -164,7 +164,10 @@
         "platform": {
             "php": "7.2.5"
         },
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {
+            "phpstan/extension-installer": true
+        }
     },
     "minimum-stability": "dev",
     "prefer-stable": true

--- a/src/Wallabag/CoreBundle/Helper/DownloadImages.php
+++ b/src/Wallabag/CoreBundle/Helper/DownloadImages.php
@@ -72,13 +72,16 @@ class DownloadImages
     {
         $imagesUrls = self::extractImagesUrlsFromHtml($html);
 
+        // ensure images aren't overlapping
+        arsort($imagesUrls);
+
         $relativePath = $this->getRelativePath($entryId);
 
         // download and save the image to the folder
         foreach ($imagesUrls as $image) {
-            $imagePath = $this->processSingleImage($entryId, $image, $url, $relativePath);
+            $newImage = $this->processSingleImage($entryId, $image, $url, $relativePath);
 
-            if (false === $imagePath) {
+            if (false === $newImage) {
                 continue;
             }
 
@@ -87,7 +90,7 @@ class DownloadImages
                 $image = str_replace('&', '&amp;', $image);
             }
 
-            $html = str_replace($image, $imagePath, $html);
+            $html = str_replace($image, $newImage, $html);
         }
 
         return $html;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Documentation | no
| Translation   | no
| License       | MIT

Fix https://github.com/wallabag/wallabag/issues/5464
Read https://github.com/wallabag/wallabag/issues/5464#issuecomment-1028873406 for a better explanation.