### PR TITLE
Add `nbEntries` to the API tags list response

### DIFF
--- a/src/Wallabag/ApiBundle/Controller/TagRestController.php
+++ b/src/Wallabag/ApiBundle/Controller/TagRestController.php
@@ -23,7 +23,7 @@ class TagRestController extends WallabagRestController
 
         $tags = $this->getDoctrine()
             ->getRepository('WallabagCoreBundle:Tag')
-            ->findAllTags($this->getUser()->getId());
+            ->findAllFlatTagsWithNbEntries($this->getUser()->getId());
 
         $json = $this->get('jms_serializer')->serialize($tags, 'json');
 

--- a/src/Wallabag/CoreBundle/Resources/views/themes/material/Tag/tags.html.twig
+++ b/src/Wallabag/CoreBundle/Resources/views/themes/material/Tag/tags.html.twig
@@ -33,8 +33,4 @@
             {% endfor %}
         </ul>
     </div>
-
-    <div>
-
-    </div>
 {% endblock %}

--- a/tests/Wallabag/ApiBundle/Controller/TagRestControllerTest.php
+++ b/tests/Wallabag/ApiBundle/Controller/TagRestControllerTest.php
@@ -20,14 +20,13 @@ class TagRestControllerTest extends WallabagApiTestCase
         $this->assertGreaterThan(0, $content);
         $this->assertArrayHasKey('id', $content[0]);
         $this->assertArrayHasKey('label', $content[0]);
+        $this->assertArrayHasKey('nbEntries', $content[0]);
 
         $tagLabels = array_map(function ($i) {
             return $i['label'];
         }, $content);
 
         $this->assertNotContains($this->otherUserTagLabel, $tagLabels, 'There is a possible tag leak');
-
-        return end($content);
     }
 
     public function testDeleteUserTag()


### PR DESCRIPTION
So client will be able to do the same as in the web UI.

Also remove empty `div` from the tags template.

Fix https://github.com/wallabag/wallabag/issues/5970

I'm wondering if this goes to 2.6.0 or 2.5.2, @wallabag/core?
As it's a small change, I'm for 2.5.2