### PR TITLE
Add an option to sort the feed entries by `updated_at`

### DIFF
--- a/src/Wallabag/CoreBundle/Repository/EntryRepository.php
+++ b/src/Wallabag/CoreBundle/Repository/EntryRepository.php
@@ -343,9 +343,9 @@ class EntryRepository extends EntityRepository
      *
      * @return array
      */
-    public function findAllByTagId($userId, $tagId)
+    public function findAllByTagId($userId, $tagId, $sort = 'createdAt')
     {
-        return $this->getSortedQueryBuilderByUser($userId)
+        return $this->getSortedQueryBuilderByUser($userId, $sort)
             ->innerJoin('e.tags', 't')
             ->andWhere('t.id = :tagId')->setParameter('tagId', $tagId)
             ->getQuery()

--- a/src/Wallabag/CoreBundle/Resources/views/themes/common/Entry/entries.xml.twig
+++ b/src/Wallabag/CoreBundle/Resources/views/themes/common/Entry/entries.xml.twig
@@ -11,8 +11,8 @@
         <title>wallabag — {{type}} {{ tag }} feed</title>
         <subtitle type="html">Atom feed for entries tagged with {{ tag }}</subtitle>
     {% endif %}
-    {% if entries | length > 0 %}
-        <updated>{{ (entries | first).createdAt | date('c') }}</updated> {# Indicates the last time the feed was modified in a significant way. #}
+    {% if updated %}
+        <updated>{{ updated | date('c') }}</updated> {# Indicates the last time the feed was modified in a significant way. #}
     {% endif %}
     <link rel="self" type="application/atom+xml" href="{{ app.request.uri }}"/>
     {% if entries.hasPreviousPage %}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Documentation | yes/no
| Translation   | no
| CHANGELOG.md  | yes/no
| License       | MIT

There is now an option to sort the feed entires by updated_at, on the
controler : a sort querystring argument that accepts either "created"
or "updated".

Fixs #5658