### PR TITLE
Back to latest composer version

### DIFF
--- a/.github/workflows/coding-standards.yml
+++ b/.github/workflows/coding-standards.yml
@@ -24,7 +24,7 @@ jobs:
         with:
           coverage: "none"
           php-version: "7.4"
-          tools: cs2pr, pecl, composer:2.2
+          tools: cs2pr, pecl
           extensions: pdo, pdo_mysql, pdo_sqlite, pdo_pgsql, curl, imagick, pgsql, gd, tidy
           ini-values: "date.timezone=Europe/Paris"
         env:

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -48,7 +48,7 @@ jobs:
         with:
           php-version: "${{ matrix.php }}"
           coverage: none
-          tools: pecl, composer:2.2
+          tools: pecl
           extensions: json, pdo, pdo_mysql, pdo_sqlite, pdo_pgsql, curl, imagick, pgsql, gd, tidy
           ini-values: "date.timezone=Europe/Paris"
 

--- a/.github/workflows/translations.yml
+++ b/.github/workflows/translations.yml
@@ -29,7 +29,7 @@ jobs:
         with:
           coverage: "none"
           php-version: "${{ matrix.php }}"
-          tools: pecl, composer:2.2
+          tools: pecl
           extensions: pdo, pdo_mysql, pdo_sqlite, pdo_pgsql, curl, imagick, pgsql, gd, tidy
           ini-values: "date.timezone=Europe/Paris"
         env:

--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,6 @@
     },
     "require": {
         "php": ">=7.4",
-        "composer": "< 2.3",
         "ext-ctype": "*",
         "ext-curl": "*",
         "ext-dom": "*",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "598bc98358673f361673a95b75c1ffa3",
+    "content-hash": "590ed41c623b7ee7204d486fc0412d99",
     "packages": [
         {
             "name": "babdev/pagerfanta-bundle",
@@ -13001,7 +13001,6 @@
     "prefer-lowest": false,
     "platform": {
         "php": ">=7.4",
-        "composer": "< 2.3",
         "ext-ctype": "*",
         "ext-curl": "*",
         "ext-dom": "*",
@@ -13023,5 +13022,5 @@
     "platform-overrides": {
         "php": "7.4.29"
     },
-    "plugin-api-version": "2.2.0"
+    "plugin-api-version": "2.3.0"
 }

--- a/docker/php/Dockerfile
+++ b/docker/php/Dockerfile
@@ -65,7 +65,7 @@ RUN npm install -g yarn
 RUN curl -L -o /usr/local/bin/envsubst https://github.com/a8m/envsubst/releases/download/v1.1.0/envsubst-`uname -s`-`uname -m`; \
     chmod +x /usr/local/bin/envsubst
 
-COPY --from=composer:2.2.12 /usr/bin/composer /usr/local/bin/composer
+COPY --from=composer:latest /usr/bin/composer /usr/local/bin/composer
 
 COPY entrypoint.sh /entrypoint.sh
 COPY config/ /opt/wallabag/config/


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Documentation | no
| Translation   | no
| CHANGELOG.md  | no
| License       | MIT

- [x] based on #5761

Composer was limited to 2.2 in #5708 because of SensioDistributionBundle. Now that #5761 removes it, we can go back to use latest Composer version :)