### PR TITLE
Automatically create the package after a release

### DIFF
--- a/.github/workflows/upload-release-package.yml
+++ b/.github/workflows/upload-release-package.yml
@@ -1,0 +1,39 @@
+name: "Upload release package"
+
+on:
+  release:
+    types:
+      - created
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        php:
+          - "7.4"
+
+    steps:
+      - name: "Checkout"
+        uses: "actions/checkout@v3"
+
+      - name: "Install PHP"
+        uses: "shivammathur/setup-php@v2"
+        with:
+          coverage: "none"
+          php-version: "${{ matrix.php }}"
+          tools: pecl, composer:2.2
+          extensions: pdo, pdo_mysql, pdo_sqlite, pdo_pgsql, curl, imagick, pgsql, gd, tidy
+          ini-values: "date.timezone=Europe/Paris"
+        env:
+          COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Create the package
+        run: make release VERSION=${{ github.event.release.tag_name }}
+
+      - name: Upload the package to the release
+        uses: shogo82148/actions-upload-release-asset@v1
+        with:
+          upload_url: ${{ github.event.release.upload_url }}
+          asset_path: /tmp/wllbg-release/wallabag-${{ github.event.release.tag_name }}.tar.gz

--- a/RELEASE_PROCESS.md
+++ b/RELEASE_PROCESS.md
@@ -16,13 +16,7 @@ During this documentation, we assume the release is `$LAST_WALLABAG_RELEASE` (li
 
 #### Create a new release on GitHub
 
-- Run this command to create the package:
-
-```
-make release VERSION=$LAST_WALLABAG_RELEASE
-```
-
-- [Create the new release on GitHub](https://github.com/wallabag/wallabag/releases/new) by targetting the `master` branch or any appropriate branch (for instance backports). You have to upload the package (generated previously).
+- [Create the new release on GitHub](https://github.com/wallabag/wallabag/releases/new) by targetting the `master` branch or any appropriate branch (for instance backports).
 - Update nginx config to change the redirect rule for `https://wllbg.org/latest-v2-package` & `http://wllbg.org/latest-v2` (they both redirect to the asset of the GitHub release)
 - Update Dockerfile https://github.com/wallabag/docker (and create a new tag)
 - Update wallabag.org website (downloads, MD5 sum, releases and new blog post)

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -9,12 +9,12 @@ ENV=$4
 
 rm -rf "${TMP_FOLDER:?}"/"$RELEASE_FOLDER"
 mkdir "$TMP_FOLDER"/"$RELEASE_FOLDER"
-git clone git@github.com:wallabag/wallabag.git "$TMP_FOLDER"/"$RELEASE_FOLDER"/"$VERSION"
+git clone https://github.com/wallabag/wallabag.git "$TMP_FOLDER"/"$RELEASE_FOLDER"/"$VERSION"
 cd "$TMP_FOLDER"/"$RELEASE_FOLDER"/"$VERSION" && SYMFONY_ENV="$ENV" COMPOSER_MEMORY_LIMIT=-1 composer install -n --no-dev
 cd "$TMP_FOLDER"/"$RELEASE_FOLDER"/"$VERSION" && php bin/console wallabag:install --env="$ENV" -n
 cd "$TMP_FOLDER"/"$RELEASE_FOLDER"/"$VERSION" && php bin/console assets:install --env="$ENV" --symlink --relative
 cd "$TMP_FOLDER"/"$RELEASE_FOLDER" && tar czf "$VERSION".tar.gz --exclude="var/cache/*" --exclude="var/logs/*" --exclude="var/sessions/*" --exclude=".git" "$VERSION"
 echo "MD5 checksum of the package for wallabag $VERSION"
-md5 "$TMP_FOLDER"/"$RELEASE_FOLDER"/"$VERSION".tar.gz
+md5sum "$VERSION".tar.gz
 echo "Package to upload to the release server:"
 echo "$TMP_FOLDER"/"$RELEASE_FOLDER"/"$VERSION".tar.gz


### PR DESCRIPTION
And then upload it to the created release.
One less step during the release process 💪

We are using that GitHub Actions: https://github.com/shogo82148/actions-upload-release-asset
I've made some tests on [my fork](https://github.com/j0k3r/wallabag/actions/workflows/upload-release-package.yml) before submitting this PR.

I've also:
- updated the release script to clone the repo using `https` instead of `git` (otherwise it failed during the build)
- use `md5sum` instead of `md5` because the latest isn't available in GitHub Actions
