### PR TITLE
Use localhost alias instead of hard coded IP

### DIFF
--- a/app/config/parameters.yml.dist
+++ b/app/config/parameters.yml.dist
@@ -11,7 +11,7 @@ parameters:
     # database_password: %env.database_password%
 
     database_driver: pdo_mysql
-    database_host: 127.0.0.1
+    database_host: localhost
     database_port: ~
     database_name: wallabag
     database_user: root


### PR DESCRIPTION
On some systems, localhost could be in other private IP ranges not just 127.0.0.1 (e.g., 10.X.X.X or 172.X.X.X). This suggestion minimizes errors in setting up Wallabag by new users who might have MYSQL/MariaDB configured on other private localhost IP ranges or on multiple bind IPs. By using 'localhost' the user doesn't need to know where MYSQL/MariaDB was set up which prevents database connection errors when installing the application because of incorrectly specified server IPs.
