### PR TITLE
Replace `iconv()` calls with Transliterator

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -40,6 +40,7 @@
         "ext-gd": "*",
         "ext-hash": "*",
         "ext-iconv": "*",
+        "ext-intl": "*",
         "ext-json": "*",
         "ext-mbstring": "*",
         "ext-pcre": "*",

--- a/src/Wallabag/CoreBundle/Helper/ContentProxy.php
+++ b/src/Wallabag/CoreBundle/Helper/ContentProxy.php
@@ -236,7 +236,9 @@ class ContentProxy
             return $rawText;
         }
 
-        return iconv('UTF-8', 'UTF-8//IGNORE', $rawText);
+        mb_substitute_character('none');
+
+        return mb_convert_encoding($rawText, 'UTF-8', 'UTF-8');
     }
 
     /**

--- a/src/Wallabag/CoreBundle/Helper/EntriesExport.php
+++ b/src/Wallabag/CoreBundle/Helper/EntriesExport.php
@@ -527,6 +527,8 @@ class EntriesExport
      */
     private function getSanitizedFilename()
     {
-        return preg_replace('/[^A-Za-z0-9\- \']/', '', iconv('utf-8', 'us-ascii//TRANSLIT', $this->title));
+        $transliterator = \Transliterator::createFromRules(':: Any-Latin; :: Latin-ASCII; :: NFD; :: [:Nonspacing Mark:] Remove; :: NFC;', \Transliterator::FORWARD);
+
+        return preg_replace('/[^A-Za-z0-9\- \']/', '', $transliterator->transliterate($this->title));
     }
 }

--- a/tests/Wallabag/CoreBundle/Controller/ExportControllerTest.php
+++ b/tests/Wallabag/CoreBundle/Controller/ExportControllerTest.php
@@ -347,6 +347,8 @@ class ExportControllerTest extends WallabagCoreTestCase
 
     private function getSanitizedFilename($title)
     {
-        return preg_replace('/[^A-Za-z0-9\- \']/', '', iconv('utf-8', 'us-ascii//TRANSLIT', $title));
+        $transliterator = \Transliterator::createFromRules(':: Any-Latin; :: Latin-ASCII; :: NFD; :: [:Nonspacing Mark:] Remove; :: NFC;', \Transliterator::FORWARD);
+
+        return preg_replace('/[^A-Za-z0-9\- \']/', '', $transliterator->transliterate($title));
     }
 }

--- a/var/SymfonyRequirements.php
+++ b/var/SymfonyRequirements.php
@@ -456,12 +456,6 @@ class SymfonyRequirements extends RequirementCollection
         }
 
         $this->addRequirement(
-            function_exists('iconv'),
-            'iconv() must be available',
-            'Install and enable the <strong>iconv</strong> extension.'
-        );
-
-        $this->addRequirement(
             function_exists('json_encode'),
             'json_encode() must be available',
             'Install and enable the <strong>JSON</strong> extension.'


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | 
| Documentation | no
| Translation   | no
| CHANGELOG.md  | no
| License       | MIT

Closes #5377