### PR TITLE
Fix random failing tests

### DIFF
--- a/tests/Wallabag/CoreBundle/Controller/EntryControllerTest.php
+++ b/tests/Wallabag/CoreBundle/Controller/EntryControllerTest.php
@@ -1497,8 +1497,8 @@ class EntryControllerTest extends WallabagCoreTestCase
                 'pt_BR',
             ],
             'es-ES' => [
-                'https://www.20minutos.es/noticia/3360685/0/gobierno-sanchez-primero-historia-mas-mujeres-que-hombres/',
-                'es_ES',
+                'https://elpais.com/internacional/2022-10-09/ultima-hora-de-la-guerra-en-ucrania-hoy-en-directo.html',
+                'es',
             ],
         ];
     }


### PR DESCRIPTION
Looks like `20minutos.es` sometimes does not return the expected language. Switching to `elpais.com` fix the problem.

<img width="1246" alt="image" src="https://user-images.githubusercontent.com/62333/194814992-23ee5cfb-752e-406e-ad21-d127f0b8f798.png">
