### PR TITLE
Add simple article correction with HTML paste support

### DIFF
--- a/src/Wallabag/CoreBundle/Form/Type/EditEntryType.php
+++ b/src/Wallabag/CoreBundle/Form/Type/EditEntryType.php
@@ -3,6 +3,7 @@
 namespace Wallabag\CoreBundle\Form\Type;
 
 use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\TextareaType;
 use Symfony\Component\Form\Extension\Core\Type\SubmitType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\Extension\Core\Type\UrlType;
@@ -29,6 +30,9 @@ class EditEntryType extends AbstractType
                 'property_path' => 'originUrl',
                 'label' => 'entry.edit.origin_url_label',
                 'default_protocol' => null,
+            ])
+            ->add('content', TextareaType::class, [
+                'label' => 'entry.edit.content_label',
             ])
             ->add('save', SubmitType::class, [
                 'label' => 'entry.edit.save_label',

--- a/src/Wallabag/CoreBundle/Resources/translations/messages.en.yml
+++ b/src/Wallabag/CoreBundle/Resources/translations/messages.en.yml
@@ -270,6 +270,7 @@ entry:
             set_as_starred: Toggle starred
             view_original_article: Original article
             re_fetch_content: Re-fetch content
+            edit_content: Correct content
             delete: Delete
             add_a_tag: Add a tag
             share_content: Share
@@ -305,6 +306,7 @@ entry:
         url_label: Url
         origin_url_label: Origin url (from where you found that entry)
         save_label: Save
+        content_label: Body
     public:
         shared_by_wallabag: This article has been shared by %username% with <a href='%wallabag_instance%'>wallabag</a>
     confirm:

--- a/src/Wallabag/CoreBundle/Resources/views/themes/material/Entry/edit.html.twig
+++ b/src/Wallabag/CoreBundle/Resources/views/themes/material/Entry/edit.html.twig
@@ -32,6 +32,11 @@
                             {{ form_label(form.origin_url) }}
                             {{ form_widget(form.origin_url) }}
                         </div>
+
+                        <div class="s12">
+                            {{ form_label(form.content) }}
+                            {{ form_widget(form.content, {'attr': {'style': 'height:20em; resize:vertical;'}}) }}
+                        </div>
                         <br>
 
                         {{ form_widget(form.save, {'attr': {'class': 'btn waves-effect waves-light'}}) }}
@@ -42,5 +47,14 @@
             </div>
         </div>
     </div>
+
+    <script>
+        document.getElementById('entry_content').addEventListener('paste', event => {
+            event.preventDefault();
+            if (event.clipboardData && event.clipboardData.getData) {
+                event.target.innerHTML = event.clipboardData.getData('text/html');
+            }
+        });
+    </script>
 
 {% endblock %}

--- a/src/Wallabag/CoreBundle/Resources/views/themes/material/Entry/entry.html.twig
+++ b/src/Wallabag/CoreBundle/Resources/views/themes/material/Entry/entry.html.twig
@@ -61,6 +61,14 @@
             <div class="collapsible-body"></div>
         </li>
 
+        <li class="bold">
+            <a class="waves-effect collapsible-header" title="{{ 'entry.view.left_menu.edit_content'|trans }}" href="{{ path('edit', { 'id': entry.id }) }}" id="edit">
+                <i class="material-icons small">edit</i>
+                <span>{{ 'entry.view.left_menu.edit_content'|trans }}</span>
+            </a>
+            <div class="collapsible-body"></div>
+        </li>
+
         {% set markAsReadLabel = 'entry.view.left_menu.set_as_unread' %}
         {% if entry.isArchived == 0 %}
             {% set markAsReadLabel = 'entry.view.left_menu.set_as_read' %}


### PR DESCRIPTION

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Documentation | no
| Translation   | no
| CHANGELOG.md  | no
| License       | MIT

Resolves https://github.com/wallabag/wallabag/issues/2229
Relates to https://github.com/wallabag/wallabag/issues/3648

Hi, I'm sure some will remember my previous attempt at this feature (#3871). I'd been wanting the ability to correct miss or partial import by pasting the article body manually. My original was over-complicated and then I didn't have time to simplify it but now I have.

I've added a simple textarea to the article edit page, linked from and Edit button in the article itself, with a small bit of JS captures the paste operation for that textarea and instead pasts raw HTML.  Technically you can edit the content further but it's really just meant for pasting in.  If this looks more acceptable then I'll sort out the page caching issue that sometimes means the article loads the old content on returning from the editor, organise translations and add it to the other theme.