### PR TITLE
Fix tagging rule match when user has a custom reading speed

### DIFF
--- a/src/Wallabag/CoreBundle/Command/TagAllCommand.php
+++ b/src/Wallabag/CoreBundle/Command/TagAllCommand.php
@@ -41,7 +41,7 @@ class TagAllCommand extends ContainerAwareCommand
 
         $entries = $tagger->tagAllForUser($user);
 
-        $io->text('Persist entries... ');
+        $io->text('Persist ' . \count($entries) . ' entries... ');
 
         $em = $this->getDoctrine()->getManager();
         foreach ($entries as $entry) {

--- a/src/Wallabag/CoreBundle/DataFixtures/ConfigFixtures.php
+++ b/src/Wallabag/CoreBundle/DataFixtures/ConfigFixtures.php
@@ -45,7 +45,7 @@ class ConfigFixtures extends Fixture implements DependentFixtureInterface
         $emptyConfig = new Config($this->getReference('empty-user'));
         $emptyConfig->setTheme('material');
         $emptyConfig->setItemsPerPage(10);
-        $emptyConfig->setReadingSpeed(200);
+        $emptyConfig->setReadingSpeed(100);
         $emptyConfig->setLanguage('en');
         $emptyConfig->setPocketConsumerKey(null);
         $emptyConfig->setActionMarkAsRead(0);

--- a/src/Wallabag/CoreBundle/DataFixtures/TaggingRuleFixtures.php
+++ b/src/Wallabag/CoreBundle/DataFixtures/TaggingRuleFixtures.php
@@ -43,6 +43,20 @@ class TaggingRuleFixtures extends Fixture implements DependentFixtureInterface
 
         $manager->persist($tr4);
 
+        $tr5 = new TaggingRule();
+        $tr5->setRule('readingTime <= 5');
+        $tr5->setTags(['shortread']);
+        $tr5->setConfig($this->getReference('empty-config'));
+
+        $manager->persist($tr5);
+
+        $tr6 = new TaggingRule();
+        $tr6->setRule('readingTime > 5');
+        $tr6->setTags(['longread']);
+        $tr6->setConfig($this->getReference('empty-config'));
+
+        $manager->persist($tr6);
+
         $manager->flush();
     }
 

--- a/tests/Wallabag/CoreBundle/Controller/EntryControllerTest.php
+++ b/tests/Wallabag/CoreBundle/Controller/EntryControllerTest.php
@@ -178,6 +178,42 @@ class EntryControllerTest extends WallabagCoreTestCase
     /**
      * @group NetworkCalls
      */
+    public function testPostNewOkWithTaggingRules()
+    {
+        $this->logInAs('empty');
+        $client = $this->getClient();
+
+        $crawler = $client->request('GET', '/new');
+
+        $this->assertSame(200, $client->getResponse()->getStatusCode());
+
+        $form = $crawler->filter('form[name=entry]')->form();
+
+        $data = [
+            'entry[url]' => $this->url,
+        ];
+
+        $client->submit($form, $data);
+
+        $this->assertSame(302, $client->getResponse()->getStatusCode());
+
+        $content = $client->getContainer()
+            ->get('doctrine.orm.entity_manager')
+            ->getRepository('WallabagCoreBundle:Entry')
+            ->findByUrlAndUserId($this->url, $this->getLoggedInUserId());
+
+        $tags = $content->getTagsLabel();
+
+        /*
+         * Without the custom reading speed of `empty` user, it'll be inversed
+         */
+        $this->assertContains('longread', $tags);
+        $this->assertNotContains('shortread', $tags);
+    }
+
+    /**
+     * @group NetworkCalls
+     */
     public function testPostWithMultipleAuthors()
     {
         $url = 'https://www.liberation.fr/planete/2017/04/05/donald-trump-et-xi-jinping-tentative-de-flirt-en-floride_1560768';

--- a/tests/Wallabag/CoreBundle/Helper/RuleBasedTaggerTest.php
+++ b/tests/Wallabag/CoreBundle/Helper/RuleBasedTaggerTest.php
@@ -202,9 +202,28 @@ class RuleBasedTaggerTest extends TestCase
             ->method('satisfies')
             ->willReturn(true);
 
-        $this->rulerz
-            ->method('filter')
+        $query = $this->getMockBuilder('Doctrine\ORM\AbstractQuery')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $query
+            ->expects($this->once())
+            ->method('getResult')
             ->willReturn([new Entry($user), new Entry($user)]);
+
+        $qb = $this->getMockBuilder('Doctrine\ORM\QueryBuilder')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $qb
+            ->expects($this->once())
+            ->method('getQuery')
+            ->willReturn($query);
+
+        $this->entryRepository
+            ->expects($this->once())
+            ->method('getBuilderForAllByUser')
+            ->willReturn($qb);
 
         $entries = $this->tagger->tagAllForUser($user);
 
@@ -222,6 +241,7 @@ class RuleBasedTaggerTest extends TestCase
     {
         $user = new User();
         $config = new Config($user);
+        $config->setReadingSpeed(200);
 
         $user->setConfig($config);
 


### PR DESCRIPTION
By default, we assume the reading speed is 200 word per minute (WPM) when we save an entry.
User can change that value in the config and the rendering is properly performed with the user reading speed.
BUT, when the matching rule is applied, it uses the default reading time defined in the entry without applying the custom reading speed of the user.
This should fix that bug.

Also update the `wallabag:tag:all` to fix the bug when tagging all entries.

Fix https://github.com/wallabag/wallabag/issues/4935