### PR TITLE
Deprecated Baggy

### DIFF
--- a/src/Wallabag/CoreBundle/Controller/ConfigController.php
+++ b/src/Wallabag/CoreBundle/Controller/ConfigController.php
@@ -43,6 +43,16 @@ class ConfigController extends Controller
         $configForm->handleRequest($request);
 
         if ($configForm->isSubmitted() && $configForm->isValid()) {
+            // force theme to material to avoid using baggy
+            if ('baggy' === $config->getTheme()) {
+                $config->setTheme('material');
+
+                $this->addFlash(
+                    'notice',
+                    'Baggy is deprecated, forced to Material theme.'
+                );
+            }
+
             $em->persist($config);
             $em->flush();
 

--- a/src/Wallabag/CoreBundle/Form/Type/ConfigType.php
+++ b/src/Wallabag/CoreBundle/Form/Type/ConfigType.php
@@ -24,7 +24,13 @@ class ConfigType extends AbstractType
         $this->themes = array_combine(
             $themes,
             array_map(function ($s) {
-                return ucwords(strtolower(str_replace('-', ' ', $s)));
+                $cleanTheme = ucwords(strtolower(str_replace('-', ' ', $s)));
+
+                if ('Baggy' === $cleanTheme) {
+                    $cleanTheme = 'Baggy (DEPRECATED)';
+                }
+
+                return $cleanTheme;
             }, $themes)
         );
 

--- a/src/Wallabag/CoreBundle/Resources/views/themes/baggy/layout.html.twig
+++ b/src/Wallabag/CoreBundle/Resources/views/themes/baggy/layout.html.twig
@@ -57,6 +57,11 @@
 {% endblock %}
 
 {% block messages %}
+    <div style="margin-top: 10px; color: #e01a15; border-left: 20px #e01a15 solid; padding-left: 10px; border-bottom: 6px #e01a15 solid; border-bottom-left-radius: 10px;">
+        <h3>⚠️ You are using the Baggy theme which is now deprecated.</h3>
+        <p>It will be removed in the next version. You can use the Material theme by <a href="{{ path('config') }}">updating the theme config</a>.</p>
+    </div>
+
     {% for flashMessage in app.session.flashbag.get('notice') %}
         <div class="messages success">
             <a href="#" class="closeMessage">×</a>


### PR DESCRIPTION
- a big message will be displayed to user using the Baggy theme

<img width="969" alt="image" src="https://user-images.githubusercontent.com/62333/164320069-b44b5593-c74a-4fbd-8a16-af77bee776a4.png">

- switching from Material to Baggy is no more allowed in config (it'll be forced to material), here is the message when you selected the Baggy theme:
<img width="474" alt="image" src="https://user-images.githubusercontent.com/62333/164320293-19689193-84e4-4ac6-9e97-b88795fdba46.png">

- the theme label in the config for Baggy is now _Baggy (DEPRECATED)_

<img width="400" alt="image" src="https://user-images.githubusercontent.com/62333/164320146-b6ba0533-927a-4a5b-ad07-6f87ab2e33a2.png">

See https://github.com/wallabag/wallabag/issues/3460

Do we need to bother translating the warning message about the forced theme? That message will be removed in 2.6.0 anyway.