### PR TITLE
CI workaround for PHP < 7.4 & MySQL 8

### DIFF
--- a/.github/workflows/assets.yml
+++ b/.github/workflows/assets.yml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
       - name: "Checkout"
-        uses: "actions/checkout@v2"
+        uses: "actions/checkout@v3"
 
       - name: "Install Node"
         uses: actions/setup-node@v2

--- a/.github/workflows/coding-standards.yml
+++ b/.github/workflows/coding-standards.yml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
       - name: "Checkout"
-        uses: "actions/checkout@v2"
+        uses: "actions/checkout@v3"
 
       - name: "Install PHP"
         uses: "shivammathur/setup-php@v2"

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -41,7 +41,7 @@ jobs:
 
     steps:
       - name: "Checkout"
-        uses: "actions/checkout@v2"
+        uses: "actions/checkout@v3"
         with:
           fetch-depth: 2
 
@@ -54,11 +54,21 @@ jobs:
           extensions: json, pdo, pdo_mysql, pdo_sqlite, pdo_pgsql, curl, imagick, pgsql, gd, tidy
           ini-values: "date.timezone=Europe/Paris"
 
+      - name: "Install MySQL (for PHP < 7.4)"
+        # there is an issue with PHP < 7.4 and MySQL 8 with `caching_sha2_password`
+        if: "${{ matrix.database == 'mysql' && (matrix.php == '7.2' || matrix.php == '7.3') }}"
+        uses: shogo82148/actions-setup-mysql@v1
+        with:
+          root-password: root
+          mysql-version: '5.7'
+
+      - name: "Install MySQL (for PHP >= 7.4)"
+        if: "${{ matrix.database == 'mysql' && matrix.php != '7.2' && matrix.php != '7.3' }}"
+        run: sudo systemctl start mysql.service
+
       - name: "Setup MySQL"
         if: "${{ matrix.database == 'mysql' }}"
-        run: |
-          sudo systemctl start mysql.service
-          sudo mysql -u root -proot -e "CREATE DATABASE wallabag_test"
+        run: sudo mysql -u root -proot -h 127.0.0.1 -e "CREATE DATABASE wallabag_test"
 
       - name: "Setup PostgreSQL"
         if: "${{ matrix.database == 'pgsql' }}"

--- a/.github/workflows/translations.yml
+++ b/.github/workflows/translations.yml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
       - name: "Checkout"
-        uses: "actions/checkout@v2"
+        uses: "actions/checkout@v3"
 
       - name: "Install PHP"
         uses: "shivammathur/setup-php@v2"

--- a/app/config/tests/parameters_test.mysql.yml
+++ b/app/config/tests/parameters_test.mysql.yml
@@ -1,6 +1,6 @@
 parameters:
     test_database_driver: pdo_mysql
-    test_database_host: localhost
+    test_database_host: 127.0.0.1
     test_database_port: 3306
     test_database_name: wallabag_test
     test_database_user: root


### PR DESCRIPTION
The error on PHP 7.2 & 7.3 is:

> PDO::__construct(): The server requested authentication method unknown to the client [caching_sha2_password]

See:
- https://stackoverflow.com/q/53066962/569101
- https://stackoverflow.com/q/52364415/569101
- https://stackoverflow.com/q/51489616/569101
- https://stackoverflow.com/q/50026939/569101
- https://github.com/phpmyadmin/phpmyadmin/commit/1ae14b59a40ff5d8b62b50f9c1172dbea0e61b1f

Also upgrade `actions/checkout` to v3