### PR TITLE
Set permissions for GitHub actions

### DIFF
--- a/.github/workflows/assets.yml
+++ b/.github/workflows/assets.yml
@@ -7,6 +7,9 @@ on:
       - master
       - 2.*
 
+permissions:
+  contents: read
+
 jobs:
   js:
     name: "Building assets"

--- a/.github/workflows/coding-standards.yml
+++ b/.github/workflows/coding-standards.yml
@@ -7,6 +7,9 @@ on:
       - master
       - 2.*
 
+permissions:
+  contents: read
+
 jobs:
   coding-standards:
     name: "CS Fixer & PHPStan"

--- a/.github/workflows/translations.yml
+++ b/.github/workflows/translations.yml
@@ -7,6 +7,9 @@ on:
       - master
       - 2.*
 
+permissions:
+  contents: read
+
 jobs:
   translations:
     name: "Translations"


### PR DESCRIPTION
- Included permissions for the action. https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions

https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions

https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs

[Keeping your GitHub Actions and workflows secure Part 1: Preventing pwn requests](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)

 Restrict the GitHub token permissions only to the required ones; this way, even if the attackers will succeed in compromising your workflow, they won’t be able to do much.

Signed-off-by: naveensrinivasan <172697+naveensrinivasan@users.noreply.github.com>
