### PR TITLE
Remove some deprecation

### DIFF
--- a/app/config/services.yml
+++ b/app/config/services.yml
@@ -152,6 +152,9 @@ services:
     bd_guzzle_site_authenticator.site_config_builder:
         alias: Wallabag\CoreBundle\GuzzleSiteAuthenticator\GrabySiteConfigBuilder
 
+    GuzzleHttp\Cookie\CookieJar:
+        alias: 'Wallabag\CoreBundle\Helper\FileCookieJar'
+
     Wallabag\CoreBundle\Helper\HttpClientFactory:
         calls:
             - ["addSubscriber", ["@bd_guzzle_site_authenticator.authenticator_subscriber"]]

--- a/src/Wallabag/CoreBundle/Event/Listener/UserLocaleListener.php
+++ b/src/Wallabag/CoreBundle/Event/Listener/UserLocaleListener.php
@@ -2,7 +2,7 @@
 
 namespace Wallabag\CoreBundle\Event\Listener;
 
-use Symfony\Component\HttpFoundation\Session\Session;
+use Symfony\Component\HttpFoundation\Session\SessionInterface;
 use Symfony\Component\Security\Http\Event\InteractiveLoginEvent;
 
 /**
@@ -15,12 +15,9 @@ use Symfony\Component\Security\Http\Event\InteractiveLoginEvent;
  */
 class UserLocaleListener
 {
-    /**
-     * @var Session
-     */
-    private $session;
+    private SessionInterface $session;
 
-    public function __construct(Session $session)
+    public function __construct(SessionInterface $session)
     {
         $this->session = $session;
     }

--- a/src/Wallabag/CoreBundle/GuzzleSiteAuthenticator/GrabySiteConfigBuilder.php
+++ b/src/Wallabag/CoreBundle/GuzzleSiteAuthenticator/GrabySiteConfigBuilder.php
@@ -6,7 +6,7 @@ use BD\GuzzleSiteAuthenticator\SiteConfig\SiteConfig;
 use BD\GuzzleSiteAuthenticator\SiteConfig\SiteConfigBuilder;
 use Graby\SiteConfig\ConfigBuilder;
 use Psr\Log\LoggerInterface;
-use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorage;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 use Wallabag\CoreBundle\Repository\SiteCredentialRepository;
 
 class GrabySiteConfigBuilder implements SiteConfigBuilder
@@ -27,14 +27,14 @@ class GrabySiteConfigBuilder implements SiteConfigBuilder
     private $logger;
 
     /**
-     * @var TokenStorage
+     * @var TokenStorageInterface
      */
     private $token;
 
     /**
      * GrabySiteConfigBuilder constructor.
      */
-    public function __construct(ConfigBuilder $grabyConfigBuilder, TokenStorage $token, SiteCredentialRepository $credentialRepository, LoggerInterface $logger)
+    public function __construct(ConfigBuilder $grabyConfigBuilder, TokenStorageInterface $token, SiteCredentialRepository $credentialRepository, LoggerInterface $logger)
     {
         $this->grabyConfigBuilder = $grabyConfigBuilder;
         $this->credentialRepository = $credentialRepository;

--- a/src/Wallabag/CoreBundle/Helper/PreparePagerForEntries.php
+++ b/src/Wallabag/CoreBundle/Helper/PreparePagerForEntries.php
@@ -4,19 +4,16 @@ namespace Wallabag\CoreBundle\Helper;
 
 use Pagerfanta\Adapter\AdapterInterface;
 use Pagerfanta\Pagerfanta;
-use Symfony\Component\Routing\Router;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 use Wallabag\UserBundle\Entity\User;
 
 class PreparePagerForEntries
 {
-    private $router;
     private $tokenStorage;
 
-    public function __construct(TokenStorageInterface $tokenStorage, Router $router)
+    public function __construct(TokenStorageInterface $tokenStorage)
     {
         $this->tokenStorage = $tokenStorage;
-        $this->router = $router;
     }
 
     /**

--- a/src/Wallabag/CoreBundle/Helper/Redirect.php
+++ b/src/Wallabag/CoreBundle/Helper/Redirect.php
@@ -2,7 +2,7 @@
 
 namespace Wallabag\CoreBundle\Helper;
 
-use Symfony\Component\Routing\Router;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 use Wallabag\CoreBundle\Entity\Config;
 
@@ -14,7 +14,7 @@ class Redirect
     private $router;
     private $tokenStorage;
 
-    public function __construct(Router $router, TokenStorageInterface $tokenStorage)
+    public function __construct(UrlGeneratorInterface $router, TokenStorageInterface $tokenStorage)
     {
         $this->router = $router;
         $this->tokenStorage = $tokenStorage;

--- a/src/Wallabag/UserBundle/EventListener/CreateConfigListener.php
+++ b/src/Wallabag/UserBundle/EventListener/CreateConfigListener.php
@@ -6,7 +6,7 @@ use Doctrine\ORM\EntityManagerInterface;
 use FOS\UserBundle\Event\UserEvent;
 use FOS\UserBundle\FOSUserEvents;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
-use Symfony\Component\HttpFoundation\Session\Session;
+use Symfony\Component\HttpFoundation\Session\SessionInterface;
 use Wallabag\CoreBundle\Entity\Config;
 
 /**
@@ -25,7 +25,7 @@ class CreateConfigListener implements EventSubscriberInterface
     private $listMode;
     private $session;
 
-    public function __construct(EntityManagerInterface $em, $theme, $itemsOnPage, $feedLimit, $language, $readingSpeed, $actionMarkAsRead, $listMode, Session $session)
+    public function __construct(EntityManagerInterface $em, $theme, $itemsOnPage, $feedLimit, $language, $readingSpeed, $actionMarkAsRead, $listMode, SessionInterface $session)
     {
         $this->em = $em;
         $this->theme = $theme;


### PR DESCRIPTION
Just some stuff deprecated and replaced by other Interface.
Might ease the Symfony upgrade (poke @yguedidi)

Also remove router from `src/Wallabag/CoreBundle/Helper/PreparePagerForEntries.php` because it's not used