### PR TITLE
Add WebP support in docker env

### DIFF
--- a/docker/php/Dockerfile
+++ b/docker/php/Dockerfile
@@ -22,6 +22,7 @@ RUN apt-get update && apt-get install -y \
         libxml2-dev \
         libpng-dev \
         libjpeg-dev \
+        libwebp-dev \
         libsqlite3-dev \
         imagemagick \
         libmagickwand-dev \
@@ -33,7 +34,7 @@ RUN apt-get update && apt-get install -y \
         git \
         build-essential \
         nodejs
-RUN docker-php-ext-configure gd --with-freetype --with-jpeg
+RUN docker-php-ext-configure gd --enable-gd --with-freetype --with-jpeg --with-webp
 RUN docker-php-ext-install -j "$(nproc)" \
         bcmath \
         gd \


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Documentation | yes
| Translation   | no
| CHANGELOG.md  | no
| License       | MIT

Add support for WebP in docker environment. 

@Kdecherf I need help, because webP is now installed but not enabled. 

```
www-data@0b622feb2ec5:~/html$ php -r "var_dump(gd_info());" 
Command line code:1:
array(14) {
  'GD Version' =>
  string(26) "bundled (2.1.0 compatible)"
  'FreeType Support' =>
  bool(true)
  'FreeType Linkage' =>
  string(13) "with freetype"
  'GIF Read Support' =>
  bool(true)
  'GIF Create Support' =>
  bool(true)
  'JPEG Support' =>
  bool(true)
  'PNG Support' =>
  bool(true)
  'WBMP Support' =>
  bool(true)
  'XPM Support' =>
  bool(false)
  'XBM Support' =>
  bool(true)
  'WebP Support' =>
  bool(false)
  'BMP Support' =>
  bool(true)
  'TGA Read Support' =>
  bool(true)
  'JIS-mapped Japanese Font Support' =>
  bool(false)
}
```