### PR TITLE
Add new endpoint for API: config

### DIFF
--- a/src/Wallabag/ApiBundle/Controller/ConfigRestController.php
+++ b/src/Wallabag/ApiBundle/Controller/ConfigRestController.php
@@ -2,6 +2,7 @@
 
 namespace Wallabag\ApiBundle\Controller;
 
+use JMS\Serializer\SerializationContext;
 use Nelmio\ApiDocBundle\Annotation\ApiDoc;
 use Symfony\Component\HttpFoundation\JsonResponse;
 
@@ -18,6 +19,14 @@ class ConfigRestController extends WallabagRestController
     {
         $this->validateAuthentication();
 
-        return $this->sendResponse($this->getUser()->getConfig());
+        $json = $this->get('jms_serializer')->serialize(
+            $this->getUser()->getConfig(),
+            'json',
+            SerializationContext::create()->setGroups(['config_api'])
+        );
+
+        return (new JsonResponse())
+            ->setJson($json)
+            ->setStatusCode(JsonResponse::HTTP_OK);
     }
 }

--- a/src/Wallabag/ApiBundle/Controller/ConfigRestController.php
+++ b/src/Wallabag/ApiBundle/Controller/ConfigRestController.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Wallabag\ApiBundle\Controller;
+
+use Nelmio\ApiDocBundle\Annotation\ApiDoc;
+use Symfony\Component\HttpFoundation\JsonResponse;
+
+class ConfigRestController extends WallabagRestController
+{
+    /**
+     * Retrieve configuration for current user.
+     *
+     * @ApiDoc()
+     *
+     * @return JsonResponse
+     */
+    public function getConfigAction()
+    {
+        $this->validateAuthentication();
+
+        return $this->sendResponse($this->getUser()->getConfig());
+    }
+}

--- a/src/Wallabag/ApiBundle/Resources/config/routing_rest.yml
+++ b/src/Wallabag/ApiBundle/Resources/config/routing_rest.yml
@@ -32,3 +32,8 @@ user:
   type: rest
   resource: "WallabagApiBundle:UserRest"
   name_prefix:  api_
+
+config:
+    type: rest
+    resource: "WallabagApiBundle:ConfigRest"
+    name_prefix:  api_

--- a/src/Wallabag/CoreBundle/DataFixtures/ConfigFixtures.php
+++ b/src/Wallabag/CoreBundle/DataFixtures/ConfigFixtures.php
@@ -24,7 +24,6 @@ class ConfigFixtures extends Fixture implements DependentFixtureInterface
         $adminConfig->setPocketConsumerKey('xxxxx');
         $adminConfig->setActionMarkAsRead(0);
         $adminConfig->setListMode(0);
-        $adminConfig->setListMode(0);
 
         $manager->persist($adminConfig);
 

--- a/src/Wallabag/CoreBundle/DataFixtures/ConfigFixtures.php
+++ b/src/Wallabag/CoreBundle/DataFixtures/ConfigFixtures.php
@@ -24,6 +24,7 @@ class ConfigFixtures extends Fixture implements DependentFixtureInterface
         $adminConfig->setPocketConsumerKey('xxxxx');
         $adminConfig->setActionMarkAsRead(0);
         $adminConfig->setListMode(0);
+        $adminConfig->setListMode(0);
 
         $manager->persist($adminConfig);
 

--- a/src/Wallabag/CoreBundle/Entity/Config.php
+++ b/src/Wallabag/CoreBundle/Entity/Config.php
@@ -40,8 +40,6 @@ class Config
      *
      * @Assert\NotBlank()
      * @ORM\Column(name="theme", type="string", nullable=false)
-     *
-     * @Groups({"config_api"})
      */
     private $theme;
 
@@ -106,8 +104,6 @@ class Config
      * @var string
      *
      * @ORM\Column(name="pocket_consumer_key", type="string", nullable=true)
-     *
-     * @Groups({"config_api"})
      */
     private $pocketConsumerKey;
 

--- a/src/Wallabag/CoreBundle/Entity/Config.php
+++ b/src/Wallabag/CoreBundle/Entity/Config.php
@@ -4,6 +4,7 @@ namespace Wallabag\CoreBundle\Entity;
 
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\ORM\Mapping as ORM;
+use JMS\Serializer\Annotation\Groups;
 use Symfony\Component\Validator\Constraints as Assert;
 use Wallabag\UserBundle\Entity\User;
 
@@ -29,6 +30,8 @@ class Config
      * @ORM\Column(name="id", type="integer")
      * @ORM\Id
      * @ORM\GeneratedValue(strategy="AUTO")
+     *
+     * @Groups({"config_api"})
      */
     private $id;
 
@@ -37,6 +40,8 @@ class Config
      *
      * @Assert\NotBlank()
      * @ORM\Column(name="theme", type="string", nullable=false)
+     *
+     * @Groups({"config_api"})
      */
     private $theme;
 
@@ -50,6 +55,8 @@ class Config
      *      maxMessage = "validator.item_per_page_too_high"
      * )
      * @ORM\Column(name="items_per_page", type="integer", nullable=false)
+     *
+     * @Groups({"config_api"})
      */
     private $itemsPerPage;
 
@@ -58,6 +65,8 @@ class Config
      *
      * @Assert\NotBlank()
      * @ORM\Column(name="language", type="string", nullable=false)
+     *
+     * @Groups({"config_api"})
      */
     private $language;
 
@@ -65,6 +74,8 @@ class Config
      * @var string
      *
      * @ORM\Column(name="feed_token", type="string", nullable=true)
+     *
+     * @Groups({"config_api"})
      */
     private $feedToken;
 
@@ -77,6 +88,8 @@ class Config
      *      max = 100000,
      *      maxMessage = "validator.feed_limit_too_high"
      * )
+     *
+     * @Groups({"config_api"})
      */
     private $feedLimit;
 
@@ -84,6 +97,8 @@ class Config
      * @var float
      *
      * @ORM\Column(name="reading_speed", type="float", nullable=true)
+     *
+     * @Groups({"config_api"})
      */
     private $readingSpeed;
 
@@ -91,6 +106,8 @@ class Config
      * @var string
      *
      * @ORM\Column(name="pocket_consumer_key", type="string", nullable=true)
+     *
+     * @Groups({"config_api"})
      */
     private $pocketConsumerKey;
 
@@ -98,6 +115,8 @@ class Config
      * @var int
      *
      * @ORM\Column(name="action_mark_as_read", type="integer", nullable=true, options={"default" = 0})
+     *
+     * @Groups({"config_api"})
      */
     private $actionMarkAsRead;
 
@@ -105,6 +124,8 @@ class Config
      * @var int
      *
      * @ORM\Column(name="list_mode", type="integer", nullable=true)
+     *
+     * @Groups({"config_api"})
      */
     private $listMode;
 

--- a/tests/Wallabag/ApiBundle/Controller/ConfigRestControllerTest.php
+++ b/tests/Wallabag/ApiBundle/Controller/ConfigRestControllerTest.php
@@ -14,17 +14,14 @@ class ConfigRestControllerTest extends WallabagApiTestCase
         $content = json_decode($this->client->getResponse()->getContent(), true);
 
         $this->assertArrayHasKey('id', $content);
-        $this->assertArrayHasKey('theme', $content);
         $this->assertArrayHasKey('items_per_page', $content);
         $this->assertArrayHasKey('language', $content);
         $this->assertArrayHasKey('reading_speed', $content);
-        $this->assertArrayHasKey('pocket_consumer_key', $content);
         $this->assertArrayHasKey('action_mark_as_read', $content);
         $this->assertArrayHasKey('list_mode', $content);
 
-        $this->assertSame('material', $content['theme']);
         $this->assertSame(200.0, $content['reading_speed']);
-        $this->assertSame('xxxxx', $content['pocket_consumer_key']);
+        $this->assertSame('en', $content['language']);
 
         $this->assertSame('application/json', $this->client->getResponse()->headers->get('Content-Type'));
     }

--- a/tests/Wallabag/ApiBundle/Controller/ConfigRestControllerTest.php
+++ b/tests/Wallabag/ApiBundle/Controller/ConfigRestControllerTest.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Tests\Wallabag\ApiBundle\Controller;
+
+use Tests\Wallabag\ApiBundle\WallabagApiTestCase;
+
+class ConfigRestControllerTest extends WallabagApiTestCase
+{
+    public function testGetConfig()
+    {
+        $this->client->request('GET', '/api/config.json');
+        $this->assertSame(200, $this->client->getResponse()->getStatusCode());
+
+        $content = json_decode($this->client->getResponse()->getContent(), true);
+
+        $this->assertArrayHasKey('id', $content);
+        $this->assertArrayHasKey('theme', $content);
+        $this->assertArrayHasKey('items_per_page', $content);
+        $this->assertArrayHasKey('language', $content);
+        $this->assertArrayHasKey('feed_token', $content);
+        $this->assertArrayHasKey('feed_limit', $content);
+        $this->assertArrayHasKey('reading_speed', $content);
+        $this->assertArrayHasKey('pocket_consumer_key', $content);
+        $this->assertArrayHasKey('action_mark_as_read', $content);
+        $this->assertArrayHasKey('list_mode', $content);
+
+        $this->assertSame('material', $content['theme']);
+        $this->assertSame(200.0, $content['reading_speed']);
+        $this->assertSame('xxxxx', $content['pocket_consumer_key']);
+
+        $this->assertSame('application/json', $this->client->getResponse()->headers->get('Content-Type'));
+    }
+
+    public function testGetConfigWithoutAuthentication()
+    {
+        $client = static::createClient();
+        $client->request('GET', '/api/config.json');
+        $this->assertSame(401, $client->getResponse()->getStatusCode());
+
+        $content = json_decode($client->getResponse()->getContent(), true);
+
+        $this->assertArrayHasKey('error', $content);
+        $this->assertArrayHasKey('error_description', $content);
+
+        $this->assertSame('access_denied', $content['error']);
+
+        $this->assertSame('application/json', $client->getResponse()->headers->get('Content-Type'));
+    }
+}

--- a/tests/Wallabag/ApiBundle/Controller/ConfigRestControllerTest.php
+++ b/tests/Wallabag/ApiBundle/Controller/ConfigRestControllerTest.php
@@ -17,8 +17,6 @@ class ConfigRestControllerTest extends WallabagApiTestCase
         $this->assertArrayHasKey('theme', $content);
         $this->assertArrayHasKey('items_per_page', $content);
         $this->assertArrayHasKey('language', $content);
-        $this->assertArrayHasKey('feed_token', $content);
-        $this->assertArrayHasKey('feed_limit', $content);
         $this->assertArrayHasKey('reading_speed', $content);
         $this->assertArrayHasKey('pocket_consumer_key', $content);
         $this->assertArrayHasKey('action_mark_as_read', $content);

--- a/tests/Wallabag/ApiBundle/Controller/ConfigRestControllerTest.php
+++ b/tests/Wallabag/ApiBundle/Controller/ConfigRestControllerTest.php
@@ -11,17 +11,19 @@ class ConfigRestControllerTest extends WallabagApiTestCase
         $this->client->request('GET', '/api/config.json');
         $this->assertSame(200, $this->client->getResponse()->getStatusCode());
 
-        $content = json_decode($this->client->getResponse()->getContent(), true);
+        $config = json_decode($this->client->getResponse()->getContent(), true);
 
-        $this->assertArrayHasKey('id', $content);
-        $this->assertArrayHasKey('items_per_page', $content);
-        $this->assertArrayHasKey('language', $content);
-        $this->assertArrayHasKey('reading_speed', $content);
-        $this->assertArrayHasKey('action_mark_as_read', $content);
-        $this->assertArrayHasKey('list_mode', $content);
+        $this->assertArrayHasKey('id', $config);
+        $this->assertArrayHasKey('items_per_page', $config);
+        $this->assertArrayHasKey('language', $config);
+        $this->assertArrayHasKey('reading_speed', $config);
+        $this->assertArrayHasKey('action_mark_as_read', $config);
+        $this->assertArrayHasKey('list_mode', $config);
 
-        $this->assertSame(200.0, $content['reading_speed']);
-        $this->assertSame('en', $content['language']);
+        $this->assertSame(200.0, $config['reading_speed']);
+        $this->assertSame('en', $config['language']);
+
+        $this->assertCount(6, $config);
 
         $this->assertSame('application/json', $this->client->getResponse()->headers->get('Content-Type'));
     }
@@ -32,12 +34,12 @@ class ConfigRestControllerTest extends WallabagApiTestCase
         $client->request('GET', '/api/config.json');
         $this->assertSame(401, $client->getResponse()->getStatusCode());
 
-        $content = json_decode($client->getResponse()->getContent(), true);
+        $config = json_decode($client->getResponse()->getContent(), true);
 
-        $this->assertArrayHasKey('error', $content);
-        $this->assertArrayHasKey('error_description', $content);
+        $this->assertArrayHasKey('error', $config);
+        $this->assertArrayHasKey('error_description', $config);
 
-        $this->assertSame('access_denied', $content['error']);
+        $this->assertSame('access_denied', $config['error']);
 
         $this->assertSame('application/json', $client->getResponse()->headers->get('Content-Type'));
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Documentation | no
| Translation   | no
| CHANGELOG.md  | yes/no
| License       | MIT

Added a new API endpoint, to get user configuration (ping @bourvill).  

Maybe one day, we can improve this endpoint (to update configuration, etc). 

~~One issue with this new feature: I don't want to get the user entries in the json response. I need to fix this.~~ 
