### PR TITLE
Remove `ContainerAwareCommand` from commands

### DIFF
--- a/app/config/services.yml
+++ b/app/config/services.yml
@@ -197,6 +197,17 @@ services:
         arguments:
             $baseFolder: "%kernel.project_dir%/web/assets/images"
 
+    Wallabag\CoreBundle\Command\ExportCommand:
+        arguments:
+            $projectDir: '%kernel.project_dir%'
+
+    Wallabag\CoreBundle\Command\InstallCommand:
+        arguments:
+            $databaseDriver: '%database_driver%'
+            $databaseName: '%database_name%'
+            $defaultSettings: '%wallabag_core.default_internal_settings%'
+            $defaultIgnoreOriginInstanceRules: '%wallabag_core.default_ignore_origin_instance_rules%'
+
     wallabag_core.entry.download_images.client:
         alias: 'httplug.client.wallabag_core.entry.download_images'
 

--- a/composer.lock
+++ b/composer.lock
@@ -7788,16 +7788,16 @@
         },
         {
             "name": "phpstan/phpdoc-parser",
-            "version": "1.15.0",
+            "version": "1.15.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpdoc-parser.git",
-                "reference": "6ff970a7101acfe99b3048e4bbfbc094e55c5b04"
+                "reference": "5941477f100993652218928039d530b75a13a9ca"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpdoc-parser/zipball/6ff970a7101acfe99b3048e4bbfbc094e55c5b04",
-                "reference": "6ff970a7101acfe99b3048e4bbfbc094e55c5b04",
+                "url": "https://api.github.com/repos/phpstan/phpdoc-parser/zipball/5941477f100993652218928039d530b75a13a9ca",
+                "reference": "5941477f100993652218928039d530b75a13a9ca",
                 "shasum": ""
             },
             "require": {
@@ -7827,9 +7827,9 @@
             "description": "PHPDoc parser with support for nullable, intersection and generic types",
             "support": {
                 "issues": "https://github.com/phpstan/phpdoc-parser/issues",
-                "source": "https://github.com/phpstan/phpdoc-parser/tree/1.15.0"
+                "source": "https://github.com/phpstan/phpdoc-parser/tree/1.15.2"
             },
-            "time": "2022-12-07T16:12:39+00:00"
+            "time": "2022-12-16T06:42:48+00:00"
         },
         {
             "name": "phpzip/phpzip",

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -16,11 +16,6 @@ parameters:
             path: src/Wallabag/ApiBundle/Controller/WallabagRestController.php
 
         -
-            message: "#^Call to an undefined method Doctrine\\\\Persistence\\\\ObjectManager\\:\\:getConnection\\(\\)\\.$#"
-            count: 5
-            path: src/Wallabag/CoreBundle/Command/InstallCommand.php
-
-        -
             message: "#^Call to an undefined method Wallabag\\\\CoreBundle\\\\Entity\\\\RuleInterface\\:\\:getConfig\\(\\)\\.$#"
             count: 1
             path: src/Wallabag/CoreBundle/Controller/ConfigController.php
@@ -39,11 +34,6 @@ parameters:
             message: "#^Call to an undefined method Lexik\\\\Bundle\\\\FormFilterBundle\\\\Filter\\\\Query\\\\QueryInterface\\:\\:getExpr\\(\\)\\.$#"
             count: 10
             path: src/Wallabag/CoreBundle/Form/Type/EntryFilterType.php
-
-        -
-            message: "#^Call to an undefined method Doctrine\\\\Persistence\\\\ObjectManager\\:\\:getConnection\\(\\)\\.$#"
-            count: 1
-            path: src/Wallabag/ImportBundle/Command/ImportCommand.php
 
         -
             message: "#^Call to an undefined method Wallabag\\\\ImportBundle\\\\Import\\\\ImportInterface\\:\\:setFilepath\\(\\)\\.$#"
@@ -84,3 +74,13 @@ parameters:
             message: "#^Property Tests\\\\Wallabag\\\\CoreBundle\\\\Helper\\\\RedirectTest\\:\\:\\$routerMock has unknown class PHPUnit_Framework_MockObject_MockObject as its type\\.$#"
             count: 1
             path: tests/Wallabag/CoreBundle/Helper/RedirectTest.php
+
+        -
+            message: "#^Method Symfony\\\\Contracts\\\\EventDispatcher\\\\EventDispatcherInterface\\:\\:dispatch()#"
+            count: 1
+            path: src/Wallabag/CoreBundle/Command/InstallCommand.php
+
+        -
+            message: "#^Method Symfony\\\\Contracts\\\\EventDispatcher\\\\EventDispatcherInterface\\:\\:dispatch()#"
+            count: 1
+            path: src/Wallabag/CoreBundle/Command/ReloadEntryCommand.php

--- a/src/Wallabag/CoreBundle/Command/CleanDownloadedImagesCommand.php
+++ b/src/Wallabag/CoreBundle/Command/CleanDownloadedImagesCommand.php
@@ -2,7 +2,7 @@
 
 namespace Wallabag\CoreBundle\Command;
 
-use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
+use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -11,8 +11,19 @@ use Symfony\Component\Finder\Finder;
 use Wallabag\CoreBundle\Helper\DownloadImages;
 use Wallabag\CoreBundle\Repository\EntryRepository;
 
-class CleanDownloadedImagesCommand extends ContainerAwareCommand
+class CleanDownloadedImagesCommand extends Command
 {
+    private EntryRepository $entryRepository;
+    private DownloadImages $downloadImages;
+
+    public function __construct(EntryRepository $entryRepository, DownloadImages $downloadImages)
+    {
+        $this->entryRepository = $entryRepository;
+        $this->downloadImages = $downloadImages;
+
+        parent::__construct();
+    }
+
     protected function configure()
     {
         $this
@@ -36,8 +47,7 @@ class CleanDownloadedImagesCommand extends ContainerAwareCommand
             $io->text('Dry run mode <info>enabled</info> (no images will be removed)');
         }
 
-        $downloadImages = $this->getContainer()->get(DownloadImages::class);
-        $baseFolder = $downloadImages->getBaseFolder();
+        $baseFolder = $this->downloadImages->getBaseFolder();
 
         $io->text('Retrieve existing images');
 
@@ -58,12 +68,12 @@ class CleanDownloadedImagesCommand extends ContainerAwareCommand
 
         $io->text('Retrieve valid folders attached to a user');
 
-        $entries = $this->getContainer()->get(EntryRepository::class)->findAllEntriesIdByUserId();
+        $entries = $this->entryRepository->findAllEntriesIdByUserId();
 
         // retrieve _valid_ folders from existing entries
         $validPaths = [];
         foreach ($entries as $entry) {
-            $path = $downloadImages->getRelativePath($entry['id']);
+            $path = $this->downloadImages->getRelativePath($entry['id']);
 
             if (!file_exists($baseFolder . '/' . $path)) {
                 continue;

--- a/src/Wallabag/CoreBundle/Command/InstallCommand.php
+++ b/src/Wallabag/CoreBundle/Command/InstallCommand.php
@@ -5,11 +5,10 @@ namespace Wallabag\CoreBundle\Command;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Exception\DriverException;
 use Doctrine\ORM\EntityManagerInterface;
-use Doctrine\Persistence\ManagerRegistry;
 use FOS\UserBundle\Event\UserEvent;
 use FOS\UserBundle\FOSUserEvents;
 use FOS\UserBundle\Model\UserManagerInterface;
-use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
+use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -22,27 +21,36 @@ use Wallabag\CoreBundle\Entity\IgnoreOriginInstanceRule;
 use Wallabag\CoreBundle\Entity\InternalSetting;
 use Wallabag\UserBundle\Entity\User;
 
-class InstallCommand extends ContainerAwareCommand
+class InstallCommand extends Command
 {
-    /**
-     * @var InputInterface
-     */
-    private $defaultInput;
-
-    /**
-     * @var SymfonyStyle
-     */
-    private $io;
-
-    /**
-     * @var array
-     */
-    private $functionExists = [
+    private InputInterface $defaultInput;
+    private SymfonyStyle $io;
+    private array $functionExists = [
         'curl_exec',
         'curl_multi_init',
     ];
-
     private bool $runOtherCommands = true;
+
+    private EntityManagerInterface $entityManager;
+    private EventDispatcherInterface $dispatcher;
+    private UserManagerInterface $userManager;
+    private string $databaseDriver;
+    private string $databaseName;
+    private array $defaultSettings;
+    private array $defaultIgnoreOriginInstanceRules;
+
+    public function __construct(EntityManagerInterface $entityManager, EventDispatcherInterface $dispatcher, UserManagerInterface $userManager, string $databaseDriver, string $databaseName, array $defaultSettings, array $defaultIgnoreOriginInstanceRules)
+    {
+        $this->entityManager = $entityManager;
+        $this->dispatcher = $dispatcher;
+        $this->userManager = $userManager;
+        $this->databaseDriver = $databaseDriver;
+        $this->databaseName = $databaseName;
+        $this->defaultSettings = $defaultSettings;
+        $this->defaultIgnoreOriginInstanceRules = $defaultIgnoreOriginInstanceRules;
+
+        parent::__construct();
+    }
 
     public function disableRunOtherCommands(): void
     {
@@ -88,8 +96,6 @@ class InstallCommand extends ContainerAwareCommand
     {
         $this->io->section('Step 1 of 4: Checking system requirements.');
 
-        $doctrineManager = $this->getContainer()->get(ManagerRegistry::class)->getManager();
-
         $rows = [];
 
         // testing if database driver exists
@@ -98,26 +104,26 @@ class InstallCommand extends ContainerAwareCommand
         $status = '<info>OK!</info>';
         $help = '';
 
-        if (!\extension_loaded($this->getContainer()->getParameter('database_driver'))) {
+        if (!\extension_loaded($this->databaseDriver)) {
             $fulfilled = false;
             $status = '<error>ERROR!</error>';
-            $help = 'Database driver "' . $this->getContainer()->getParameter('database_driver') . '" is not installed.';
+            $help = 'Database driver "' . $this->databaseDriver . '" is not installed.';
         }
 
-        $rows[] = [sprintf($label, $this->getContainer()->getParameter('database_driver')), $status, $help];
+        $rows[] = [sprintf($label, $this->databaseDriver), $status, $help];
 
         // testing if connection to the database can be etablished
         $label = '<comment>Database connection</comment>';
         $status = '<info>OK!</info>';
         $help = '';
 
-        $conn = $this->getContainer()->get(ManagerRegistry::class)->getManager()->getConnection();
+        $conn = $this->entityManager->getConnection();
 
         try {
             $conn->connect();
         } catch (\Exception $e) {
             if (false === strpos($e->getMessage(), 'Unknown database')
-                && false === strpos($e->getMessage(), 'database "' . $this->getContainer()->getParameter('database_name') . '" does not exist')) {
+                && false === strpos($e->getMessage(), 'database "' . $this->databaseName . '" does not exist')) {
                 $fulfilled = false;
                 $status = '<error>ERROR!</error>';
                 $help = 'Can\'t connect to the database: ' . $e->getMessage();
@@ -146,7 +152,7 @@ class InstallCommand extends ContainerAwareCommand
         // testing if PostgreSQL > 9.1
         if ($conn->isConnected() && 'postgresql' === $conn->getDatabasePlatform()->getName()) {
             // return version should be like "PostgreSQL 9.5.4 on x86_64-apple-darwin15.6.0, compiled by Apple LLVM version 8.0.0 (clang-800.0.38), 64-bit"
-            $version = $doctrineManager->getConnection()->query('SELECT version();')->fetchColumn();
+            $version = $conn->query('SELECT version();')->fetchColumn();
 
             preg_match('/PostgreSQL ([0-9\.]+)/i', $version, $matches);
 
@@ -260,10 +266,7 @@ class InstallCommand extends ContainerAwareCommand
             return $this;
         }
 
-        $em = $this->getContainer()->get(EntityManagerInterface::class);
-
-        $userManager = $this->getContainer()->get(UserManagerInterface::class);
-        $user = $userManager->createUser();
+        $user = $this->userManager->createUser();
         \assert($user instanceof User);
 
         $user->setUsername($this->io->ask('Username', 'wallabag'));
@@ -277,11 +280,10 @@ class InstallCommand extends ContainerAwareCommand
         $user->setEnabled(true);
         $user->addRole('ROLE_SUPER_ADMIN');
 
-        $em->persist($user);
+        $this->entityManager->persist($user);
 
         // dispatch a created event so the associated config will be created
-        $event = new UserEvent($user);
-        $this->getContainer()->get(EventDispatcherInterface::class)->dispatch($event, FOSUserEvents::USER_CREATED);
+        $this->dispatcher->dispatch(new UserEvent($user), FOSUserEvents::USER_CREATED);
 
         $this->io->text('<info>Administration successfully setup.</info>');
 
@@ -291,27 +293,28 @@ class InstallCommand extends ContainerAwareCommand
     private function setupConfig()
     {
         $this->io->section('Step 4 of 4: Config setup.');
-        $em = $this->getContainer()->get(EntityManagerInterface::class);
 
         // cleanup before insert new stuff
-        $em->createQuery('DELETE FROM Wallabag\CoreBundle\Entity\InternalSetting')->execute();
-        $em->createQuery('DELETE FROM Wallabag\CoreBundle\Entity\IgnoreOriginInstanceRule')->execute();
+        $this->entityManager->createQuery('DELETE FROM Wallabag\CoreBundle\Entity\InternalSetting')->execute();
+        $this->entityManager->createQuery('DELETE FROM Wallabag\CoreBundle\Entity\IgnoreOriginInstanceRule')->execute();
 
-        foreach ($this->getContainer()->getParameter('wallabag_core.default_internal_settings') as $setting) {
+        foreach ($this->defaultSettings as $setting) {
             $newSetting = new InternalSetting();
             $newSetting->setName($setting['name']);
             $newSetting->setValue($setting['value']);
             $newSetting->setSection($setting['section']);
-            $em->persist($newSetting);
+
+            $this->entityManager->persist($newSetting);
         }
 
-        foreach ($this->getContainer()->getParameter('wallabag_core.default_ignore_origin_instance_rules') as $ignore_origin_instance_rule) {
+        foreach ($this->defaultIgnoreOriginInstanceRules as $ignore_origin_instance_rule) {
             $newIgnoreOriginInstanceRule = new IgnoreOriginInstanceRule();
             $newIgnoreOriginInstanceRule->setRule($ignore_origin_instance_rule['rule']);
-            $em->persist($newIgnoreOriginInstanceRule);
+
+            $this->entityManager->persist($newIgnoreOriginInstanceRule);
         }
 
-        $em->flush();
+        $this->entityManager->flush();
 
         $this->io->text('<info>Config successfully setup.</info>');
 
@@ -350,7 +353,7 @@ class InstallCommand extends ContainerAwareCommand
 
         // PDO does not always close the connection after Doctrine commands.
         // See https://github.com/symfony/symfony/issues/11750.
-        $this->getContainer()->get(ManagerRegistry::class)->getManager()->getConnection()->close();
+        $this->entityManager->getConnection()->close();
 
         if (0 !== $exitCode) {
             $this->getApplication()->setAutoExit(true);
@@ -368,7 +371,7 @@ class InstallCommand extends ContainerAwareCommand
      */
     private function isDatabasePresent()
     {
-        $connection = $this->getContainer()->get(ManagerRegistry::class)->getManager()->getConnection();
+        $connection = $this->entityManager->getConnection();
         $databaseName = $connection->getDatabase();
 
         try {
@@ -389,7 +392,7 @@ class InstallCommand extends ContainerAwareCommand
 
         // custom verification for sqlite, since `getListDatabasesSQL` doesn't work for sqlite
         if ('sqlite' === $schemaManager->getDatabasePlatform()->getName()) {
-            $params = $this->getContainer()->get(Connection::class)->getParams();
+            $params = $connection->getParams();
 
             if (isset($params['path']) && file_exists($params['path'])) {
                 return true;
@@ -415,7 +418,7 @@ class InstallCommand extends ContainerAwareCommand
      */
     private function isSchemaPresent()
     {
-        $schemaManager = $this->getContainer()->get(ManagerRegistry::class)->getManager()->getConnection()->getSchemaManager();
+        $schemaManager = $this->entityManager->getConnection()->getSchemaManager();
 
         return \count($schemaManager->listTableNames()) > 0 ? true : false;
     }

--- a/src/Wallabag/CoreBundle/Command/ListUserCommand.php
+++ b/src/Wallabag/CoreBundle/Command/ListUserCommand.php
@@ -2,7 +2,7 @@
 
 namespace Wallabag\CoreBundle\Command;
 
-use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
+use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -10,8 +10,17 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 use Wallabag\UserBundle\Repository\UserRepository;
 
-class ListUserCommand extends ContainerAwareCommand
+class ListUserCommand extends Command
 {
+    private UserRepository $userRepository;
+
+    public function __construct(UserRepository $userRepository)
+    {
+        $this->userRepository = $userRepository;
+
+        parent::__construct();
+    }
+
     protected function configure()
     {
         $this
@@ -27,13 +36,13 @@ class ListUserCommand extends ContainerAwareCommand
     {
         $io = new SymfonyStyle($input, $output);
 
-        $users = $this->getContainer()->get(UserRepository::class)
+        $users = $this->userRepository
             ->getQueryBuilderForSearch($input->getArgument('search'))
             ->setMaxResults($input->getOption('limit'))
             ->getQuery()
             ->getResult();
 
-        $nbUsers = $this->getContainer()->get(UserRepository::class)
+        $nbUsers = $this->userRepository
             ->getSumUsers();
 
         $rows = [];

--- a/src/Wallabag/CoreBundle/Command/ReloadEntryCommand.php
+++ b/src/Wallabag/CoreBundle/Command/ReloadEntryCommand.php
@@ -2,9 +2,9 @@
 
 namespace Wallabag\CoreBundle\Command;
 
+use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\NoResultException;
-use Doctrine\Persistence\ManagerRegistry;
-use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
+use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -15,8 +15,25 @@ use Wallabag\CoreBundle\Helper\ContentProxy;
 use Wallabag\CoreBundle\Repository\EntryRepository;
 use Wallabag\UserBundle\Repository\UserRepository;
 
-class ReloadEntryCommand extends ContainerAwareCommand
+class ReloadEntryCommand extends Command
 {
+    private EntryRepository $entryRepository;
+    private UserRepository $userRepository;
+    private EntityManagerInterface $entityManager;
+    private ContentProxy $contentProxy;
+    private EventDispatcherInterface $dispatcher;
+
+    public function __construct(EntryRepository $entryRepository, UserRepository $userRepository, EntityManagerInterface $entityManager, ContentProxy $contentProxy, EventDispatcherInterface $dispatcher)
+    {
+        $this->entryRepository = $entryRepository;
+        $this->userRepository = $userRepository;
+        $this->entityManager = $entityManager;
+        $this->contentProxy = $contentProxy;
+        $this->dispatcher = $dispatcher;
+
+        parent::__construct();
+    }
+
     protected function configure()
     {
         $this
@@ -34,8 +51,7 @@ class ReloadEntryCommand extends ContainerAwareCommand
         $userId = null;
         if ($username = $input->getArgument('username')) {
             try {
-                $userId = $this->getContainer()
-                    ->get(UserRepository::class)
+                $userId = $this->userRepository
                     ->findOneByUserName($username)
                     ->getId();
             } catch (NoResultException $e) {
@@ -45,8 +61,7 @@ class ReloadEntryCommand extends ContainerAwareCommand
             }
         }
 
-        $entryRepository = $this->getContainer()->get(EntryRepository::class);
-        $entryIds = $entryRepository->findAllEntriesIdByUserId($userId);
+        $entryIds = $this->entryRepository->findAllEntriesIdByUserId($userId);
 
         $nbEntries = \count($entryIds);
         if (!$nbEntries) {
@@ -68,22 +83,18 @@ class ReloadEntryCommand extends ContainerAwareCommand
 
         $progressBar = $io->createProgressBar($nbEntries);
 
-        $contentProxy = $this->getContainer()->get(ContentProxy::class);
-        $em = $this->getContainer()->get(ManagerRegistry::class)->getManager();
-        $dispatcher = $this->getContainer()->get(EventDispatcherInterface::class);
-
         $progressBar->start();
         foreach ($entryIds as $entryId) {
-            $entry = $entryRepository->find($entryId);
+            $entry = $this->entryRepository->find($entryId);
 
-            $contentProxy->updateEntry($entry, $entry->getUrl());
-            $em->persist($entry);
-            $em->flush();
+            $this->contentProxy->updateEntry($entry, $entry->getUrl());
+            $this->entityManager->persist($entry);
+            $this->entityManager->flush();
 
-            $dispatcher->dispatch(new EntrySavedEvent($entry), EntrySavedEvent::NAME);
+            $this->dispatcher->dispatch(new EntrySavedEvent($entry), EntrySavedEvent::NAME);
             $progressBar->advance();
 
-            $em->detach($entry);
+            $this->entityManager->detach($entry);
         }
         $progressBar->finish();
 

--- a/src/Wallabag/CoreBundle/Command/ShowUserCommand.php
+++ b/src/Wallabag/CoreBundle/Command/ShowUserCommand.php
@@ -3,7 +3,7 @@
 namespace Wallabag\CoreBundle\Command;
 
 use Doctrine\ORM\NoResultException;
-use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
+use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -11,10 +11,17 @@ use Symfony\Component\Console\Style\SymfonyStyle;
 use Wallabag\UserBundle\Entity\User;
 use Wallabag\UserBundle\Repository\UserRepository;
 
-class ShowUserCommand extends ContainerAwareCommand
+class ShowUserCommand extends Command
 {
-    /** @var SymfonyStyle */
-    protected $io;
+    protected SymfonyStyle $io;
+    private UserRepository $userRepository;
+
+    public function __construct(UserRepository $userRepository)
+    {
+        $this->userRepository = $userRepository;
+
+        parent::__construct();
+    }
 
     protected function configure()
     {
@@ -69,6 +76,6 @@ class ShowUserCommand extends ContainerAwareCommand
      */
     private function getUser($username)
     {
-        return $this->getContainer()->get(UserRepository::class)->findOneByUserName($username);
+        return $this->userRepository->findOneByUserName($username);
     }
 }

--- a/src/Wallabag/CoreBundle/Command/TagAllCommand.php
+++ b/src/Wallabag/CoreBundle/Command/TagAllCommand.php
@@ -2,9 +2,9 @@
 
 namespace Wallabag\CoreBundle\Command;
 
+use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\NoResultException;
-use Doctrine\Persistence\ManagerRegistry;
-use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
+use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -13,8 +13,21 @@ use Wallabag\CoreBundle\Helper\RuleBasedTagger;
 use Wallabag\UserBundle\Entity\User;
 use Wallabag\UserBundle\Repository\UserRepository;
 
-class TagAllCommand extends ContainerAwareCommand
+class TagAllCommand extends Command
 {
+    private EntityManagerInterface $entityManager;
+    private RuleBasedTagger $ruleBasedTagger;
+    private UserRepository $userRepository;
+
+    public function __construct(EntityManagerInterface $entityManager, RuleBasedTagger $ruleBasedTagger, UserRepository $userRepository)
+    {
+        $this->entityManager = $entityManager;
+        $this->ruleBasedTagger = $ruleBasedTagger;
+        $this->userRepository = $userRepository;
+
+        parent::__construct();
+    }
+
     protected function configure()
     {
         $this
@@ -39,19 +52,17 @@ class TagAllCommand extends ContainerAwareCommand
 
             return 1;
         }
-        $tagger = $this->getContainer()->get(RuleBasedTagger::class);
 
         $io->text(sprintf('Tagging entries for user <info>%s</info>...', $user->getUserName()));
 
-        $entries = $tagger->tagAllForUser($user);
+        $entries = $this->ruleBasedTagger->tagAllForUser($user);
 
         $io->text('Persist ' . \count($entries) . ' entries... ');
 
-        $em = $this->getContainer()->get('doctrine')->getManager();
         foreach ($entries as $entry) {
-            $em->persist($entry);
+            $this->entityManager->persist($entry);
         }
-        $em->flush();
+        $this->entityManager->flush();
 
         $io->success('Done.');
 
@@ -67,11 +78,6 @@ class TagAllCommand extends ContainerAwareCommand
      */
     private function getUser($username)
     {
-        return $this->getContainer()->get(UserRepository::class)->findOneByUserName($username);
-    }
-
-    private function getDoctrine()
-    {
-        return $this->getContainer()->get(ManagerRegistry::class);
+        return $this->userRepository->findOneByUserName($username);
     }
 }

--- a/src/Wallabag/ImportBundle/Command/RedisWorkerCommand.php
+++ b/src/Wallabag/ImportBundle/Command/RedisWorkerCommand.php
@@ -3,15 +3,25 @@
 namespace Wallabag\ImportBundle\Command;
 
 use Simpleue\Worker\QueueWorker;
-use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
 use Symfony\Component\Config\Definition\Exception\Exception;
+use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 
-class RedisWorkerCommand extends ContainerAwareCommand
+class RedisWorkerCommand extends Command
 {
+    private $container;
+
+    public function __construct(ContainerInterface $container)
+    {
+        $this->container = $container;
+
+        parent::__construct();
+    }
+
     protected function configure()
     {
         $this
@@ -29,13 +39,13 @@ class RedisWorkerCommand extends ContainerAwareCommand
 
         $serviceName = $input->getArgument('serviceName');
 
-        if (!$this->getContainer()->has('wallabag_import.queue.redis.' . $serviceName) || !$this->getContainer()->has('wallabag_import.consumer.redis.' . $serviceName)) {
+        if (!$this->container->has('wallabag_import.queue.redis.' . $serviceName) || !$this->container->has('wallabag_import.consumer.redis.' . $serviceName)) {
             throw new Exception(sprintf('No queue or consumer found for service name: "%s"', $input->getArgument('serviceName')));
         }
 
         $worker = new QueueWorker(
-            $this->getContainer()->get('wallabag_import.queue.redis.' . $serviceName),
-            $this->getContainer()->get('wallabag_import.consumer.redis.' . $serviceName),
+            $this->container->get('wallabag_import.queue.redis.' . $serviceName),
+            $this->container->get('wallabag_import.consumer.redis.' . $serviceName),
             (int) $input->getOption('maxIterations')
         );
 


### PR DESCRIPTION
And use DI to retrieve services in commands (except for `RedisWorkerCommand` where the container is injected, hard to find a better way, at least for now).

Most of the work was done by @Kdecherf in https://github.com/wallabag/wallabag/pull/5342