### PR TITLE
Remove `weblate` PR from the automated changelog

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -4,3 +4,4 @@ changelog:
       - Dependencies
     authors:
       - dependabot
+      - weblate


### PR DESCRIPTION
Instead of having each PR from @weblate we just put a link to all PRs for the closed milestone.
For example: https://github.com/wallabag/wallabag/pulls?q=is%3Apr+author%3Aweblate+milestone%3A2.5.2+is%3Amerged