### PR TITLE
Fix composer version in docker dev configuration

### DIFF
--- a/docker/php/Dockerfile
+++ b/docker/php/Dockerfile
@@ -64,7 +64,7 @@ RUN npm install -g yarn
 RUN curl -L -o /usr/local/bin/envsubst https://github.com/a8m/envsubst/releases/download/v1.1.0/envsubst-`uname -s`-`uname -m`; \
     chmod +x /usr/local/bin/envsubst
 
-COPY --from=composer:latest /usr/bin/composer /usr/local/bin/composer
+COPY --from=composer:2.2.10 /usr/bin/composer /usr/local/bin/composer
 
 COPY entrypoint.sh /entrypoint.sh
 COPY config/ /opt/wallabag/config/


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | ye
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Documentation | no
| Translation   | no
| CHANGELOG.md  | no
| License       | MIT

Because Composer 2.3 isn't compatible with wallabag #5708.