### PR TITLE
Fix PHP Docker image

### DIFF
--- a/docker/php/Dockerfile
+++ b/docker/php/Dockerfile
@@ -64,7 +64,7 @@ RUN npm install -g yarn
 RUN curl -L -o /usr/local/bin/envsubst https://github.com/a8m/envsubst/releases/download/v1.1.0/envsubst-`uname -s`-`uname -m`; \
     chmod +x /usr/local/bin/envsubst
 
-COPY --from=composer:2.2.10 /usr/bin/composer /usr/local/bin/composer
+COPY --from=composer:2.2.12 /usr/bin/composer /usr/local/bin/composer
 
 COPY entrypoint.sh /entrypoint.sh
 COPY config/ /opt/wallabag/config/

--- a/docker/php/Dockerfile
+++ b/docker/php/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:8.0-fpm AS rootless
+FROM php:7.4-fpm AS rootless
 
 ARG DEBIAN_FRONTEND=noninteractive
 ARG NODE_VERSION=14

--- a/docker/php/Dockerfile
+++ b/docker/php/Dockerfile
@@ -22,6 +22,7 @@ RUN apt-get update && apt-get install -y \
         libxml2-dev \
         libpng-dev \
         libjpeg-dev \
+        libwebp-dev \
         libsqlite3-dev \
         imagemagick \
         libmagickwand-dev \
@@ -33,7 +34,7 @@ RUN apt-get update && apt-get install -y \
         git \
         build-essential \
         nodejs
-RUN docker-php-ext-configure gd --with-freetype --with-jpeg
+RUN docker-php-ext-configure gd --with-freetype --with-jpeg --with-webp
 RUN docker-php-ext-install -j "$(nproc)" \
         bcmath \
         gd \


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Documentation | no
| Translation   | no
| CHANGELOG.md  | no
| License       | MIT

This ensure that it's possible to run tests with the Docker setup, so that Redis tests are executed, without the need of installing Redis on local machine.
There were an issue with a missing GD support for WebP that is now fixed
Bonus change is the update of the Composer version used in Docker.

Also, this downgrades the PHP version of the Docker image to be as near as possible to the lowest supported one (7.2).
I managed locally to have tests running and green on PHP 7.2, but there is an issue with deprecation report because of a bug in PHP < 7.3.16 (see [the Core fixe in the changelog](https://www.php.net/ChangeLog-7.php#7.3.16) about `restore_error_hander`).
Consequence of that bug is that deprecations are reported as `THE ERROR HANDLER HAS CHANGED!`.
Root issue found by trying a setup with 7.3.15 and seeing the same issue with deprecations.

I decided to stay on PHP 7.3 and have working deprecation report that being on PHP 7.2 with no deprecation report.
I assume we will soon increase the minimum PHP requirement. (with Symfony 6.1 coming with minimum PHP 8.1, I hope wallabag will align soon enough to unlock amazing new possibilities :crossed_fingers: )