### PR TITLE
Enabled greek translation

### DIFF
--- a/app/config/wallabag.yml
+++ b/app/config/wallabag.yml
@@ -22,6 +22,7 @@ wallabag_core:
         uk: 'Українська'
         hr: 'Hrvatski'
         cs: 'Čeština'
+        el: 'Ελληνικά'
     items_on_page: 12
     theme: material
     language: '%locale%'


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Documentation | no
| Translation   | yes
| CHANGELOG.md  | no
| License       | MIT

Should close #5649. 

The greek translation was already there, just need to enable it in configuration. 

![Capture d’écran_2022-03-08_15-31-42](https://user-images.githubusercontent.com/121870/157258738-0c8abb35-0a6c-4610-a618-79226fff8bf4.png)

