### PR TITLE
Add support to download SVG locally

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,6 @@
     },
     "require": {
         "php": ">=7.4",
-        "composer": "< 2.3",
         "ext-ctype": "*",
         "ext-curl": "*",
         "ext-dom": "*",
@@ -51,6 +50,7 @@
         "ext-tidy": "*",
         "ext-tokenizer": "*",
         "ext-xml": "*",
+        "composer": "< 2.3",
         "babdev/pagerfanta-bundle": "^2.5",
         "bdunogier/guzzle-site-authenticator": "^1.0.0",
         "craue/config-bundle": "^2.3.0",
@@ -59,6 +59,7 @@
         "doctrine/doctrine-cache-bundle": "^1.3",
         "doctrine/doctrine-migrations-bundle": "^1.3",
         "doctrine/orm": "^2.6",
+        "enshrined/svg-sanitize": "^0.15.4",
         "friendsofsymfony/jsrouting-bundle": "^2.2",
         "friendsofsymfony/oauth-server-bundle": "^1.5",
         "friendsofsymfony/rest-bundle": "~2.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "0d0c51bee0ced9698321d0fd2ad33aca",
+    "content-hash": "5aec7c6af1a3c05510db2e1243da8db5",
     "packages": [
         {
             "name": "babdev/pagerfanta-bundle",
@@ -2059,6 +2059,51 @@
                 }
             ],
             "time": "2022-06-18T20:57:19+00:00"
+        },
+        {
+            "name": "enshrined/svg-sanitize",
+            "version": "0.15.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/darylldoyle/svg-sanitizer.git",
+                "reference": "e50b83a2f1f296ca61394fe88fbfe3e896a84cf4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/darylldoyle/svg-sanitizer/zipball/e50b83a2f1f296ca61394fe88fbfe3e896a84cf4",
+                "reference": "e50b83a2f1f296ca61394fe88fbfe3e896a84cf4",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-libxml": "*",
+                "php": "^7.0 || ^8.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^6.5 || ^8.5"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "enshrined\\svgSanitize\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Daryll Doyle",
+                    "email": "daryll@enshrined.co.uk"
+                }
+            ],
+            "description": "An SVG sanitizer for PHP",
+            "support": {
+                "issues": "https://github.com/darylldoyle/svg-sanitizer/issues",
+                "source": "https://github.com/darylldoyle/svg-sanitizer/tree/0.15.4"
+            },
+            "time": "2022-02-21T09:13:59+00:00"
         },
         {
             "name": "fig/link-util",
@@ -12997,7 +13042,6 @@
     "prefer-lowest": false,
     "platform": {
         "php": ">=7.4",
-        "composer": "< 2.3",
         "ext-ctype": "*",
         "ext-curl": "*",
         "ext-dom": "*",
@@ -13013,7 +13057,8 @@
         "ext-simplexml": "*",
         "ext-tidy": "*",
         "ext-tokenizer": "*",
-        "ext-xml": "*"
+        "ext-xml": "*",
+        "composer": "< 2.3"
     },
     "platform-dev": [],
     "platform-overrides": {

--- a/tests/Wallabag/CoreBundle/Helper/DownloadImagesTest.php
+++ b/tests/Wallabag/CoreBundle/Helper/DownloadImagesTest.php
@@ -220,4 +220,32 @@ class DownloadImagesTest extends TestCase
 
         $this->assertSame('<img src="http://wallabag.io/assets/images/9/b/9b0ead26/6bef06fe.png" srcset="http://wallabag.io/assets/images/9/b/9b0ead26/43cc0123.png 1290w" height="573" width="860" alt="" referrerpolicy="no-referrer">', $res);
     }
+
+    public function testProcessSingleImageWithSvg()
+    {
+        $httpMockClient = new HttpMockClient();
+        $httpMockClient->addResponse(new Response(200, ['content-type' => 'image/svg+xml'], file_get_contents(__DIR__ . '/../fixtures/modal-content.svg')));
+
+        $logHandler = new TestHandler();
+        $logger = new Logger('test', [$logHandler]);
+
+        $download = new DownloadImages($httpMockClient, sys_get_temp_dir() . '/wallabag_test', 'http://wallabag.io/', $logger);
+        $res = $download->processSingleImage(123, 'modal-content.svg', 'http://imgur.com/gallery/WxtWY');
+
+        $this->assertStringContainsString('/assets/images/9/b/9b0ead26/400e29f9.svg', $res);
+    }
+
+    public function testProcessSingleImageWithBadSvg()
+    {
+        $httpMockClient = new HttpMockClient();
+        $httpMockClient->addResponse(new Response(200, ['content-type' => 'image/svg+xml'], file_get_contents(__DIR__ . '/../fixtures/unnamed.png')));
+
+        $logHandler = new TestHandler();
+        $logger = new Logger('test', [$logHandler]);
+
+        $download = new DownloadImages($httpMockClient, sys_get_temp_dir() . '/wallabag_test', 'http://wallabag.io/', $logger);
+        $res = $download->processSingleImage(123, 'modal-content.svg', 'http://imgur.com/gallery/WxtWY');
+
+        $this->assertFalse($res);
+    }
 }

--- a/tests/Wallabag/CoreBundle/fixtures/modal-content.svg
+++ b/tests/Wallabag/CoreBundle/fixtures/modal-content.svg
@@ -1,0 +1,237 @@
+<svg width="120" height="125" viewBox="0 0 120 125" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g clip-path="url(#clip0)">
+<g filter="url(#filter0_d)">
+<path d="M82.7311 12.7383H26.7744C23.5022 12.7383 20.8496 15.4119 20.8496 18.7099V105.63C20.8496 108.928 23.5022 111.601 26.7744 111.601H82.7311C86.0033 111.601 88.6559 108.928 88.6559 105.63V18.7099C88.6559 15.4119 86.0033 12.7383 82.7311 12.7383Z" fill="black"/>
+</g>
+<path d="M82.7311 12.7383H26.7744C23.5022 12.7383 20.8496 15.4119 20.8496 18.7099V105.63C20.8496 108.928 23.5022 111.601 26.7744 111.601H82.7311C86.0033 111.601 88.6559 108.928 88.6559 105.63V18.7099C88.6559 15.4119 86.0033 12.7383 82.7311 12.7383Z" fill="white"/>
+<path d="M80.8066 28.9941H26.9237C25.8329 28.9941 24.9487 29.8853 24.9487 30.9847V64.492C24.9487 65.5913 25.8329 66.4825 26.9237 66.4825H80.8066C81.8974 66.4825 82.7816 65.5913 82.7816 64.492V30.9847C82.7816 29.8853 81.8974 28.9941 80.8066 28.9941Z" fill="#ECF1F5" fill-opacity="0.49"/>
+<path d="M80.9927 69.3936H27.1097C26.019 69.3936 25.1348 70.2847 25.1348 71.3841V86.479C25.1348 87.5783 26.019 88.4695 27.1097 88.4695H80.9927C82.0834 88.4695 82.9676 87.5783 82.9676 86.479V71.3841C82.9676 70.2847 82.0834 69.3936 80.9927 69.3936Z" fill="#ECF1F5" fill-opacity="0.49"/>
+<path d="M80.9927 91.3809H27.1097C26.019 91.3809 25.1348 92.2721 25.1348 93.3714V95.0302C25.1348 96.1295 26.019 97.0207 27.1097 97.0207H80.9927C82.0834 97.0207 82.9676 96.1295 82.9676 95.0302V93.3714C82.9676 92.2721 82.0834 91.3809 80.9927 91.3809Z" fill="#ECF1F5" fill-opacity="0.49"/>
+<path d="M75.6812 99.9316H27.6995C26.6088 99.9316 25.7246 100.823 25.7246 101.922V103.581C25.7246 104.68 26.6088 105.571 27.6995 105.571H75.6812C76.7719 105.571 77.6561 104.68 77.6561 103.581V101.922C77.6561 100.823 76.7719 99.9316 75.6812 99.9316Z" fill="#ECF1F5" fill-opacity="0.49"/>
+<path d="M26.5945 23.5549C27.5035 23.5549 28.2403 22.8122 28.2403 21.8961C28.2403 20.98 27.5035 20.2373 26.5945 20.2373C25.6856 20.2373 24.9487 20.98 24.9487 21.8961C24.9487 22.8122 25.6856 23.5549 26.5945 23.5549Z" fill="#ECF1F5" fill-opacity="0.49"/>
+<path d="M36.469 23.5549C37.378 23.5549 38.1148 22.8122 38.1148 21.8961C38.1148 20.98 37.378 20.2373 36.469 20.2373C35.5601 20.2373 34.8232 20.98 34.8232 21.8961C34.8232 22.8122 35.5601 23.5549 36.469 23.5549Z" fill="#ECF1F5" fill-opacity="0.49"/>
+<path d="M31.532 23.5549C32.441 23.5549 33.1778 22.8122 33.1778 21.8961C33.1778 20.98 32.441 20.2373 31.532 20.2373C30.6231 20.2373 29.8862 20.98 29.8862 21.8961C29.8862 22.8122 30.6231 23.5549 31.532 23.5549Z" fill="#ECF1F5" fill-opacity="0.49"/>
+<g opacity="0.541969">
+<g opacity="0.541969" filter="url(#filter1_f)">
+<path d="M33.9366 58.0879H30.0588C29.5134 58.0879 29.0713 58.5335 29.0713 59.0832V62.9916C29.0713 63.5412 29.5134 63.9868 30.0588 63.9868H33.9366C34.4819 63.9868 34.924 63.5412 34.924 62.9916V59.0832C34.924 58.5335 34.4819 58.0879 33.9366 58.0879Z" fill="#C0C0C0"/>
+<path d="M33.9366 58.0879H30.0588C29.5134 58.0879 29.0713 58.5335 29.0713 59.0832V62.9916C29.0713 63.5412 29.5134 63.9868 30.0588 63.9868H33.9366C34.4819 63.9868 34.924 63.5412 34.924 62.9916V59.0832C34.924 58.5335 34.4819 58.0879 33.9366 58.0879Z" stroke="white" stroke-width="0.588656"/>
+</g>
+<path opacity="0.541969" d="M34.3017 56.5303H29.6935C29.1482 56.5303 28.7061 56.9759 28.7061 57.5255V62.1701C28.7061 62.7198 29.1482 63.1654 29.6935 63.1654H34.3017C34.8471 63.1654 35.2892 62.7198 35.2892 62.1701V57.5255C35.2892 56.9759 34.8471 56.5303 34.3017 56.5303Z" fill="#E4EBF1" stroke="white" stroke-opacity="0.695558" stroke-width="0.588656"/>
+</g>
+<g opacity="0.541969">
+<g opacity="0.541969" filter="url(#filter2_f)">
+<path d="M33.9366 69.9834H30.0588C29.5134 69.9834 29.0713 70.429 29.0713 70.9787V74.8871C29.0713 75.4368 29.5134 75.8824 30.0588 75.8824H33.9366C34.4819 75.8824 34.924 75.4368 34.924 74.8871V70.9787C34.924 70.429 34.4819 69.9834 33.9366 69.9834Z" fill="#C0C0C0"/>
+<path d="M33.9366 69.9834H30.0588C29.5134 69.9834 29.0713 70.429 29.0713 70.9787V74.8871C29.0713 75.4368 29.5134 75.8824 30.0588 75.8824H33.9366C34.4819 75.8824 34.924 75.4368 34.924 74.8871V70.9787C34.924 70.429 34.4819 69.9834 33.9366 69.9834Z" stroke="white" stroke-width="0.588656"/>
+</g>
+<path opacity="0.541969" d="M34.3017 68.4258H29.6935C29.1482 68.4258 28.7061 68.8714 28.7061 69.4211V74.0656C28.7061 74.6153 29.1482 75.0609 29.6935 75.0609H34.3017C34.8471 75.0609 35.2892 74.6153 35.2892 74.0656V69.4211C35.2892 68.8714 34.8471 68.4258 34.3017 68.4258Z" fill="#E4EBF1" stroke="white" stroke-opacity="0.695558" stroke-width="0.588656"/>
+</g>
+<g opacity="0.541969">
+<g opacity="0.541969" filter="url(#filter3_f)">
+<path d="M33.9366 81.6152H30.0588C29.5134 81.6152 29.0713 82.0608 29.0713 82.6105V86.5189C29.0713 87.0686 29.5134 87.5142 30.0588 87.5142H33.9366C34.4819 87.5142 34.924 87.0686 34.924 86.5189V82.6105C34.924 82.0608 34.4819 81.6152 33.9366 81.6152Z" fill="#C0C0C0"/>
+<path d="M33.9366 81.6152H30.0588C29.5134 81.6152 29.0713 82.0608 29.0713 82.6105V86.5189C29.0713 87.0686 29.5134 87.5142 30.0588 87.5142H33.9366C34.4819 87.5142 34.924 87.0686 34.924 86.5189V82.6105C34.924 82.0608 34.4819 81.6152 33.9366 81.6152Z" stroke="white" stroke-width="0.588656"/>
+</g>
+<path opacity="0.541969" d="M34.3017 80.0576H29.6935C29.1482 80.0576 28.7061 80.5032 28.7061 81.0529V85.6975C28.7061 86.2471 29.1482 86.6927 29.6935 86.6927H34.3017C34.8471 86.6927 35.2892 86.2471 35.2892 85.6975V81.0529C35.2892 80.5032 34.8471 80.0576 34.3017 80.0576Z" fill="#E4EBF1" stroke="white" stroke-opacity="0.695558" stroke-width="0.588656"/>
+</g>
+<g filter="url(#filter4_d)">
+<path d="M109.293 61.5762H71.5871C69.9611 61.5762 68.6431 62.3515 68.6431 63.3079V69.369C68.6431 70.3254 69.9611 71.1008 71.5871 71.1008H109.293C110.919 71.1008 112.237 70.3254 112.237 69.369V63.3079C112.237 62.3515 110.919 61.5762 109.293 61.5762Z" fill="black"/>
+</g>
+<path d="M110.098 59.3086H71.1762C69.4978 59.3086 68.1372 60.4162 68.1372 61.7825V70.4413C68.1372 71.8076 69.4978 72.9152 71.1762 72.9152H110.098C111.777 72.9152 113.137 71.8076 113.137 70.4413V61.7825C113.137 60.4162 111.777 59.3086 110.098 59.3086Z" fill="white"/>
+<path d="M105.265 63.0889H81.5132V65.4828H105.265V63.0889Z" fill="#8AEBE3" fill-opacity="0.3"/>
+<path d="M93.389 67.2783H81.5132V69.6722H93.389V67.2783Z" fill="#8AEBE3" fill-opacity="0.3"/>
+<g filter="url(#filter5_d)">
+<path d="M56.7928 89.21H19.0871C17.4611 89.21 16.1431 89.9853 16.1431 90.9417V97.0028C16.1431 97.9593 17.4611 98.7346 19.0871 98.7346H56.7928C58.4188 98.7346 59.7368 97.9593 59.7368 97.0028V90.9417C59.7368 89.9853 58.4188 89.21 56.7928 89.21Z" fill="black"/>
+</g>
+<path d="M56.9302 87.2783H17.5552C16.0019 87.2783 14.7427 88.4967 14.7427 89.9996V98.1636C14.7427 99.6665 16.0019 100.885 17.5552 100.885H56.9302C58.4835 100.885 59.7427 99.6665 59.7427 98.1636V89.9996C59.7427 88.4967 58.4835 87.2783 56.9302 87.2783Z" fill="white"/>
+<path d="M51.75 91.0576H29.25V93.5178H51.75V91.0576Z" fill="#1DB868" fill-opacity="0.16226"/>
+<path d="M39.75 95.5928H29.25V97.8605H39.75V95.5928Z" fill="#1DB868" fill-opacity="0.16226"/>
+<g filter="url(#filter6_d)">
+<path d="M70.6744 74.8701C74.9376 74.8701 78.3937 71.3867 78.3937 67.0898C78.3937 62.7929 74.9376 59.3096 70.6744 59.3096C66.4111 59.3096 62.9551 62.7929 62.9551 67.0898C62.9551 71.3867 66.4111 74.8701 70.6744 74.8701Z" fill="black"/>
+</g>
+<path d="M70.6744 74.8701C74.9376 74.8701 78.3937 71.3867 78.3937 67.0898C78.3937 62.7929 74.9376 59.3096 70.6744 59.3096C66.4111 59.3096 62.9551 62.7929 62.9551 67.0898C62.9551 71.3867 66.4111 74.8701 70.6744 74.8701Z" fill="#0CA090"/>
+<mask id="mask0" mask-type="alpha" maskUnits="userSpaceOnUse" x="55" y="50" width="20" height="24">
+<path d="M74.25 54.7431V72.3759C74.25 73.0916 73.6711 73.6718 72.9569 73.6718H56.7931C56.0789 73.6718 55.5 73.0916 55.5 72.3759V52.29C55.5 51.5743 56.0789 50.9941 56.7931 50.9941H71.0322L74.25 54.7431Z" fill="white"/>
+</mask>
+<g mask="url(#mask0)">
+<g filter="url(#filter7_d)">
+<path d="M74.25 54.7431V72.3759C74.25 73.0916 73.6711 73.6718 72.9569 73.6718H56.7931C56.0789 73.6718 55.5 73.0916 55.5 72.3759V52.29C55.5 51.5743 56.0789 50.9941 56.7931 50.9941H71.0322L74.25 54.7431Z" fill="black"/>
+</g>
+<path d="M74.25 54.7431V72.3759C74.25 73.0916 73.6711 73.6718 72.9569 73.6718H56.7931C56.0789 73.6718 55.5 73.0916 55.5 72.3759V52.29C55.5 51.5743 56.0789 50.9941 56.7931 50.9941H71.0322L74.25 54.7431Z" fill="url(#paint0_linear)"/>
+<g filter="url(#filter8_d)">
+<path d="M74.7579 54.3307H71.9518C71.5642 54.3307 71.25 54.014 71.25 53.6234V50.2383L74.7579 54.3307Z" fill="black"/>
+</g>
+<path d="M74.4313 54.774H71.6251C71.2375 54.774 70.9233 54.4574 70.9233 54.0667V50.6816L74.4313 54.774Z" fill="#D0FFFA"/>
+</g>
+<g filter="url(#filter9_d)">
+<path fill-rule="evenodd" clip-rule="evenodd" d="M66.2193 67.6725L63.7757 65.0544L69.5705 57.2429L66.2193 67.6725Z" fill="url(#paint1_linear)"/>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M63.7756 65.0539L63.6674 62.8067L69.5703 57.2424L63.7756 65.0539Z" fill="#9BE6BF"/>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M59.25 60.6495L61.7872 62.8084L69.5704 57.2441L59.25 60.6495Z" fill="url(#paint2_linear)"/>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M61.7871 62.8084H63.6674L69.5704 57.2441L61.7871 62.8084Z" fill="url(#paint3_linear)"/>
+</g>
+<g filter="url(#filter10_d)">
+<path d="M14.0331 104.067C19.459 104.067 23.8576 99.6336 23.8576 94.1648C23.8576 88.696 19.459 84.2627 14.0331 84.2627C8.6071 84.2627 4.2085 88.696 4.2085 94.1648C4.2085 99.6336 8.6071 104.067 14.0331 104.067Z" fill="black"/>
+</g>
+<path d="M14.0331 104.059C19.459 104.059 23.8576 99.6258 23.8576 94.157C23.8576 88.6882 19.459 84.2549 14.0331 84.2549C8.6071 84.2549 4.2085 88.6882 4.2085 94.157C4.2085 99.6258 8.6071 104.059 14.0331 104.059Z" fill="url(#paint4_linear)"/>
+<g filter="url(#filter11_d)">
+<path fill-rule="evenodd" clip-rule="evenodd" d="M14.1968 89.873C16.6837 89.873 18.6997 91.7203 18.6997 93.9989C18.6997 96.2776 16.6837 98.1248 14.1968 98.1248C13.4439 98.1248 12.7343 97.9555 12.1106 97.6563L10.4774 98.8638L10.4769 96.3247C9.98281 95.6625 9.69385 94.8616 9.69385 93.9989C9.69385 91.7203 11.7099 89.873 14.1968 89.873Z" fill="#EFFFF7"/>
+</g>
+<g filter="url(#filter12_d)">
+<path d="M23.737 35.876H10.763C10.2035 35.876 9.75 37.1067 9.75 38.6248V48.2456C9.75 49.7637 10.2035 50.9944 10.763 50.9944H23.737C24.2965 50.9944 24.75 49.7637 24.75 48.2456V38.6248C24.75 37.1067 24.2965 35.876 23.737 35.876Z" fill="black"/>
+</g>
+<path d="M18.534 55.6747C24.9289 55.6747 30.113 50.4497 30.113 44.0043C30.113 37.559 24.9289 32.334 18.534 32.334C12.1391 32.334 6.95508 37.559 6.95508 44.0043C6.95508 50.4497 12.1391 55.6747 18.534 55.6747Z" fill="url(#paint5_linear)"/>
+<path d="M35.9351 41.249H21.4126C20.8873 41.249 20.4614 41.6782 20.4614 42.2077C20.4614 42.7371 20.8873 43.1663 21.4126 43.1663H35.9351C36.4604 43.1663 36.8862 42.7371 36.8862 42.2077C36.8862 41.6782 36.4604 41.249 35.9351 41.249Z" fill="#FFE9CC"/>
+<path d="M29.5593 45.29H21.4126C20.8873 45.29 20.4614 45.7192 20.4614 46.2487C20.4614 46.7781 20.8873 47.2073 21.4126 47.2073H29.5593C30.0846 47.2073 30.5105 46.7781 30.5105 46.2487C30.5105 45.7192 30.0846 45.29 29.5593 45.29Z" fill="#FFE9CC"/>
+<g filter="url(#filter13_d)">
+<path d="M17.2503 51.8505C16.0075 51.8505 15 50.8351 15 49.5825V40.3627C15 39.1102 16.0075 38.0947 17.2503 38.0947H35.2497C36.4925 38.0947 37.5 39.1102 37.5 40.3627V49.5825C37.5 50.8351 36.4925 51.8505 35.2497 51.8505H21.6485L19.991 53.3851C19.7758 53.5844 19.445 53.5844 19.2298 53.3851L17.5723 51.8505H17.2503Z" fill="black"/>
+</g>
+<path d="M17.2503 51.8505C16.0075 51.8505 15 50.8351 15 49.5825V40.3627C15 39.1102 16.0075 38.0947 17.2503 38.0947H35.2497C36.4925 38.0947 37.5 39.1102 37.5 40.3627V49.5825C37.5 50.8351 36.4925 51.8505 35.2497 51.8505H21.6485L19.991 53.3851C19.7758 53.5844 19.445 53.5844 19.2298 53.3851L17.5723 51.8505H17.2503Z" fill="url(#paint6_linear)"/>
+<path d="M31.031 42.8271H19.3889C18.9678 42.8271 18.6265 43.1712 18.6265 43.5956C18.6265 44.0201 18.9678 44.3641 19.3889 44.3641H31.031C31.4521 44.3641 31.7935 44.0201 31.7935 43.5956C31.7935 43.1712 31.4521 42.8271 31.031 42.8271Z" fill="#FFE9CC"/>
+<path d="M25.9198 46.0674H19.3889C18.9678 46.0674 18.6265 46.4115 18.6265 46.8359C18.6265 47.2603 18.9678 47.6044 19.3889 47.6044H25.9198C26.3409 47.6044 26.6823 47.2603 26.6823 46.8359C26.6823 46.4115 26.3409 46.0674 25.9198 46.0674Z" fill="#FFE9CC"/>
+</g>
+<defs>
+<filter id="filter0_d" x="8.84961" y="2.73828" width="91.8063" height="122.863" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0"/>
+<feOffset dy="2"/>
+<feGaussianBlur stdDeviation="6"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0.832587 0 0 0 0 0.899956 0 0 0 0 0.904167 0 0 0 0.7 0"/>
+<feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow"/>
+<feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow" result="shape"/>
+</filter>
+<filter id="filter1_f" x="27.9359" y="56.953" width="8.12326" height="8.16946" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feBlend mode="normal" in="SourceGraphic" in2="BackgroundImageFix" result="shape"/>
+<feGaussianBlur stdDeviation="0.420468" result="effect1_foregroundBlur"/>
+</filter>
+<filter id="filter2_f" x="27.9359" y="68.8485" width="8.12326" height="8.16949" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feBlend mode="normal" in="SourceGraphic" in2="BackgroundImageFix" result="shape"/>
+<feGaussianBlur stdDeviation="0.420468" result="effect1_foregroundBlur"/>
+</filter>
+<filter id="filter3_f" x="27.9359" y="80.4804" width="8.12326" height="8.16948" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feBlend mode="normal" in="SourceGraphic" in2="BackgroundImageFix" result="shape"/>
+<feGaussianBlur stdDeviation="0.420468" result="effect1_foregroundBlur"/>
+</filter>
+<filter id="filter4_d" x="56.6431" y="51.5762" width="67.5938" height="33.5246" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0"/>
+<feOffset dy="2"/>
+<feGaussianBlur stdDeviation="6"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0.891304 0 0 0 0 0.891304 0 0 0 0 0.891304 0 0 0 1 0"/>
+<feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow"/>
+<feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow" result="shape"/>
+</filter>
+<filter id="filter5_d" x="4.14307" y="79.21" width="67.5938" height="33.5246" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0"/>
+<feOffset dy="2"/>
+<feGaussianBlur stdDeviation="6"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0.891304 0 0 0 0 0.891304 0 0 0 0 0.891304 0 0 0 1 0"/>
+<feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow"/>
+<feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow" result="shape"/>
+</filter>
+<filter id="filter6_d" x="58.9551" y="57.3096" width="23.4386" height="23.5605" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0"/>
+<feOffset dy="2"/>
+<feGaussianBlur stdDeviation="2"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0.0470588 0 0 0 0 0.627451 0 0 0 0 0.564706 0 0 0 0.406441 0"/>
+<feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow"/>
+<feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow" result="shape"/>
+</filter>
+<filter id="filter7_d" x="50.5" y="45.9941" width="28.75" height="32.6776" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0"/>
+<feOffset/>
+<feGaussianBlur stdDeviation="2.5"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0.0509804 0 0 0 0 0.768627 0 0 0 0 0.705882 0 0 0 0.8 0"/>
+<feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow"/>
+<feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow" result="shape"/>
+</filter>
+<filter id="filter8_d" x="69.25" y="49.2383" width="7.50792" height="8.09238" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0"/>
+<feOffset dy="1"/>
+<feGaussianBlur stdDeviation="1"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0.0735419 0 0 0 0 0.599298 0 0 0 0 0.544595 0 0 0 1 0"/>
+<feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow"/>
+<feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow" result="shape"/>
+</filter>
+<filter id="filter9_d" x="57.25" y="57.2422" width="14.3206" height="14.4305" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0"/>
+<feOffset dy="2"/>
+<feGaussianBlur stdDeviation="1"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0.0693481 0 0 0 0 0.648154 0 0 0 0 0.595253 0 0 0 1 0"/>
+<feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow"/>
+<feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow" result="shape"/>
+</filter>
+<filter id="filter10_d" x="-0.791504" y="79.2627" width="29.6491" height="29.8042" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0"/>
+<feOffset/>
+<feGaussianBlur stdDeviation="2.5"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0.0117647 0 0 0 0 0.866667 0 0 0 0 0.423529 0 0 0 0.447279 0"/>
+<feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow"/>
+<feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow" result="shape"/>
+</filter>
+<filter id="filter11_d" x="7.69385" y="89.873" width="13.0058" height="12.9907" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0"/>
+<feOffset dy="2"/>
+<feGaussianBlur stdDeviation="1"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0.0693481 0 0 0 0 0.648154 0 0 0 0 0.595253 0 0 0 0.3 0"/>
+<feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow"/>
+<feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow" result="shape"/>
+</filter>
+<filter id="filter12_d" x="-2.25" y="25.876" width="39" height="39.1184" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0"/>
+<feOffset dy="2"/>
+<feGaussianBlur stdDeviation="6"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0.891304 0 0 0 0 0.891304 0 0 0 0 0.891304 0 0 0 1 0"/>
+<feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow"/>
+<feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow" result="shape"/>
+</filter>
+<filter id="filter13_d" x="10" y="33.0947" width="32.5" height="25.4398" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0"/>
+<feOffset/>
+<feGaussianBlur stdDeviation="2.5"/>
+<feColorMatrix type="matrix" values="0 0 0 0 1 0 0 0 0 0.589163 0 0 0 0 0.0862745 0 0 0 0.4 0"/>
+<feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow"/>
+<feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow" result="shape"/>
+</filter>
+<linearGradient id="paint0_linear" x1="64.875" y1="50.9941" x2="72.615" y2="72.8737" gradientUnits="userSpaceOnUse">
+<stop stop-color="#21C3B0"/>
+<stop offset="1" stop-color="#07C7B7" stop-opacity="0.951568"/>
+</linearGradient>
+<linearGradient id="paint1_linear" x1="67.5909" y1="57.2777" x2="64.0443" y2="65.877" gradientUnits="userSpaceOnUse">
+<stop stop-color="#8EFAD9"/>
+<stop offset="1" stop-color="#E8FFF4"/>
+</linearGradient>
+<linearGradient id="paint2_linear" x1="62.1065" y1="58.6431" x2="63.8688" y2="62.3316" gradientUnits="userSpaceOnUse">
+<stop stop-color="#CFFFE6"/>
+<stop offset="0.4914" stop-color="#EDFFF6"/>
+</linearGradient>
+<linearGradient id="paint3_linear" x1="69.2728" y1="58.6265" x2="64.4964" y2="62.9103" gradientUnits="userSpaceOnUse">
+<stop stop-color="#DDFFD0"/>
+<stop offset="1" stop-color="#BBFCDF"/>
+</linearGradient>
+<linearGradient id="paint4_linear" x1="14.0331" y1="84.2549" x2="14.0331" y2="104.059" gradientUnits="userSpaceOnUse">
+<stop stop-color="#02E26E"/>
+<stop offset="1" stop-color="#08C362"/>
+</linearGradient>
+<linearGradient id="paint5_linear" x1="18.534" y1="55.6747" x2="12.201" y2="32.359" gradientUnits="userSpaceOnUse">
+<stop stop-color="#FFC000"/>
+<stop offset="1" stop-color="#FE6E00"/>
+</linearGradient>
+<linearGradient id="paint6_linear" x1="18.7983" y1="55.4826" x2="20.2852" y2="36.758" gradientUnits="userSpaceOnUse">
+<stop stop-color="#FFDB78"/>
+<stop offset="1" stop-color="#FDAC43"/>
+</linearGradient>
+<clipPath id="clip0">
+<rect width="120" height="123.971" fill="white" transform="translate(0 0.347656)"/>
+</clipPath>
+</defs>
+</svg>


### PR DESCRIPTION
We can't process a SVG using PHP (with GD) so instead we sanitize the SVG (to ensure it's a real SVG and not a bad input file) and then just copy the response from the server locally.

Using that method my only concern is about security. Is https://github.com/darylldoyle/svg-sanitizer safe enough to trust it?
What kind of other security check we can add?

Related https://github.com/wallabag/wallabag/issues/5328