### PR TITLE
Use FQCN to fetch services

### DIFF
--- a/app/config/services.yml
+++ b/app/config/services.yml
@@ -53,6 +53,54 @@ services:
         resource: '../../src/Wallabag/UserBundle/*'
         exclude: '../../src/Wallabag/UserBundle/{Controller,Entity}'
 
+    Doctrine\DBAL\Connection:
+        alias: doctrine.dbal.default_connection
+
+    Doctrine\ORM\EntityManagerInterface:
+        alias: doctrine.orm.entity_manager
+
+    Doctrine\Persistence\ManagerRegistry:
+        alias: doctrine
+
+    Craue\ConfigBundle\Util\Config:
+        alias: craue_config
+
+    JMS\Serializer\SerializerInterface:
+        alias: jms_serializer
+
+    Lexik\Bundle\FormFilterBundle\Filter\FilterBuilderUpdaterInterface:
+        alias: lexik_form_filter.query_builder_updater
+
+    Liip\ThemeBundle\ActiveTheme:
+        alias: liip_theme.active_theme
+
+    Scheb\TwoFactorBundle\Security\TwoFactor\Provider\Google\GoogleAuthenticatorInterface:
+        alias: scheb_two_factor.security.google_authenticator
+
+    Symfony\Component\HttpFoundation\Session\SessionInterface:
+        alias: session
+
+    Symfony\Component\EventDispatcher\EventDispatcherInterface:
+        alias: event_dispatcher
+
+    Symfony\Component\Form\FormFactoryInterface:
+        alias: form.factory
+
+    Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface:
+        alias: security.token_storage
+
+    Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface:
+        alias: security.authorization_checker
+
+    Symfony\Component\Translation\TranslatorInterface:
+        alias: translator
+
+    Symfony\Component\Validator\Validator\ValidatorInterface:
+        alias: validator
+
+    FOS\UserBundle\Model\UserManagerInterface:
+        alias: fos_user.user_manager
+
     Twig_Extensions_Extension_Text:
         class: Twig_Extensions_Extension_Text
 

--- a/src/Wallabag/AnnotationBundle/Controller/WallabagAnnotationController.php
+++ b/src/Wallabag/AnnotationBundle/Controller/WallabagAnnotationController.php
@@ -3,7 +3,9 @@
 namespace Wallabag\AnnotationBundle\Controller;
 
 use FOS\RestBundle\Controller\AbstractFOSRestController;
+use JMS\Serializer\SerializerInterface;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\ParamConverter;
+use Symfony\Component\Form\FormFactoryInterface;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Wallabag\AnnotationBundle\Entity\Annotation;
@@ -29,7 +31,7 @@ class WallabagAnnotationController extends AbstractFOSRestController
         $total = \count($annotationRows);
         $annotations = ['total' => $total, 'rows' => $annotationRows];
 
-        $json = $this->get('jms_serializer')->serialize($annotations, 'json');
+        $json = $this->get(SerializerInterface::class)->serialize($annotations, 'json');
 
         return (new JsonResponse())->setJson($json);
     }
@@ -49,7 +51,7 @@ class WallabagAnnotationController extends AbstractFOSRestController
         $annotation = new Annotation($this->getUser());
         $annotation->setEntry($entry);
 
-        $form = $this->get('form.factory')->createNamed('', NewAnnotationType::class, $annotation, [
+        $form = $this->get(FormFactoryInterface::class)->createNamed('', NewAnnotationType::class, $annotation, [
             'csrf_protection' => false,
             'allow_extra_fields' => true,
         ]);
@@ -59,7 +61,7 @@ class WallabagAnnotationController extends AbstractFOSRestController
             $em->persist($annotation);
             $em->flush();
 
-            $json = $this->get('jms_serializer')->serialize($annotation, 'json');
+            $json = $this->get(SerializerInterface::class)->serialize($annotation, 'json');
 
             return JsonResponse::fromJsonString($json);
         }
@@ -80,7 +82,7 @@ class WallabagAnnotationController extends AbstractFOSRestController
     {
         $data = json_decode($request->getContent(), true);
 
-        $form = $this->get('form.factory')->createNamed('', EditAnnotationType::class, $annotation, [
+        $form = $this->get(FormFactoryInterface::class)->createNamed('', EditAnnotationType::class, $annotation, [
             'csrf_protection' => false,
             'allow_extra_fields' => true,
         ]);
@@ -91,7 +93,7 @@ class WallabagAnnotationController extends AbstractFOSRestController
             $em->persist($annotation);
             $em->flush();
 
-            $json = $this->get('jms_serializer')->serialize($annotation, 'json');
+            $json = $this->get(SerializerInterface::class)->serialize($annotation, 'json');
 
             return JsonResponse::fromJsonString($json);
         }
@@ -114,7 +116,7 @@ class WallabagAnnotationController extends AbstractFOSRestController
         $em->remove($annotation);
         $em->flush();
 
-        $json = $this->get('jms_serializer')->serialize($annotation, 'json');
+        $json = $this->get(SerializerInterface::class)->serialize($annotation, 'json');
 
         return (new JsonResponse())->setJson($json);
     }

--- a/src/Wallabag/ApiBundle/Controller/ConfigRestController.php
+++ b/src/Wallabag/ApiBundle/Controller/ConfigRestController.php
@@ -3,6 +3,7 @@
 namespace Wallabag\ApiBundle\Controller;
 
 use JMS\Serializer\SerializationContext;
+use JMS\Serializer\SerializerInterface;
 use Nelmio\ApiDocBundle\Annotation\ApiDoc;
 use Symfony\Component\HttpFoundation\JsonResponse;
 
@@ -19,7 +20,7 @@ class ConfigRestController extends WallabagRestController
     {
         $this->validateAuthentication();
 
-        $json = $this->get('jms_serializer')->serialize(
+        $json = $this->get(SerializerInterface::class)->serialize(
             $this->getUser()->getConfig(),
             'json',
             SerializationContext::create()->setGroups(['config_api'])

--- a/src/Wallabag/ApiBundle/Controller/DeveloperController.php
+++ b/src/Wallabag/ApiBundle/Controller/DeveloperController.php
@@ -4,7 +4,9 @@ namespace Wallabag\ApiBundle\Controller;
 
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Session\SessionInterface;
 use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Translation\TranslatorInterface;
 use Wallabag\ApiBundle\Entity\Client;
 use Wallabag\ApiBundle\Form\Type\ClientType;
 
@@ -45,9 +47,9 @@ class DeveloperController extends Controller
             $em->persist($client);
             $em->flush();
 
-            $this->get('session')->getFlashBag()->add(
+            $this->get(SessionInterface::class)->getFlashBag()->add(
                 'notice',
-                $this->get('translator')->trans('flashes.developer.notice.client_created', ['%name%' => $client->getName()])
+                $this->get(TranslatorInterface::class)->trans('flashes.developer.notice.client_created', ['%name%' => $client->getName()])
             );
 
             return $this->render('@WallabagCore/themes/common/Developer/client_parameters.html.twig', [
@@ -79,9 +81,9 @@ class DeveloperController extends Controller
         $em->remove($client);
         $em->flush();
 
-        $this->get('session')->getFlashBag()->add(
+        $this->get(SessionInterface::class)->getFlashBag()->add(
             'notice',
-            $this->get('translator')->trans('flashes.developer.notice.client_deleted', ['%name%' => $client->getName()])
+            $this->get(TranslatorInterface::class)->trans('flashes.developer.notice.client_deleted', ['%name%' => $client->getName()])
         );
 
         return $this->redirect($this->generateUrl('developer'));

--- a/src/Wallabag/ApiBundle/Controller/EntryRestController.php
+++ b/src/Wallabag/ApiBundle/Controller/EntryRestController.php
@@ -5,6 +5,7 @@ namespace Wallabag\ApiBundle\Controller;
 use Hateoas\Configuration\Route;
 use Hateoas\Representation\Factory\PagerfantaFactory;
 use Nelmio\ApiDocBundle\Annotation\ApiDoc;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -257,7 +258,7 @@ class EntryRestController extends WallabagRestController
 
             if (false !== $entry) {
                 // entry deleted, dispatch event about it!
-                $this->get('event_dispatcher')->dispatch(EntryDeletedEvent::NAME, new EntryDeletedEvent($entry));
+                $this->get(EventDispatcherInterface::class)->dispatch(EntryDeletedEvent::NAME, new EntryDeletedEvent($entry));
 
                 $em = $this->getDoctrine()->getManager();
                 $em->remove($entry);
@@ -322,7 +323,7 @@ class EntryRestController extends WallabagRestController
             $results[$key]['entry'] = $entry instanceof Entry ? $entry->getId() : false;
 
             // entry saved, dispatch event about it!
-            $this->get('event_dispatcher')->dispatch(EntrySavedEvent::NAME, new EntrySavedEvent($entry));
+            $this->get(EventDispatcherInterface::class)->dispatch(EntrySavedEvent::NAME, new EntrySavedEvent($entry));
         }
 
         return $this->sendResponse($results);
@@ -430,7 +431,7 @@ class EntryRestController extends WallabagRestController
         $em->flush();
 
         // entry saved, dispatch event about it!
-        $this->get('event_dispatcher')->dispatch(EntrySavedEvent::NAME, new EntrySavedEvent($entry));
+        $this->get(EventDispatcherInterface::class)->dispatch(EntrySavedEvent::NAME, new EntrySavedEvent($entry));
 
         return $this->sendResponse($entry);
     }
@@ -547,7 +548,7 @@ class EntryRestController extends WallabagRestController
         $em->flush();
 
         // entry saved, dispatch event about it!
-        $this->get('event_dispatcher')->dispatch(EntrySavedEvent::NAME, new EntrySavedEvent($entry));
+        $this->get(EventDispatcherInterface::class)->dispatch(EntrySavedEvent::NAME, new EntrySavedEvent($entry));
 
         return $this->sendResponse($entry);
     }
@@ -590,7 +591,7 @@ class EntryRestController extends WallabagRestController
         $em->flush();
 
         // entry saved, dispatch event about it!
-        $this->get('event_dispatcher')->dispatch(EntrySavedEvent::NAME, new EntrySavedEvent($entry));
+        $this->get(EventDispatcherInterface::class)->dispatch(EntrySavedEvent::NAME, new EntrySavedEvent($entry));
 
         return $this->sendResponse($entry);
     }
@@ -628,7 +629,7 @@ class EntryRestController extends WallabagRestController
         }
 
         // entry deleted, dispatch event about it!
-        $this->get('event_dispatcher')->dispatch(EntryDeletedEvent::NAME, new EntryDeletedEvent($entry));
+        $this->get(EventDispatcherInterface::class)->dispatch(EntryDeletedEvent::NAME, new EntryDeletedEvent($entry));
 
         $em = $this->getDoctrine()->getManager();
         $em->remove($entry);

--- a/src/Wallabag/ApiBundle/Controller/TagRestController.php
+++ b/src/Wallabag/ApiBundle/Controller/TagRestController.php
@@ -2,6 +2,7 @@
 
 namespace Wallabag\ApiBundle\Controller;
 
+use JMS\Serializer\SerializerInterface;
 use Nelmio\ApiDocBundle\Annotation\ApiDoc;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
@@ -25,7 +26,7 @@ class TagRestController extends WallabagRestController
             ->getRepository(Tag::class)
             ->findAllTags($this->getUser()->getId());
 
-        $json = $this->get('jms_serializer')->serialize($tags, 'json');
+        $json = $this->get(SerializerInterface::class)->serialize($tags, 'json');
 
         return (new JsonResponse())->setJson($json);
     }
@@ -60,7 +61,7 @@ class TagRestController extends WallabagRestController
 
         $this->cleanOrphanTag($tag);
 
-        $json = $this->get('jms_serializer')->serialize($tag, 'json');
+        $json = $this->get(SerializerInterface::class)->serialize($tag, 'json');
 
         return (new JsonResponse())->setJson($json);
     }
@@ -94,7 +95,7 @@ class TagRestController extends WallabagRestController
 
         $this->cleanOrphanTag($tags);
 
-        $json = $this->get('jms_serializer')->serialize($tags, 'json');
+        $json = $this->get(SerializerInterface::class)->serialize($tags, 'json');
 
         return (new JsonResponse())->setJson($json);
     }
@@ -126,7 +127,7 @@ class TagRestController extends WallabagRestController
 
         $this->cleanOrphanTag($tag);
 
-        $json = $this->get('jms_serializer')->serialize($tag, 'json');
+        $json = $this->get(SerializerInterface::class)->serialize($tag, 'json');
 
         return (new JsonResponse())->setJson($json);
     }

--- a/src/Wallabag/ApiBundle/Controller/WallabagRestController.php
+++ b/src/Wallabag/ApiBundle/Controller/WallabagRestController.php
@@ -4,8 +4,11 @@ namespace Wallabag\ApiBundle\Controller;
 
 use FOS\RestBundle\Controller\AbstractFOSRestController;
 use JMS\Serializer\SerializationContext;
+use JMS\Serializer\SerializerInterface;
 use Nelmio\ApiDocBundle\Annotation\ApiDoc;
 use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
+use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
 use Symfony\Component\Security\Core\Exception\AccessDeniedException;
 
 class WallabagRestController extends AbstractFOSRestController
@@ -22,7 +25,7 @@ class WallabagRestController extends AbstractFOSRestController
     public function getVersionAction()
     {
         $version = $this->container->getParameter('wallabag_core.version');
-        $json = $this->get('jms_serializer')->serialize($version, 'json');
+        $json = $this->get(SerializerInterface::class)->serialize($version, 'json');
 
         return (new JsonResponse())->setJson($json);
     }
@@ -42,12 +45,12 @@ class WallabagRestController extends AbstractFOSRestController
             'allowed_registration' => $this->container->getParameter('fosuser_registration'),
         ];
 
-        return (new JsonResponse())->setJson($this->get('jms_serializer')->serialize($info, 'json'));
+        return (new JsonResponse())->setJson($this->get(SerializerInterface::class)->serialize($info, 'json'));
     }
 
     protected function validateAuthentication()
     {
-        if (false === $this->get('security.authorization_checker')->isGranted('IS_AUTHENTICATED_FULLY')) {
+        if (false === $this->get(AuthorizationCheckerInterface::class)->isGranted('IS_AUTHENTICATED_FULLY')) {
             throw new AccessDeniedException();
         }
     }
@@ -60,7 +63,7 @@ class WallabagRestController extends AbstractFOSRestController
      */
     protected function validateUserAccess($requestUserId)
     {
-        $user = $this->get('security.token_storage')->getToken()->getUser();
+        $user = $this->get(TokenStorageInterface::class)->getToken()->getUser();
         if ($requestUserId !== $user->getId()) {
             throw $this->createAccessDeniedException('Access forbidden. Entry user id: ' . $requestUserId . ', logged user id: ' . $user->getId());
         }
@@ -79,7 +82,7 @@ class WallabagRestController extends AbstractFOSRestController
         $context = new SerializationContext();
         $context->setSerializeNull(true);
 
-        $json = $this->get('jms_serializer')->serialize($data, 'json', $context);
+        $json = $this->get(SerializerInterface::class)->serialize($data, 'json', $context);
 
         return (new JsonResponse())->setJson($json);
     }

--- a/src/Wallabag/CoreBundle/Command/CleanDuplicatesCommand.php
+++ b/src/Wallabag/CoreBundle/Command/CleanDuplicatesCommand.php
@@ -2,6 +2,7 @@
 
 namespace Wallabag\CoreBundle\Command;
 
+use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\NoResultException;
 use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
 use Symfony\Component\Console\Input\InputArgument;
@@ -67,7 +68,7 @@ class CleanDuplicatesCommand extends ContainerAwareCommand
 
     private function cleanDuplicates(User $user)
     {
-        $em = $this->getContainer()->get('doctrine.orm.entity_manager');
+        $em = $this->getContainer()->get(EntityManagerInterface::class);
         $repo = $this->getContainer()->get(EntryRepository::class);
 
         $entries = $repo->findAllEntriesIdAndUrlByUserId($user->getId());

--- a/src/Wallabag/CoreBundle/Command/GenerateUrlHashesCommand.php
+++ b/src/Wallabag/CoreBundle/Command/GenerateUrlHashesCommand.php
@@ -2,7 +2,9 @@
 
 namespace Wallabag\CoreBundle\Command;
 
+use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\NoResultException;
+use Doctrine\Persistence\ManagerRegistry;
 use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
@@ -57,7 +59,7 @@ class GenerateUrlHashesCommand extends ContainerAwareCommand
 
     private function generateHashedUrls(User $user)
     {
-        $em = $this->getContainer()->get('doctrine.orm.entity_manager');
+        $em = $this->getContainer()->get(EntityManagerInterface::class);
         $repo = $this->getDoctrine()->getRepository(Entry::class);
 
         $entries = $repo->findByEmptyHashedUrlAndUserId($user->getId());
@@ -92,6 +94,6 @@ class GenerateUrlHashesCommand extends ContainerAwareCommand
 
     private function getDoctrine()
     {
-        return $this->getContainer()->get('doctrine');
+        return $this->getContainer()->get(ManagerRegistry::class);
     }
 }

--- a/src/Wallabag/CoreBundle/Command/InstallCommand.php
+++ b/src/Wallabag/CoreBundle/Command/InstallCommand.php
@@ -2,8 +2,12 @@
 
 namespace Wallabag\CoreBundle\Command;
 
+use Doctrine\DBAL\Connection;
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\Persistence\ManagerRegistry;
 use FOS\UserBundle\Event\UserEvent;
 use FOS\UserBundle\FOSUserEvents;
+use FOS\UserBundle\Model\UserManagerInterface;
 use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
 use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Input\InputInterface;
@@ -12,6 +16,7 @@ use Symfony\Component\Console\Output\BufferedOutput;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Question\Question;
 use Symfony\Component\Console\Style\SymfonyStyle;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Wallabag\CoreBundle\Entity\IgnoreOriginInstanceRule;
 use Wallabag\CoreBundle\Entity\InternalSetting;
 
@@ -72,7 +77,7 @@ class InstallCommand extends ContainerAwareCommand
     {
         $this->io->section('Step 1 of 4: Checking system requirements.');
 
-        $doctrineManager = $this->getContainer()->get('doctrine')->getManager();
+        $doctrineManager = $this->getContainer()->get(ManagerRegistry::class)->getManager();
 
         $rows = [];
 
@@ -95,7 +100,7 @@ class InstallCommand extends ContainerAwareCommand
         $status = '<info>OK!</info>';
         $help = '';
 
-        $conn = $this->getContainer()->get('doctrine')->getManager()->getConnection();
+        $conn = $this->getContainer()->get(ManagerRegistry::class)->getManager()->getConnection();
 
         try {
             $conn->connect();
@@ -244,9 +249,9 @@ class InstallCommand extends ContainerAwareCommand
             return $this;
         }
 
-        $em = $this->getContainer()->get('doctrine.orm.entity_manager');
+        $em = $this->getContainer()->get(EntityManagerInterface::class);
 
-        $userManager = $this->getContainer()->get('fos_user.user_manager');
+        $userManager = $this->getContainer()->get(UserManagerInterface::class);
         $user = $userManager->createUser();
 
         $user->setUsername($this->io->ask('Username', 'wallabag'));
@@ -264,7 +269,7 @@ class InstallCommand extends ContainerAwareCommand
 
         // dispatch a created event so the associated config will be created
         $event = new UserEvent($user);
-        $this->getContainer()->get('event_dispatcher')->dispatch(FOSUserEvents::USER_CREATED, $event);
+        $this->getContainer()->get(EventDispatcherInterface::class)->dispatch(FOSUserEvents::USER_CREATED, $event);
 
         $this->io->text('<info>Administration successfully setup.</info>');
 
@@ -274,7 +279,7 @@ class InstallCommand extends ContainerAwareCommand
     protected function setupConfig()
     {
         $this->io->section('Step 4 of 4: Config setup.');
-        $em = $this->getContainer()->get('doctrine.orm.entity_manager');
+        $em = $this->getContainer()->get(EntityManagerInterface::class);
 
         // cleanup before insert new stuff
         $em->createQuery('DELETE FROM Wallabag\CoreBundle\Entity\InternalSetting')->execute();
@@ -329,7 +334,7 @@ class InstallCommand extends ContainerAwareCommand
 
         // PDO does not always close the connection after Doctrine commands.
         // See https://github.com/symfony/symfony/issues/11750.
-        $this->getContainer()->get('doctrine')->getManager()->getConnection()->close();
+        $this->getContainer()->get(ManagerRegistry::class)->getManager()->getConnection()->close();
 
         if (0 !== $exitCode) {
             $this->getApplication()->setAutoExit(true);
@@ -347,7 +352,7 @@ class InstallCommand extends ContainerAwareCommand
      */
     private function isDatabasePresent()
     {
-        $connection = $this->getContainer()->get('doctrine')->getManager()->getConnection();
+        $connection = $this->getContainer()->get(ManagerRegistry::class)->getManager()->getConnection();
         $databaseName = $connection->getDatabase();
 
         try {
@@ -368,7 +373,7 @@ class InstallCommand extends ContainerAwareCommand
 
         // custom verification for sqlite, since `getListDatabasesSQL` doesn't work for sqlite
         if ('sqlite' === $schemaManager->getDatabasePlatform()->getName()) {
-            $params = $this->getContainer()->get('doctrine.dbal.default_connection')->getParams();
+            $params = $this->getContainer()->get(Connection::class)->getParams();
 
             if (isset($params['path']) && file_exists($params['path'])) {
                 return true;
@@ -394,7 +399,7 @@ class InstallCommand extends ContainerAwareCommand
      */
     private function isSchemaPresent()
     {
-        $schemaManager = $this->getContainer()->get('doctrine')->getManager()->getConnection()->getSchemaManager();
+        $schemaManager = $this->getContainer()->get(ManagerRegistry::class)->getManager()->getConnection()->getSchemaManager();
 
         return \count($schemaManager->listTableNames()) > 0 ? true : false;
     }

--- a/src/Wallabag/CoreBundle/Command/ReloadEntryCommand.php
+++ b/src/Wallabag/CoreBundle/Command/ReloadEntryCommand.php
@@ -3,11 +3,13 @@
 namespace Wallabag\CoreBundle\Command;
 
 use Doctrine\ORM\NoResultException;
+use Doctrine\Persistence\ManagerRegistry;
 use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Wallabag\CoreBundle\Event\EntrySavedEvent;
 use Wallabag\CoreBundle\Helper\ContentProxy;
 use Wallabag\CoreBundle\Repository\EntryRepository;
@@ -67,8 +69,8 @@ class ReloadEntryCommand extends ContainerAwareCommand
         $progressBar = $io->createProgressBar($nbEntries);
 
         $contentProxy = $this->getContainer()->get(ContentProxy::class);
-        $em = $this->getContainer()->get('doctrine')->getManager();
-        $dispatcher = $this->getContainer()->get('event_dispatcher');
+        $em = $this->getContainer()->get(ManagerRegistry::class)->getManager();
+        $dispatcher = $this->getContainer()->get(EventDispatcherInterface::class);
 
         $progressBar->start();
         foreach ($entryIds as $entryId) {

--- a/src/Wallabag/CoreBundle/Command/TagAllCommand.php
+++ b/src/Wallabag/CoreBundle/Command/TagAllCommand.php
@@ -3,6 +3,7 @@
 namespace Wallabag\CoreBundle\Command;
 
 use Doctrine\ORM\NoResultException;
+use Doctrine\Persistence\ManagerRegistry;
 use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
@@ -70,6 +71,6 @@ class TagAllCommand extends ContainerAwareCommand
 
     private function getDoctrine()
     {
-        return $this->getContainer()->get('doctrine');
+        return $this->getContainer()->get(ManagerRegistry::class);
     }
 }

--- a/src/Wallabag/CoreBundle/Controller/ConfigController.php
+++ b/src/Wallabag/CoreBundle/Controller/ConfigController.php
@@ -14,7 +14,7 @@ use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
 use Symfony\Component\Routing\Annotation\Route;
 use Symfony\Component\Validator\Constraints\Locale as LocaleConstraint;
 use Wallabag\AnnotationBundle\Entity\Annotation;
-use Wallabag\CoreBundle\Entity\Config;
+use Wallabag\CoreBundle\Entity\Config as ConfigEntity;
 use Wallabag\CoreBundle\Entity\IgnoreOriginUserRule;
 use Wallabag\CoreBundle\Entity\RuleInterface;
 use Wallabag\CoreBundle\Entity\TaggingRule;
@@ -760,17 +760,17 @@ class ConfigController extends Controller
      * Retrieve config for the current user.
      * If no config were found, create a new one.
      *
-     * @return Config
+     * @return ConfigEntity
      */
     private function getConfig()
     {
         $config = $this->getDoctrine()
-            ->getRepository(Config::class)
+            ->getRepository(ConfigEntity::class)
             ->findOneByUser($this->getUser());
 
         // should NEVER HAPPEN ...
         if (!$config) {
-            $config = new Config($this->getUser());
+            $config = new ConfigEntity($this->getUser());
         }
 
         return $config;

--- a/src/Wallabag/CoreBundle/Controller/ConfigController.php
+++ b/src/Wallabag/CoreBundle/Controller/ConfigController.php
@@ -2,9 +2,14 @@
 
 namespace Wallabag\CoreBundle\Controller;
 
+use Craue\ConfigBundle\Util\Config;
+use Doctrine\Persistence\ManagerRegistry;
+use FOS\UserBundle\Model\UserManagerInterface;
 use JMS\Serializer\SerializationContext;
 use JMS\Serializer\SerializerBuilder;
+use Liip\ThemeBundle\ActiveTheme;
 use PragmaRX\Recovery\Recovery as BackupCodes;
+use Scheb\TwoFactorBundle\Security\TwoFactor\Provider\Google\GoogleAuthenticatorInterface;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\RedirectResponse;
@@ -12,7 +17,9 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
 use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 use Symfony\Component\Validator\Constraints\Locale as LocaleConstraint;
+use Symfony\Component\Validator\Validator\ValidatorInterface;
 use Wallabag\AnnotationBundle\Entity\Annotation;
 use Wallabag\CoreBundle\Entity\Config as ConfigEntity;
 use Wallabag\CoreBundle\Entity\IgnoreOriginUserRule;
@@ -39,7 +46,7 @@ class ConfigController extends Controller
     {
         $em = $this->getDoctrine()->getManager();
         $config = $this->getConfig();
-        $userManager = $this->container->get('fos_user.user_manager');
+        $userManager = $this->container->get(UserManagerInterface::class);
         $user = $this->getUser();
 
         // handle basic config detail (this form is defined as a service)
@@ -63,7 +70,7 @@ class ConfigController extends Controller
             $request->getSession()->set('_locale', $config->getLanguage());
 
             // switch active theme
-            $activeTheme = $this->get('liip_theme.active_theme');
+            $activeTheme = $this->get(ActiveTheme::class);
             $activeTheme->setName($config->getTheme());
 
             $this->addFlash(
@@ -79,7 +86,7 @@ class ConfigController extends Controller
         $pwdForm->handleRequest($request);
 
         if ($pwdForm->isSubmitted() && $pwdForm->isValid()) {
-            if ($this->get('craue_config')->get('demo_mode_enabled') && $this->get('craue_config')->get('demo_mode_username') === $user->getUsername()) {
+            if ($this->get(Config::class)->get('demo_mode_enabled') && $this->get(Config::class)->get('demo_mode_username') === $user->getUsername()) {
                 $message = 'flashes.config.notice.password_not_updated_demo';
             } else {
                 $message = 'flashes.config.notice.password_updated';
@@ -258,7 +265,7 @@ class ConfigController extends Controller
         $user = $this->getUser();
         $user->setEmailTwoFactor(false);
 
-        $this->container->get('fos_user.user_manager')->updateUser($user, true);
+        $this->container->get(UserManagerInterface::class)->updateUser($user, true);
 
         $this->addFlash(
             'notice',
@@ -285,7 +292,7 @@ class ConfigController extends Controller
         $user->setBackupCodes(null);
         $user->setEmailTwoFactor(true);
 
-        $this->container->get('fos_user.user_manager')->updateUser($user, true);
+        $this->container->get(UserManagerInterface::class)->updateUser($user, true);
 
         $this->addFlash(
             'notice',
@@ -311,7 +318,7 @@ class ConfigController extends Controller
         $user->setGoogleAuthenticatorSecret('');
         $user->setBackupCodes(null);
 
-        $this->container->get('fos_user.user_manager')->updateUser($user, true);
+        $this->container->get(UserManagerInterface::class)->updateUser($user, true);
 
         $this->addFlash(
             'notice',
@@ -333,7 +340,7 @@ class ConfigController extends Controller
         }
 
         $user = $this->getUser();
-        $secret = $this->get('scheb_two_factor.security.google_authenticator')->generateSecret();
+        $secret = $this->get(GoogleAuthenticatorInterface::class)->generateSecret();
 
         $user->setGoogleAuthenticatorSecret($secret);
         $user->setEmailTwoFactor(false);
@@ -348,7 +355,7 @@ class ConfigController extends Controller
 
         $user->setBackupCodes($backupCodesHashed);
 
-        $this->container->get('fos_user.user_manager')->updateUser($user, true);
+        $this->container->get(UserManagerInterface::class)->updateUser($user, true);
 
         $this->addFlash(
             'notice',
@@ -357,7 +364,7 @@ class ConfigController extends Controller
 
         return $this->render('@WallabagCore/Config/otp_app.html.twig', [
             'backupCodes' => $backupCodes,
-            'qr_code' => $this->get('scheb_two_factor.security.google_authenticator')->getQRContent($user),
+            'qr_code' => $this->get(GoogleAuthenticatorInterface::class)->getQRContent($user),
             'secret' => $secret,
         ]);
     }
@@ -377,7 +384,7 @@ class ConfigController extends Controller
         $user->setGoogleAuthenticatorSecret(null);
         $user->setBackupCodes(null);
 
-        $this->container->get('fos_user.user_manager')->updateUser($user, true);
+        $this->container->get(UserManagerInterface::class)->updateUser($user, true);
 
         return $this->redirect($this->generateUrl('config') . '#set3');
     }
@@ -389,7 +396,7 @@ class ConfigController extends Controller
      */
     public function otpAppCheckAction(Request $request)
     {
-        $isValid = $this->get('scheb_two_factor.security.google_authenticator')->checkCode(
+        $isValid = $this->get(GoogleAuthenticatorInterface::class)->checkCode(
             $this->getUser(),
             $request->get('_auth_code')
         );
@@ -558,7 +565,7 @@ class ConfigController extends Controller
             case 'entries':
                 // SQLite doesn't care about cascading remove, so we need to manually remove associated stuff
                 // otherwise they won't be removed ...
-                if ($this->get('doctrine')->getConnection()->getDatabasePlatform() instanceof \Doctrine\DBAL\Platforms\SqlitePlatform) {
+                if ($this->get(ManagerRegistry::class)->getConnection()->getDatabasePlatform() instanceof \Doctrine\DBAL\Platforms\SqlitePlatform) {
                     $this->getDoctrine()->getRepository(Annotation::class)->removeAllByUserId($this->getUser()->getId());
                 }
 
@@ -568,7 +575,7 @@ class ConfigController extends Controller
                 $this->get(EntryRepository::class)->removeAllByUserId($this->getUser()->getId());
                 break;
             case 'archived':
-                if ($this->get('doctrine')->getConnection()->getDatabasePlatform() instanceof \Doctrine\DBAL\Platforms\SqlitePlatform) {
+                if ($this->get(ManagerRegistry::class)->getConnection()->getDatabasePlatform() instanceof \Doctrine\DBAL\Platforms\SqlitePlatform) {
                     $this->removeAnnotationsForArchivedByUserId($this->getUser()->getId());
                 }
 
@@ -608,10 +615,10 @@ class ConfigController extends Controller
         $user = $this->getUser();
 
         // logout current user
-        $this->get('security.token_storage')->setToken(null);
+        $this->get(TokenStorageInterface::class)->setToken(null);
         $request->getSession()->invalidate();
 
-        $em = $this->get('fos_user.user_manager');
+        $em = $this->get(UserManagerInterface::class);
         $em->deleteUser($user);
 
         return $this->redirect($this->generateUrl('fos_user_security_login'));
@@ -647,7 +654,7 @@ class ConfigController extends Controller
      */
     public function setLocaleAction(Request $request, $language = null)
     {
-        $errors = $this->get('validator')->validate($language, (new LocaleConstraint()));
+        $errors = $this->get(ValidatorInterface::class)->validate($language, (new LocaleConstraint()));
 
         if (0 === \count($errors)) {
             $request->getSession()->set('_locale', $language);

--- a/src/Wallabag/CoreBundle/Controller/IgnoreOriginInstanceRuleController.php
+++ b/src/Wallabag/CoreBundle/Controller/IgnoreOriginInstanceRuleController.php
@@ -4,7 +4,9 @@ namespace Wallabag\CoreBundle\Controller;
 
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Session\SessionInterface;
 use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Translation\TranslatorInterface;
 use Wallabag\CoreBundle\Entity\IgnoreOriginInstanceRule;
 use Wallabag\CoreBundle\Repository\IgnoreOriginInstanceRuleRepository;
 
@@ -48,9 +50,9 @@ class IgnoreOriginInstanceRuleController extends Controller
             $em->persist($ignoreOriginInstanceRule);
             $em->flush();
 
-            $this->get('session')->getFlashBag()->add(
+            $this->get(SessionInterface::class)->getFlashBag()->add(
                 'notice',
-                $this->get('translator')->trans('flashes.ignore_origin_instance_rule.notice.added')
+                $this->get(TranslatorInterface::class)->trans('flashes.ignore_origin_instance_rule.notice.added')
             );
 
             return $this->redirectToRoute('ignore_origin_instance_rules_index');
@@ -80,9 +82,9 @@ class IgnoreOriginInstanceRuleController extends Controller
             $em->persist($ignoreOriginInstanceRule);
             $em->flush();
 
-            $this->get('session')->getFlashBag()->add(
+            $this->get(SessionInterface::class)->getFlashBag()->add(
                 'notice',
-                $this->get('translator')->trans('flashes.ignore_origin_instance_rule.notice.updated')
+                $this->get(TranslatorInterface::class)->trans('flashes.ignore_origin_instance_rule.notice.updated')
             );
 
             return $this->redirectToRoute('ignore_origin_instance_rules_index');
@@ -108,9 +110,9 @@ class IgnoreOriginInstanceRuleController extends Controller
         $form->handleRequest($request);
 
         if ($form->isSubmitted() && $form->isValid()) {
-            $this->get('session')->getFlashBag()->add(
+            $this->get(SessionInterface::class)->getFlashBag()->add(
                 'notice',
-                $this->get('translator')->trans('flashes.ignore_origin_instance_rule.notice.deleted')
+                $this->get(TranslatorInterface::class)->trans('flashes.ignore_origin_instance_rule.notice.deleted')
             );
 
             $em = $this->getDoctrine()->getManager();

--- a/src/Wallabag/CoreBundle/Controller/SiteCredentialController.php
+++ b/src/Wallabag/CoreBundle/Controller/SiteCredentialController.php
@@ -2,9 +2,12 @@
 
 namespace Wallabag\CoreBundle\Controller;
 
+use Craue\ConfigBundle\Util\Config;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Session\SessionInterface;
 use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Translation\TranslatorInterface;
 use Wallabag\CoreBundle\Entity\SiteCredential;
 use Wallabag\CoreBundle\Helper\CryptoProxy;
 use Wallabag\CoreBundle\Repository\SiteCredentialRepository;
@@ -57,9 +60,9 @@ class SiteCredentialController extends Controller
             $em->persist($credential);
             $em->flush();
 
-            $this->get('session')->getFlashBag()->add(
+            $this->get(SessionInterface::class)->getFlashBag()->add(
                 'notice',
-                $this->get('translator')->trans('flashes.site_credential.notice.added', ['%host%' => $credential->getHost()])
+                $this->get(TranslatorInterface::class)->trans('flashes.site_credential.notice.added', ['%host%' => $credential->getHost()])
             );
 
             return $this->redirectToRoute('site_credentials_index');
@@ -96,9 +99,9 @@ class SiteCredentialController extends Controller
             $em->persist($siteCredential);
             $em->flush();
 
-            $this->get('session')->getFlashBag()->add(
+            $this->get(SessionInterface::class)->getFlashBag()->add(
                 'notice',
-                $this->get('translator')->trans('flashes.site_credential.notice.updated', ['%host%' => $siteCredential->getHost()])
+                $this->get(TranslatorInterface::class)->trans('flashes.site_credential.notice.updated', ['%host%' => $siteCredential->getHost()])
             );
 
             return $this->redirectToRoute('site_credentials_index');
@@ -128,9 +131,9 @@ class SiteCredentialController extends Controller
         $form->handleRequest($request);
 
         if ($form->isSubmitted() && $form->isValid()) {
-            $this->get('session')->getFlashBag()->add(
+            $this->get(SessionInterface::class)->getFlashBag()->add(
                 'notice',
-                $this->get('translator')->trans('flashes.site_credential.notice.deleted', ['%host%' => $siteCredential->getHost()])
+                $this->get(TranslatorInterface::class)->trans('flashes.site_credential.notice.deleted', ['%host%' => $siteCredential->getHost()])
             );
 
             $em = $this->getDoctrine()->getManager();
@@ -146,7 +149,7 @@ class SiteCredentialController extends Controller
      */
     private function isSiteCredentialsEnabled()
     {
-        if (!$this->get('craue_config')->get('restricted_access')) {
+        if (!$this->get(Config::class)->get('restricted_access')) {
             throw $this->createNotFoundException('Feature "restricted_access" is disabled, controllers too.');
         }
     }

--- a/src/Wallabag/CoreBundle/Controller/TagController.php
+++ b/src/Wallabag/CoreBundle/Controller/TagController.php
@@ -8,6 +8,7 @@ use Pagerfanta\Exception\OutOfRangeCurrentPageException;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\ParamConverter;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Session\SessionInterface;
 use Symfony\Component\Routing\Annotation\Route;
 use Wallabag\CoreBundle\Entity\Entry;
 use Wallabag\CoreBundle\Entity\Tag;
@@ -41,7 +42,7 @@ class TagController extends Controller
             $em->persist($entry);
             $em->flush();
 
-            $this->get('session')->getFlashBag()->add(
+            $this->get(SessionInterface::class)->getFlashBag()->add(
                 'notice',
                 'flashes.tag.notice.tag_added'
             );
@@ -188,7 +189,7 @@ class TagController extends Controller
 
             $this->getDoctrine()->getManager()->flush();
 
-            $this->get('session')->getFlashBag()->add(
+            $this->get(SessionInterface::class)->getFlashBag()->add(
                 'notice',
                 'flashes.tag.notice.tag_renamed'
             );

--- a/src/Wallabag/ImportBundle/Command/ImportCommand.php
+++ b/src/Wallabag/ImportBundle/Command/ImportCommand.php
@@ -2,12 +2,14 @@
 
 namespace Wallabag\ImportBundle\Command;
 
+use Doctrine\Persistence\ManagerRegistry;
 use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
 use Symfony\Component\Config\Definition\Exception\Exception;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
 use Wallabag\ImportBundle\Import\ChromeImport;
 use Wallabag\ImportBundle\Import\DeliciousImport;
@@ -43,7 +45,7 @@ class ImportCommand extends ContainerAwareCommand
             throw new Exception(sprintf('File "%s" not found', $input->getArgument('filepath')));
         }
 
-        $em = $this->getContainer()->get('doctrine')->getManager();
+        $em = $this->getContainer()->get(ManagerRegistry::class)->getManager();
         // Turning off doctrine default logs queries for saving memory
         $em->getConnection()->getConfiguration()->setSQLLogger(null);
 
@@ -64,8 +66,8 @@ class ImportCommand extends ContainerAwareCommand
             'main',
             $entityUser->getRoles());
 
-        $this->getContainer()->get('security.token_storage')->setToken($token);
-        $user = $this->getContainer()->get('security.token_storage')->getToken()->getUser();
+        $this->getContainer()->get(TokenStorageInterface::class)->setToken($token);
+        $user = $this->getContainer()->get(TokenStorageInterface::class)->getToken()->getUser();
 
         switch ($input->getOption('importer')) {
             case 'v2':

--- a/src/Wallabag/ImportBundle/Controller/BrowserController.php
+++ b/src/Wallabag/ImportBundle/Controller/BrowserController.php
@@ -5,7 +5,9 @@ namespace Wallabag\ImportBundle\Controller;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpFoundation\Session\SessionInterface;
 use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Translation\TranslatorInterface;
 use Wallabag\ImportBundle\Form\Type\UploadImportType;
 
 abstract class BrowserController extends Controller
@@ -38,13 +40,13 @@ abstract class BrowserController extends Controller
 
                 if (true === $res) {
                     $summary = $wallabag->getSummary();
-                    $message = $this->get('translator')->trans('flashes.import.notice.summary', [
+                    $message = $this->get(TranslatorInterface::class)->trans('flashes.import.notice.summary', [
                         '%imported%' => $summary['imported'],
                         '%skipped%' => $summary['skipped'],
                     ]);
 
                     if (0 < $summary['queued']) {
-                        $message = $this->get('translator')->trans('flashes.import.notice.summary_with_queue', [
+                        $message = $this->get(TranslatorInterface::class)->trans('flashes.import.notice.summary_with_queue', [
                             '%queued%' => $summary['queued'],
                         ]);
                     }
@@ -52,14 +54,14 @@ abstract class BrowserController extends Controller
                     unlink($this->getParameter('wallabag_import.resource_dir') . '/' . $name);
                 }
 
-                $this->get('session')->getFlashBag()->add(
+                $this->get(SessionInterface::class)->getFlashBag()->add(
                     'notice',
                     $message
                 );
 
                 return $this->redirect($this->generateUrl('homepage'));
             }
-            $this->get('session')->getFlashBag()->add(
+            $this->get(SessionInterface::class)->getFlashBag()->add(
                     'notice',
                     'flashes.import.notice.failed_on_file'
                 );

--- a/src/Wallabag/ImportBundle/Controller/ChromeController.php
+++ b/src/Wallabag/ImportBundle/Controller/ChromeController.php
@@ -2,6 +2,7 @@
 
 namespace Wallabag\ImportBundle\Controller;
 
+use Craue\ConfigBundle\Util\Config;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Routing\Annotation\Route;
 use Wallabag\ImportBundle\Import\ChromeImport;
@@ -23,9 +24,9 @@ class ChromeController extends BrowserController
     {
         $service = $this->get(ChromeImport::class);
 
-        if ($this->get('craue_config')->get('import_with_rabbitmq')) {
+        if ($this->get(Config::class)->get('import_with_rabbitmq')) {
             $service->setProducer($this->get('old_sound_rabbit_mq.import_chrome_producer'));
-        } elseif ($this->get('craue_config')->get('import_with_redis')) {
+        } elseif ($this->get(Config::class)->get('import_with_redis')) {
             $service->setProducer($this->get('wallabag_import.producer.redis.chrome'));
         }
 

--- a/src/Wallabag/ImportBundle/Controller/DeliciousController.php
+++ b/src/Wallabag/ImportBundle/Controller/DeliciousController.php
@@ -2,9 +2,12 @@
 
 namespace Wallabag\ImportBundle\Controller;
 
+use Craue\ConfigBundle\Util\Config;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Session\SessionInterface;
 use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Translation\TranslatorInterface;
 use Wallabag\ImportBundle\Form\Type\UploadImportType;
 use Wallabag\ImportBundle\Import\DeliciousImport;
 
@@ -21,9 +24,9 @@ class DeliciousController extends Controller
         $delicious = $this->get(DeliciousImport::class);
         $delicious->setUser($this->getUser());
 
-        if ($this->get('craue_config')->get('import_with_rabbitmq')) {
+        if ($this->get(Config::class)->get('import_with_rabbitmq')) {
             $delicious->setProducer($this->get('old_sound_rabbit_mq.import_delicious_producer'));
-        } elseif ($this->get('craue_config')->get('import_with_redis')) {
+        } elseif ($this->get(Config::class)->get('import_with_redis')) {
             $delicious->setProducer($this->get('wallabag_import.producer.redis.delicious'));
         }
 
@@ -42,13 +45,13 @@ class DeliciousController extends Controller
 
                 if (true === $res) {
                     $summary = $delicious->getSummary();
-                    $message = $this->get('translator')->trans('flashes.import.notice.summary', [
+                    $message = $this->get(TranslatorInterface::class)->trans('flashes.import.notice.summary', [
                         '%imported%' => $summary['imported'],
                         '%skipped%' => $summary['skipped'],
                     ]);
 
                     if (0 < $summary['queued']) {
-                        $message = $this->get('translator')->trans('flashes.import.notice.summary_with_queue', [
+                        $message = $this->get(TranslatorInterface::class)->trans('flashes.import.notice.summary_with_queue', [
                             '%queued%' => $summary['queued'],
                         ]);
                     }
@@ -56,7 +59,7 @@ class DeliciousController extends Controller
                     unlink($this->getParameter('wallabag_import.resource_dir') . '/' . $name);
                 }
 
-                $this->get('session')->getFlashBag()->add(
+                $this->get(SessionInterface::class)->getFlashBag()->add(
                     'notice',
                     $message
                 );
@@ -64,7 +67,7 @@ class DeliciousController extends Controller
                 return $this->redirect($this->generateUrl('homepage'));
             }
 
-            $this->get('session')->getFlashBag()->add(
+            $this->get(SessionInterface::class)->getFlashBag()->add(
                 'notice',
                 'flashes.import.notice.failed_on_file'
             );

--- a/src/Wallabag/ImportBundle/Controller/ElcuratorController.php
+++ b/src/Wallabag/ImportBundle/Controller/ElcuratorController.php
@@ -2,6 +2,7 @@
 
 namespace Wallabag\ImportBundle\Controller;
 
+use Craue\ConfigBundle\Util\Config;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Routing\Annotation\Route;
 use Wallabag\ImportBundle\Import\ElcuratorImport;
@@ -23,9 +24,9 @@ class ElcuratorController extends WallabagController
     {
         $service = $this->get(ElcuratorImport::class);
 
-        if ($this->get('craue_config')->get('import_with_rabbitmq')) {
+        if ($this->get(Config::class)->get('import_with_rabbitmq')) {
             $service->setProducer($this->get('old_sound_rabbit_mq.import_elcurator_producer'));
-        } elseif ($this->get('craue_config')->get('import_with_redis')) {
+        } elseif ($this->get(Config::class)->get('import_with_redis')) {
             $service->setProducer($this->get('wallabag_import.producer.redis.elcurator'));
         }
 

--- a/src/Wallabag/ImportBundle/Controller/FirefoxController.php
+++ b/src/Wallabag/ImportBundle/Controller/FirefoxController.php
@@ -2,6 +2,7 @@
 
 namespace Wallabag\ImportBundle\Controller;
 
+use Craue\ConfigBundle\Util\Config;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Routing\Annotation\Route;
 use Wallabag\ImportBundle\Import\FirefoxImport;
@@ -23,9 +24,9 @@ class FirefoxController extends BrowserController
     {
         $service = $this->get(FirefoxImport::class);
 
-        if ($this->get('craue_config')->get('import_with_rabbitmq')) {
+        if ($this->get(Config::class)->get('import_with_rabbitmq')) {
             $service->setProducer($this->get('old_sound_rabbit_mq.import_firefox_producer'));
-        } elseif ($this->get('craue_config')->get('import_with_redis')) {
+        } elseif ($this->get(Config::class)->get('import_with_redis')) {
             $service->setProducer($this->get('wallabag_import.producer.redis.firefox'));
         }
 

--- a/src/Wallabag/ImportBundle/Controller/ImportController.php
+++ b/src/Wallabag/ImportBundle/Controller/ImportController.php
@@ -2,9 +2,11 @@
 
 namespace Wallabag\ImportBundle\Controller;
 
+use Craue\ConfigBundle\Util\Config;
 use Predis\Client;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
 use Wallabag\ImportBundle\Import\ImportChain;
 
 class ImportController extends Controller
@@ -30,11 +32,11 @@ class ImportController extends Controller
         $redisNotInstalled = false;
         $rabbitNotInstalled = false;
 
-        if (!$this->get('security.authorization_checker')->isGranted('ROLE_SUPER_ADMIN')) {
+        if (!$this->get(AuthorizationCheckerInterface::class)->isGranted('ROLE_SUPER_ADMIN')) {
             return $this->render('@WallabagImport/Import/check_queue.html.twig');
         }
 
-        if ($this->get('craue_config')->get('import_with_rabbitmq')) {
+        if ($this->get(Config::class)->get('import_with_rabbitmq')) {
             // in case rabbit is activated but not installed
             try {
                 $nbRabbitMessages = $this->getTotalMessageInRabbitQueue('pocket')
@@ -51,7 +53,7 @@ class ImportController extends Controller
             } catch (\Exception $e) {
                 $rabbitNotInstalled = true;
             }
-        } elseif ($this->get('craue_config')->get('import_with_redis')) {
+        } elseif ($this->get(Config::class)->get('import_with_redis')) {
             $redis = $this->get(Client::class);
 
             try {

--- a/src/Wallabag/ImportBundle/Controller/InstapaperController.php
+++ b/src/Wallabag/ImportBundle/Controller/InstapaperController.php
@@ -2,9 +2,12 @@
 
 namespace Wallabag\ImportBundle\Controller;
 
+use Craue\ConfigBundle\Util\Config;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Session\SessionInterface;
 use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Translation\TranslatorInterface;
 use Wallabag\ImportBundle\Form\Type\UploadImportType;
 use Wallabag\ImportBundle\Import\InstapaperImport;
 
@@ -21,9 +24,9 @@ class InstapaperController extends Controller
         $instapaper = $this->get(InstapaperImport::class);
         $instapaper->setUser($this->getUser());
 
-        if ($this->get('craue_config')->get('import_with_rabbitmq')) {
+        if ($this->get(Config::class)->get('import_with_rabbitmq')) {
             $instapaper->setProducer($this->get('old_sound_rabbit_mq.import_instapaper_producer'));
-        } elseif ($this->get('craue_config')->get('import_with_redis')) {
+        } elseif ($this->get(Config::class)->get('import_with_redis')) {
             $instapaper->setProducer($this->get('wallabag_import.producer.redis.instapaper'));
         }
 
@@ -42,13 +45,13 @@ class InstapaperController extends Controller
 
                 if (true === $res) {
                     $summary = $instapaper->getSummary();
-                    $message = $this->get('translator')->trans('flashes.import.notice.summary', [
+                    $message = $this->get(TranslatorInterface::class)->trans('flashes.import.notice.summary', [
                         '%imported%' => $summary['imported'],
                         '%skipped%' => $summary['skipped'],
                     ]);
 
                     if (0 < $summary['queued']) {
-                        $message = $this->get('translator')->trans('flashes.import.notice.summary_with_queue', [
+                        $message = $this->get(TranslatorInterface::class)->trans('flashes.import.notice.summary_with_queue', [
                             '%queued%' => $summary['queued'],
                         ]);
                     }
@@ -56,7 +59,7 @@ class InstapaperController extends Controller
                     unlink($this->getParameter('wallabag_import.resource_dir') . '/' . $name);
                 }
 
-                $this->get('session')->getFlashBag()->add(
+                $this->get(SessionInterface::class)->getFlashBag()->add(
                     'notice',
                     $message
                 );
@@ -64,7 +67,7 @@ class InstapaperController extends Controller
                 return $this->redirect($this->generateUrl('homepage'));
             }
 
-            $this->get('session')->getFlashBag()->add(
+            $this->get(SessionInterface::class)->getFlashBag()->add(
                 'notice',
                 'flashes.import.notice.failed_on_file'
             );

--- a/src/Wallabag/ImportBundle/Controller/PinboardController.php
+++ b/src/Wallabag/ImportBundle/Controller/PinboardController.php
@@ -2,9 +2,12 @@
 
 namespace Wallabag\ImportBundle\Controller;
 
+use Craue\ConfigBundle\Util\Config;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Session\SessionInterface;
 use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Translation\TranslatorInterface;
 use Wallabag\ImportBundle\Form\Type\UploadImportType;
 use Wallabag\ImportBundle\Import\PinboardImport;
 
@@ -21,9 +24,9 @@ class PinboardController extends Controller
         $pinboard = $this->get(PinboardImport::class);
         $pinboard->setUser($this->getUser());
 
-        if ($this->get('craue_config')->get('import_with_rabbitmq')) {
+        if ($this->get(Config::class)->get('import_with_rabbitmq')) {
             $pinboard->setProducer($this->get('old_sound_rabbit_mq.import_pinboard_producer'));
-        } elseif ($this->get('craue_config')->get('import_with_redis')) {
+        } elseif ($this->get(Config::class)->get('import_with_redis')) {
             $pinboard->setProducer($this->get('wallabag_import.producer.redis.pinboard'));
         }
 
@@ -42,13 +45,13 @@ class PinboardController extends Controller
 
                 if (true === $res) {
                     $summary = $pinboard->getSummary();
-                    $message = $this->get('translator')->trans('flashes.import.notice.summary', [
+                    $message = $this->get(TranslatorInterface::class)->trans('flashes.import.notice.summary', [
                         '%imported%' => $summary['imported'],
                         '%skipped%' => $summary['skipped'],
                     ]);
 
                     if (0 < $summary['queued']) {
-                        $message = $this->get('translator')->trans('flashes.import.notice.summary_with_queue', [
+                        $message = $this->get(TranslatorInterface::class)->trans('flashes.import.notice.summary_with_queue', [
                             '%queued%' => $summary['queued'],
                         ]);
                     }
@@ -56,7 +59,7 @@ class PinboardController extends Controller
                     unlink($this->getParameter('wallabag_import.resource_dir') . '/' . $name);
                 }
 
-                $this->get('session')->getFlashBag()->add(
+                $this->get(SessionInterface::class)->getFlashBag()->add(
                     'notice',
                     $message
                 );
@@ -64,7 +67,7 @@ class PinboardController extends Controller
                 return $this->redirect($this->generateUrl('homepage'));
             }
 
-            $this->get('session')->getFlashBag()->add(
+            $this->get(SessionInterface::class)->getFlashBag()->add(
                 'notice',
                 'flashes.import.notice.failed_on_file'
             );

--- a/src/Wallabag/ImportBundle/Controller/PocketController.php
+++ b/src/Wallabag/ImportBundle/Controller/PocketController.php
@@ -2,11 +2,14 @@
 
 namespace Wallabag\ImportBundle\Controller;
 
+use Craue\ConfigBundle\Util\Config;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Session\SessionInterface;
 use Symfony\Component\Routing\Annotation\Route;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+use Symfony\Component\Translation\TranslatorInterface;
 use Wallabag\ImportBundle\Import\PocketImport;
 
 class PocketController extends Controller
@@ -40,7 +43,7 @@ class PocketController extends Controller
             ->getRequestToken($this->generateUrl('import', [], UrlGeneratorInterface::ABSOLUTE_URL));
 
         if (false === $requestToken) {
-            $this->get('session')->getFlashBag()->add(
+            $this->get(SessionInterface::class)->getFlashBag()->add(
                 'notice',
                 'flashes.import.notice.failed'
             );
@@ -50,9 +53,9 @@ class PocketController extends Controller
 
         $form = $request->request->get('form');
 
-        $this->get('session')->set('import.pocket.code', $requestToken);
+        $this->get(SessionInterface::class)->set('import.pocket.code', $requestToken);
         if (null !== $form && \array_key_exists('mark_as_read', $form)) {
-            $this->get('session')->set('mark_as_read', $form['mark_as_read']);
+            $this->get(SessionInterface::class)->set('mark_as_read', $form['mark_as_read']);
         }
 
         return $this->redirect(
@@ -69,12 +72,12 @@ class PocketController extends Controller
         $message = 'flashes.import.notice.failed';
         $pocket = $this->getPocketImportService();
 
-        $markAsRead = $this->get('session')->get('mark_as_read');
-        $this->get('session')->remove('mark_as_read');
+        $markAsRead = $this->get(SessionInterface::class)->get('mark_as_read');
+        $this->get(SessionInterface::class)->remove('mark_as_read');
 
         // something bad happend on pocket side
-        if (false === $pocket->authorize($this->get('session')->get('import.pocket.code'))) {
-            $this->get('session')->getFlashBag()->add(
+        if (false === $pocket->authorize($this->get(SessionInterface::class)->get('import.pocket.code'))) {
+            $this->get(SessionInterface::class)->getFlashBag()->add(
                 'notice',
                 $message
             );
@@ -84,19 +87,19 @@ class PocketController extends Controller
 
         if (true === $pocket->setMarkAsRead($markAsRead)->import()) {
             $summary = $pocket->getSummary();
-            $message = $this->get('translator')->trans('flashes.import.notice.summary', [
+            $message = $this->get(TranslatorInterface::class)->trans('flashes.import.notice.summary', [
                 '%imported%' => null !== $summary && \array_key_exists('imported', $summary) ? $summary['imported'] : 0,
                 '%skipped%' => null !== $summary && \array_key_exists('skipped', $summary) ? $summary['skipped'] : 0,
             ]);
 
             if (null !== $summary && \array_key_exists('queued', $summary) && 0 < $summary['queued']) {
-                $message = $this->get('translator')->trans('flashes.import.notice.summary_with_queue', [
+                $message = $this->get(TranslatorInterface::class)->trans('flashes.import.notice.summary_with_queue', [
                     '%queued%' => $summary['queued'],
                 ]);
             }
         }
 
-        $this->get('session')->getFlashBag()->add(
+        $this->get(SessionInterface::class)->getFlashBag()->add(
             'notice',
             $message
         );
@@ -114,9 +117,9 @@ class PocketController extends Controller
         $pocket = $this->get(PocketImport::class);
         $pocket->setUser($this->getUser());
 
-        if ($this->get('craue_config')->get('import_with_rabbitmq')) {
+        if ($this->get(Config::class)->get('import_with_rabbitmq')) {
             $pocket->setProducer($this->get('old_sound_rabbit_mq.import_pocket_producer'));
-        } elseif ($this->get('craue_config')->get('import_with_redis')) {
+        } elseif ($this->get(Config::class)->get('import_with_redis')) {
             $pocket->setProducer($this->get('wallabag_import.producer.redis.pocket'));
         }
 

--- a/src/Wallabag/ImportBundle/Controller/ReadabilityController.php
+++ b/src/Wallabag/ImportBundle/Controller/ReadabilityController.php
@@ -2,9 +2,12 @@
 
 namespace Wallabag\ImportBundle\Controller;
 
+use Craue\ConfigBundle\Util\Config;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Session\SessionInterface;
 use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Translation\TranslatorInterface;
 use Wallabag\ImportBundle\Form\Type\UploadImportType;
 use Wallabag\ImportBundle\Import\ReadabilityImport;
 
@@ -21,9 +24,9 @@ class ReadabilityController extends Controller
         $readability = $this->get(ReadabilityImport::class);
         $readability->setUser($this->getUser());
 
-        if ($this->get('craue_config')->get('import_with_rabbitmq')) {
+        if ($this->get(Config::class)->get('import_with_rabbitmq')) {
             $readability->setProducer($this->get('old_sound_rabbit_mq.import_readability_producer'));
-        } elseif ($this->get('craue_config')->get('import_with_redis')) {
+        } elseif ($this->get(Config::class)->get('import_with_redis')) {
             $readability->setProducer($this->get('wallabag_import.producer.redis.readability'));
         }
 
@@ -42,13 +45,13 @@ class ReadabilityController extends Controller
 
                 if (true === $res) {
                     $summary = $readability->getSummary();
-                    $message = $this->get('translator')->trans('flashes.import.notice.summary', [
+                    $message = $this->get(TranslatorInterface::class)->trans('flashes.import.notice.summary', [
                         '%imported%' => $summary['imported'],
                         '%skipped%' => $summary['skipped'],
                     ]);
 
                     if (0 < $summary['queued']) {
-                        $message = $this->get('translator')->trans('flashes.import.notice.summary_with_queue', [
+                        $message = $this->get(TranslatorInterface::class)->trans('flashes.import.notice.summary_with_queue', [
                             '%queued%' => $summary['queued'],
                         ]);
                     }
@@ -56,7 +59,7 @@ class ReadabilityController extends Controller
                     unlink($this->getParameter('wallabag_import.resource_dir') . '/' . $name);
                 }
 
-                $this->get('session')->getFlashBag()->add(
+                $this->get(SessionInterface::class)->getFlashBag()->add(
                     'notice',
                     $message
                 );
@@ -64,7 +67,7 @@ class ReadabilityController extends Controller
                 return $this->redirect($this->generateUrl('homepage'));
             }
 
-            $this->get('session')->getFlashBag()->add(
+            $this->get(SessionInterface::class)->getFlashBag()->add(
                 'notice',
                 'flashes.import.notice.failed_on_file'
             );

--- a/src/Wallabag/ImportBundle/Controller/WallabagController.php
+++ b/src/Wallabag/ImportBundle/Controller/WallabagController.php
@@ -6,6 +6,8 @@ use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpFoundation\Session\SessionInterface;
+use Symfony\Component\Translation\TranslatorInterface;
 use Wallabag\ImportBundle\Form\Type\UploadImportType;
 
 /**
@@ -41,13 +43,13 @@ abstract class WallabagController extends Controller
 
                 if (true === $res) {
                     $summary = $wallabag->getSummary();
-                    $message = $this->get('translator')->trans('flashes.import.notice.summary', [
+                    $message = $this->get(TranslatorInterface::class)->trans('flashes.import.notice.summary', [
                         '%imported%' => $summary['imported'],
                         '%skipped%' => $summary['skipped'],
                     ]);
 
                     if (0 < $summary['queued']) {
-                        $message = $this->get('translator')->trans('flashes.import.notice.summary_with_queue', [
+                        $message = $this->get(TranslatorInterface::class)->trans('flashes.import.notice.summary_with_queue', [
                             '%queued%' => $summary['queued'],
                         ]);
                     }
@@ -55,7 +57,7 @@ abstract class WallabagController extends Controller
                     unlink($this->getParameter('wallabag_import.resource_dir') . '/' . $name);
                 }
 
-                $this->get('session')->getFlashBag()->add(
+                $this->get(SessionInterface::class)->getFlashBag()->add(
                     'notice',
                     $message
                 );
@@ -63,7 +65,7 @@ abstract class WallabagController extends Controller
                 return $this->redirect($this->generateUrl('homepage'));
             }
 
-            $this->get('session')->getFlashBag()->add(
+            $this->get(SessionInterface::class)->getFlashBag()->add(
                 'notice',
                 'flashes.import.notice.failed_on_file'
             );

--- a/src/Wallabag/ImportBundle/Controller/WallabagV1Controller.php
+++ b/src/Wallabag/ImportBundle/Controller/WallabagV1Controller.php
@@ -2,6 +2,7 @@
 
 namespace Wallabag\ImportBundle\Controller;
 
+use Craue\ConfigBundle\Util\Config;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Routing\Annotation\Route;
 use Wallabag\ImportBundle\Import\WallabagV1Import;
@@ -23,9 +24,9 @@ class WallabagV1Controller extends WallabagController
     {
         $service = $this->get(WallabagV1Import::class);
 
-        if ($this->get('craue_config')->get('import_with_rabbitmq')) {
+        if ($this->get(Config::class)->get('import_with_rabbitmq')) {
             $service->setProducer($this->get('old_sound_rabbit_mq.import_wallabag_v1_producer'));
-        } elseif ($this->get('craue_config')->get('import_with_redis')) {
+        } elseif ($this->get(Config::class)->get('import_with_redis')) {
             $service->setProducer($this->get('wallabag_import.producer.redis.wallabag_v1'));
         }
 

--- a/src/Wallabag/ImportBundle/Controller/WallabagV2Controller.php
+++ b/src/Wallabag/ImportBundle/Controller/WallabagV2Controller.php
@@ -2,6 +2,7 @@
 
 namespace Wallabag\ImportBundle\Controller;
 
+use Craue\ConfigBundle\Util\Config;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Routing\Annotation\Route;
 use Wallabag\ImportBundle\Import\WallabagV2Import;
@@ -23,9 +24,9 @@ class WallabagV2Controller extends WallabagController
     {
         $service = $this->get(WallabagV2Import::class);
 
-        if ($this->get('craue_config')->get('import_with_rabbitmq')) {
+        if ($this->get(Config::class)->get('import_with_rabbitmq')) {
             $service->setProducer($this->get('old_sound_rabbit_mq.import_wallabag_v2_producer'));
-        } elseif ($this->get('craue_config')->get('import_with_redis')) {
+        } elseif ($this->get(Config::class)->get('import_with_redis')) {
             $service->setProducer($this->get('wallabag_import.producer.redis.wallabag_v2'));
         }
 

--- a/tests/Wallabag/AnnotationBundle/Controller/AnnotationControllerTest.php
+++ b/tests/Wallabag/AnnotationBundle/Controller/AnnotationControllerTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Wallabag\AnnotationBundle\Controller;
 
+use Doctrine\ORM\EntityManagerInterface;
 use Tests\Wallabag\AnnotationBundle\WallabagAnnotationTestCase;
 use Wallabag\AnnotationBundle\Entity\Annotation;
 use Wallabag\CoreBundle\Entity\Entry;
@@ -29,7 +30,7 @@ class AnnotationControllerTest extends WallabagAnnotationTestCase
      */
     public function testGetAnnotations($prefixUrl)
     {
-        $em = $this->client->getContainer()->get('doctrine.orm.entity_manager');
+        $em = $this->client->getContainer()->get(EntityManagerInterface::class);
 
         $user = $em
             ->getRepository(User::class)
@@ -70,7 +71,7 @@ class AnnotationControllerTest extends WallabagAnnotationTestCase
      */
     public function testSetAnnotation($prefixUrl)
     {
-        $em = $this->client->getContainer()->get('doctrine.orm.entity_manager');
+        $em = $this->client->getContainer()->get(EntityManagerInterface::class);
 
         if ('annotations' === $prefixUrl) {
             $this->logInAs('admin');
@@ -110,7 +111,7 @@ class AnnotationControllerTest extends WallabagAnnotationTestCase
 
     public function testAllowEmptyQuote()
     {
-        $em = $this->client->getContainer()->get('doctrine.orm.entity_manager');
+        $em = $this->client->getContainer()->get(EntityManagerInterface::class);
 
         /** @var Entry $entry */
         $entry = $em
@@ -139,7 +140,7 @@ class AnnotationControllerTest extends WallabagAnnotationTestCase
 
     public function testAllowOmmittedQuote()
     {
-        $em = $this->client->getContainer()->get('doctrine.orm.entity_manager');
+        $em = $this->client->getContainer()->get(EntityManagerInterface::class);
 
         /** @var Entry $entry */
         $entry = $em
@@ -170,7 +171,7 @@ class AnnotationControllerTest extends WallabagAnnotationTestCase
      */
     public function testSetAnnotationWithQuoteTooLong($prefixUrl)
     {
-        $em = $this->client->getContainer()->get('doctrine.orm.entity_manager');
+        $em = $this->client->getContainer()->get(EntityManagerInterface::class);
 
         if ('annotations' === $prefixUrl) {
             $this->logInAs('admin');
@@ -202,7 +203,7 @@ class AnnotationControllerTest extends WallabagAnnotationTestCase
      */
     public function testEditAnnotation($prefixUrl)
     {
-        $em = $this->client->getContainer()->get('doctrine.orm.entity_manager');
+        $em = $this->client->getContainer()->get(EntityManagerInterface::class);
 
         $user = $em
             ->getRepository(User::class)
@@ -250,7 +251,7 @@ class AnnotationControllerTest extends WallabagAnnotationTestCase
      */
     public function testDeleteAnnotation($prefixUrl)
     {
-        $em = $this->client->getContainer()->get('doctrine.orm.entity_manager');
+        $em = $this->client->getContainer()->get(EntityManagerInterface::class);
 
         $user = $em
             ->getRepository(User::class)

--- a/tests/Wallabag/AnnotationBundle/WallabagAnnotationTestCase.php
+++ b/tests/Wallabag/AnnotationBundle/WallabagAnnotationTestCase.php
@@ -4,6 +4,8 @@ namespace Tests\Wallabag\AnnotationBundle;
 
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 use Symfony\Component\BrowserKit\Cookie;
+use Symfony\Component\HttpFoundation\Session\SessionInterface;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 
 abstract class WallabagAnnotationTestCase extends WebTestCase
 {
@@ -52,10 +54,10 @@ abstract class WallabagAnnotationTestCase extends WebTestCase
         $loginManager->logInUser($firewallName, $this->user);
 
         // save the login token into the session and put it in a cookie
-        $container->get('session')->set('_security_' . $firewallName, serialize($container->get('security.token_storage')->getToken()));
-        $container->get('session')->save();
+        $container->get(SessionInterface::class)->set('_security_' . $firewallName, serialize($container->get(TokenStorageInterface::class)->getToken()));
+        $container->get(SessionInterface::class)->save();
 
-        $session = $container->get('session');
+        $session = $container->get(SessionInterface::class);
         $client->getCookieJar()->set(new Cookie($session->getName(), $session->getId()));
 
         return $client;

--- a/tests/Wallabag/ApiBundle/Controller/DeveloperControllerTest.php
+++ b/tests/Wallabag/ApiBundle/Controller/DeveloperControllerTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Wallabag\ApiBundle\Controller;
 
+use Doctrine\ORM\EntityManagerInterface;
 use Tests\Wallabag\CoreBundle\WallabagCoreTestCase;
 use Wallabag\ApiBundle\Entity\Client;
 
@@ -11,7 +12,7 @@ class DeveloperControllerTest extends WallabagCoreTestCase
     {
         $this->logInAs('admin');
         $client = $this->getClient();
-        $em = $client->getContainer()->get('doctrine.orm.entity_manager');
+        $em = $client->getContainer()->get(EntityManagerInterface::class);
         $nbClients = $em->getRepository(Client::class)->findAll();
 
         $crawler = $client->request('GET', '/developer/client/create');
@@ -74,7 +75,7 @@ class DeveloperControllerTest extends WallabagCoreTestCase
     {
         $this->logInAs('admin');
         $client = $this->getClient();
-        $em = $client->getContainer()->get('doctrine.orm.entity_manager');
+        $em = $client->getContainer()->get(EntityManagerInterface::class);
         $nbClients = $em->getRepository(Client::class)->findAll();
 
         $crawler = $client->request('GET', '/developer');
@@ -95,7 +96,7 @@ class DeveloperControllerTest extends WallabagCoreTestCase
     {
         $client = $this->getClient();
         $adminApiClient = $this->createApiClientForUser('admin');
-        $em = $client->getContainer()->get('doctrine.orm.entity_manager');
+        $em = $client->getContainer()->get(EntityManagerInterface::class);
 
         // Try to remove an admin's client with a wrong user
         $this->logInAs('bob');
@@ -134,7 +135,7 @@ class DeveloperControllerTest extends WallabagCoreTestCase
     private function createApiClientForUser($username, $grantTypes = ['password'])
     {
         $client = $this->getClient();
-        $em = $client->getContainer()->get('doctrine.orm.entity_manager');
+        $em = $client->getContainer()->get(EntityManagerInterface::class);
         $userManager = $client->getContainer()->get('fos_user.user_manager.test');
         $user = $userManager->findUserBy(['username' => $username]);
         $apiClient = new Client($user);

--- a/tests/Wallabag/ApiBundle/Controller/EntryRestControllerTest.php
+++ b/tests/Wallabag/ApiBundle/Controller/EntryRestControllerTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Wallabag\ApiBundle\Controller;
 
+use Doctrine\ORM\EntityManagerInterface;
 use Tests\Wallabag\ApiBundle\WallabagApiTestCase;
 use Wallabag\CoreBundle\Entity\Entry;
 use Wallabag\CoreBundle\Entity\Tag;
@@ -13,7 +14,7 @@ class EntryRestControllerTest extends WallabagApiTestCase
     public function testGetOneEntry()
     {
         $entry = $this->client->getContainer()
-            ->get('doctrine.orm.entity_manager')
+            ->get(EntityManagerInterface::class)
             ->getRepository(Entry::class)
             ->findOneBy(['user' => $this->getUserId(), 'isArchived' => false]);
 
@@ -39,7 +40,7 @@ class EntryRestControllerTest extends WallabagApiTestCase
     public function testGetOneEntryWithOriginUrl()
     {
         $entry = $this->client->getContainer()
-            ->get('doctrine.orm.entity_manager')
+            ->get(EntityManagerInterface::class)
             ->getRepository(Entry::class)
             ->findOneBy(['user' => $this->getUserId(), 'url' => 'http://0.0.0.0/entry2']);
 
@@ -58,7 +59,7 @@ class EntryRestControllerTest extends WallabagApiTestCase
     public function testExportEntry()
     {
         $entry = $this->client->getContainer()
-            ->get('doctrine.orm.entity_manager')
+            ->get(EntityManagerInterface::class)
             ->getRepository(Entry::class)
             ->findOneBy(['user' => $this->getUserId(), 'isArchived' => false]);
 
@@ -106,7 +107,7 @@ class EntryRestControllerTest extends WallabagApiTestCase
     public function testGetOneEntryWrongUser()
     {
         $entry = $this->client->getContainer()
-            ->get('doctrine.orm.entity_manager')
+            ->get(EntityManagerInterface::class)
             ->getRepository(Entry::class)
             ->findOneBy(['user' => $this->getUserId('bob'), 'isArchived' => false]);
 
@@ -204,7 +205,7 @@ class EntryRestControllerTest extends WallabagApiTestCase
     public function testGetEntriesPublicOnly()
     {
         $entry = $this->client->getContainer()
-            ->get('doctrine.orm.entity_manager')
+            ->get(EntityManagerInterface::class)
             ->getRepository(Entry::class)
             ->findOneByUser($this->getUserId());
 
@@ -215,7 +216,7 @@ class EntryRestControllerTest extends WallabagApiTestCase
         // generate at least one public entry
         $entry->generateUid();
 
-        $em = $this->client->getContainer()->get('doctrine.orm.entity_manager');
+        $em = $this->client->getContainer()->get(EntityManagerInterface::class);
         $em->persist($entry);
         $em->flush();
 
@@ -421,7 +422,7 @@ class EntryRestControllerTest extends WallabagApiTestCase
 
     public function testDeleteEntry()
     {
-        $em = $this->client->getContainer()->get('doctrine.orm.entity_manager');
+        $em = $this->client->getContainer()->get(EntityManagerInterface::class);
         $entry = new Entry($em->getReference(User::class, 1));
         $entry->setUrl('http://0.0.0.0/test-delete-entry');
         $entry->setTitle('Test delete entry');
@@ -455,7 +456,7 @@ class EntryRestControllerTest extends WallabagApiTestCase
 
     public function testDeleteEntryExpectId()
     {
-        $em = $this->client->getContainer()->get('doctrine.orm.entity_manager');
+        $em = $this->client->getContainer()->get(EntityManagerInterface::class);
         $entry = new Entry($em->getReference(User::class, 1));
         $entry->setUrl('http://0.0.0.0/test-delete-entry-id');
         $em->persist($entry);
@@ -526,7 +527,7 @@ class EntryRestControllerTest extends WallabagApiTestCase
 
     public function testPostSameEntry()
     {
-        $em = $this->client->getContainer()->get('doctrine.orm.entity_manager');
+        $em = $this->client->getContainer()->get(EntityManagerInterface::class);
         $entry = new Entry($em->getReference(User::class, $this->getUserId()));
         $entry->setUrl('https://www.lemonde.fr/pixels/article/2015/03/28/plongee-dans-l-univers-d-ingress-le-jeu-de-google-aux-frontieres-du-reel_4601155_4408996.html');
         $entry->setArchived(true);
@@ -580,7 +581,7 @@ class EntryRestControllerTest extends WallabagApiTestCase
         } finally {
             // Remove the created entry to avoid side effects on other tests
             if (isset($content['id'])) {
-                $em = $this->client->getContainer()->get('doctrine.orm.entity_manager');
+                $em = $this->client->getContainer()->get(EntityManagerInterface::class);
                 $entry = $em->getReference(Entry::class, $content['id']);
                 $em->remove($entry);
                 $em->flush();
@@ -654,7 +655,7 @@ class EntryRestControllerTest extends WallabagApiTestCase
     public function testPatchEntry()
     {
         $entry = $this->client->getContainer()
-            ->get('doctrine.orm.entity_manager')
+            ->get(EntityManagerInterface::class)
             ->getRepository(Entry::class)
             ->findOneByUser($this->getUserId());
 
@@ -696,7 +697,7 @@ class EntryRestControllerTest extends WallabagApiTestCase
     public function testPatchEntryWithoutQuotes()
     {
         $entry = $this->client->getContainer()
-            ->get('doctrine.orm.entity_manager')
+            ->get(EntityManagerInterface::class)
             ->getRepository(Entry::class)
             ->findOneByUser($this->getUserId());
 
@@ -730,7 +731,7 @@ class EntryRestControllerTest extends WallabagApiTestCase
     public function testPatchEntryWithOriginUrl()
     {
         $entry = $this->client->getContainer()
-            ->get('doctrine.orm.entity_manager')
+            ->get(EntityManagerInterface::class)
             ->getRepository(Entry::class)
             ->findOneByUser($this->getUserId());
 
@@ -761,7 +762,7 @@ class EntryRestControllerTest extends WallabagApiTestCase
     public function testPatchEntryRemoveOriginUrl()
     {
         $entry = $this->client->getContainer()
-        ->get('doctrine.orm.entity_manager')
+        ->get(EntityManagerInterface::class)
         ->getRepository(Entry::class)
         ->findOneByUser($this->getUserId());
 
@@ -793,7 +794,7 @@ class EntryRestControllerTest extends WallabagApiTestCase
     public function testPatchEntryNullOriginUrl()
     {
         $entry = $this->client->getContainer()
-            ->get('doctrine.orm.entity_manager')
+            ->get(EntityManagerInterface::class)
             ->getRepository(Entry::class)
             ->findOneByUser($this->getUserId());
 
@@ -815,7 +816,7 @@ class EntryRestControllerTest extends WallabagApiTestCase
     public function testGetTagsEntry()
     {
         $entry = $this->client->getContainer()
-            ->get('doctrine.orm.entity_manager')
+            ->get(EntityManagerInterface::class)
             ->getRepository(Entry::class)
             ->findOneWithTags($this->user->getId());
 
@@ -838,7 +839,7 @@ class EntryRestControllerTest extends WallabagApiTestCase
     public function testPostTagsOnEntry()
     {
         $entry = $this->client->getContainer()
-            ->get('doctrine.orm.entity_manager')
+            ->get(EntityManagerInterface::class)
             ->getRepository(Entry::class)
             ->findOneByUser($this->getUserId());
 
@@ -860,7 +861,7 @@ class EntryRestControllerTest extends WallabagApiTestCase
         $this->assertCount($nbTags + 3, $content['tags']);
 
         $entryDB = $this->client->getContainer()
-            ->get('doctrine.orm.entity_manager')
+            ->get(EntityManagerInterface::class)
             ->getRepository(Entry::class)
             ->find($entry->getId());
 
@@ -877,7 +878,7 @@ class EntryRestControllerTest extends WallabagApiTestCase
     public function testDeleteOneTagEntry()
     {
         $entry = $this->client->getContainer()
-            ->get('doctrine.orm.entity_manager')
+            ->get(EntityManagerInterface::class)
             ->getRepository(Entry::class)
             ->findOneWithTags($this->user->getId());
         $entry = $entry[0];
@@ -903,7 +904,7 @@ class EntryRestControllerTest extends WallabagApiTestCase
     public function testSaveIsArchivedAfterPost()
     {
         $entry = $this->client->getContainer()
-            ->get('doctrine.orm.entity_manager')
+            ->get(EntityManagerInterface::class)
             ->getRepository(Entry::class)
             ->findOneBy(['user' => $this->getUserId(), 'isArchived' => true]);
 
@@ -925,7 +926,7 @@ class EntryRestControllerTest extends WallabagApiTestCase
     public function testSaveIsStarredAfterPost()
     {
         $entry = $this->client->getContainer()
-            ->get('doctrine.orm.entity_manager')
+            ->get(EntityManagerInterface::class)
             ->getRepository(Entry::class)
             ->findOneBy(['user' => $this->getUserId(), 'isStarred' => true]);
 
@@ -947,7 +948,7 @@ class EntryRestControllerTest extends WallabagApiTestCase
     public function testSaveIsArchivedAfterPatch()
     {
         $entry = $this->client->getContainer()
-            ->get('doctrine.orm.entity_manager')
+            ->get(EntityManagerInterface::class)
             ->getRepository(Entry::class)
             ->findOneBy(['user' => $this->getUserId(), 'isArchived' => true]);
 
@@ -973,7 +974,7 @@ class EntryRestControllerTest extends WallabagApiTestCase
     {
         $now = new \DateTime();
         $entry = $this->client->getContainer()
-            ->get('doctrine.orm.entity_manager')
+            ->get(EntityManagerInterface::class)
             ->getRepository(Entry::class)
             ->findOneBy(['user' => $this->getUserId(), 'isStarred' => true]);
 
@@ -1134,7 +1135,7 @@ class EntryRestControllerTest extends WallabagApiTestCase
 
     public function testReloadEntryErrorWhileFetching()
     {
-        $entry = $this->client->getContainer()->get('doctrine.orm.entity_manager')
+        $entry = $this->client->getContainer()->get(EntityManagerInterface::class)
             ->getRepository(Entry::class)
             ->findByUrlAndUserId('http://0.0.0.0/entry4', $this->getUserId());
 
@@ -1170,7 +1171,7 @@ class EntryRestControllerTest extends WallabagApiTestCase
 
     public function testPostEntriesTagsListAction()
     {
-        $entry = $this->client->getContainer()->get('doctrine.orm.entity_manager')
+        $entry = $this->client->getContainer()->get(EntityManagerInterface::class)
             ->getRepository(Entry::class)
             ->findByUrlAndUserId('http://0.0.0.0/entry4', $this->getUserId());
 
@@ -1194,7 +1195,7 @@ class EntryRestControllerTest extends WallabagApiTestCase
         $this->assertIsInt($content[0]['entry']);
         $this->assertSame('http://0.0.0.0/entry4', $content[0]['url']);
 
-        $entry = $this->client->getContainer()->get('doctrine.orm.entity_manager')
+        $entry = $this->client->getContainer()->get(EntityManagerInterface::class)
             ->getRepository(Entry::class)
             ->findByUrlAndUserId('http://0.0.0.0/entry4', $this->getUserId());
 
@@ -1215,7 +1216,7 @@ class EntryRestControllerTest extends WallabagApiTestCase
 
     public function testDeleteEntriesTagsListAction()
     {
-        $em = $this->client->getContainer()->get('doctrine.orm.entity_manager');
+        $em = $this->client->getContainer()->get(EntityManagerInterface::class);
         $entry = new Entry($em->getReference(User::class, $this->getUserId()));
         $entry->setUrl('http://0.0.0.0/test-entry');
         $entry->addTag((new Tag())->setLabel('foo-tag'));
@@ -1283,7 +1284,7 @@ class EntryRestControllerTest extends WallabagApiTestCase
 
     public function testDeleteEntriesListAction()
     {
-        $em = $this->client->getContainer()->get('doctrine.orm.entity_manager');
+        $em = $this->client->getContainer()->get(EntityManagerInterface::class);
         $em->persist((new Entry($em->getReference(User::class, $this->getUserId())))->setUrl('http://0.0.0.0/test-entry1'));
 
         $em->flush();
@@ -1341,7 +1342,7 @@ class EntryRestControllerTest extends WallabagApiTestCase
 
     public function testRePostEntryAndReUsePublishedAt()
     {
-        $em = $this->client->getContainer()->get('doctrine.orm.entity_manager');
+        $em = $this->client->getContainer()->get(EntityManagerInterface::class);
         $entry = new Entry($em->getReference(User::class, $this->getUserId()));
         $entry->setTitle('Antoine de Caunes : « Je veux avoir le droit de tâtonner »');
         $entry->setContent('hihi');

--- a/tests/Wallabag/ApiBundle/Controller/TagRestControllerTest.php
+++ b/tests/Wallabag/ApiBundle/Controller/TagRestControllerTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Wallabag\ApiBundle\Controller;
 
+use Doctrine\ORM\EntityManagerInterface;
 use Tests\Wallabag\ApiBundle\WallabagApiTestCase;
 use Wallabag\CoreBundle\Entity\Entry;
 use Wallabag\CoreBundle\Entity\Tag;
@@ -33,9 +34,9 @@ class TagRestControllerTest extends WallabagApiTestCase
 
     public function testDeleteUserTag()
     {
-        $em = $this->client->getContainer()->get('doctrine.orm.entity_manager');
+        $em = $this->client->getContainer()->get(EntityManagerInterface::class);
         $entry = $this->client->getContainer()
-            ->get('doctrine.orm.entity_manager')
+            ->get(EntityManagerInterface::class)
             ->getRepository(Entry::class)
             ->findOneWithTags($this->user->getId());
 
@@ -74,7 +75,7 @@ class TagRestControllerTest extends WallabagApiTestCase
 
     public function testDeleteOtherUserTag()
     {
-        $em = $this->client->getContainer()->get('doctrine.orm.entity_manager');
+        $em = $this->client->getContainer()->get(EntityManagerInterface::class);
         $tag = $em->getRepository(Tag::class)->findOneByLabel($this->otherUserTagLabel);
 
         $this->client->request('DELETE', '/api/tags/' . $tag->getId() . '.json');
@@ -95,9 +96,9 @@ class TagRestControllerTest extends WallabagApiTestCase
      */
     public function testDeleteTagByLabel($useQueryString)
     {
-        $em = $this->client->getContainer()->get('doctrine.orm.entity_manager');
+        $em = $this->client->getContainer()->get(EntityManagerInterface::class);
         $entry = $this->client->getContainer()
-            ->get('doctrine.orm.entity_manager')
+            ->get(EntityManagerInterface::class)
             ->getRepository(Entry::class)
             ->findOneWithTags($this->user->getId());
 
@@ -127,7 +128,7 @@ class TagRestControllerTest extends WallabagApiTestCase
         $this->assertSame($tag->getSlug(), $content['slug']);
 
         $entries = $this->client->getContainer()
-            ->get('doctrine.orm.entity_manager')
+            ->get(EntityManagerInterface::class)
             ->getRepository(Entry::class)
             ->findAllByTagId($this->user->getId(), $tag->getId());
 
@@ -153,9 +154,9 @@ class TagRestControllerTest extends WallabagApiTestCase
      */
     public function testDeleteTagsByLabel($useQueryString)
     {
-        $em = $this->client->getContainer()->get('doctrine.orm.entity_manager');
+        $em = $this->client->getContainer()->get(EntityManagerInterface::class);
         $entry = $this->client->getContainer()
-            ->get('doctrine.orm.entity_manager')
+            ->get(EntityManagerInterface::class)
             ->getRepository(Entry::class)
             ->findOneWithTags($this->user->getId());
 
@@ -196,14 +197,14 @@ class TagRestControllerTest extends WallabagApiTestCase
         $this->assertSame($tag2->getSlug(), $content[1]['slug']);
 
         $entries = $this->client->getContainer()
-            ->get('doctrine.orm.entity_manager')
+            ->get(EntityManagerInterface::class)
             ->getRepository(Entry::class)
             ->findAllByTagId($this->user->getId(), $tag->getId());
 
         $this->assertCount(0, $entries);
 
         $entries = $this->client->getContainer()
-            ->get('doctrine.orm.entity_manager')
+            ->get(EntityManagerInterface::class)
             ->getRepository(Entry::class)
             ->findAllByTagId($this->user->getId(), $tag2->getId());
 

--- a/tests/Wallabag/ApiBundle/Controller/UserRestControllerTest.php
+++ b/tests/Wallabag/ApiBundle/Controller/UserRestControllerTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Wallabag\ApiBundle\Controller;
 
+use Craue\ConfigBundle\Util\Config;
 use Tests\Wallabag\ApiBundle\WallabagApiTestCase;
 
 class UserRestControllerTest extends WallabagApiTestCase
@@ -45,7 +46,7 @@ class UserRestControllerTest extends WallabagApiTestCase
 
     public function testCreateNewUser()
     {
-        $this->client->getContainer()->get('craue_config')->set('api_user_registration', 1);
+        $this->client->getContainer()->get(Config::class)->set('api_user_registration', 1);
         $this->client->request('PUT', '/api/user.json', [
             'username' => 'google',
             'password' => 'googlegoogle',
@@ -73,14 +74,14 @@ class UserRestControllerTest extends WallabagApiTestCase
 
         $this->assertSame('application/json', $this->client->getResponse()->headers->get('Content-Type'));
 
-        $this->client->getContainer()->get('craue_config')->set('api_user_registration', 0);
+        $this->client->getContainer()->get(Config::class)->set('api_user_registration', 0);
     }
 
     public function testCreateNewUserWithoutAuthentication()
     {
         // create a new client instead of using $this->client to be sure client isn't authenticated
         $client = static::createClient();
-        $client->getContainer()->get('craue_config')->set('api_user_registration', 1);
+        $client->getContainer()->get(Config::class)->set('api_user_registration', 1);
         $client->request('PUT', '/api/user.json', [
             'username' => 'google',
             'password' => 'googlegoogle',
@@ -109,13 +110,13 @@ class UserRestControllerTest extends WallabagApiTestCase
 
         $this->assertSame('application/json', $client->getResponse()->headers->get('Content-Type'));
 
-        $client->getContainer()->get('craue_config')->set('api_user_registration', 0);
+        $client->getContainer()->get(Config::class)->set('api_user_registration', 0);
     }
 
     public function testCreateNewUserWithExistingEmail()
     {
         $client = static::createClient();
-        $client->getContainer()->get('craue_config')->set('api_user_registration', 1);
+        $client->getContainer()->get(Config::class)->set('api_user_registration', 1);
         $client->request('PUT', '/api/user.json', [
             'username' => 'admin',
             'password' => 'googlegoogle',
@@ -138,13 +139,13 @@ class UserRestControllerTest extends WallabagApiTestCase
 
         $this->assertSame('application/json', $client->getResponse()->headers->get('Content-Type'));
 
-        $client->getContainer()->get('craue_config')->set('api_user_registration', 0);
+        $client->getContainer()->get(Config::class)->set('api_user_registration', 0);
     }
 
     public function testCreateNewUserWithTooShortPassword()
     {
         $client = static::createClient();
-        $client->getContainer()->get('craue_config')->set('api_user_registration', 1);
+        $client->getContainer()->get(Config::class)->set('api_user_registration', 1);
         $client->request('PUT', '/api/user.json', [
             'username' => 'facebook',
             'password' => 'face',
@@ -162,7 +163,7 @@ class UserRestControllerTest extends WallabagApiTestCase
 
         $this->assertSame('application/json', $client->getResponse()->headers->get('Content-Type'));
 
-        $client->getContainer()->get('craue_config')->set('api_user_registration', 0);
+        $client->getContainer()->get(Config::class)->set('api_user_registration', 0);
     }
 
     public function testCreateNewUserWhenRegistrationIsDisabled()

--- a/tests/Wallabag/ApiBundle/WallabagApiTestCase.php
+++ b/tests/Wallabag/ApiBundle/WallabagApiTestCase.php
@@ -2,8 +2,11 @@
 
 namespace Tests\Wallabag\ApiBundle;
 
+use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 use Symfony\Component\BrowserKit\Cookie;
+use Symfony\Component\HttpFoundation\Session\SessionInterface;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 use Wallabag\UserBundle\Entity\User;
 
 abstract class WallabagApiTestCase extends WebTestCase
@@ -41,10 +44,10 @@ abstract class WallabagApiTestCase extends WebTestCase
         $loginManager->logInUser($firewallName, $this->user);
 
         // save the login token into the session and put it in a cookie
-        $container->get('session')->set('_security_' . $firewallName, serialize($container->get('security.token_storage')->getToken()));
-        $container->get('session')->save();
+        $container->get(SessionInterface::class)->set('_security_' . $firewallName, serialize($container->get(TokenStorageInterface::class)->getToken()));
+        $container->get(SessionInterface::class)->save();
 
-        $session = $container->get('session');
+        $session = $container->get(SessionInterface::class);
         $client->getCookieJar()->set(new Cookie($session->getName(), $session->getId()));
 
         return $client;
@@ -63,7 +66,7 @@ abstract class WallabagApiTestCase extends WebTestCase
     {
         return $this->client
             ->getContainer()
-            ->get('doctrine.orm.entity_manager')
+            ->get(EntityManagerInterface::class)
             ->getRepository(User::class)
             ->findOneByUserName($username)
             ->getId();

--- a/tests/Wallabag/CoreBundle/Command/CleanDuplicatesCommandTest.php
+++ b/tests/Wallabag/CoreBundle/Command/CleanDuplicatesCommandTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Wallabag\CoreBundle\Command;
 
+use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Bundle\FrameworkBundle\Console\Application;
 use Symfony\Component\Console\Tester\CommandTester;
 use Tests\Wallabag\CoreBundle\WallabagCoreTestCase;
@@ -63,7 +64,7 @@ class CleanDuplicatesCommandTest extends WallabagCoreTestCase
     {
         $url = 'https://www.lemonde.fr/sport/visuel/2017/05/05/rondelle-prison-blanchissage-comprendre-le-hockey-sur-glace_5122587_3242.html';
         $client = $this->getClient();
-        $em = $client->getContainer()->get('doctrine.orm.entity_manager');
+        $em = $client->getContainer()->get(EntityManagerInterface::class);
 
         $this->logInAs('admin');
 

--- a/tests/Wallabag/CoreBundle/Command/GenerateUrlHashesCommandTest.php
+++ b/tests/Wallabag/CoreBundle/Command/GenerateUrlHashesCommandTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Wallabag\CoreBundle\Command;
 
+use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Bundle\FrameworkBundle\Console\Application;
 use Symfony\Component\Console\Tester\CommandTester;
 use Tests\Wallabag\CoreBundle\WallabagCoreTestCase;
@@ -63,7 +64,7 @@ class GenerateUrlHashesCommandTest extends WallabagCoreTestCase
     {
         $url = 'http://www.lemonde.fr/sport/visuel/2017/05/05/rondelle-prison-blanchissage-comprendre-le-hockey-sur-glace_5122587_3242.html';
         $client = $this->getClient();
-        $em = $client->getContainer()->get('doctrine.orm.entity_manager');
+        $em = $client->getContainer()->get(EntityManagerInterface::class);
 
         $this->logInAs('admin');
 

--- a/tests/Wallabag/CoreBundle/Command/InstallCommandTest.php
+++ b/tests/Wallabag/CoreBundle/Command/InstallCommandTest.php
@@ -8,6 +8,7 @@ use Doctrine\Bundle\DoctrineBundle\Command\DropDatabaseDoctrineCommand;
 use Doctrine\Bundle\MigrationsBundle\Command\MigrationsMigrateDoctrineCommand;
 use Doctrine\DBAL\Platforms\PostgreSqlPlatform;
 use Doctrine\DBAL\Platforms\SqlitePlatform;
+use Doctrine\Persistence\ManagerRegistry;
 use Symfony\Bundle\FrameworkBundle\Console\Application;
 use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Output\NullOutput;
@@ -35,7 +36,7 @@ class InstallCommandTest extends WallabagCoreTestCase
         parent::setUp();
 
         /** @var \Doctrine\DBAL\Connection $connection */
-        $connection = $this->getClient()->getContainer()->get('doctrine')->getConnection();
+        $connection = $this->getClient()->getContainer()->get(ManagerRegistry::class)->getConnection();
         if ($connection->getDatabasePlatform() instanceof PostgreSqlPlatform) {
             /*
              * LOG:  statement: CREATE DATABASE "wallabag"
@@ -142,7 +143,7 @@ class InstallCommandTest extends WallabagCoreTestCase
     {
         // skipped SQLite check when database is removed because while testing for the connection,
         // the driver will create the file (so the database) before testing if database exist
-        if ($this->getClient()->getContainer()->get('doctrine')->getConnection()->getDatabasePlatform() instanceof \Doctrine\DBAL\Platforms\SqlitePlatform) {
+        if ($this->getClient()->getContainer()->get(ManagerRegistry::class)->getConnection()->getDatabasePlatform() instanceof \Doctrine\DBAL\Platforms\SqlitePlatform) {
             $this->markTestSkipped('SQLite spotted: can\'t test with database removed.');
         }
 
@@ -224,7 +225,7 @@ class InstallCommandTest extends WallabagCoreTestCase
             '--force' => true,
         ]), new NullOutput());
 
-        $this->getClient()->getContainer()->get('doctrine')->getConnection()->close();
+        $this->getClient()->getContainer()->get(ManagerRegistry::class)->getConnection()->close();
 
         $command = new CreateDatabaseDoctrineCommand();
         $command->setApplication($application);

--- a/tests/Wallabag/CoreBundle/Command/ShowUserCommandTest.php
+++ b/tests/Wallabag/CoreBundle/Command/ShowUserCommandTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Wallabag\CoreBundle\Command;
 
+use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Bundle\FrameworkBundle\Console\Application;
 use Symfony\Component\Console\Tester\CommandTester;
 use Tests\Wallabag\CoreBundle\WallabagCoreTestCase;
@@ -65,7 +66,7 @@ class ShowUserCommandTest extends WallabagCoreTestCase
     public function testShowUser()
     {
         $client = $this->getClient();
-        $em = $client->getContainer()->get('doctrine.orm.entity_manager');
+        $em = $client->getContainer()->get(EntityManagerInterface::class);
 
         $this->logInAs('admin');
 

--- a/tests/Wallabag/CoreBundle/Controller/ConfigControllerTest.php
+++ b/tests/Wallabag/CoreBundle/Controller/ConfigControllerTest.php
@@ -2,7 +2,11 @@
 
 namespace Tests\Wallabag\CoreBundle\Controller;
 
+use Craue\ConfigBundle\Util\Config;
+use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
+use Symfony\Component\HttpFoundation\Session\SessionInterface;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 use Tests\Wallabag\CoreBundle\WallabagCoreTestCase;
 use Wallabag\AnnotationBundle\Entity\Annotation;
 use Wallabag\CoreBundle\Entity\Config as ConfigEntity;
@@ -306,7 +310,7 @@ class ConfigControllerTest extends WallabagCoreTestCase
         $client = $this->getClient();
 
         // reset the token
-        $em = $client->getContainer()->get('doctrine.orm.entity_manager');
+        $em = $client->getContainer()->get(EntityManagerInterface::class);
         $user = $em
             ->getRepository(User::class)
             ->findOneByUsername('admin');
@@ -571,7 +575,7 @@ class ConfigControllerTest extends WallabagCoreTestCase
         $this->logInAs('bob');
         $client = $this->getClient();
 
-        $rule = $client->getContainer()->get('doctrine.orm.entity_manager')
+        $rule = $client->getContainer()->get(EntityManagerInterface::class)
             ->getRepository(TaggingRule::class)
             ->findAll()[0];
 
@@ -587,7 +591,7 @@ class ConfigControllerTest extends WallabagCoreTestCase
         $this->logInAs('bob');
         $client = $this->getClient();
 
-        $rule = $client->getContainer()->get('doctrine.orm.entity_manager')
+        $rule = $client->getContainer()->get(EntityManagerInterface::class)
             ->getRepository(TaggingRule::class)
             ->findAll()[0];
 
@@ -708,7 +712,7 @@ class ConfigControllerTest extends WallabagCoreTestCase
         $this->logInAs('bob');
         $client = $this->getClient();
 
-        $rule = $client->getContainer()->get('doctrine.orm.entity_manager')
+        $rule = $client->getContainer()->get(EntityManagerInterface::class)
             ->getRepository(IgnoreOriginUserRule::class)
             ->findAll()[0];
 
@@ -724,7 +728,7 @@ class ConfigControllerTest extends WallabagCoreTestCase
         $this->logInAs('bob');
         $client = $this->getClient();
 
-        $rule = $client->getContainer()->get('doctrine.orm.entity_manager')
+        $rule = $client->getContainer()->get(EntityManagerInterface::class)
             ->getRepository(IgnoreOriginUserRule::class)
             ->findAll()[0];
 
@@ -740,7 +744,7 @@ class ConfigControllerTest extends WallabagCoreTestCase
         $this->logInAs('admin');
         $client = $this->getClient();
 
-        $config = $client->getContainer()->get('craue_config');
+        $config = $client->getContainer()->get(Config::class);
         $config->set('demo_mode_enabled', 1);
         $config->set('demo_mode_username', 'admin');
 
@@ -759,7 +763,7 @@ class ConfigControllerTest extends WallabagCoreTestCase
         $client->submit($form, $data);
 
         $this->assertSame(302, $client->getResponse()->getStatusCode());
-        $this->assertStringContainsString('flashes.config.notice.password_not_updated_demo', $client->getContainer()->get('session')->getFlashBag()->get('notice')[0]);
+        $this->assertStringContainsString('flashes.config.notice.password_not_updated_demo', $client->getContainer()->get(SessionInterface::class)->getFlashBag()->get('notice')[0]);
 
         $config->set('demo_mode_enabled', 0);
         $config->set('demo_mode_username', 'wallabag');
@@ -775,7 +779,7 @@ class ConfigControllerTest extends WallabagCoreTestCase
         $this->assertGreaterThan(1, $body = $crawler->filter('body')->extract(['_text']));
         $this->assertStringContainsString('config.form_user.delete.button', $body[0]);
 
-        $em = $client->getContainer()->get('doctrine.orm.entity_manager');
+        $em = $client->getContainer()->get(EntityManagerInterface::class);
 
         $user = $em
             ->getRepository(User::class)
@@ -820,7 +824,7 @@ class ConfigControllerTest extends WallabagCoreTestCase
     public function testDeleteAccount()
     {
         $client = $this->getClient();
-        $em = $client->getContainer()->get('doctrine.orm.entity_manager');
+        $em = $client->getContainer()->get(EntityManagerInterface::class);
 
         $user = new User();
         $user->setName('Wallace');
@@ -867,7 +871,7 @@ class ConfigControllerTest extends WallabagCoreTestCase
         $client->click($deleteLink);
         $this->assertSame(302, $client->getResponse()->getStatusCode());
 
-        $em = $client->getContainer()->get('doctrine.orm.entity_manager');
+        $em = $client->getContainer()->get(EntityManagerInterface::class);
         $user = $em
             ->getRepository(User::class)
             ->createQueryBuilder('u')
@@ -879,7 +883,7 @@ class ConfigControllerTest extends WallabagCoreTestCase
         $this->assertNull($user);
 
         $entries = $client->getContainer()
-            ->get('doctrine.orm.entity_manager')
+            ->get(EntityManagerInterface::class)
             ->getRepository(Entry::class)
             ->findByUser($loggedInUserId);
 
@@ -891,9 +895,9 @@ class ConfigControllerTest extends WallabagCoreTestCase
         $this->logInAs('empty');
         $client = $this->getClient();
 
-        $em = $client->getContainer()->get('doctrine.orm.entity_manager');
+        $em = $client->getContainer()->get(EntityManagerInterface::class);
 
-        $user = static::$kernel->getContainer()->get('security.token_storage')->getToken()->getUser();
+        $user = static::$kernel->getContainer()->get(TokenStorageInterface::class)->getToken()->getUser();
 
         $tag = new Tag();
         $tag->setLabel('super');
@@ -930,7 +934,7 @@ class ConfigControllerTest extends WallabagCoreTestCase
         $crawler = $client->click($crawler->selectLink('config.reset.annotations')->link());
 
         $this->assertSame(302, $client->getResponse()->getStatusCode());
-        $this->assertStringContainsString('flashes.config.notice.annotations_reset', $client->getContainer()->get('session')->getFlashBag()->get('notice')[0]);
+        $this->assertStringContainsString('flashes.config.notice.annotations_reset', $client->getContainer()->get(SessionInterface::class)->getFlashBag()->get('notice')[0]);
 
         $annotationsReset = $em
             ->getRepository(Annotation::class)
@@ -946,7 +950,7 @@ class ConfigControllerTest extends WallabagCoreTestCase
         $crawler = $client->click($crawler->selectLink('config.reset.tags')->link());
 
         $this->assertSame(302, $client->getResponse()->getStatusCode());
-        $this->assertStringContainsString('flashes.config.notice.tags_reset', $client->getContainer()->get('session')->getFlashBag()->get('notice')[0]);
+        $this->assertStringContainsString('flashes.config.notice.tags_reset', $client->getContainer()->get(SessionInterface::class)->getFlashBag()->get('notice')[0]);
 
         $tagReset = $em
             ->getRepository(Tag::class)
@@ -962,7 +966,7 @@ class ConfigControllerTest extends WallabagCoreTestCase
         $crawler = $client->click($crawler->selectLink('config.reset.entries')->link());
 
         $this->assertSame(302, $client->getResponse()->getStatusCode());
-        $this->assertStringContainsString('flashes.config.notice.entries_reset', $client->getContainer()->get('session')->getFlashBag()->get('notice')[0]);
+        $this->assertStringContainsString('flashes.config.notice.entries_reset', $client->getContainer()->get(SessionInterface::class)->getFlashBag()->get('notice')[0]);
 
         $entryReset = $em
             ->getRepository(Entry::class)
@@ -976,9 +980,9 @@ class ConfigControllerTest extends WallabagCoreTestCase
         $this->logInAs('empty');
         $client = $this->getClient();
 
-        $em = $client->getContainer()->get('doctrine.orm.entity_manager');
+        $em = $client->getContainer()->get(EntityManagerInterface::class);
 
-        $user = static::$kernel->getContainer()->get('security.token_storage')->getToken()->getUser();
+        $user = static::$kernel->getContainer()->get(TokenStorageInterface::class)->getToken()->getUser();
 
         $tag = new Tag();
         $tag->setLabel('super');
@@ -1026,7 +1030,7 @@ class ConfigControllerTest extends WallabagCoreTestCase
         $crawler = $client->click($crawler->selectLink('config.reset.archived')->link());
 
         $this->assertSame(302, $client->getResponse()->getStatusCode());
-        $this->assertStringContainsString('flashes.config.notice.archived_reset', $client->getContainer()->get('session')->getFlashBag()->get('notice')[0]);
+        $this->assertStringContainsString('flashes.config.notice.archived_reset', $client->getContainer()->get(SessionInterface::class)->getFlashBag()->get('notice')[0]);
 
         $entryReset = $em
             ->getRepository(Entry::class)
@@ -1052,9 +1056,9 @@ class ConfigControllerTest extends WallabagCoreTestCase
         $this->logInAs('empty');
         $client = $this->getClient();
 
-        $em = $client->getContainer()->get('doctrine.orm.entity_manager');
+        $em = $client->getContainer()->get(EntityManagerInterface::class);
 
-        $user = static::$kernel->getContainer()->get('security.token_storage')->getToken()->getUser();
+        $user = static::$kernel->getContainer()->get(TokenStorageInterface::class)->getToken()->getUser();
 
         $tag = new Tag();
         $tag->setLabel('super');
@@ -1083,7 +1087,7 @@ class ConfigControllerTest extends WallabagCoreTestCase
         $crawler = $client->click($crawler->selectLink('config.reset.entries')->link());
 
         $this->assertSame(302, $client->getResponse()->getStatusCode());
-        $this->assertStringContainsString('flashes.config.notice.entries_reset', $client->getContainer()->get('session')->getFlashBag()->get('notice')[0]);
+        $this->assertStringContainsString('flashes.config.notice.entries_reset', $client->getContainer()->get(SessionInterface::class)->getFlashBag()->get('notice')[0]);
 
         $entryReset = $em
             ->getRepository(Entry::class)
@@ -1132,7 +1136,7 @@ class ConfigControllerTest extends WallabagCoreTestCase
         $client->followRedirect();
 
         $this->assertSame('de', $client->getRequest()->getLocale());
-        $this->assertSame('de', $client->getContainer()->get('session')->get('_locale'));
+        $this->assertSame('de', $client->getContainer()->get(SessionInterface::class)->get('_locale'));
     }
 
     public function testChangeLocaleWithReferer()
@@ -1144,7 +1148,7 @@ class ConfigControllerTest extends WallabagCoreTestCase
         $client->followRedirect();
 
         $this->assertSame('de', $client->getRequest()->getLocale());
-        $this->assertSame('de', $client->getContainer()->get('session')->get('_locale'));
+        $this->assertSame('de', $client->getContainer()->get(SessionInterface::class)->get('_locale'));
     }
 
     public function testChangeLocaleToBadLocale()
@@ -1156,7 +1160,7 @@ class ConfigControllerTest extends WallabagCoreTestCase
         $client->followRedirect();
 
         $this->assertNotSame('yuyuyuyu', $client->getRequest()->getLocale());
-        $this->assertNotSame('yuyuyuyu', $client->getContainer()->get('session')->get('_locale'));
+        $this->assertNotSame('yuyuyuyu', $client->getContainer()->get(SessionInterface::class)->get('_locale'));
     }
 
     public function testUserEnable2faEmail()

--- a/tests/Wallabag/CoreBundle/Controller/ConfigControllerTest.php
+++ b/tests/Wallabag/CoreBundle/Controller/ConfigControllerTest.php
@@ -5,7 +5,7 @@ namespace Tests\Wallabag\CoreBundle\Controller;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
 use Tests\Wallabag\CoreBundle\WallabagCoreTestCase;
 use Wallabag\AnnotationBundle\Entity\Annotation;
-use Wallabag\CoreBundle\Entity\Config;
+use Wallabag\CoreBundle\Entity\Config as ConfigEntity;
 use Wallabag\CoreBundle\Entity\Entry;
 use Wallabag\CoreBundle\Entity\IgnoreOriginUserRule;
 use Wallabag\CoreBundle\Entity\Tag;
@@ -832,7 +832,7 @@ class ConfigControllerTest extends WallabagCoreTestCase
 
         $em->persist($user);
 
-        $config = new Config($user);
+        $config = new ConfigEntity($user);
 
         $config->setTheme('material');
         $config->setItemsPerPage(30);

--- a/tests/Wallabag/CoreBundle/Controller/EntryControllerTest.php
+++ b/tests/Wallabag/CoreBundle/Controller/EntryControllerTest.php
@@ -4,7 +4,7 @@ namespace Tests\Wallabag\CoreBundle\Controller;
 
 use Tests\Wallabag\CoreBundle\WallabagCoreTestCase;
 use Wallabag\AnnotationBundle\Entity\Annotation;
-use Wallabag\CoreBundle\Entity\Config;
+use Wallabag\CoreBundle\Entity\Config as ConfigEntity;
 use Wallabag\CoreBundle\Entity\Entry;
 use Wallabag\CoreBundle\Entity\SiteCredential;
 use Wallabag\CoreBundle\Entity\Tag;
@@ -1268,7 +1268,7 @@ class EntryControllerTest extends WallabagCoreTestCase
 
         // Redirect to homepage
         $config = $this->getLoggedInUser()->getConfig();
-        $config->setActionMarkAsRead(Config::REDIRECT_TO_HOMEPAGE);
+        $config->setActionMarkAsRead(ConfigEntity::REDIRECT_TO_HOMEPAGE);
         $this->getEntityManager()->persist($config);
 
         $entry = new Entry($this->getLoggedInUser());
@@ -1291,7 +1291,7 @@ class EntryControllerTest extends WallabagCoreTestCase
 
         // Redirect to current page
         $config = $this->getLoggedInUser()->getConfig();
-        $config->setActionMarkAsRead(Config::REDIRECT_TO_CURRENT_PAGE);
+        $config->setActionMarkAsRead(ConfigEntity::REDIRECT_TO_CURRENT_PAGE);
         $this->getEntityManager()->persist($config);
 
         $entry = new Entry($this->getLoggedInUser());

--- a/tests/Wallabag/CoreBundle/Controller/EntryControllerTest.php
+++ b/tests/Wallabag/CoreBundle/Controller/EntryControllerTest.php
@@ -2,6 +2,9 @@
 
 namespace Tests\Wallabag\CoreBundle\Controller;
 
+use Craue\ConfigBundle\Util\Config;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 use Tests\Wallabag\CoreBundle\WallabagCoreTestCase;
 use Wallabag\AnnotationBundle\Entity\Annotation;
 use Wallabag\CoreBundle\Entity\Config as ConfigEntity;
@@ -28,7 +31,7 @@ class EntryControllerTest extends WallabagCoreTestCase
     {
         if ($this->downloadImagesEnabled) {
             $client = static::createClient();
-            $client->getContainer()->get('craue_config')->set('download_images_enabled', 0);
+            $client->getContainer()->get(Config::class)->set('download_images_enabled', 0);
 
             $this->downloadImagesEnabled = false;
         }
@@ -114,7 +117,7 @@ class EntryControllerTest extends WallabagCoreTestCase
         $this->assertCount(5, $crawler->filter($this->entryDataTestAttribute));
 
         $em = $client->getContainer()
-            ->get('doctrine.orm.entity_manager');
+            ->get(EntityManagerInterface::class);
         $entry = $em
             ->getRepository(Entry::class)
             ->findByUrlAndUserId($this->url, $this->getLoggedInUserId());
@@ -148,7 +151,7 @@ class EntryControllerTest extends WallabagCoreTestCase
         $this->logInAs('admin');
         $client = $this->getClient();
 
-        $client->getContainer()->get('craue_config')->set('store_article_headers', 1);
+        $client->getContainer()->get(Config::class)->set('store_article_headers', 1);
 
         $crawler = $client->request('GET', '/new');
 
@@ -165,7 +168,7 @@ class EntryControllerTest extends WallabagCoreTestCase
         $this->assertSame(302, $client->getResponse()->getStatusCode());
 
         $content = $client->getContainer()
-            ->get('doctrine.orm.entity_manager')
+            ->get(EntityManagerInterface::class)
             ->getRepository(Entry::class)
             ->findByUrlAndUserId($this->url, $this->getLoggedInUserId());
 
@@ -176,7 +179,7 @@ class EntryControllerTest extends WallabagCoreTestCase
         $this->assertStringContainsString('la cryptomonnaie de Facebook', $content->getTitle());
         $this->assertSame('fr', $content->getLanguage());
         $this->assertArrayHasKey('x-frame-options', $content->getHeaders());
-        $client->getContainer()->get('craue_config')->set('store_article_headers', 0);
+        $client->getContainer()->get(Config::class)->set('store_article_headers', 0);
     }
 
     /**
@@ -202,7 +205,7 @@ class EntryControllerTest extends WallabagCoreTestCase
         $this->assertSame(302, $client->getResponse()->getStatusCode());
 
         $content = $client->getContainer()
-            ->get('doctrine.orm.entity_manager')
+            ->get(EntityManagerInterface::class)
             ->getRepository(Entry::class)
             ->findByUrlAndUserId($this->url, $this->getLoggedInUserId());
 
@@ -239,7 +242,7 @@ class EntryControllerTest extends WallabagCoreTestCase
         $this->assertSame(302, $client->getResponse()->getStatusCode());
 
         $content = $client->getContainer()
-            ->get('doctrine.orm.entity_manager')
+            ->get(EntityManagerInterface::class)
             ->getRepository(Entry::class)
             ->findByUrlAndUserId($url, $this->getLoggedInUserId());
 
@@ -378,7 +381,7 @@ class EntryControllerTest extends WallabagCoreTestCase
         $this->assertStringContainsString('/', $client->getResponse()->getTargetUrl());
 
         $em = $client->getContainer()
-            ->get('doctrine.orm.entity_manager');
+            ->get(EntityManagerInterface::class);
         $entry = $em
             ->getRepository(Entry::class)
             ->findOneByUrl($url);
@@ -645,7 +648,7 @@ class EntryControllerTest extends WallabagCoreTestCase
         $this->assertSame(302, $client->getResponse()->getStatusCode());
 
         $res = $client->getContainer()
-            ->get('doctrine.orm.entity_manager')
+            ->get(EntityManagerInterface::class)
             ->getRepository(Entry::class)
             ->find($entry->getId());
 
@@ -668,7 +671,7 @@ class EntryControllerTest extends WallabagCoreTestCase
         $this->assertSame(302, $client->getResponse()->getStatusCode());
 
         $res = $client->getContainer()
-            ->get('doctrine.orm.entity_manager')
+            ->get(EntityManagerInterface::class)
             ->getRepository(Entry::class)
             ->findOneById($entry->getId());
 
@@ -707,7 +710,7 @@ class EntryControllerTest extends WallabagCoreTestCase
         $client = $this->getClient();
 
         $em = $client->getContainer()
-            ->get('doctrine.orm.entity_manager');
+            ->get(EntityManagerInterface::class);
 
         // add a new content to be removed later
         $user = $em
@@ -743,7 +746,7 @@ class EntryControllerTest extends WallabagCoreTestCase
         $client = $this->getClient();
 
         $content = $client->getContainer()
-            ->get('doctrine.orm.entity_manager')
+            ->get(EntityManagerInterface::class)
             ->getRepository(Entry::class)
             ->findOneByUsernameAndNotArchived('bob');
 
@@ -948,7 +951,7 @@ class EntryControllerTest extends WallabagCoreTestCase
         $entry = new Entry($this->getLoggedInUser());
         $entry->setUrl($this->url);
 
-        $em = $this->getClient()->getContainer()->get('doctrine.orm.entity_manager');
+        $em = $this->getClient()->getContainer()->get(EntityManagerInterface::class);
         $user = $em
             ->getRepository(User::class)
             ->findOneByUserName('admin');
@@ -1134,7 +1137,7 @@ class EntryControllerTest extends WallabagCoreTestCase
         $client = $this->getClient();
 
         // sharing is enabled
-        $client->getContainer()->get('craue_config')->set('share_public', 1);
+        $client->getContainer()->get(Config::class)->set('share_public', 1);
 
         $content = new Entry($this->getLoggedInUser());
         $content->setUrl($this->url);
@@ -1168,7 +1171,7 @@ class EntryControllerTest extends WallabagCoreTestCase
         $this->assertStringContainsString('og:image', $client->getResponse()->getContent());
 
         // sharing is now disabled
-        $client->getContainer()->get('craue_config')->set('share_public', 0);
+        $client->getContainer()->get(Config::class)->set('share_public', 0);
         $client->request('GET', '/share/' . $content->getUid());
         $this->assertSame(404, $client->getResponse()->getStatusCode());
 
@@ -1191,7 +1194,7 @@ class EntryControllerTest extends WallabagCoreTestCase
         $client = $this->getClient();
 
         $url = self::AN_URL_CONTAINING_AN_ARTICLE_WITH_IMAGE;
-        $client->getContainer()->get('craue_config')->set('download_images_enabled', 1);
+        $client->getContainer()->get(Config::class)->set('download_images_enabled', 1);
 
         $crawler = $client->request('GET', '/new');
 
@@ -1208,7 +1211,7 @@ class EntryControllerTest extends WallabagCoreTestCase
         $this->assertSame(302, $client->getResponse()->getStatusCode());
 
         $em = $client->getContainer()
-            ->get('doctrine.orm.entity_manager');
+            ->get(EntityManagerInterface::class);
 
         $entry = $em
             ->getRepository(Entry::class)
@@ -1220,7 +1223,7 @@ class EntryControllerTest extends WallabagCoreTestCase
         // instead of checking for the filename (which might change) check that the image is now local
         $this->assertStringContainsString(rtrim($client->getContainer()->getParameter('domain_name'), '/') . '/assets/images/', $entry->getContent());
 
-        $client->getContainer()->get('craue_config')->set('download_images_enabled', 0);
+        $client->getContainer()->get(Config::class)->set('download_images_enabled', 0);
     }
 
     /**
@@ -1233,7 +1236,7 @@ class EntryControllerTest extends WallabagCoreTestCase
         $client = $this->getClient();
 
         $url = self::AN_URL_CONTAINING_AN_ARTICLE_WITH_IMAGE;
-        $client->getContainer()->get('craue_config')->set('download_images_enabled', 1);
+        $client->getContainer()->get(Config::class)->set('download_images_enabled', 1);
 
         $crawler = $client->request('GET', '/new');
 
@@ -1250,7 +1253,7 @@ class EntryControllerTest extends WallabagCoreTestCase
         $this->assertSame(302, $client->getResponse()->getStatusCode());
 
         $content = $client->getContainer()
-            ->get('doctrine.orm.entity_manager')
+            ->get(EntityManagerInterface::class)
             ->getRepository(Entry::class)
             ->findByUrlAndUserId($url, $this->getLoggedInUserId());
 
@@ -1258,7 +1261,7 @@ class EntryControllerTest extends WallabagCoreTestCase
 
         $this->assertSame(302, $client->getResponse()->getStatusCode());
 
-        $client->getContainer()->get('craue_config')->set('download_images_enabled', 0);
+        $client->getContainer()->get(Config::class)->set('download_images_enabled', 0);
     }
 
     public function testRedirectToHomepage()
@@ -1529,7 +1532,7 @@ class EntryControllerTest extends WallabagCoreTestCase
         $this->assertSame(302, $client->getResponse()->getStatusCode());
 
         $content = $client->getContainer()
-            ->get('doctrine.orm.entity_manager')
+            ->get(EntityManagerInterface::class)
             ->getRepository(Entry::class)
             ->findByUrlAndUserId($url, $this->getLoggedInUserId());
 
@@ -1546,13 +1549,13 @@ class EntryControllerTest extends WallabagCoreTestCase
         $url = 'https://www.monde-diplomatique.fr/2017/05/BONNET/57476';
         $this->logInAs('admin');
         $client = $this->getClient();
-        $em = $client->getContainer()->get('doctrine.orm.entity_manager');
+        $em = $client->getContainer()->get(EntityManagerInterface::class);
 
         // enable restricted access
-        $client->getContainer()->get('craue_config')->set('restricted_access', 1);
+        $client->getContainer()->get(Config::class)->set('restricted_access', 1);
 
         // create a new site_credential
-        $user = $client->getContainer()->get('security.token_storage')->getToken()->getUser();
+        $user = $client->getContainer()->get(TokenStorageInterface::class)->getToken()->getUser();
         $credential = new SiteCredential($user);
         $credential->setHost('monde-diplomatique.fr');
         $credential->setUsername($client->getContainer()->get(CryptoProxy::class)->crypt('foo'));
@@ -1587,7 +1590,7 @@ class EntryControllerTest extends WallabagCoreTestCase
         $this->assertInstanceOf('Wallabag\CoreBundle\Entity\Entry', $content);
         $this->assertSame('Quand Manille manœuvre', $content->getTitle());
 
-        $client->getContainer()->get('craue_config')->set('restricted_access', 0);
+        $client->getContainer()->get(Config::class)->set('restricted_access', 0);
     }
 
     public function testPostEntryWhenFetchFails()
@@ -1629,7 +1632,7 @@ class EntryControllerTest extends WallabagCoreTestCase
         $this->assertSame(302, $client->getResponse()->getStatusCode());
 
         $content = $client->getContainer()
-            ->get('doctrine.orm.entity_manager')
+            ->get(EntityManagerInterface::class)
             ->getRepository(Entry::class)
             ->findByUrlAndUserId($url, $this->getLoggedInUserId());
 
@@ -1643,7 +1646,7 @@ class EntryControllerTest extends WallabagCoreTestCase
         $this->logInAs('admin');
         $client = $this->getClient();
 
-        $em = $client->getContainer()->get('doctrine.orm.entity_manager');
+        $em = $client->getContainer()->get(EntityManagerInterface::class);
         $entry = $em->getRepository(Entry::class)->findByUrlAndUserId('http://0.0.0.0/entry1', $this->getLoggedInUserId());
         $tag = $entry->getTags()[0];
 
@@ -1720,14 +1723,14 @@ class EntryControllerTest extends WallabagCoreTestCase
         $this->assertSame(302, $client->getResponse()->getStatusCode());
 
         $res = $client->getContainer()
-            ->get('doctrine.orm.entity_manager')
+            ->get(EntityManagerInterface::class)
             ->getRepository(Entry::class)
             ->find($entry1->getId());
 
         $this->assertSame(1, $res->isArchived());
 
         $res = $client->getContainer()
-            ->get('doctrine.orm.entity_manager')
+            ->get(EntityManagerInterface::class)
             ->getRepository(Entry::class)
             ->find($entry2->getId());
 
@@ -1742,14 +1745,14 @@ class EntryControllerTest extends WallabagCoreTestCase
         $this->assertSame(302, $client->getResponse()->getStatusCode());
 
         $res = $client->getContainer()
-            ->get('doctrine.orm.entity_manager')
+            ->get(EntityManagerInterface::class)
             ->getRepository(Entry::class)
             ->find($entry1->getId());
 
         $this->assertSame(1, $res->isStarred());
 
         $res = $client->getContainer()
-            ->get('doctrine.orm.entity_manager')
+            ->get(EntityManagerInterface::class)
             ->getRepository(Entry::class)
             ->find($entry2->getId());
 
@@ -1765,21 +1768,21 @@ class EntryControllerTest extends WallabagCoreTestCase
         $this->assertSame(302, $client->getResponse()->getStatusCode());
 
         $res = $client->getContainer()
-            ->get('doctrine.orm.entity_manager')
+            ->get(EntityManagerInterface::class)
             ->getRepository(Entry::class)
             ->find($entry1->getId());
 
         $this->assertContains('foo', $res->getTagsLabel());
 
         $res = $client->getContainer()
-            ->get('doctrine.orm.entity_manager')
+            ->get(EntityManagerInterface::class)
             ->getRepository(Entry::class)
             ->find($entry2->getId());
 
         $this->assertContains('foo', $res->getTagsLabel());
 
         $res = $client->getContainer()
-            ->get('doctrine.orm.entity_manager')
+            ->get(EntityManagerInterface::class)
             ->getRepository(Entry::class)
             ->find($entry3->getId());
 

--- a/tests/Wallabag/CoreBundle/Controller/ExportControllerTest.php
+++ b/tests/Wallabag/CoreBundle/Controller/ExportControllerTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Wallabag\CoreBundle\Controller;
 
+use Doctrine\ORM\EntityManagerInterface;
 use Tests\Wallabag\CoreBundle\WallabagCoreTestCase;
 use Wallabag\CoreBundle\Entity\Entry;
 
@@ -49,7 +50,7 @@ class ExportControllerTest extends WallabagCoreTestCase
         $this->assertSame(404, $client->getResponse()->getStatusCode());
 
         $content = $client->getContainer()
-            ->get('doctrine.orm.entity_manager')
+            ->get(EntityManagerInterface::class)
             ->getRepository(Entry::class)
             ->findOneByUsernameAndNotArchived('admin');
 
@@ -90,7 +91,7 @@ class ExportControllerTest extends WallabagCoreTestCase
         $client = $this->getClient();
 
         $content = $client->getContainer()
-            ->get('doctrine.orm.entity_manager')
+            ->get(EntityManagerInterface::class)
             ->getRepository(Entry::class)
             ->findOneByUsernameAndNotArchived('admin');
 
@@ -158,7 +159,7 @@ class ExportControllerTest extends WallabagCoreTestCase
 
         // to be sure results are the same
         $contentInDB = $client->getContainer()
-            ->get('doctrine.orm.entity_manager')
+            ->get(EntityManagerInterface::class)
             ->getRepository(Entry::class)
             ->createQueryBuilder('e')
             ->select('e, t')
@@ -204,7 +205,7 @@ class ExportControllerTest extends WallabagCoreTestCase
         $client = $this->getClient();
 
         $contentInDB = $client->getContainer()
-            ->get('doctrine.orm.entity_manager')
+            ->get(EntityManagerInterface::class)
             ->getRepository(Entry::class)
             ->findByUrlAndUserId('http://0.0.0.0/entry1', $this->getLoggedInUserId());
 
@@ -278,7 +279,7 @@ class ExportControllerTest extends WallabagCoreTestCase
 
         // to be sure results are the same
         $contentInDB = $client->getContainer()
-            ->get('doctrine.orm.entity_manager')
+            ->get(EntityManagerInterface::class)
             ->getRepository(Entry::class)
             ->createQueryBuilder('e')
             ->leftJoin('e.user', 'u')

--- a/tests/Wallabag/CoreBundle/Controller/FeedControllerTest.php
+++ b/tests/Wallabag/CoreBundle/Controller/FeedControllerTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Wallabag\CoreBundle\Controller;
 
+use Doctrine\ORM\EntityManagerInterface;
 use Tests\Wallabag\CoreBundle\WallabagCoreTestCase;
 use Wallabag\CoreBundle\Entity\Entry;
 use Wallabag\UserBundle\Entity\User;
@@ -91,7 +92,7 @@ class FeedControllerTest extends WallabagCoreTestCase
     public function testUnread()
     {
         $client = $this->getClient();
-        $em = $client->getContainer()->get('doctrine.orm.entity_manager');
+        $em = $client->getContainer()->get(EntityManagerInterface::class);
         $user = $em
             ->getRepository(User::class)
             ->findOneByUsername('admin');
@@ -112,7 +113,7 @@ class FeedControllerTest extends WallabagCoreTestCase
     public function testStarred()
     {
         $client = $this->getClient();
-        $em = $client->getContainer()->get('doctrine.orm.entity_manager');
+        $em = $client->getContainer()->get(EntityManagerInterface::class);
         $user = $em
             ->getRepository(User::class)
             ->findOneByUsername('admin');
@@ -134,7 +135,7 @@ class FeedControllerTest extends WallabagCoreTestCase
     public function testArchives()
     {
         $client = $this->getClient();
-        $em = $client->getContainer()->get('doctrine.orm.entity_manager');
+        $em = $client->getContainer()->get(EntityManagerInterface::class);
         $user = $em
             ->getRepository(User::class)
             ->findOneByUsername('admin');
@@ -156,7 +157,7 @@ class FeedControllerTest extends WallabagCoreTestCase
     public function testAll()
     {
         $client = $this->getClient();
-        $em = $client->getContainer()->get('doctrine.orm.entity_manager');
+        $em = $client->getContainer()->get(EntityManagerInterface::class);
         $user = $em
             ->getRepository(User::class)
             ->findOneByUsername('admin');
@@ -178,7 +179,7 @@ class FeedControllerTest extends WallabagCoreTestCase
     public function testPagination()
     {
         $client = $this->getClient();
-        $em = $client->getContainer()->get('doctrine.orm.entity_manager');
+        $em = $client->getContainer()->get(EntityManagerInterface::class);
         $user = $em
             ->getRepository(User::class)
             ->findOneByUsername('admin');
@@ -206,7 +207,7 @@ class FeedControllerTest extends WallabagCoreTestCase
     public function testTags()
     {
         $client = $this->getClient();
-        $em = $client->getContainer()->get('doctrine.orm.entity_manager');
+        $em = $client->getContainer()->get(EntityManagerInterface::class);
         $user = $em
             ->getRepository(User::class)
             ->findOneByUsername('admin');

--- a/tests/Wallabag/CoreBundle/Controller/SecurityControllerTest.php
+++ b/tests/Wallabag/CoreBundle/Controller/SecurityControllerTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Wallabag\CoreBundle\Controller;
 
+use Doctrine\ORM\EntityManagerInterface;
 use Tests\Wallabag\CoreBundle\WallabagCoreTestCase;
 use Wallabag\UserBundle\Entity\User;
 
@@ -39,7 +40,7 @@ class SecurityControllerTest extends WallabagCoreTestCase
 
         $client->followRedirects();
 
-        $em = $client->getContainer()->get('doctrine.orm.entity_manager');
+        $em = $client->getContainer()->get(EntityManagerInterface::class);
         $user = $em
             ->getRepository(User::class)
             ->findOneByUsername('admin');
@@ -72,7 +73,7 @@ class SecurityControllerTest extends WallabagCoreTestCase
 
         $client->followRedirects();
 
-        $em = $client->getContainer()->get('doctrine.orm.entity_manager');
+        $em = $client->getContainer()->get(EntityManagerInterface::class);
         $user = $em
             ->getRepository(User::class)
             ->findOneByUsername('admin');

--- a/tests/Wallabag/CoreBundle/Controller/SiteCredentialControllerTest.php
+++ b/tests/Wallabag/CoreBundle/Controller/SiteCredentialControllerTest.php
@@ -2,6 +2,8 @@
 
 namespace Tests\Wallabag\CoreBundle\Controller;
 
+use Craue\ConfigBundle\Util\Config;
+use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Bundle\FrameworkBundle\Client;
 use Tests\Wallabag\CoreBundle\WallabagCoreTestCase;
 use Wallabag\CoreBundle\Entity\SiteCredential;
@@ -13,13 +15,13 @@ class SiteCredentialControllerTest extends WallabagCoreTestCase
         $this->logInAs('admin');
         $client = $this->getClient();
 
-        $client->getContainer()->get('craue_config')->set('restricted_access', 0);
+        $client->getContainer()->get(Config::class)->set('restricted_access', 0);
 
         $client->request('GET', '/site-credentials/');
 
         $this->assertSame(404, $client->getResponse()->getStatusCode());
 
-        $client->getContainer()->get('craue_config')->set('restricted_access', 1);
+        $client->getContainer()->get(Config::class)->set('restricted_access', 1);
     }
 
     public function testListSiteCredential()
@@ -144,7 +146,7 @@ class SiteCredentialControllerTest extends WallabagCoreTestCase
         $credential->setUsername('sergei');
         $credential->setPassword('microsoft');
 
-        $em = $client->getContainer()->get('doctrine.orm.entity_manager');
+        $em = $client->getContainer()->get(EntityManagerInterface::class);
         $em->persist($credential);
         $em->flush();
 

--- a/tests/Wallabag/CoreBundle/Controller/TagControllerTest.php
+++ b/tests/Wallabag/CoreBundle/Controller/TagControllerTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Wallabag\CoreBundle\Controller;
 
+use Doctrine\ORM\EntityManagerInterface;
 use Tests\Wallabag\CoreBundle\WallabagCoreTestCase;
 use Wallabag\CoreBundle\Entity\Entry;
 use Wallabag\CoreBundle\Entity\Tag;
@@ -77,7 +78,7 @@ class TagControllerTest extends WallabagCoreTestCase
         $client = $this->getClient();
 
         $entry = $client->getContainer()
-            ->get('doctrine.orm.entity_manager')
+            ->get(EntityManagerInterface::class)
             ->getRepository(Entry::class)
             ->findByUrlAndUserId('http://0.0.0.0/entry2', $this->getLoggedInUserId());
 
@@ -93,7 +94,7 @@ class TagControllerTest extends WallabagCoreTestCase
         $this->assertSame(302, $client->getResponse()->getStatusCode());
 
         $newEntry = $client->getContainer()
-            ->get('doctrine.orm.entity_manager')
+            ->get(EntityManagerInterface::class)
             ->getRepository(Entry::class)
             ->find($entry->getId());
 
@@ -138,7 +139,7 @@ class TagControllerTest extends WallabagCoreTestCase
         $this->assertSame(404, $client->getResponse()->getStatusCode());
 
         $tag = $client->getContainer()
-            ->get('doctrine.orm.entity_manager')
+            ->get(EntityManagerInterface::class)
             ->getRepository(Tag::class)
             ->findOneByLabel($this->tagName);
 
@@ -170,7 +171,7 @@ class TagControllerTest extends WallabagCoreTestCase
         $client->click($link);
 
         $tag = $client->getContainer()
-            ->get('doctrine.orm.entity_manager')
+            ->get(EntityManagerInterface::class)
             ->getRepository(Tag::class)
             ->findOneByLabel($this->tagName);
 
@@ -181,12 +182,12 @@ class TagControllerTest extends WallabagCoreTestCase
             ->findOneByUserName('admin');
 
         $entry = $client->getContainer()
-            ->get('doctrine.orm.entity_manager')
+            ->get(EntityManagerInterface::class)
             ->getRepository(Entry::class)
             ->findByUrlAndUserId('http://0.0.0.0/foo', $user->getId());
 
         $entry2 = $client->getContainer()
-            ->get('doctrine.orm.entity_manager')
+            ->get(EntityManagerInterface::class)
             ->getRepository(Entry::class)
             ->findByUrlAndUserId('http://0.0.0.0/bar', $user->getId());
 
@@ -199,13 +200,13 @@ class TagControllerTest extends WallabagCoreTestCase
         $this->logInAs('admin');
         $client = $this->getClient();
         $em = $client->getContainer()
-            ->get('doctrine.orm.entity_manager');
+            ->get(EntityManagerInterface::class);
 
         $tag = new Tag();
         $tag->setLabel($this->tagName);
 
         $entry = $client->getContainer()
-            ->get('doctrine.orm.entity_manager')
+            ->get(EntityManagerInterface::class)
             ->getRepository(Entry::class)
             ->findByUrlAndUserId('http://0.0.0.0/entry4', $this->getLoggedInUserId());
 
@@ -216,7 +217,7 @@ class TagControllerTest extends WallabagCoreTestCase
         $em->flush();
 
         $tag = $client->getContainer()
-            ->get('doctrine.orm.entity_manager')
+            ->get(EntityManagerInterface::class)
             ->getRepository(Tag::class)
             ->findOneByEntryAndTagLabel($entry, $this->tagName);
 
@@ -269,12 +270,12 @@ class TagControllerTest extends WallabagCoreTestCase
         $this->assertStringContainsString('flashes.tag.notice.tag_renamed', $crawler->filter('body')->extract(['_text'])[0]);
 
         $freshEntry = $client->getContainer()
-            ->get('doctrine.orm.entity_manager')
+            ->get(EntityManagerInterface::class)
             ->getRepository(Entry::class)
             ->find($entry->getId());
 
         $freshEntry2 = $client->getContainer()
-            ->get('doctrine.orm.entity_manager')
+            ->get(EntityManagerInterface::class)
             ->getRepository(Entry::class)
             ->find($entry2->getId());
 
@@ -293,7 +294,7 @@ class TagControllerTest extends WallabagCoreTestCase
         $this->assertFalse(array_search($tag->getLabel(), $tags, true), 'Previous tag is not attach to entries anymore.');
 
         $newTag = $client->getContainer()
-            ->get('doctrine.orm.entity_manager')
+            ->get(EntityManagerInterface::class)
             ->getRepository(Tag::class)
             ->findByLabel($newTagLabel);
 
@@ -333,7 +334,7 @@ class TagControllerTest extends WallabagCoreTestCase
         $this->assertStringNotContainsString('flashes.tag.notice.tag_renamed', $crawler->filter('body')->extract(['_text'])[0]);
 
         $freshEntry = $client->getContainer()
-            ->get('doctrine.orm.entity_manager')
+            ->get(EntityManagerInterface::class)
             ->getRepository(Entry::class)
             ->find($entry->getId());
 
@@ -347,7 +348,7 @@ class TagControllerTest extends WallabagCoreTestCase
         $this->assertNotFalse(array_search($tag->getLabel(), $tags, true), 'Tag is still assigned to the entry.');
 
         $newTag = $client->getContainer()
-            ->get('doctrine.orm.entity_manager')
+            ->get(EntityManagerInterface::class)
             ->getRepository(Tag::class)
             ->findByLabel($tagLabel);
 
@@ -388,7 +389,7 @@ class TagControllerTest extends WallabagCoreTestCase
         $this->assertStringNotContainsString('flashes.tag.notice.tag_renamed', $crawler->filter('body')->extract(['_text'])[0]);
 
         $freshEntry = $client->getContainer()
-            ->get('doctrine.orm.entity_manager')
+            ->get(EntityManagerInterface::class)
             ->getRepository(Entry::class)
             ->find($entry->getId());
 
@@ -402,12 +403,12 @@ class TagControllerTest extends WallabagCoreTestCase
         $this->assertFalse(array_search($newTagLabel, $tags, true));
 
         $tagFromRepo = $client->getContainer()
-            ->get('doctrine.orm.entity_manager')
+            ->get(EntityManagerInterface::class)
             ->getRepository(Tag::class)
             ->findByLabel($tagLabel);
 
         $newTagFromRepo = $client->getContainer()
-            ->get('doctrine.orm.entity_manager')
+            ->get(EntityManagerInterface::class)
             ->getRepository(Tag::class)
             ->findByLabel($newTagLabel);
 
@@ -458,22 +459,22 @@ class TagControllerTest extends WallabagCoreTestCase
         $this->assertStringNotContainsString('flashes.tag.notice.tag_renamed', $crawler->filter('body')->extract(['_text'])[0]);
 
         $freshEntry1 = $client->getContainer()
-            ->get('doctrine.orm.entity_manager')
+            ->get(EntityManagerInterface::class)
             ->getRepository(Entry::class)
             ->find($entry1->getId());
 
         $freshEntry2 = $client->getContainer()
-            ->get('doctrine.orm.entity_manager')
+            ->get(EntityManagerInterface::class)
             ->getRepository(Entry::class)
             ->find($entry2->getId());
 
         $tagFromRepo = $client->getContainer()
-            ->get('doctrine.orm.entity_manager')
+            ->get(EntityManagerInterface::class)
             ->getRepository(Tag::class)
             ->findByLabel($tagLabel);
 
         $previousTagFromRepo = $client->getContainer()
-            ->get('doctrine.orm.entity_manager')
+            ->get(EntityManagerInterface::class)
             ->getRepository(Tag::class)
             ->findByLabel($previousTagLabel);
 
@@ -516,7 +517,7 @@ class TagControllerTest extends WallabagCoreTestCase
         $client->submit($form, $data);
 
         $newEntry = $client->getContainer()
-            ->get('doctrine.orm.entity_manager')
+            ->get(EntityManagerInterface::class)
             ->getRepository(Entry::class)
             ->find($entry->getId());
 
@@ -549,7 +550,7 @@ class TagControllerTest extends WallabagCoreTestCase
         $client->followRedirect();
 
         $entries = $client->getContainer()
-            ->get('doctrine.orm.entity_manager')
+            ->get(EntityManagerInterface::class)
             ->getRepository(Entry::class)
             ->getBuilderForSearchByUser($this->getLoggedInUserId(), 'title', 'unread')
             ->getQuery()->getResult();

--- a/tests/Wallabag/CoreBundle/WallabagCoreTestCase.php
+++ b/tests/Wallabag/CoreBundle/WallabagCoreTestCase.php
@@ -2,12 +2,15 @@
 
 namespace Tests\Wallabag\CoreBundle;
 
+use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Bundle\FrameworkBundle\Client;
 use Symfony\Bundle\FrameworkBundle\Console\Application;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 use Symfony\Component\BrowserKit\Cookie;
 use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Output\NullOutput;
+use Symfony\Component\HttpFoundation\Session\SessionInterface;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 use Wallabag\CoreBundle\Entity\Config;
 use Wallabag\UserBundle\Entity\User;
 
@@ -70,7 +73,7 @@ abstract class WallabagCoreTestCase extends WebTestCase
 
     public function getEntityManager()
     {
-        return $this->client->getContainer()->get('doctrine.orm.entity_manager');
+        return $this->client->getContainer()->get(EntityManagerInterface::class);
     }
 
     /**
@@ -82,7 +85,7 @@ abstract class WallabagCoreTestCase extends WebTestCase
     public function logInAs($username)
     {
         $container = $this->client->getContainer();
-        $session = $container->get('session');
+        $session = $container->get(SessionInterface::class);
 
         $userManager = $container->get('fos_user.user_manager.test');
         $loginManager = $container->get('fos_user.security.login_manager.test');
@@ -96,7 +99,7 @@ abstract class WallabagCoreTestCase extends WebTestCase
 
         $loginManager->logInUser($firewallName, $user);
 
-        $session->set('_security_' . $firewallName, serialize($container->get('security.token_storage')->getToken()));
+        $session->set('_security_' . $firewallName, serialize($container->get(TokenStorageInterface::class)->getToken()));
         $session->save();
 
         $cookie = new Cookie($session->getName(), $session->getId());
@@ -129,7 +132,7 @@ abstract class WallabagCoreTestCase extends WebTestCase
      */
     public function getLoggedInUser()
     {
-        $token = static::$kernel->getContainer()->get('security.token_storage')->getToken();
+        $token = static::$kernel->getContainer()->get(TokenStorageInterface::class)->getToken();
 
         if (null !== $token) {
             return $token->getUser();

--- a/tests/Wallabag/ImportBundle/Controller/ChromeControllerTest.php
+++ b/tests/Wallabag/ImportBundle/Controller/ChromeControllerTest.php
@@ -2,6 +2,8 @@
 
 namespace Tests\Wallabag\ImportBundle\Controller;
 
+use Craue\ConfigBundle\Util\Config;
+use Doctrine\ORM\EntityManagerInterface;
 use Predis\Client;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
 use Tests\Wallabag\CoreBundle\WallabagCoreTestCase;
@@ -26,7 +28,7 @@ class ChromeControllerTest extends WallabagCoreTestCase
         $this->logInAs('admin');
         $client = $this->getClient();
 
-        $client->getContainer()->get('craue_config')->set('import_with_rabbitmq', 1);
+        $client->getContainer()->get(Config::class)->set('import_with_rabbitmq', 1);
 
         $crawler = $client->request('GET', '/import/chrome');
 
@@ -34,7 +36,7 @@ class ChromeControllerTest extends WallabagCoreTestCase
         $this->assertSame(1, $crawler->filter('form[name=upload_import_file] > button[type=submit]')->count());
         $this->assertSame(1, $crawler->filter('input[type=file]')->count());
 
-        $client->getContainer()->get('craue_config')->set('import_with_rabbitmq', 0);
+        $client->getContainer()->get(Config::class)->set('import_with_rabbitmq', 0);
     }
 
     public function testImportChromeBadFile()
@@ -59,7 +61,7 @@ class ChromeControllerTest extends WallabagCoreTestCase
         $this->checkRedis();
         $this->logInAs('admin');
         $client = $this->getClient();
-        $client->getContainer()->get('craue_config')->set('import_with_redis', 1);
+        $client->getContainer()->get(Config::class)->set('import_with_redis', 1);
 
         $crawler = $client->request('GET', '/import/chrome');
 
@@ -86,7 +88,7 @@ class ChromeControllerTest extends WallabagCoreTestCase
 
         $this->assertNotEmpty($client->getContainer()->get(Client::class)->lpop('wallabag.import.chrome'));
 
-        $client->getContainer()->get('craue_config')->set('import_with_redis', 0);
+        $client->getContainer()->get(Config::class)->set('import_with_redis', 0);
     }
 
     public function testImportWallabagWithChromeFile()
@@ -113,7 +115,7 @@ class ChromeControllerTest extends WallabagCoreTestCase
         $this->assertStringContainsString('flashes.import.notice.summary', $body[0]);
 
         $content = $client->getContainer()
-            ->get('doctrine.orm.entity_manager')
+            ->get(EntityManagerInterface::class)
             ->getRepository(Entry::class)
             ->findByUrlAndUserId(
                 'https://www.20minutes.fr/sport/3256363-20220321-tournoi-vi-nations-trophee-gagne-xv-france-fini-fond-seine',

--- a/tests/Wallabag/ImportBundle/Controller/DeliciousControllerTest.php
+++ b/tests/Wallabag/ImportBundle/Controller/DeliciousControllerTest.php
@@ -2,6 +2,8 @@
 
 namespace Tests\Wallabag\ImportBundle\Controller;
 
+use Craue\ConfigBundle\Util\Config;
+use Doctrine\ORM\EntityManagerInterface;
 use Predis\Client;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
 use Tests\Wallabag\CoreBundle\WallabagCoreTestCase;
@@ -26,7 +28,7 @@ class DeliciousControllerTest extends WallabagCoreTestCase
         $this->logInAs('admin');
         $client = $this->getClient();
 
-        $client->getContainer()->get('craue_config')->set('import_with_rabbitmq', 1);
+        $client->getContainer()->get(Config::class)->set('import_with_rabbitmq', 1);
 
         $crawler = $client->request('GET', '/import/delicious');
 
@@ -34,7 +36,7 @@ class DeliciousControllerTest extends WallabagCoreTestCase
         $this->assertSame(1, $crawler->filter('form[name=upload_import_file] > button[type=submit]')->count());
         $this->assertSame(1, $crawler->filter('input[type=file]')->count());
 
-        $client->getContainer()->get('craue_config')->set('import_with_rabbitmq', 0);
+        $client->getContainer()->get(Config::class)->set('import_with_rabbitmq', 0);
     }
 
     public function testImportDeliciousBadFile()
@@ -59,7 +61,7 @@ class DeliciousControllerTest extends WallabagCoreTestCase
         $this->checkRedis();
         $this->logInAs('admin');
         $client = $this->getClient();
-        $client->getContainer()->get('craue_config')->set('import_with_redis', 1);
+        $client->getContainer()->get(Config::class)->set('import_with_redis', 1);
 
         $crawler = $client->request('GET', '/import/delicious');
 
@@ -86,7 +88,7 @@ class DeliciousControllerTest extends WallabagCoreTestCase
 
         $this->assertNotEmpty($client->getContainer()->get(Client::class)->lpop('wallabag.import.delicious'));
 
-        $client->getContainer()->get('craue_config')->set('import_with_redis', 0);
+        $client->getContainer()->get(Config::class)->set('import_with_redis', 0);
     }
 
     public function testImportDeliciousWithFile()
@@ -110,7 +112,7 @@ class DeliciousControllerTest extends WallabagCoreTestCase
         $crawler = $client->followRedirect();
 
         $content = $client->getContainer()
-            ->get('doctrine.orm.entity_manager')
+            ->get(EntityManagerInterface::class)
             ->getRepository(Entry::class)
             ->findByUrlAndUserId(
                 'https://feross.org/spoofmac/',
@@ -152,7 +154,7 @@ class DeliciousControllerTest extends WallabagCoreTestCase
         $crawler = $client->followRedirect();
 
         $content1 = $client->getContainer()
-            ->get('doctrine.orm.entity_manager')
+            ->get(EntityManagerInterface::class)
             ->getRepository(Entry::class)
             ->findByUrlAndUserId(
                 'https://stackoverflow.com/review/',
@@ -162,7 +164,7 @@ class DeliciousControllerTest extends WallabagCoreTestCase
         $this->assertInstanceOf('Wallabag\CoreBundle\Entity\Entry', $content1);
 
         $content2 = $client->getContainer()
-            ->get('doctrine.orm.entity_manager')
+            ->get(EntityManagerInterface::class)
             ->getRepository(Entry::class)
             ->findByUrlAndUserId(
                 'https://addyosmani.com/basket.js/',

--- a/tests/Wallabag/ImportBundle/Controller/ElcuratorControllerTest.php
+++ b/tests/Wallabag/ImportBundle/Controller/ElcuratorControllerTest.php
@@ -2,6 +2,8 @@
 
 namespace Tests\Wallabag\ImportBundle\Controller;
 
+use Craue\ConfigBundle\Util\Config;
+use Doctrine\ORM\EntityManagerInterface;
 use Predis\Client;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
 use Tests\Wallabag\CoreBundle\WallabagCoreTestCase;
@@ -26,7 +28,7 @@ class ElcuratorControllerTest extends WallabagCoreTestCase
         $this->logInAs('admin');
         $client = $this->getClient();
 
-        $client->getContainer()->get('craue_config')->set('import_with_rabbitmq', 1);
+        $client->getContainer()->get(Config::class)->set('import_with_rabbitmq', 1);
 
         $crawler = $client->request('GET', '/import/elcurator');
 
@@ -34,7 +36,7 @@ class ElcuratorControllerTest extends WallabagCoreTestCase
         $this->assertSame(1, $crawler->filter('form[name=upload_import_file] > button[type=submit]')->count());
         $this->assertSame(1, $crawler->filter('input[type=file]')->count());
 
-        $client->getContainer()->get('craue_config')->set('import_with_rabbitmq', 0);
+        $client->getContainer()->get(Config::class)->set('import_with_rabbitmq', 0);
     }
 
     public function testImportElcuratorBadFile()
@@ -60,7 +62,7 @@ class ElcuratorControllerTest extends WallabagCoreTestCase
         $this->logInAs('admin');
         $client = $this->getClient();
 
-        $client->getContainer()->get('craue_config')->set('import_with_redis', 1);
+        $client->getContainer()->get(Config::class)->set('import_with_redis', 1);
 
         $crawler = $client->request('GET', '/import/elcurator');
 
@@ -87,7 +89,7 @@ class ElcuratorControllerTest extends WallabagCoreTestCase
 
         $this->assertNotEmpty($client->getContainer()->get(Client::class)->lpop('wallabag.import.elcurator'));
 
-        $client->getContainer()->get('craue_config')->set('import_with_redis', 0);
+        $client->getContainer()->get(Config::class)->set('import_with_redis', 0);
     }
 
     public function testImportElcuratorWithFile()
@@ -114,7 +116,7 @@ class ElcuratorControllerTest extends WallabagCoreTestCase
         $this->assertStringContainsString('flashes.import.notice.summary', $body[0]);
 
         $content = $client->getContainer()
-            ->get('doctrine.orm.entity_manager')
+            ->get(EntityManagerInterface::class)
             ->getRepository(Entry::class)
             ->findByUrlAndUserId(
                 'https://devblog.lexik.fr/git/qualite-de-code-integration-de-php-git-hooks-dans-symfony2-2842',

--- a/tests/Wallabag/ImportBundle/Controller/FirefoxControllerTest.php
+++ b/tests/Wallabag/ImportBundle/Controller/FirefoxControllerTest.php
@@ -2,6 +2,8 @@
 
 namespace Tests\Wallabag\ImportBundle\Controller;
 
+use Craue\ConfigBundle\Util\Config;
+use Doctrine\ORM\EntityManagerInterface;
 use Predis\Client;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
 use Tests\Wallabag\CoreBundle\WallabagCoreTestCase;
@@ -26,7 +28,7 @@ class FirefoxControllerTest extends WallabagCoreTestCase
         $this->logInAs('admin');
         $client = $this->getClient();
 
-        $client->getContainer()->get('craue_config')->set('import_with_rabbitmq', 1);
+        $client->getContainer()->get(Config::class)->set('import_with_rabbitmq', 1);
 
         $crawler = $client->request('GET', '/import/firefox');
 
@@ -34,7 +36,7 @@ class FirefoxControllerTest extends WallabagCoreTestCase
         $this->assertSame(1, $crawler->filter('form[name=upload_import_file] > button[type=submit]')->count());
         $this->assertSame(1, $crawler->filter('input[type=file]')->count());
 
-        $client->getContainer()->get('craue_config')->set('import_with_rabbitmq', 0);
+        $client->getContainer()->get(Config::class)->set('import_with_rabbitmq', 0);
     }
 
     public function testImportFirefoxBadFile()
@@ -59,7 +61,7 @@ class FirefoxControllerTest extends WallabagCoreTestCase
         $this->checkRedis();
         $this->logInAs('admin');
         $client = $this->getClient();
-        $client->getContainer()->get('craue_config')->set('import_with_redis', 1);
+        $client->getContainer()->get(Config::class)->set('import_with_redis', 1);
 
         $crawler = $client->request('GET', '/import/firefox');
 
@@ -86,7 +88,7 @@ class FirefoxControllerTest extends WallabagCoreTestCase
 
         $this->assertNotEmpty($client->getContainer()->get(Client::class)->lpop('wallabag.import.firefox'));
 
-        $client->getContainer()->get('craue_config')->set('import_with_redis', 0);
+        $client->getContainer()->get(Config::class)->set('import_with_redis', 0);
     }
 
     public function testImportWallabagWithFirefoxFile()
@@ -113,7 +115,7 @@ class FirefoxControllerTest extends WallabagCoreTestCase
         $this->assertStringContainsString('flashes.import.notice.summary', $body[0]);
 
         $content = $client->getContainer()
-            ->get('doctrine.orm.entity_manager')
+            ->get(EntityManagerInterface::class)
             ->getRepository(Entry::class)
             ->findByUrlAndUserId(
                 'https://lexpansion.lexpress.fr/high-tech/orange-offre-un-meilleur-reseau-mobile-que-bouygues-et-sfr-free-derriere_1811554.html',
@@ -127,7 +129,7 @@ class FirefoxControllerTest extends WallabagCoreTestCase
         $this->assertCount(3, $content->getTags());
 
         $content = $client->getContainer()
-            ->get('doctrine.orm.entity_manager')
+            ->get(EntityManagerInterface::class)
             ->getRepository(Entry::class)
             ->findByUrlAndUserId(
                 'https://www.lemonde.fr/disparitions/article/2018/07/05/le-journaliste-et-cineaste-claude-lanzmann-est-mort_5326313_3382.html',

--- a/tests/Wallabag/ImportBundle/Controller/InstapaperControllerTest.php
+++ b/tests/Wallabag/ImportBundle/Controller/InstapaperControllerTest.php
@@ -2,6 +2,8 @@
 
 namespace Tests\Wallabag\ImportBundle\Controller;
 
+use Craue\ConfigBundle\Util\Config;
+use Doctrine\ORM\EntityManagerInterface;
 use Predis\Client;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
 use Tests\Wallabag\CoreBundle\WallabagCoreTestCase;
@@ -26,7 +28,7 @@ class InstapaperControllerTest extends WallabagCoreTestCase
         $this->logInAs('admin');
         $client = $this->getClient();
 
-        $client->getContainer()->get('craue_config')->set('import_with_rabbitmq', 1);
+        $client->getContainer()->get(Config::class)->set('import_with_rabbitmq', 1);
 
         $crawler = $client->request('GET', '/import/instapaper');
 
@@ -34,7 +36,7 @@ class InstapaperControllerTest extends WallabagCoreTestCase
         $this->assertSame(1, $crawler->filter('form[name=upload_import_file] > button[type=submit]')->count());
         $this->assertSame(1, $crawler->filter('input[type=file]')->count());
 
-        $client->getContainer()->get('craue_config')->set('import_with_rabbitmq', 0);
+        $client->getContainer()->get(Config::class)->set('import_with_rabbitmq', 0);
     }
 
     public function testImportInstapaperBadFile()
@@ -59,7 +61,7 @@ class InstapaperControllerTest extends WallabagCoreTestCase
         $this->checkRedis();
         $this->logInAs('admin');
         $client = $this->getClient();
-        $client->getContainer()->get('craue_config')->set('import_with_redis', 1);
+        $client->getContainer()->get(Config::class)->set('import_with_redis', 1);
 
         $crawler = $client->request('GET', '/import/instapaper');
 
@@ -86,7 +88,7 @@ class InstapaperControllerTest extends WallabagCoreTestCase
 
         $this->assertNotEmpty($client->getContainer()->get(Client::class)->lpop('wallabag.import.instapaper'));
 
-        $client->getContainer()->get('craue_config')->set('import_with_redis', 0);
+        $client->getContainer()->get(Config::class)->set('import_with_redis', 0);
     }
 
     public function testImportInstapaperWithFile()
@@ -113,7 +115,7 @@ class InstapaperControllerTest extends WallabagCoreTestCase
         $this->assertStringContainsString('flashes.import.notice.summary', $body[0]);
 
         $content = $client->getContainer()
-            ->get('doctrine.orm.entity_manager')
+            ->get(EntityManagerInterface::class)
             ->getRepository(Entry::class)
             ->findByUrlAndUserId(
                 'https://www.liberation.fr/societe/police-justice/cours-dassises-on-efface-le-peuple-dun-processus-judiciaire-dont-il-est-pourtant-le-coeur-battant-20210414_FYUNIZENHRGHZLAZEKSMKZYEPI/',
@@ -130,7 +132,7 @@ class InstapaperControllerTest extends WallabagCoreTestCase
         $this->assertInstanceOf(\DateTime::class, $content->getCreatedAt());
 
         $content = $client->getContainer()
-            ->get('doctrine.orm.entity_manager')
+            ->get(EntityManagerInterface::class)
             ->getRepository(Entry::class)
             ->findByUrlAndUserId(
                 'https://www.20minutes.fr/high-tech/2077615-20170531-quoi-exactement-tweet-covfefe-donald-trump-persiste-signe',
@@ -165,7 +167,7 @@ class InstapaperControllerTest extends WallabagCoreTestCase
         $crawler = $client->followRedirect();
 
         $content1 = $client->getContainer()
-            ->get('doctrine.orm.entity_manager')
+            ->get(EntityManagerInterface::class)
             ->getRepository(Entry::class)
             ->findByUrlAndUserId(
                 'https://redditblog.com/2016/09/20/amp-and-reactredux/',
@@ -175,7 +177,7 @@ class InstapaperControllerTest extends WallabagCoreTestCase
         $this->assertTrue($content1->isArchived());
 
         $content2 = $client->getContainer()
-            ->get('doctrine.orm.entity_manager')
+            ->get(EntityManagerInterface::class)
             ->getRepository(Entry::class)
             ->findByUrlAndUserId(
                 'https://medium.com/@the_minh/why-foursquare-swarm-is-still-my-favourite-social-network-e38228493e6c',

--- a/tests/Wallabag/ImportBundle/Controller/PinboardControllerTest.php
+++ b/tests/Wallabag/ImportBundle/Controller/PinboardControllerTest.php
@@ -2,6 +2,8 @@
 
 namespace Tests\Wallabag\ImportBundle\Controller;
 
+use Craue\ConfigBundle\Util\Config;
+use Doctrine\ORM\EntityManagerInterface;
 use Predis\Client;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
 use Tests\Wallabag\CoreBundle\WallabagCoreTestCase;
@@ -26,7 +28,7 @@ class PinboardControllerTest extends WallabagCoreTestCase
         $this->logInAs('admin');
         $client = $this->getClient();
 
-        $client->getContainer()->get('craue_config')->set('import_with_rabbitmq', 1);
+        $client->getContainer()->get(Config::class)->set('import_with_rabbitmq', 1);
 
         $crawler = $client->request('GET', '/import/pinboard');
 
@@ -34,7 +36,7 @@ class PinboardControllerTest extends WallabagCoreTestCase
         $this->assertSame(1, $crawler->filter('form[name=upload_import_file] > button[type=submit]')->count());
         $this->assertSame(1, $crawler->filter('input[type=file]')->count());
 
-        $client->getContainer()->get('craue_config')->set('import_with_rabbitmq', 0);
+        $client->getContainer()->get(Config::class)->set('import_with_rabbitmq', 0);
     }
 
     public function testImportPinboardBadFile()
@@ -59,7 +61,7 @@ class PinboardControllerTest extends WallabagCoreTestCase
         $this->checkRedis();
         $this->logInAs('admin');
         $client = $this->getClient();
-        $client->getContainer()->get('craue_config')->set('import_with_redis', 1);
+        $client->getContainer()->get(Config::class)->set('import_with_redis', 1);
 
         $crawler = $client->request('GET', '/import/pinboard');
 
@@ -86,7 +88,7 @@ class PinboardControllerTest extends WallabagCoreTestCase
 
         $this->assertNotEmpty($client->getContainer()->get(Client::class)->lpop('wallabag.import.pinboard'));
 
-        $client->getContainer()->get('craue_config')->set('import_with_redis', 0);
+        $client->getContainer()->get(Config::class)->set('import_with_redis', 0);
     }
 
     public function testImportPinboardWithFile()
@@ -110,7 +112,7 @@ class PinboardControllerTest extends WallabagCoreTestCase
         $crawler = $client->followRedirect();
 
         $content = $client->getContainer()
-            ->get('doctrine.orm.entity_manager')
+            ->get(EntityManagerInterface::class)
             ->getRepository(Entry::class)
             ->findByUrlAndUserId(
                 'https://ma.ttias.be/varnish-explained/',
@@ -157,7 +159,7 @@ class PinboardControllerTest extends WallabagCoreTestCase
         $crawler = $client->followRedirect();
 
         $content1 = $client->getContainer()
-            ->get('doctrine.orm.entity_manager')
+            ->get(EntityManagerInterface::class)
             ->getRepository(Entry::class)
             ->findByUrlAndUserId(
                 'https://ilia.ws/files/nginx_torontophpug.pdf',
@@ -168,7 +170,7 @@ class PinboardControllerTest extends WallabagCoreTestCase
         $this->assertTrue($content1->isArchived());
 
         $content2 = $client->getContainer()
-            ->get('doctrine.orm.entity_manager')
+            ->get(EntityManagerInterface::class)
             ->getRepository(Entry::class)
             ->findByUrlAndUserId(
                 'https://developers.google.com/web/updates/2016/07/infinite-scroller',

--- a/tests/Wallabag/ImportBundle/Controller/PocketControllerTest.php
+++ b/tests/Wallabag/ImportBundle/Controller/PocketControllerTest.php
@@ -2,6 +2,8 @@
 
 namespace Tests\Wallabag\ImportBundle\Controller;
 
+use Craue\ConfigBundle\Util\Config;
+use Symfony\Component\HttpFoundation\Session\SessionInterface;
 use Tests\Wallabag\CoreBundle\WallabagCoreTestCase;
 use Wallabag\ImportBundle\Import\PocketImport;
 
@@ -23,14 +25,14 @@ class PocketControllerTest extends WallabagCoreTestCase
         $this->logInAs('admin');
         $client = $this->getClient();
 
-        $client->getContainer()->get('craue_config')->set('import_with_rabbitmq', 1);
+        $client->getContainer()->get(Config::class)->set('import_with_rabbitmq', 1);
 
         $crawler = $client->request('GET', '/import/pocket');
 
         $this->assertSame(200, $client->getResponse()->getStatusCode());
         $this->assertSame(1, $crawler->filter('button[name=action]')->count());
 
-        $client->getContainer()->get('craue_config')->set('import_with_rabbitmq', 0);
+        $client->getContainer()->get(Config::class)->set('import_with_rabbitmq', 0);
     }
 
     public function testImportPocketWithRedisEnabled()
@@ -39,14 +41,14 @@ class PocketControllerTest extends WallabagCoreTestCase
         $this->logInAs('admin');
         $client = $this->getClient();
 
-        $client->getContainer()->get('craue_config')->set('import_with_redis', 1);
+        $client->getContainer()->get(Config::class)->set('import_with_redis', 1);
 
         $crawler = $client->request('GET', '/import/pocket');
 
         $this->assertSame(200, $client->getResponse()->getStatusCode());
         $this->assertSame(1, $crawler->filter('button[name=action]')->count());
 
-        $client->getContainer()->get('craue_config')->set('import_with_redis', 0);
+        $client->getContainer()->get(Config::class)->set('import_with_redis', 0);
     }
 
     public function testImportPocketAuthBadToken()
@@ -101,7 +103,7 @@ class PocketControllerTest extends WallabagCoreTestCase
 
         $this->assertSame(302, $client->getResponse()->getStatusCode());
         $this->assertStringContainsString('/', $client->getResponse()->headers->get('location'), 'Import is ok, redirect to homepage');
-        $this->assertSame('flashes.import.notice.failed', $client->getContainer()->get('session')->getFlashBag()->peek('notice')[0]);
+        $this->assertSame('flashes.import.notice.failed', $client->getContainer()->get(SessionInterface::class)->getFlashBag()->peek('notice')[0]);
     }
 
     public function testImportPocketCallback()
@@ -135,6 +137,6 @@ class PocketControllerTest extends WallabagCoreTestCase
 
         $this->assertSame(302, $client->getResponse()->getStatusCode());
         $this->assertStringContainsString('/', $client->getResponse()->headers->get('location'), 'Import is ok, redirect to homepage');
-        $this->assertSame('flashes.import.notice.summary', $client->getContainer()->get('session')->getFlashBag()->peek('notice')[0]);
+        $this->assertSame('flashes.import.notice.summary', $client->getContainer()->get(SessionInterface::class)->getFlashBag()->peek('notice')[0]);
     }
 }

--- a/tests/Wallabag/ImportBundle/Controller/ReadabilityControllerTest.php
+++ b/tests/Wallabag/ImportBundle/Controller/ReadabilityControllerTest.php
@@ -2,6 +2,8 @@
 
 namespace Tests\Wallabag\ImportBundle\Controller;
 
+use Craue\ConfigBundle\Util\Config;
+use Doctrine\ORM\EntityManagerInterface;
 use Predis\Client;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
 use Tests\Wallabag\CoreBundle\WallabagCoreTestCase;
@@ -26,7 +28,7 @@ class ReadabilityControllerTest extends WallabagCoreTestCase
         $this->logInAs('admin');
         $client = $this->getClient();
 
-        $client->getContainer()->get('craue_config')->set('import_with_rabbitmq', 1);
+        $client->getContainer()->get(Config::class)->set('import_with_rabbitmq', 1);
 
         $crawler = $client->request('GET', '/import/readability');
 
@@ -34,7 +36,7 @@ class ReadabilityControllerTest extends WallabagCoreTestCase
         $this->assertSame(1, $crawler->filter('form[name=upload_import_file] > button[type=submit]')->count());
         $this->assertSame(1, $crawler->filter('input[type=file]')->count());
 
-        $client->getContainer()->get('craue_config')->set('import_with_rabbitmq', 0);
+        $client->getContainer()->get(Config::class)->set('import_with_rabbitmq', 0);
     }
 
     public function testImportReadabilityBadFile()
@@ -59,7 +61,7 @@ class ReadabilityControllerTest extends WallabagCoreTestCase
         $this->checkRedis();
         $this->logInAs('admin');
         $client = $this->getClient();
-        $client->getContainer()->get('craue_config')->set('import_with_redis', 1);
+        $client->getContainer()->get(Config::class)->set('import_with_redis', 1);
 
         $crawler = $client->request('GET', '/import/readability');
 
@@ -86,7 +88,7 @@ class ReadabilityControllerTest extends WallabagCoreTestCase
 
         $this->assertNotEmpty($client->getContainer()->get(Client::class)->lpop('wallabag.import.readability'));
 
-        $client->getContainer()->get('craue_config')->set('import_with_redis', 0);
+        $client->getContainer()->get(Config::class)->set('import_with_redis', 0);
     }
 
     public function testImportReadabilityWithFile()
@@ -110,7 +112,7 @@ class ReadabilityControllerTest extends WallabagCoreTestCase
         $crawler = $client->followRedirect();
 
         $content = $client->getContainer()
-            ->get('doctrine.orm.entity_manager')
+            ->get(EntityManagerInterface::class)
             ->getRepository(Entry::class)
             ->findByUrlAndUserId(
                 'https://www.20minutes.fr/bordeaux/2120479-20170823-bordeaux-poche-chocolatine-association-traduit-etudiants-etrangers-mots-sud-ouest',
@@ -155,7 +157,7 @@ class ReadabilityControllerTest extends WallabagCoreTestCase
         $crawler = $client->followRedirect();
 
         $content1 = $client->getContainer()
-            ->get('doctrine.orm.entity_manager')
+            ->get(EntityManagerInterface::class)
             ->getRepository(Entry::class)
             ->findByUrlAndUserId(
                 'https://blog.travis-ci.com/2016-07-28-what-we-learned-from-analyzing-2-million-travis-builds/',
@@ -166,7 +168,7 @@ class ReadabilityControllerTest extends WallabagCoreTestCase
         $this->assertTrue($content1->isArchived());
 
         $content2 = $client->getContainer()
-            ->get('doctrine.orm.entity_manager')
+            ->get(EntityManagerInterface::class)
             ->getRepository(Entry::class)
             ->findByUrlAndUserId(
                 'https://facebook.github.io/graphql/October2016/',

--- a/tests/Wallabag/ImportBundle/Controller/WallabagV1ControllerTest.php
+++ b/tests/Wallabag/ImportBundle/Controller/WallabagV1ControllerTest.php
@@ -2,6 +2,8 @@
 
 namespace Tests\Wallabag\ImportBundle\Controller;
 
+use Craue\ConfigBundle\Util\Config;
+use Doctrine\ORM\EntityManagerInterface;
 use Predis\Client;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
 use Tests\Wallabag\CoreBundle\WallabagCoreTestCase;
@@ -26,7 +28,7 @@ class WallabagV1ControllerTest extends WallabagCoreTestCase
         $this->logInAs('admin');
         $client = $this->getClient();
 
-        $client->getContainer()->get('craue_config')->set('import_with_rabbitmq', 1);
+        $client->getContainer()->get(Config::class)->set('import_with_rabbitmq', 1);
 
         $crawler = $client->request('GET', '/import/wallabag-v1');
 
@@ -34,7 +36,7 @@ class WallabagV1ControllerTest extends WallabagCoreTestCase
         $this->assertSame(1, $crawler->filter('form[name=upload_import_file] > button[type=submit]')->count());
         $this->assertSame(1, $crawler->filter('input[type=file]')->count());
 
-        $client->getContainer()->get('craue_config')->set('import_with_rabbitmq', 0);
+        $client->getContainer()->get(Config::class)->set('import_with_rabbitmq', 0);
     }
 
     public function testImportWallabagBadFile()
@@ -60,7 +62,7 @@ class WallabagV1ControllerTest extends WallabagCoreTestCase
         $this->logInAs('admin');
         $client = $this->getClient();
 
-        $client->getContainer()->get('craue_config')->set('import_with_redis', 1);
+        $client->getContainer()->get(Config::class)->set('import_with_redis', 1);
 
         $crawler = $client->request('GET', '/import/wallabag-v1');
 
@@ -87,7 +89,7 @@ class WallabagV1ControllerTest extends WallabagCoreTestCase
 
         $this->assertNotEmpty($client->getContainer()->get(Client::class)->lpop('wallabag.import.wallabag_v1'));
 
-        $client->getContainer()->get('craue_config')->set('import_with_redis', 0);
+        $client->getContainer()->get(Config::class)->set('import_with_redis', 0);
     }
 
     public function testImportWallabagWithFile()
@@ -111,7 +113,7 @@ class WallabagV1ControllerTest extends WallabagCoreTestCase
         $crawler = $client->followRedirect();
 
         $content = $client->getContainer()
-            ->get('doctrine.orm.entity_manager')
+            ->get(EntityManagerInterface::class)
             ->getRepository(Entry::class)
             ->findByUrlAndUserId(
                 'http://www.framablog.org/index.php/post/2014/02/05/Framabag-service-libre-gratuit-interview-developpeur',
@@ -156,7 +158,7 @@ class WallabagV1ControllerTest extends WallabagCoreTestCase
         $crawler = $client->followRedirect();
 
         $content1 = $client->getContainer()
-            ->get('doctrine.orm.entity_manager')
+            ->get(EntityManagerInterface::class)
             ->getRepository(Entry::class)
             ->findByUrlAndUserId(
                 'http://gilbert.pellegrom.me/recreating-the-square-slider',
@@ -167,7 +169,7 @@ class WallabagV1ControllerTest extends WallabagCoreTestCase
         $this->assertTrue($content1->isArchived());
 
         $content2 = $client->getContainer()
-            ->get('doctrine.orm.entity_manager')
+            ->get(EntityManagerInterface::class)
             ->getRepository(Entry::class)
             ->findByUrlAndUserId(
                 'https://www.wallabag.org/features/',

--- a/tests/Wallabag/ImportBundle/Controller/WallabagV2ControllerTest.php
+++ b/tests/Wallabag/ImportBundle/Controller/WallabagV2ControllerTest.php
@@ -2,6 +2,8 @@
 
 namespace Tests\Wallabag\ImportBundle\Controller;
 
+use Craue\ConfigBundle\Util\Config;
+use Doctrine\ORM\EntityManagerInterface;
 use Predis\Client;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
 use Tests\Wallabag\CoreBundle\WallabagCoreTestCase;
@@ -26,7 +28,7 @@ class WallabagV2ControllerTest extends WallabagCoreTestCase
         $this->logInAs('admin');
         $client = $this->getClient();
 
-        $client->getContainer()->get('craue_config')->set('import_with_rabbitmq', 1);
+        $client->getContainer()->get(Config::class)->set('import_with_rabbitmq', 1);
 
         $crawler = $client->request('GET', '/import/wallabag-v2');
 
@@ -34,7 +36,7 @@ class WallabagV2ControllerTest extends WallabagCoreTestCase
         $this->assertSame(1, $crawler->filter('form[name=upload_import_file] > button[type=submit]')->count());
         $this->assertSame(1, $crawler->filter('input[type=file]')->count());
 
-        $client->getContainer()->get('craue_config')->set('import_with_rabbitmq', 0);
+        $client->getContainer()->get(Config::class)->set('import_with_rabbitmq', 0);
     }
 
     public function testImportWallabagBadFile()
@@ -60,7 +62,7 @@ class WallabagV2ControllerTest extends WallabagCoreTestCase
         $this->logInAs('admin');
         $client = $this->getClient();
 
-        $client->getContainer()->get('craue_config')->set('import_with_redis', 1);
+        $client->getContainer()->get(Config::class)->set('import_with_redis', 1);
 
         $crawler = $client->request('GET', '/import/wallabag-v2');
 
@@ -87,7 +89,7 @@ class WallabagV2ControllerTest extends WallabagCoreTestCase
 
         $this->assertNotEmpty($client->getContainer()->get(Client::class)->lpop('wallabag.import.wallabag_v2'));
 
-        $client->getContainer()->get('craue_config')->set('import_with_redis', 0);
+        $client->getContainer()->get(Config::class)->set('import_with_redis', 0);
     }
 
     public function testImportWallabagWithFile()
@@ -114,7 +116,7 @@ class WallabagV2ControllerTest extends WallabagCoreTestCase
         $this->assertStringContainsString('flashes.import.notice.summary', $body[0]);
 
         $content = $client->getContainer()
-            ->get('doctrine.orm.entity_manager')
+            ->get(EntityManagerInterface::class)
             ->getRepository(Entry::class)
             ->findByUrlAndUserId(
                 'https://www.liberation.fr/planete/2015/10/26/refugies-l-ue-va-creer-100-000-places-d-accueil-dans-les-balkans_1408867',
@@ -133,7 +135,7 @@ class WallabagV2ControllerTest extends WallabagCoreTestCase
         $this->assertCount(1, $tags);
 
         $content = $client->getContainer()
-            ->get('doctrine.orm.entity_manager')
+            ->get(EntityManagerInterface::class)
             ->getRepository(Entry::class)
             ->findByUrlAndUserId(
                 'https://www.mediapart.fr/',


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Documentation | no
| Translation   | no
| CHANGELOG.md  | no
| License       | MIT

This is a preparation work to make services private, to unlock Symfony 4 upgrade.
I will use [Rector](https://github.com/rectorphp/rector#rector---instant-upgrades-and-automated-refactoring) to refactor the code and make the service injected in constructor (see for example [this rector](https://github.com/rectorphp/rector-symfony/blob/main/docs/rector_rules_overview.md#gettoconstructorinjectionrector))
But to work it needs the FQCN.

Note that there is a remaining service not migrated, the `logger`, because it gets inlined in the container so not accessible.
It will be handled separately when making service private. (teasing: I already have a WIP on my computer 🙂)