### PR TITLE
Fix EventDispatcher & events

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -84,18 +84,3 @@ parameters:
             message: "#^Property Tests\\\\Wallabag\\\\CoreBundle\\\\Helper\\\\RedirectTest\\:\\:\\$routerMock has unknown class PHPUnit_Framework_MockObject_MockObject as its type\\.$#"
             count: 1
             path: tests/Wallabag/CoreBundle/Helper/RedirectTest.php
-
-        -
-            message: "#^Method Symfony\\\\Contracts\\\\EventDispatcher\\\\EventDispatcherInterface\\:\\:dispatch()#"
-            count: 1
-            path: src/Wallabag/ApiBundle/Controller/UserRestController.php
-
-        -
-            message: "#^Method Symfony\\\\Contracts\\\\EventDispatcher\\\\EventDispatcherInterface\\:\\:dispatch()#"
-            count: 1
-            path: src/Wallabag/CoreBundle/Command/InstallCommand.php
-
-        -
-            message: "#^Method Symfony\\\\Contracts\\\\EventDispatcher\\\\EventDispatcherInterface\\:\\:dispatch()#"
-            count: 1
-            path: src/Wallabag/UserBundle/Controller/ManageController.php

--- a/src/Wallabag/ApiBundle/Controller/EntryRestController.php
+++ b/src/Wallabag/ApiBundle/Controller/EntryRestController.php
@@ -462,7 +462,7 @@ class EntryRestController extends WallabagRestController
 
             if (false !== $entry) {
                 // entry deleted, dispatch event about it!
-                $this->get(EventDispatcherInterface::class)->dispatch(EntryDeletedEvent::NAME, new EntryDeletedEvent($entry));
+                $this->get(EventDispatcherInterface::class)->dispatch(new EntryDeletedEvent($entry), EntryDeletedEvent::NAME);
 
                 $em = $this->get('doctrine')->getManager();
                 $em->remove($entry);
@@ -539,7 +539,7 @@ class EntryRestController extends WallabagRestController
             $results[$key]['entry'] = $entry instanceof Entry ? $entry->getId() : false;
 
             // entry saved, dispatch event about it!
-            $this->get(EventDispatcherInterface::class)->dispatch(EntrySavedEvent::NAME, new EntrySavedEvent($entry));
+            $this->get(EventDispatcherInterface::class)->dispatch(new EntrySavedEvent($entry), EntrySavedEvent::NAME);
         }
 
         return $this->sendResponse($results);
@@ -760,7 +760,7 @@ class EntryRestController extends WallabagRestController
         $em->flush();
 
         // entry saved, dispatch event about it!
-        $this->get(EventDispatcherInterface::class)->dispatch(EntrySavedEvent::NAME, new EntrySavedEvent($entry));
+        $this->get(EventDispatcherInterface::class)->dispatch(new EntrySavedEvent($entry), EntrySavedEvent::NAME);
 
         return $this->sendResponse($entry);
     }
@@ -976,7 +976,7 @@ class EntryRestController extends WallabagRestController
         $em->flush();
 
         // entry saved, dispatch event about it!
-        $this->get(EventDispatcherInterface::class)->dispatch(EntrySavedEvent::NAME, new EntrySavedEvent($entry));
+        $this->get(EventDispatcherInterface::class)->dispatch(new EntrySavedEvent($entry), EntrySavedEvent::NAME);
 
         return $this->sendResponse($entry);
     }
@@ -1032,7 +1032,7 @@ class EntryRestController extends WallabagRestController
         $em->flush();
 
         // entry saved, dispatch event about it!
-        $this->get(EventDispatcherInterface::class)->dispatch(EntrySavedEvent::NAME, new EntrySavedEvent($entry));
+        $this->get(EventDispatcherInterface::class)->dispatch(new EntrySavedEvent($entry), EntrySavedEvent::NAME);
 
         return $this->sendResponse($entry);
     }
@@ -1083,7 +1083,7 @@ class EntryRestController extends WallabagRestController
         }
 
         // entry deleted, dispatch event about it!
-        $this->get(EventDispatcherInterface::class)->dispatch(EntryDeletedEvent::NAME, new EntryDeletedEvent($entry));
+        $this->get(EventDispatcherInterface::class)->dispatch(new EntryDeletedEvent($entry), EntryDeletedEvent::NAME);
 
         $em = $this->get('doctrine')->getManager();
         $em->remove($entry);

--- a/src/Wallabag/ApiBundle/Controller/UserRestController.php
+++ b/src/Wallabag/ApiBundle/Controller/UserRestController.php
@@ -11,7 +11,6 @@ use JMS\Serializer\SerializerInterface;
 use Nelmio\ApiDocBundle\Annotation\Operation;
 use Swagger\Annotations as SWG;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
-use Symfony\Component\EventDispatcher\LegacyEventDispatcherProxy;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Routing\Annotation\Route;
@@ -160,7 +159,7 @@ class UserRestController extends WallabagRestController
 
         // dispatch a created event so the associated config will be created
         $event = new UserEvent($user, $request);
-        LegacyEventDispatcherProxy::decorate($this->get(EventDispatcherInterface::class))->dispatch($event, FOSUserEvents::USER_CREATED);
+        $this->get(EventDispatcherInterface::class)->dispatch($event, FOSUserEvents::USER_CREATED);
 
         return $this->sendUser($user, 'user_api_with_client', JsonResponse::HTTP_CREATED);
     }

--- a/src/Wallabag/CoreBundle/Command/InstallCommand.php
+++ b/src/Wallabag/CoreBundle/Command/InstallCommand.php
@@ -18,7 +18,6 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Question\Question;
 use Symfony\Component\Console\Style\SymfonyStyle;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
-use Symfony\Component\EventDispatcher\LegacyEventDispatcherProxy;
 use Wallabag\CoreBundle\Entity\IgnoreOriginInstanceRule;
 use Wallabag\CoreBundle\Entity\InternalSetting;
 use Wallabag\UserBundle\Entity\User;
@@ -282,7 +281,7 @@ class InstallCommand extends ContainerAwareCommand
 
         // dispatch a created event so the associated config will be created
         $event = new UserEvent($user);
-        LegacyEventDispatcherProxy::decorate($this->getContainer()->get(EventDispatcherInterface::class))->dispatch($event, FOSUserEvents::USER_CREATED);
+        $this->getContainer()->get(EventDispatcherInterface::class)->dispatch($event, FOSUserEvents::USER_CREATED);
 
         $this->io->text('<info>Administration successfully setup.</info>');
 

--- a/src/Wallabag/CoreBundle/Command/ReloadEntryCommand.php
+++ b/src/Wallabag/CoreBundle/Command/ReloadEntryCommand.php
@@ -80,7 +80,7 @@ class ReloadEntryCommand extends ContainerAwareCommand
             $em->persist($entry);
             $em->flush();
 
-            $dispatcher->dispatch(EntrySavedEvent::NAME, new EntrySavedEvent($entry));
+            $dispatcher->dispatch(new EntrySavedEvent($entry), EntrySavedEvent::NAME);
             $progressBar->advance();
 
             $em->detach($entry);

--- a/src/Wallabag/CoreBundle/Controller/EntryController.php
+++ b/src/Wallabag/CoreBundle/Controller/EntryController.php
@@ -102,7 +102,7 @@ class EntryController extends Controller
                         $entry->removeTag($tag);
                     }
                 } elseif ('delete' === $action) {
-                    $this->get(EventDispatcherInterface::class)->dispatch(EntryDeletedEvent::NAME, new EntryDeletedEvent($entry));
+                    $this->get(EventDispatcherInterface::class)->dispatch(new EntryDeletedEvent($entry), EntryDeletedEvent::NAME);
                     $em->remove($entry);
                 }
             }
@@ -178,7 +178,7 @@ class EntryController extends Controller
             $em->flush();
 
             // entry saved, dispatch event about it!
-            $this->get(EventDispatcherInterface::class)->dispatch(EntrySavedEvent::NAME, new EntrySavedEvent($entry));
+            $this->get(EventDispatcherInterface::class)->dispatch(new EntrySavedEvent($entry), EntrySavedEvent::NAME);
 
             return $this->redirect($this->generateUrl('homepage'));
         }
@@ -206,7 +206,7 @@ class EntryController extends Controller
             $em->flush();
 
             // entry saved, dispatch event about it!
-            $this->get(EventDispatcherInterface::class)->dispatch(EntrySavedEvent::NAME, new EntrySavedEvent($entry));
+            $this->get(EventDispatcherInterface::class)->dispatch(new EntrySavedEvent($entry), EntrySavedEvent::NAME);
         }
 
         return $this->redirect($this->generateUrl('homepage'));
@@ -414,7 +414,7 @@ class EntryController extends Controller
         $em->flush();
 
         // entry saved, dispatch event about it!
-        $this->get(EventDispatcherInterface::class)->dispatch(EntrySavedEvent::NAME, new EntrySavedEvent($entry));
+        $this->get(EventDispatcherInterface::class)->dispatch(new EntrySavedEvent($entry), EntrySavedEvent::NAME);
 
         return $this->redirect($this->generateUrl('view', ['id' => $entry->getId()]));
     }
@@ -498,7 +498,7 @@ class EntryController extends Controller
         );
 
         // entry deleted, dispatch event about it!
-        $this->get(EventDispatcherInterface::class)->dispatch(EntryDeletedEvent::NAME, new EntryDeletedEvent($entry));
+        $this->get(EventDispatcherInterface::class)->dispatch(new EntryDeletedEvent($entry), EntryDeletedEvent::NAME);
 
         $em = $this->get('doctrine')->getManager();
         $em->remove($entry);

--- a/src/Wallabag/CoreBundle/Event/EntryDeletedEvent.php
+++ b/src/Wallabag/CoreBundle/Event/EntryDeletedEvent.php
@@ -2,7 +2,7 @@
 
 namespace Wallabag\CoreBundle\Event;
 
-use Symfony\Component\EventDispatcher\Event;
+use Symfony\Contracts\EventDispatcher\Event;
 use Wallabag\CoreBundle\Entity\Entry;
 
 /**
@@ -19,7 +19,7 @@ class EntryDeletedEvent extends Event
         $this->entry = $entry;
     }
 
-    public function getEntry()
+    public function getEntry(): Entry
     {
         return $this->entry;
     }

--- a/src/Wallabag/CoreBundle/Event/EntrySavedEvent.php
+++ b/src/Wallabag/CoreBundle/Event/EntrySavedEvent.php
@@ -2,7 +2,7 @@
 
 namespace Wallabag\CoreBundle\Event;
 
-use Symfony\Component\EventDispatcher\Event;
+use Symfony\Contracts\EventDispatcher\Event;
 use Wallabag\CoreBundle\Entity\Entry;
 
 /**
@@ -19,7 +19,7 @@ class EntrySavedEvent extends Event
         $this->entry = $entry;
     }
 
-    public function getEntry()
+    public function getEntry(): Entry
     {
         return $this->entry;
     }

--- a/src/Wallabag/ImportBundle/Consumer/AbstractConsumer.php
+++ b/src/Wallabag/ImportBundle/Consumer/AbstractConsumer.php
@@ -72,7 +72,7 @@ abstract class AbstractConsumer
             $this->em->flush();
 
             // entry saved, dispatch event about it!
-            $this->eventDispatcher->dispatch(EntrySavedEvent::NAME, new EntrySavedEvent($entry));
+            $this->eventDispatcher->dispatch(new EntrySavedEvent($entry), EntrySavedEvent::NAME);
 
             // clear only affected entities
             $this->em->clear(Entry::class);

--- a/src/Wallabag/ImportBundle/Import/AbstractImport.php
+++ b/src/Wallabag/ImportBundle/Import/AbstractImport.php
@@ -171,7 +171,7 @@ abstract class AbstractImport implements ImportInterface
                 $this->em->flush();
 
                 foreach ($entryToBeFlushed as $entry) {
-                    $this->eventDispatcher->dispatch(EntrySavedEvent::NAME, new EntrySavedEvent($entry));
+                    $this->eventDispatcher->dispatch(new EntrySavedEvent($entry), EntrySavedEvent::NAME);
                 }
 
                 $entryToBeFlushed = [];
@@ -187,7 +187,7 @@ abstract class AbstractImport implements ImportInterface
 
         if (!empty($entryToBeFlushed)) {
             foreach ($entryToBeFlushed as $entry) {
-                $this->eventDispatcher->dispatch(EntrySavedEvent::NAME, new EntrySavedEvent($entry));
+                $this->eventDispatcher->dispatch(new EntrySavedEvent($entry), EntrySavedEvent::NAME);
             }
         }
     }

--- a/src/Wallabag/ImportBundle/Import/BrowserImport.php
+++ b/src/Wallabag/ImportBundle/Import/BrowserImport.php
@@ -173,7 +173,7 @@ abstract class BrowserImport extends AbstractImport
                 $this->em->flush();
 
                 foreach ($entryToBeFlushed as $entry) {
-                    $this->eventDispatcher->dispatch(EntrySavedEvent::NAME, new EntrySavedEvent($entry));
+                    $this->eventDispatcher->dispatch(new EntrySavedEvent($entry), EntrySavedEvent::NAME);
                 }
 
                 $entryToBeFlushed = [];
@@ -185,7 +185,7 @@ abstract class BrowserImport extends AbstractImport
 
         if (!empty($entryToBeFlushed)) {
             foreach ($entryToBeFlushed as $entry) {
-                $this->eventDispatcher->dispatch(EntrySavedEvent::NAME, new EntrySavedEvent($entry));
+                $this->eventDispatcher->dispatch(new EntrySavedEvent($entry), EntrySavedEvent::NAME);
             }
         }
     }

--- a/src/Wallabag/UserBundle/Controller/ManageController.php
+++ b/src/Wallabag/UserBundle/Controller/ManageController.php
@@ -11,7 +11,6 @@ use Pagerfanta\Pagerfanta;
 use Scheb\TwoFactorBundle\Security\TwoFactor\Provider\Google\GoogleAuthenticatorInterface;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
-use Symfony\Component\EventDispatcher\LegacyEventDispatcherProxy;
 use Symfony\Component\Form\Form;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -50,7 +49,7 @@ class ManageController extends Controller
 
             // dispatch a created event so the associated config will be created
             $event = new UserEvent($user, $request);
-            LegacyEventDispatcherProxy::decorate($this->get(EventDispatcherInterface::class))->dispatch($event, FOSUserEvents::USER_CREATED);
+            $this->get(EventDispatcherInterface::class)->dispatch($event, FOSUserEvents::USER_CREATED);
 
             $this->get(SessionInterface::class)->getFlashBag()->add(
                 'notice',

--- a/tests/Wallabag/CoreBundle/Event/Listener/LocaleListenerTest.php
+++ b/tests/Wallabag/CoreBundle/Event/Listener/LocaleListenerTest.php
@@ -69,8 +69,8 @@ class LocaleListenerTest extends TestCase
         $dispatcher->addSubscriber($listener);
 
         $dispatcher->dispatch(
-            KernelEvents::REQUEST,
-            $event
+            $event,
+            KernelEvents::REQUEST
         );
 
         $this->assertSame('fr', $request->getLocale());

--- a/tests/Wallabag/UserBundle/EventListener/AuthenticationFailureListenerTest.php
+++ b/tests/Wallabag/UserBundle/EventListener/AuthenticationFailureListenerTest.php
@@ -57,8 +57,8 @@ class AuthenticationFailureListenerTest extends TestCase
         );
 
         $this->dispatcher->dispatch(
-            AuthenticationEvents::AUTHENTICATION_FAILURE,
-            $event
+            $event,
+            AuthenticationEvents::AUTHENTICATION_FAILURE
         );
 
         $records = $this->logHandler->getRecords();

--- a/tests/Wallabag/UserBundle/EventListener/CreateConfigListenerTest.php
+++ b/tests/Wallabag/UserBundle/EventListener/CreateConfigListenerTest.php
@@ -72,8 +72,8 @@ class CreateConfigListenerTest extends TestCase
             ->method('flush');
 
         $this->dispatcher->dispatch(
-            FOSUserEvents::REGISTRATION_COMPLETED,
-            $event
+            $event,
+            FOSUserEvents::REGISTRATION_COMPLETED
         );
     }
 }


### PR DESCRIPTION
Looks like parameter for the `->dispatch(` have been flipped (event first then event name). Define events should now extends `Symfony\Contracts\EventDispatcher\Event`