### PR TITLE
Move to controller as a service

### DIFF
--- a/app/config/routing_dev.yml
+++ b/app/config/routing_dev.yml
@@ -7,7 +7,7 @@ _profiler:
     prefix: /_profiler
 
 _errors:
-    resource: "@TwigBundle/Resources/config/routing/errors.xml"
+    resource: '@TwigBundle/Resources/config/routing/errors.xml'
     prefix: /_error
 
 _main:

--- a/app/config/services.yml
+++ b/app/config/services.yml
@@ -43,6 +43,79 @@ services:
         resource: '../../src/Wallabag/CoreBundle/*'
         exclude: ['../../src/Wallabag/CoreBundle/{Controller,Entity}', '../../src/Wallabag/CoreBundle/Event/*Event.php']
 
+    # controllers are imported separately to make sure services can be injected
+    # as action arguments even if you don't extend any base controller class
+    Wallabag\AnnotationBundle\Controller\:
+        resource: '../../src/Wallabag/AnnotationBundle/Controller/'
+        tags: ['controller.service_arguments']
+
+    Wallabag\ApiBundle\Controller\:
+        resource: '../../src/Wallabag/ApiBundle/Controller/'
+        tags: ['controller.service_arguments']
+
+    Wallabag\CoreBundle\Controller\:
+        resource: '../../src/Wallabag/CoreBundle/Controller/'
+        tags: ['controller.service_arguments']
+
+    Wallabag\ImportBundle\Controller\:
+        resource: '../../src/Wallabag/ImportBundle/Controller/'
+        tags: ['controller.service_arguments']
+
+    Wallabag\UserBundle\Controller\:
+        resource: '../../src/Wallabag/UserBundle/Controller/'
+        tags: ['controller.service_arguments']
+
+    # inject alias service into controllers
+    Wallabag\ImportBundle\Controller\ChromeController:
+        arguments:
+            $rabbitMqProducer: '@old_sound_rabbit_mq.import_chrome_producer'
+            $redisProducer: '@wallabag_import.producer.redis.chrome'
+
+    Wallabag\ImportBundle\Controller\DeliciousController:
+        arguments:
+            $rabbitMqProducer: '@old_sound_rabbit_mq.import_delicious_producer'
+            $redisProducer: '@wallabag_import.producer.redis.delicious'
+
+    Wallabag\ImportBundle\Controller\ElcuratorController:
+        arguments:
+            $rabbitMqProducer: '@old_sound_rabbit_mq.import_elcurator_producer'
+            $redisProducer: '@wallabag_import.producer.redis.elcurator'
+
+    Wallabag\ImportBundle\Controller\FirefoxController:
+        arguments:
+            $rabbitMqProducer: '@old_sound_rabbit_mq.import_firefox_producer'
+            $redisProducer: '@wallabag_import.producer.redis.firefox'
+
+    Wallabag\ImportBundle\Controller\InstapaperController:
+        arguments:
+            $rabbitMqProducer: '@old_sound_rabbit_mq.import_instapaper_producer'
+            $redisProducer: '@wallabag_import.producer.redis.instapaper'
+
+    Wallabag\ImportBundle\Controller\PinboardController:
+        arguments:
+            $rabbitMqProducer: '@old_sound_rabbit_mq.import_pinboard_producer'
+            $redisProducer: '@wallabag_import.producer.redis.pinboard'
+
+    Wallabag\ImportBundle\Controller\PocketController:
+        arguments:
+            $rabbitMqProducer: '@old_sound_rabbit_mq.import_pocket_producer'
+            $redisProducer: '@wallabag_import.producer.redis.pocket'
+
+    Wallabag\ImportBundle\Controller\ReadabilityController:
+        arguments:
+            $rabbitMqProducer: '@old_sound_rabbit_mq.import_readability_producer'
+            $redisProducer: '@wallabag_import.producer.redis.readability'
+
+    Wallabag\ImportBundle\Controller\WallabagV1Controller:
+        arguments:
+            $rabbitMqProducer: '@old_sound_rabbit_mq.import_wallabag_v1_producer'
+            $redisProducer: '@wallabag_import.producer.redis.wallabag_v1'
+
+    Wallabag\ImportBundle\Controller\WallabagV2Controller:
+        arguments:
+            $rabbitMqProducer: '@old_sound_rabbit_mq.import_wallabag_v2_producer'
+            $redisProducer: '@wallabag_import.producer.redis.wallabag_v2'
+
     Wallabag\ImportBundle\:
         resource: '../../src/Wallabag/ImportBundle/*'
         exclude: '../../src/Wallabag/ImportBundle/{Consumer,Controller,Redis}'
@@ -182,8 +255,6 @@ services:
                 port: '%redis_port%'
                 path: '%redis_path%'
                 password: '%redis_password%'
-
-    Wallabag\CoreBundle\Controller\ExceptionController: ~
 
     Wallabag\CoreBundle\Event\Subscriber\SQLiteCascadeDeleteSubscriber:
         tags:

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,29 +1,9 @@
 parameters:
     ignoreErrors:
         -
-            message: "#^Call to an undefined method Psr\\\\Container\\\\ContainerInterface\\:\\:getParameter\\(\\)\\.$#"
-            count: 2
-            path: src/Wallabag/ApiBundle/Controller/EntryRestController.php
-
-        -
-            message: "#^Call to an undefined method Psr\\\\Container\\\\ContainerInterface\\:\\:getParameter\\(\\)\\.$#"
-            count: 1
-            path: src/Wallabag/ApiBundle/Controller/UserRestController.php
-
-        -
-            message: "#^Call to an undefined method Psr\\\\Container\\\\ContainerInterface\\:\\:getParameter\\(\\)\\.$#"
-            count: 3
-            path: src/Wallabag/ApiBundle/Controller/WallabagRestController.php
-
-        -
             message: "#^Call to an undefined method Wallabag\\\\CoreBundle\\\\Entity\\\\RuleInterface\\:\\:getConfig\\(\\)\\.$#"
             count: 1
             path: src/Wallabag/CoreBundle/Controller/ConfigController.php
-
-        -
-            message: "#^Call to an undefined method Psr\\\\Container\\\\ContainerInterface\\:\\:getParameter\\(\\)\\.$#"
-            count: 1
-            path: src/Wallabag/CoreBundle/Controller/StaticController.php
 
         -
             message: "#^Call to an undefined method Lexik\\\\Bundle\\\\FormFilterBundle\\\\Filter\\\\Query\\\\QueryInterface\\:\\:getExpressionBuilder\\(\\)\\.$#"
@@ -77,10 +57,10 @@ parameters:
 
         -
             message: "#^Method Symfony\\\\Contracts\\\\EventDispatcher\\\\EventDispatcherInterface\\:\\:dispatch()#"
-            count: 1
-            path: src/Wallabag/CoreBundle/Command/InstallCommand.php
+            count: 15
+            path: src/*
 
         -
-            message: "#^Method Symfony\\\\Contracts\\\\EventDispatcher\\\\EventDispatcherInterface\\:\\:dispatch()#"
-            count: 1
-            path: src/Wallabag/CoreBundle/Command/ReloadEntryCommand.php
+            message: "#^Method FOS\\\\UserBundle\\\\Model\\\\UserManagerInterface\\:\\:updateUser()#"
+            count: 7
+            path: src/Wallabag/CoreBundle/Controller/ConfigController.php

--- a/src/Wallabag/ApiBundle/Controller/ConfigRestController.php
+++ b/src/Wallabag/ApiBundle/Controller/ConfigRestController.php
@@ -27,11 +27,11 @@ class ConfigRestController extends WallabagRestController
      *
      * @return JsonResponse
      */
-    public function getConfigAction()
+    public function getConfigAction(SerializerInterface $serializer)
     {
         $this->validateAuthentication();
 
-        $json = $this->get(SerializerInterface::class)->serialize(
+        $json = $serializer->serialize(
             $this->getUser()->getConfig(),
             'json',
             SerializationContext::create()->setGroups(['config_api'])

--- a/src/Wallabag/ApiBundle/Controller/DeveloperController.php
+++ b/src/Wallabag/ApiBundle/Controller/DeveloperController.php
@@ -2,17 +2,18 @@
 
 namespace Wallabag\ApiBundle\Controller;
 
-use Symfony\Bundle\FrameworkBundle\Controller\Controller;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\HttpFoundation\Session\SessionInterface;
 use Symfony\Component\Routing\Annotation\Route;
-use Symfony\Component\Translation\TranslatorInterface;
+use Symfony\Contracts\Translation\TranslatorInterface;
 use Wallabag\ApiBundle\Entity\Client;
 use Wallabag\ApiBundle\Form\Type\ClientType;
+use Wallabag\ApiBundle\Repository\ClientRepository;
 
-class DeveloperController extends Controller
+class DeveloperController extends AbstractController
 {
     /**
      * List all clients and link to create a new one.
@@ -21,9 +22,9 @@ class DeveloperController extends Controller
      *
      * @return Response
      */
-    public function indexAction()
+    public function indexAction(ClientRepository $repo)
     {
-        $clients = $this->get('doctrine')->getRepository(Client::class)->findByUser($this->getUser()->getId());
+        $clients = $repo->findByUser($this->getUser()->getId());
 
         return $this->render('@WallabagCore/Developer/index.html.twig', [
             'clients' => $clients,
@@ -37,21 +38,20 @@ class DeveloperController extends Controller
      *
      * @return Response
      */
-    public function createClientAction(Request $request)
+    public function createClientAction(Request $request, EntityManagerInterface $entityManager, TranslatorInterface $translator)
     {
-        $em = $this->get('doctrine')->getManager();
         $client = new Client($this->getUser());
         $clientForm = $this->createForm(ClientType::class, $client);
         $clientForm->handleRequest($request);
 
         if ($clientForm->isSubmitted() && $clientForm->isValid()) {
             $client->setAllowedGrantTypes(['token', 'authorization_code', 'password', 'refresh_token']);
-            $em->persist($client);
-            $em->flush();
+            $entityManager->persist($client);
+            $entityManager->flush();
 
-            $this->get(SessionInterface::class)->getFlashBag()->add(
+            $this->addFlash(
                 'notice',
-                $this->get(TranslatorInterface::class)->trans('flashes.developer.notice.client_created', ['%name%' => $client->getName()])
+                $translator->trans('flashes.developer.notice.client_created', ['%name%' => $client->getName()])
             );
 
             return $this->render('@WallabagCore/Developer/client_parameters.html.twig', [
@@ -73,19 +73,18 @@ class DeveloperController extends Controller
      *
      * @return RedirectResponse
      */
-    public function deleteClientAction(Client $client)
+    public function deleteClientAction(Client $client, EntityManagerInterface $entityManager, TranslatorInterface $translator)
     {
         if (null === $this->getUser() || $client->getUser()->getId() !== $this->getUser()->getId()) {
             throw $this->createAccessDeniedException('You can not access this client.');
         }
 
-        $em = $this->get('doctrine')->getManager();
-        $em->remove($client);
-        $em->flush();
+        $entityManager->remove($client);
+        $entityManager->flush();
 
-        $this->get(SessionInterface::class)->getFlashBag()->add(
+        $this->addFlash(
             'notice',
-            $this->get(TranslatorInterface::class)->trans('flashes.developer.notice.client_deleted', ['%name%' => $client->getName()])
+            $translator->trans('flashes.developer.notice.client_deleted', ['%name%' => $client->getName()])
         );
 
         return $this->redirect($this->generateUrl('developer'));

--- a/src/Wallabag/ApiBundle/Controller/SearchRestController.php
+++ b/src/Wallabag/ApiBundle/Controller/SearchRestController.php
@@ -58,7 +58,7 @@ class SearchRestController extends WallabagRestController
      *
      * @return JsonResponse
      */
-    public function getSearchAction(Request $request)
+    public function getSearchAction(Request $request, EntryRepository $entryRepository)
     {
         $this->validateAuthentication();
 
@@ -66,12 +66,11 @@ class SearchRestController extends WallabagRestController
         $page = (int) $request->query->get('page', 1);
         $perPage = (int) $request->query->get('perPage', 30);
 
-        $qb = $this->get(EntryRepository::class)
-            ->getBuilderForSearchByUser(
-                $this->getUser()->getId(),
-                $term,
-                null
-            );
+        $qb = $entryRepository->getBuilderForSearchByUser(
+            $this->getUser()->getId(),
+            $term,
+            null
+        );
 
         $pagerAdapter = new DoctrineORMAdapter($qb->getQuery(), true, false);
         $pager = new Pagerfanta($pagerAdapter);

--- a/src/Wallabag/ApiBundle/Controller/TagRestController.php
+++ b/src/Wallabag/ApiBundle/Controller/TagRestController.php
@@ -2,7 +2,6 @@
 
 namespace Wallabag\ApiBundle\Controller;
 
-use JMS\Serializer\SerializerInterface;
 use Nelmio\ApiDocBundle\Annotation\Operation;
 use Swagger\Annotations as SWG;
 use Symfony\Component\HttpFoundation\JsonResponse;
@@ -10,6 +9,8 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Routing\Annotation\Route;
 use Wallabag\CoreBundle\Entity\Entry;
 use Wallabag\CoreBundle\Entity\Tag;
+use Wallabag\CoreBundle\Repository\EntryRepository;
+use Wallabag\CoreBundle\Repository\TagRepository;
 
 class TagRestController extends WallabagRestController
 {
@@ -29,15 +30,13 @@ class TagRestController extends WallabagRestController
      *
      * @return JsonResponse
      */
-    public function getTagsAction()
+    public function getTagsAction(TagRepository $tagRepository)
     {
         $this->validateAuthentication();
 
-        $tags = $this->get('doctrine')
-            ->getRepository(Tag::class)
-            ->findAllFlatTagsWithNbEntries($this->getUser()->getId());
+        $tags = $tagRepository->findAllFlatTagsWithNbEntries($this->getUser()->getId());
 
-        $json = $this->get(SerializerInterface::class)->serialize($tags, 'json');
+        $json = $this->serializer->serialize($tags, 'json');
 
         return (new JsonResponse())->setJson($json);
     }
@@ -66,12 +65,12 @@ class TagRestController extends WallabagRestController
      *
      * @return JsonResponse
      */
-    public function deleteTagLabelAction(Request $request)
+    public function deleteTagLabelAction(Request $request, TagRepository $tagRepository, EntryRepository $entryRepository)
     {
         $this->validateAuthentication();
         $label = $request->get('tag', '');
 
-        $tags = $this->get('doctrine')->getRepository(Tag::class)->findByLabelsAndUser([$label], $this->getUser()->getId());
+        $tags = $tagRepository->findByLabelsAndUser([$label], $this->getUser()->getId());
 
         if (empty($tags)) {
             throw $this->createNotFoundException('Tag not found');
@@ -79,13 +78,11 @@ class TagRestController extends WallabagRestController
 
         $tag = $tags[0];
 
-        $this->get('doctrine')
-            ->getRepository(Entry::class)
-            ->removeTag($this->getUser()->getId(), $tag);
+        $entryRepository->removeTag($this->getUser()->getId(), $tag);
 
         $this->cleanOrphanTag($tag);
 
-        $json = $this->get(SerializerInterface::class)->serialize($tag, 'json');
+        $json = $this->serializer->serialize($tag, 'json');
 
         return (new JsonResponse())->setJson($json);
     }
@@ -116,25 +113,23 @@ class TagRestController extends WallabagRestController
      *
      * @return JsonResponse
      */
-    public function deleteTagsLabelAction(Request $request)
+    public function deleteTagsLabelAction(Request $request, TagRepository $tagRepository, EntryRepository $entryRepository)
     {
         $this->validateAuthentication();
 
         $tagsLabels = $request->get('tags', '');
 
-        $tags = $this->get('doctrine')->getRepository(Tag::class)->findByLabelsAndUser(explode(',', $tagsLabels), $this->getUser()->getId());
+        $tags = $tagRepository->findByLabelsAndUser(explode(',', $tagsLabels), $this->getUser()->getId());
 
         if (empty($tags)) {
             throw $this->createNotFoundException('Tags not found');
         }
 
-        $this->get('doctrine')
-            ->getRepository(Entry::class)
-            ->removeTags($this->getUser()->getId(), $tags);
+        $entryRepository->removeTags($this->getUser()->getId(), $tags);
 
         $this->cleanOrphanTag($tags);
 
-        $json = $this->get(SerializerInterface::class)->serialize($tags, 'json');
+        $json = $this->serializer->serialize($tags, 'json');
 
         return (new JsonResponse())->setJson($json);
     }
@@ -163,23 +158,21 @@ class TagRestController extends WallabagRestController
      *
      * @return JsonResponse
      */
-    public function deleteTagAction(Tag $tag)
+    public function deleteTagAction(Tag $tag, TagRepository $tagRepository, EntryRepository $entryRepository)
     {
         $this->validateAuthentication();
 
-        $tagFromDb = $this->get('doctrine')->getRepository(Tag::class)->findByLabelsAndUser([$tag->getLabel()], $this->getUser()->getId());
+        $tagFromDb = $tagRepository->findByLabelsAndUser([$tag->getLabel()], $this->getUser()->getId());
 
         if (empty($tagFromDb)) {
             throw $this->createNotFoundException('Tag not found');
         }
 
-        $this->get('doctrine')
-            ->getRepository(Entry::class)
-            ->removeTag($this->getUser()->getId(), $tag);
+        $entryRepository->removeTag($this->getUser()->getId(), $tag);
 
         $this->cleanOrphanTag($tag);
 
-        $json = $this->get(SerializerInterface::class)->serialize($tag, 'json');
+        $json = $this->serializer->serialize($tag, 'json');
 
         return (new JsonResponse())->setJson($json);
     }
@@ -195,14 +188,12 @@ class TagRestController extends WallabagRestController
             $tags = [$tags];
         }
 
-        $em = $this->get('doctrine')->getManager();
-
         foreach ($tags as $tag) {
             if (0 === \count($tag->getEntries())) {
-                $em->remove($tag);
+                $this->entityManager->remove($tag);
             }
         }
 
-        $em->flush();
+        $this->entityManager->flush();
     }
 }

--- a/src/Wallabag/ApiBundle/Controller/WallabagRestController.php
+++ b/src/Wallabag/ApiBundle/Controller/WallabagRestController.php
@@ -2,6 +2,7 @@
 
 namespace Wallabag\ApiBundle\Controller;
 
+use Doctrine\ORM\EntityManagerInterface;
 use FOS\RestBundle\Controller\AbstractFOSRestController;
 use JMS\Serializer\SerializationContext;
 use JMS\Serializer\SerializerInterface;
@@ -12,10 +13,26 @@ use Symfony\Component\Routing\Annotation\Route;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
 use Symfony\Component\Security\Core\Exception\AccessDeniedException;
+use Symfony\Contracts\Translation\TranslatorInterface;
 use Wallabag\UserBundle\Entity\User;
 
 class WallabagRestController extends AbstractFOSRestController
 {
+    protected EntityManagerInterface $entityManager;
+    protected SerializerInterface $serializer;
+    protected AuthorizationCheckerInterface $authorizationChecker;
+    protected TokenStorageInterface $tokenStorage;
+    protected TranslatorInterface $translator;
+
+    public function __construct(EntityManagerInterface $entityManager, SerializerInterface $serializer, AuthorizationCheckerInterface $authorizationChecker, TokenStorageInterface $tokenStorage, TranslatorInterface $translator)
+    {
+        $this->entityManager = $entityManager;
+        $this->serializer = $serializer;
+        $this->authorizationChecker = $authorizationChecker;
+        $this->tokenStorage = $tokenStorage;
+        $this->translator = $translator;
+    }
+
     /**
      * Retrieve version number.
      *
@@ -36,8 +53,8 @@ class WallabagRestController extends AbstractFOSRestController
      */
     public function getVersionAction()
     {
-        $version = $this->container->getParameter('wallabag_core.version');
-        $json = $this->get(SerializerInterface::class)->serialize($version, 'json');
+        $version = $this->getParameter('wallabag_core.version');
+        $json = $this->serializer->serialize($version, 'json');
 
         return (new JsonResponse())->setJson($json);
     }
@@ -62,16 +79,16 @@ class WallabagRestController extends AbstractFOSRestController
     {
         $info = [
             'appname' => 'wallabag',
-            'version' => $this->container->getParameter('wallabag_core.version'),
-            'allowed_registration' => $this->container->getParameter('fosuser_registration'),
+            'version' => $this->getParameter('wallabag_core.version'),
+            'allowed_registration' => $this->getParameter('fosuser_registration'),
         ];
 
-        return (new JsonResponse())->setJson($this->get(SerializerInterface::class)->serialize($info, 'json'));
+        return (new JsonResponse())->setJson($this->serializer->serialize($info, 'json'));
     }
 
     protected function validateAuthentication()
     {
-        if (false === $this->get(AuthorizationCheckerInterface::class)->isGranted('IS_AUTHENTICATED_FULLY')) {
+        if (false === $this->authorizationChecker->isGranted('IS_AUTHENTICATED_FULLY')) {
             throw new AccessDeniedException();
         }
     }
@@ -84,8 +101,9 @@ class WallabagRestController extends AbstractFOSRestController
      */
     protected function validateUserAccess($requestUserId)
     {
-        $user = $this->get(TokenStorageInterface::class)->getToken()->getUser();
+        $user = $this->tokenStorage->getToken()->getUser();
         \assert($user instanceof User);
+
         if ($requestUserId !== $user->getId()) {
             throw $this->createAccessDeniedException('Access forbidden. Entry user id: ' . $requestUserId . ', logged user id: ' . $user->getId());
         }
@@ -104,7 +122,7 @@ class WallabagRestController extends AbstractFOSRestController
         $context = new SerializationContext();
         $context->setSerializeNull(true);
 
-        $json = $this->get(SerializerInterface::class)->serialize($data, 'json', $context);
+        $json = $this->serializer->serialize($data, 'json', $context);
 
         return (new JsonResponse())->setJson($json);
     }

--- a/src/Wallabag/CoreBundle/Controller/ConfigController.php
+++ b/src/Wallabag/CoreBundle/Controller/ConfigController.php
@@ -4,13 +4,13 @@ namespace Wallabag\CoreBundle\Controller;
 
 use Craue\ConfigBundle\Util\Config;
 use Doctrine\DBAL\Platforms\SqlitePlatform;
-use Doctrine\Persistence\ManagerRegistry;
+use Doctrine\ORM\EntityManagerInterface;
 use FOS\UserBundle\Model\UserManagerInterface;
 use JMS\Serializer\SerializationContext;
 use JMS\Serializer\SerializerBuilder;
 use PragmaRX\Recovery\Recovery as BackupCodes;
 use Scheb\TwoFactorBundle\Security\TwoFactor\Provider\Google\GoogleAuthenticatorInterface;
-use Symfony\Bundle\FrameworkBundle\Controller\Controller;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
@@ -20,7 +20,7 @@ use Symfony\Component\Routing\Annotation\Route;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 use Symfony\Component\Validator\Constraints\Locale as LocaleConstraint;
 use Symfony\Component\Validator\Validator\ValidatorInterface;
-use Wallabag\AnnotationBundle\Entity\Annotation;
+use Wallabag\AnnotationBundle\Repository\AnnotationRepository;
 use Wallabag\CoreBundle\Entity\Config as ConfigEntity;
 use Wallabag\CoreBundle\Entity\IgnoreOriginUserRule;
 use Wallabag\CoreBundle\Entity\RuleInterface;
@@ -32,21 +32,39 @@ use Wallabag\CoreBundle\Form\Type\IgnoreOriginUserRuleType;
 use Wallabag\CoreBundle\Form\Type\TaggingRuleImportType;
 use Wallabag\CoreBundle\Form\Type\TaggingRuleType;
 use Wallabag\CoreBundle\Form\Type\UserInformationType;
+use Wallabag\CoreBundle\Repository\ConfigRepository;
 use Wallabag\CoreBundle\Repository\EntryRepository;
+use Wallabag\CoreBundle\Repository\IgnoreOriginUserRuleRepository;
+use Wallabag\CoreBundle\Repository\TaggingRuleRepository;
 use Wallabag\CoreBundle\Repository\TagRepository;
 use Wallabag\CoreBundle\Tools\Utils;
 use Wallabag\UserBundle\Repository\UserRepository;
 
-class ConfigController extends Controller
+class ConfigController extends AbstractController
 {
+    private EntityManagerInterface $entityManager;
+    private UserManagerInterface $userManager;
+    private EntryRepository $entryRepository;
+    private TagRepository $tagRepository;
+    private AnnotationRepository $annotationRepository;
+    private ConfigRepository $configRepository;
+
+    public function __construct(EntityManagerInterface $entityManager, UserManagerInterface $userManager, EntryRepository $entryRepository, TagRepository $tagRepository, AnnotationRepository $annotationRepository, ConfigRepository $configRepository)
+    {
+        $this->entityManager = $entityManager;
+        $this->userManager = $userManager;
+        $this->entryRepository = $entryRepository;
+        $this->tagRepository = $tagRepository;
+        $this->annotationRepository = $annotationRepository;
+        $this->configRepository = $configRepository;
+    }
+
     /**
      * @Route("/config", name="config")
      */
-    public function indexAction(Request $request)
+    public function indexAction(Request $request, Config $craueConfig, TaggingRuleRepository $taggingRuleRepository, IgnoreOriginUserRuleRepository $ignoreOriginUserRuleRepository, UserRepository $userRepository)
     {
-        $em = $this->get('doctrine')->getManager();
         $config = $this->getConfig();
-        $userManager = $this->container->get(UserManagerInterface::class);
         $user = $this->getUser();
 
         // handle basic config detail (this form is defined as a service)
@@ -54,8 +72,8 @@ class ConfigController extends Controller
         $configForm->handleRequest($request);
 
         if ($configForm->isSubmitted() && $configForm->isValid()) {
-            $em->persist($config);
-            $em->flush();
+            $this->entityManager->persist($config);
+            $this->entityManager->flush();
 
             $request->getSession()->set('_locale', $config->getLanguage());
 
@@ -72,13 +90,13 @@ class ConfigController extends Controller
         $pwdForm->handleRequest($request);
 
         if ($pwdForm->isSubmitted() && $pwdForm->isValid()) {
-            if ($this->get(Config::class)->get('demo_mode_enabled') && $this->get(Config::class)->get('demo_mode_username') === $user->getUsername()) {
+            if ($craueConfig->get('demo_mode_enabled') && $craueConfig->get('demo_mode_username') === $user->getUsername()) {
                 $message = 'flashes.config.notice.password_not_updated_demo';
             } else {
                 $message = 'flashes.config.notice.password_updated';
 
                 $user->setPlainPassword($pwdForm->get('new_password')->getData());
-                $userManager->updateUser($user, true);
+                $this->userManager->updateUser($user, true);
             }
 
             $this->addFlash('notice', $message);
@@ -94,7 +112,7 @@ class ConfigController extends Controller
         $userForm->handleRequest($request);
 
         if ($userForm->isSubmitted() && $userForm->isValid()) {
-            $userManager->updateUser($user, true);
+            $this->userManager->updateUser($user, true);
 
             $this->addFlash(
                 'notice',
@@ -109,8 +127,8 @@ class ConfigController extends Controller
         $feedForm->handleRequest($request);
 
         if ($feedForm->isSubmitted() && $feedForm->isValid()) {
-            $em->persist($config);
-            $em->flush();
+            $this->entityManager->persist($config);
+            $this->entityManager->flush();
 
             $this->addFlash(
                 'notice',
@@ -125,9 +143,7 @@ class ConfigController extends Controller
         $action = $this->generateUrl('config') . '#set5';
 
         if ($request->query->has('tagging-rule')) {
-            $taggingRule = $this->get('doctrine')
-                ->getRepository(TaggingRule::class)
-                ->find($request->query->get('tagging-rule'));
+            $taggingRule = $taggingRuleRepository->find($request->query->get('tagging-rule'));
 
             if ($this->getUser()->getId() !== $taggingRule->getConfig()->getUser()->getId()) {
                 return $this->redirect($action);
@@ -141,8 +157,8 @@ class ConfigController extends Controller
 
         if ($newTaggingRule->isSubmitted() && $newTaggingRule->isValid()) {
             $taggingRule->setConfig($config);
-            $em->persist($taggingRule);
-            $em->flush();
+            $this->entityManager->persist($taggingRule);
+            $this->entityManager->flush();
 
             $this->addFlash(
                 'notice',
@@ -169,10 +185,10 @@ class ConfigController extends Controller
                         $taggingRule->setRule($rule['rule']);
                         $taggingRule->setTags($rule['tags']);
                         $taggingRule->setConfig($config);
-                        $em->persist($taggingRule);
+                        $this->entityManager->persist($taggingRule);
                     }
 
-                    $em->flush();
+                    $this->entityManager->flush();
 
                     $message = 'flashes.config.notice.tagging_rules_imported';
                 }
@@ -188,8 +204,7 @@ class ConfigController extends Controller
         $action = $this->generateUrl('config') . '#set6';
 
         if ($request->query->has('ignore-origin-user-rule')) {
-            $ignoreOriginUserRule = $this->get('doctrine')
-                ->getRepository(IgnoreOriginUserRule::class)
+            $ignoreOriginUserRule = $ignoreOriginUserRuleRepository
                 ->find($request->query->get('ignore-origin-user-rule'));
 
             if ($this->getUser()->getId() !== $ignoreOriginUserRule->getConfig()->getUser()->getId()) {
@@ -206,8 +221,8 @@ class ConfigController extends Controller
 
         if ($newIgnoreOriginUserRule->isSubmitted() && $newIgnoreOriginUserRule->isValid()) {
             $ignoreOriginUserRule->setConfig($config);
-            $em->persist($ignoreOriginUserRule);
-            $em->flush();
+            $this->entityManager->persist($ignoreOriginUserRule);
+            $this->entityManager->flush();
 
             $this->addFlash(
                 'notice',
@@ -233,7 +248,7 @@ class ConfigController extends Controller
             ],
             'twofactor_auth' => $this->getParameter('twofactor_auth'),
             'wallabag_url' => $this->getParameter('domain_name'),
-            'enabled_users' => $this->get(UserRepository::class)->getSumEnabledUsers(),
+            'enabled_users' => $userRepository->getSumEnabledUsers(),
         ]);
     }
 
@@ -251,7 +266,7 @@ class ConfigController extends Controller
         $user = $this->getUser();
         $user->setEmailTwoFactor(false);
 
-        $this->container->get(UserManagerInterface::class)->updateUser($user, true);
+        $this->userManager->updateUser($user, true);
 
         $this->addFlash(
             'notice',
@@ -278,7 +293,7 @@ class ConfigController extends Controller
         $user->setBackupCodes(null);
         $user->setEmailTwoFactor(true);
 
-        $this->container->get(UserManagerInterface::class)->updateUser($user, true);
+        $this->userManager->updateUser($user, true);
 
         $this->addFlash(
             'notice',
@@ -304,7 +319,7 @@ class ConfigController extends Controller
         $user->setGoogleAuthenticatorSecret('');
         $user->setBackupCodes(null);
 
-        $this->container->get(UserManagerInterface::class)->updateUser($user, true);
+        $this->userManager->updateUser($user, true);
 
         $this->addFlash(
             'notice',
@@ -319,14 +334,14 @@ class ConfigController extends Controller
      *
      * @Route("/config/otp/app", name="config_otp_app")
      */
-    public function otpAppAction()
+    public function otpAppAction(GoogleAuthenticatorInterface $googleAuthenticator)
     {
         if (!$this->getParameter('twofactor_auth')) {
             return $this->createNotFoundException('two_factor not enabled');
         }
 
         $user = $this->getUser();
-        $secret = $this->get(GoogleAuthenticatorInterface::class)->generateSecret();
+        $secret = $googleAuthenticator->generateSecret();
 
         $user->setGoogleAuthenticatorSecret($secret);
         $user->setEmailTwoFactor(false);
@@ -341,7 +356,7 @@ class ConfigController extends Controller
 
         $user->setBackupCodes($backupCodesHashed);
 
-        $this->container->get(UserManagerInterface::class)->updateUser($user, true);
+        $this->userManager->updateUser($user, true);
 
         $this->addFlash(
             'notice',
@@ -350,7 +365,7 @@ class ConfigController extends Controller
 
         return $this->render('@WallabagCore/Config/otp_app.html.twig', [
             'backupCodes' => $backupCodes,
-            'qr_code' => $this->get(GoogleAuthenticatorInterface::class)->getQRContent($user),
+            'qr_code' => $googleAuthenticator->getQRContent($user),
             'secret' => $secret,
         ]);
     }
@@ -370,7 +385,7 @@ class ConfigController extends Controller
         $user->setGoogleAuthenticatorSecret(null);
         $user->setBackupCodes(null);
 
-        $this->container->get(UserManagerInterface::class)->updateUser($user, true);
+        $this->userManager->updateUser($user, true);
 
         return $this->redirect($this->generateUrl('config') . '#set3');
     }
@@ -380,9 +395,9 @@ class ConfigController extends Controller
      *
      * @Route("/config/otp/app/check", name="config_otp_app_check")
      */
-    public function otpAppCheckAction(Request $request)
+    public function otpAppCheckAction(Request $request, GoogleAuthenticatorInterface $googleAuthenticator)
     {
-        $isValid = $this->get(GoogleAuthenticatorInterface::class)->checkCode(
+        $isValid = $googleAuthenticator->checkCode(
             $this->getUser(),
             $request->get('_auth_code')
         );
@@ -414,9 +429,8 @@ class ConfigController extends Controller
         $config = $this->getConfig();
         $config->setFeedToken(Utils::generateToken());
 
-        $em = $this->get('doctrine')->getManager();
-        $em->persist($config);
-        $em->flush();
+        $this->entityManager->persist($config);
+        $this->entityManager->flush();
 
         if ($request->isXmlHttpRequest()) {
             return new JsonResponse(['token' => $config->getFeedToken()]);
@@ -440,9 +454,8 @@ class ConfigController extends Controller
         $config = $this->getConfig();
         $config->setFeedToken(null);
 
-        $em = $this->get('doctrine')->getManager();
-        $em->persist($config);
-        $em->flush();
+        $this->entityManager->persist($config);
+        $this->entityManager->flush();
 
         if ($request->isXmlHttpRequest()) {
             return new JsonResponse();
@@ -467,9 +480,8 @@ class ConfigController extends Controller
     {
         $this->validateRuleAction($rule);
 
-        $em = $this->get('doctrine')->getManager();
-        $em->remove($rule);
-        $em->flush();
+        $this->entityManager->remove($rule);
+        $this->entityManager->flush();
 
         $this->addFlash(
             'notice',
@@ -504,9 +516,8 @@ class ConfigController extends Controller
     {
         $this->validateRuleAction($rule);
 
-        $em = $this->get('doctrine')->getManager();
-        $em->remove($rule);
-        $em->flush();
+        $this->entityManager->remove($rule);
+        $this->entityManager->flush();
 
         $this->addFlash(
             'notice',
@@ -537,13 +548,11 @@ class ConfigController extends Controller
      *
      * @return RedirectResponse
      */
-    public function resetAction($type)
+    public function resetAction(string $type, AnnotationRepository $annotationRepository, EntryRepository $entryRepository)
     {
         switch ($type) {
             case 'annotations':
-                $this->get('doctrine')
-                    ->getRepository(Annotation::class)
-                    ->removeAllByUserId($this->getUser()->getId());
+                $annotationRepository->removeAllByUserId($this->getUser()->getId());
                 break;
             case 'tags':
                 $this->removeAllTagsByUserId($this->getUser()->getId());
@@ -551,24 +560,24 @@ class ConfigController extends Controller
             case 'entries':
                 // SQLite doesn't care about cascading remove, so we need to manually remove associated stuff
                 // otherwise they won't be removed ...
-                if ($this->get(ManagerRegistry::class)->getConnection()->getDatabasePlatform() instanceof SqlitePlatform) {
-                    $this->get('doctrine')->getRepository(Annotation::class)->removeAllByUserId($this->getUser()->getId());
+                if ($this->entityManager->getConnection()->getDatabasePlatform() instanceof SqlitePlatform) {
+                    $annotationRepository->removeAllByUserId($this->getUser()->getId());
                 }
 
                 // manually remove tags to avoid orphan tag
                 $this->removeAllTagsByUserId($this->getUser()->getId());
 
-                $this->get(EntryRepository::class)->removeAllByUserId($this->getUser()->getId());
+                $entryRepository->removeAllByUserId($this->getUser()->getId());
                 break;
             case 'archived':
-                if ($this->get(ManagerRegistry::class)->getConnection()->getDatabasePlatform() instanceof SqlitePlatform) {
+                if ($this->entityManager->getConnection()->getDatabasePlatform() instanceof SqlitePlatform) {
                     $this->removeAnnotationsForArchivedByUserId($this->getUser()->getId());
                 }
 
                 // manually remove tags to avoid orphan tag
                 $this->removeTagsForArchivedByUserId($this->getUser()->getId());
 
-                $this->get(EntryRepository::class)->removeArchivedByUserId($this->getUser()->getId());
+                $entryRepository->removeArchivedByUserId($this->getUser()->getId());
                 break;
         }
 
@@ -589,10 +598,9 @@ class ConfigController extends Controller
      *
      * @return RedirectResponse
      */
-    public function deleteAccountAction(Request $request)
+    public function deleteAccountAction(Request $request, UserRepository $userRepository, TokenStorageInterface $tokenStorage)
     {
-        $enabledUsers = $this->get(UserRepository::class)
-            ->getSumEnabledUsers();
+        $enabledUsers = $userRepository->getSumEnabledUsers();
 
         if ($enabledUsers <= 1) {
             throw new AccessDeniedHttpException();
@@ -601,11 +609,10 @@ class ConfigController extends Controller
         $user = $this->getUser();
 
         // logout current user
-        $this->get(TokenStorageInterface::class)->setToken(null);
+        $tokenStorage->setToken(null);
         $request->getSession()->invalidate();
 
-        $em = $this->get(UserManagerInterface::class);
-        $em->deleteUser($user);
+        $this->userManager->deleteUser($user);
 
         return $this->redirect($this->generateUrl('fos_user_security_login'));
     }
@@ -622,9 +629,8 @@ class ConfigController extends Controller
         $user = $this->getUser();
         $user->getConfig()->setListMode(!$user->getConfig()->getListMode());
 
-        $em = $this->get('doctrine')->getManager();
-        $em->persist($user);
-        $em->flush();
+        $this->entityManager->persist($user);
+        $this->entityManager->flush();
 
         return $this->redirect($request->headers->get('referer'));
     }
@@ -638,9 +644,9 @@ class ConfigController extends Controller
      *
      * @return RedirectResponse
      */
-    public function setLocaleAction(Request $request, $language = null)
+    public function setLocaleAction(Request $request, ValidatorInterface $validator, $language = null)
     {
-        $errors = $this->get(ValidatorInterface::class)->validate($language, (new LocaleConstraint()));
+        $errors = $validator->validate($language, (new LocaleConstraint()));
 
         if (0 === \count($errors)) {
             $request->getSession()->set('_locale', $language);
@@ -687,19 +693,16 @@ class ConfigController extends Controller
             return;
         }
 
-        $this->get(EntryRepository::class)
-            ->removeTags($userId, $tags);
+        $this->entryRepository->removeTags($userId, $tags);
 
         // cleanup orphan tags
-        $em = $this->get('doctrine')->getManager();
-
         foreach ($tags as $tag) {
             if (0 === \count($tag->getEntries())) {
-                $em->remove($tag);
+                $this->entityManager->remove($tag);
             }
         }
 
-        $em->flush();
+        $this->entityManager->flush();
     }
 
     /**
@@ -709,7 +712,7 @@ class ConfigController extends Controller
      */
     private function removeAllTagsByUserId($userId)
     {
-        $tags = $this->get(TagRepository::class)->findAllTags($userId);
+        $tags = $this->tagRepository->findAllTags($userId);
         $this->removeAllTagsByStatusAndUserId($tags, $userId);
     }
 
@@ -720,23 +723,20 @@ class ConfigController extends Controller
      */
     private function removeTagsForArchivedByUserId($userId)
     {
-        $tags = $this->get(TagRepository::class)->findForArchivedArticlesByUser($userId);
+        $tags = $this->tagRepository->findForArchivedArticlesByUser($userId);
         $this->removeAllTagsByStatusAndUserId($tags, $userId);
     }
 
     private function removeAnnotationsForArchivedByUserId($userId)
     {
-        $em = $this->get('doctrine')->getManager();
-
-        $archivedEntriesAnnotations = $this->get('doctrine')
-            ->getRepository(Annotation::class)
+        $archivedEntriesAnnotations = $this->annotationRepository
             ->findAllArchivedEntriesByUser($userId);
 
         foreach ($archivedEntriesAnnotations as $archivedEntriesAnnotation) {
-            $em->remove($archivedEntriesAnnotation);
+            $this->entityManager->remove($archivedEntriesAnnotation);
         }
 
-        $em->flush();
+        $this->entityManager->flush();
     }
 
     /**
@@ -757,9 +757,7 @@ class ConfigController extends Controller
      */
     private function getConfig()
     {
-        $config = $this->get('doctrine')
-            ->getRepository(ConfigEntity::class)
-            ->findOneByUser($this->getUser());
+        $config = $this->configRepository->findOneByUser($this->getUser());
 
         // should NEVER HAPPEN ...
         if (!$config) {

--- a/src/Wallabag/CoreBundle/Controller/ExportController.php
+++ b/src/Wallabag/CoreBundle/Controller/ExportController.php
@@ -21,8 +21,6 @@ class ExportController extends Controller
     /**
      * Gets one entry content.
      *
-     * @param string $format
-     *
      * @Route("/export/{id}.{format}", name="export_entry", requirements={
      *     "format": "epub|mobi|pdf|json|xml|txt|csv",
      *     "id": "\d+"
@@ -30,10 +28,10 @@ class ExportController extends Controller
      *
      * @return Response
      */
-    public function downloadEntryAction(Entry $entry, $format)
+    public function downloadEntryAction(Entry $entry, EntriesExport $entriesExport, string $format)
     {
         try {
-            return $this->get(EntriesExport::class)
+            return $entriesExport
                 ->setEntries($entry)
                 ->updateTitle('entry')
                 ->updateAuthor('entry')
@@ -46,9 +44,6 @@ class ExportController extends Controller
     /**
      * Export all entries for current user.
      *
-     * @param string $format
-     * @param string $category
-     *
      * @Route("/export/{category}.{format}", name="export_entries", requirements={
      *     "format": "epub|mobi|pdf|json|xml|txt|csv",
      *     "category": "all|unread|starred|archive|tag_entries|untagged|search|annotated|same_domain"
@@ -56,17 +51,16 @@ class ExportController extends Controller
      *
      * @return Response
      */
-    public function downloadEntriesAction(Request $request, $format, $category)
+    public function downloadEntriesAction(Request $request, EntryRepository $entryRepository, TagRepository $tagRepository, EntriesExport $entriesExport, string $format, string $category)
     {
         $method = ucfirst($category);
         $methodBuilder = 'getBuilderFor' . $method . 'ByUser';
-        $repository = $this->get(EntryRepository::class);
         $title = $method;
 
         if ('tag_entries' === $category) {
-            $tag = $this->get(TagRepository::class)->findOneBySlug($request->query->get('tag'));
+            $tag = $tagRepository->findOneBySlug($request->query->get('tag'));
 
-            $entries = $repository->findAllByTagId(
+            $entries = $entryRepository->findAllByTagId(
                 $this->getUser()->getId(),
                 $tag->getId()
             );
@@ -76,7 +70,7 @@ class ExportController extends Controller
             $searchTerm = (isset($request->get('search_entry')['term']) ? $request->get('search_entry')['term'] : '');
             $currentRoute = (null !== $request->query->get('currentRoute') ? $request->query->get('currentRoute') : '');
 
-            $entries = $repository->getBuilderForSearchByUser(
+            $entries = $entryRepository->getBuilderForSearchByUser(
                     $this->getUser()->getId(),
                     $searchTerm,
                     $currentRoute
@@ -85,21 +79,21 @@ class ExportController extends Controller
 
             $title = 'Search ' . $searchTerm;
         } elseif ('annotated' === $category) {
-            $entries = $repository->getBuilderForAnnotationsByUser(
+            $entries = $entryRepository->getBuilderForAnnotationsByUser(
                 $this->getUser()->getId()
             )->getQuery()
              ->getResult();
 
             $title = 'With annotations';
         } else {
-            $entries = $repository
+            $entries = $entryRepository
                 ->$methodBuilder($this->getUser()->getId())
                 ->getQuery()
                 ->getResult();
         }
 
         try {
-            return $this->get(EntriesExport::class)
+            return $entriesExport
                 ->setEntries($entries)
                 ->updateTitle($title)
                 ->updateAuthor($method)

--- a/src/Wallabag/CoreBundle/Controller/FeedController.php
+++ b/src/Wallabag/CoreBundle/Controller/FeedController.php
@@ -20,6 +20,13 @@ use Wallabag\UserBundle\Entity\User;
 
 class FeedController extends Controller
 {
+    private EntryRepository $entryRepository;
+
+    public function __construct(EntryRepository $entryRepository)
+    {
+        $this->entryRepository = $entryRepository;
+    }
+
     /**
      * Shows unread entries for current user.
      *
@@ -92,7 +99,7 @@ class FeedController extends Controller
      *
      * @return Response
      */
-    public function showTagsFeedAction(Request $request, User $user, Tag $tag, $page)
+    public function showTagsFeedAction(Request $request, User $user, Tag $tag, PreparePagerForEntries $preparePagerForEntries, $page)
     {
         $sort = $request->query->get('sort', 'created');
 
@@ -115,7 +122,7 @@ class FeedController extends Controller
             UrlGeneratorInterface::ABSOLUTE_URL
         );
 
-        $entriesByTag = $this->get(EntryRepository::class)->findAllByTagId(
+        $entriesByTag = $this->entryRepository->findAllByTagId(
             $user->getId(),
             $tag->getId(),
             $sorts[$sort]
@@ -123,7 +130,7 @@ class FeedController extends Controller
 
         $pagerAdapter = new ArrayAdapter($entriesByTag);
 
-        $entries = $this->get(PreparePagerForEntries::class)->prepare(
+        $entries = $preparePagerForEntries->prepare(
             $pagerAdapter,
             $user
         );
@@ -184,22 +191,20 @@ class FeedController extends Controller
      *
      * @return Response
      */
-    private function showEntries($type, User $user, $page = 1)
+    private function showEntries(string $type, User $user, $page = 1)
     {
-        $repository = $this->get(EntryRepository::class);
-
         switch ($type) {
             case 'starred':
-                $qb = $repository->getBuilderForStarredByUser($user->getId());
+                $qb = $this->entryRepository->getBuilderForStarredByUser($user->getId());
                 break;
             case 'archive':
-                $qb = $repository->getBuilderForArchiveByUser($user->getId());
+                $qb = $this->entryRepository->getBuilderForArchiveByUser($user->getId());
                 break;
             case 'unread':
-                $qb = $repository->getBuilderForUnreadByUser($user->getId());
+                $qb = $this->entryRepository->getBuilderForUnreadByUser($user->getId());
                 break;
             case 'all':
-                $qb = $repository->getBuilderForAllByUser($user->getId());
+                $qb = $this->entryRepository->getBuilderForAllByUser($user->getId());
                 break;
             default:
                 throw new \InvalidArgumentException(sprintf('Type "%s" is not implemented.', $type));

--- a/src/Wallabag/CoreBundle/Controller/IgnoreOriginInstanceRuleController.php
+++ b/src/Wallabag/CoreBundle/Controller/IgnoreOriginInstanceRuleController.php
@@ -2,14 +2,14 @@
 
 namespace Wallabag\CoreBundle\Controller;
 
+use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Component\Form\Form;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\HttpFoundation\Session\SessionInterface;
 use Symfony\Component\Routing\Annotation\Route;
-use Symfony\Component\Translation\TranslatorInterface;
+use Symfony\Contracts\Translation\TranslatorInterface;
 use Wallabag\CoreBundle\Entity\IgnoreOriginInstanceRule;
 use Wallabag\CoreBundle\Form\Type\IgnoreOriginInstanceRuleType;
 use Wallabag\CoreBundle\Repository\IgnoreOriginInstanceRuleRepository;
@@ -21,14 +21,23 @@ use Wallabag\CoreBundle\Repository\IgnoreOriginInstanceRuleRepository;
  */
 class IgnoreOriginInstanceRuleController extends Controller
 {
+    private EntityManagerInterface $entityManager;
+    private TranslatorInterface $translator;
+
+    public function __construct(EntityManagerInterface $entityManager, TranslatorInterface $translator)
+    {
+        $this->entityManager = $entityManager;
+        $this->translator = $translator;
+    }
+
     /**
      * Lists all IgnoreOriginInstanceRule entities.
      *
      * @Route("/", name="ignore_origin_instance_rules_index", methods={"GET"})
      */
-    public function indexAction()
+    public function indexAction(IgnoreOriginInstanceRuleRepository $repository)
     {
-        $rules = $this->get(IgnoreOriginInstanceRuleRepository::class)->findAll();
+        $rules = $repository->findAll();
 
         return $this->render('@WallabagCore/IgnoreOriginInstanceRule/index.html.twig', [
             'rules' => $rules,
@@ -50,13 +59,12 @@ class IgnoreOriginInstanceRuleController extends Controller
         $form->handleRequest($request);
 
         if ($form->isSubmitted() && $form->isValid()) {
-            $em = $this->get('doctrine')->getManager();
-            $em->persist($ignoreOriginInstanceRule);
-            $em->flush();
+            $this->entityManager->persist($ignoreOriginInstanceRule);
+            $this->entityManager->flush();
 
-            $this->get(SessionInterface::class)->getFlashBag()->add(
+            $this->addFlash(
                 'notice',
-                $this->get(TranslatorInterface::class)->trans('flashes.ignore_origin_instance_rule.notice.added')
+                $this->translator->trans('flashes.ignore_origin_instance_rule.notice.added')
             );
 
             return $this->redirectToRoute('ignore_origin_instance_rules_index');
@@ -82,13 +90,12 @@ class IgnoreOriginInstanceRuleController extends Controller
         $editForm->handleRequest($request);
 
         if ($editForm->isSubmitted() && $editForm->isValid()) {
-            $em = $this->get('doctrine')->getManager();
-            $em->persist($ignoreOriginInstanceRule);
-            $em->flush();
+            $this->entityManager->persist($ignoreOriginInstanceRule);
+            $this->entityManager->flush();
 
-            $this->get(SessionInterface::class)->getFlashBag()->add(
+            $this->addFlash(
                 'notice',
-                $this->get(TranslatorInterface::class)->trans('flashes.ignore_origin_instance_rule.notice.updated')
+                $this->translator->trans('flashes.ignore_origin_instance_rule.notice.updated')
             );
 
             return $this->redirectToRoute('ignore_origin_instance_rules_index');
@@ -114,14 +121,13 @@ class IgnoreOriginInstanceRuleController extends Controller
         $form->handleRequest($request);
 
         if ($form->isSubmitted() && $form->isValid()) {
-            $this->get(SessionInterface::class)->getFlashBag()->add(
+            $this->addFlash(
                 'notice',
-                $this->get(TranslatorInterface::class)->trans('flashes.ignore_origin_instance_rule.notice.deleted')
+                $this->translator->trans('flashes.ignore_origin_instance_rule.notice.deleted')
             );
 
-            $em = $this->get('doctrine')->getManager();
-            $em->remove($ignoreOriginInstanceRule);
-            $em->flush();
+            $this->entityManager->remove($ignoreOriginInstanceRule);
+            $this->entityManager->flush();
         }
 
         return $this->redirectToRoute('ignore_origin_instance_rules_index');

--- a/src/Wallabag/CoreBundle/Controller/SiteCredentialController.php
+++ b/src/Wallabag/CoreBundle/Controller/SiteCredentialController.php
@@ -3,14 +3,14 @@
 namespace Wallabag\CoreBundle\Controller;
 
 use Craue\ConfigBundle\Util\Config;
+use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Component\Form\Form;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\HttpFoundation\Session\SessionInterface;
 use Symfony\Component\Routing\Annotation\Route;
-use Symfony\Component\Translation\TranslatorInterface;
+use Symfony\Contracts\Translation\TranslatorInterface;
 use Wallabag\CoreBundle\Entity\SiteCredential;
 use Wallabag\CoreBundle\Form\Type\SiteCredentialType;
 use Wallabag\CoreBundle\Helper\CryptoProxy;
@@ -24,16 +24,29 @@ use Wallabag\UserBundle\Entity\User;
  */
 class SiteCredentialController extends Controller
 {
+    private EntityManagerInterface $entityManager;
+    private TranslatorInterface $translator;
+    private CryptoProxy $cryptoProxy;
+    private Config $craueConfig;
+
+    public function __construct(EntityManagerInterface $entityManager, TranslatorInterface $translator, CryptoProxy $cryptoProxy, Config $craueConfig)
+    {
+        $this->entityManager = $entityManager;
+        $this->translator = $translator;
+        $this->cryptoProxy = $cryptoProxy;
+        $this->craueConfig = $craueConfig;
+    }
+
     /**
      * Lists all User entities.
      *
      * @Route("/", name="site_credentials_index", methods={"GET"})
      */
-    public function indexAction()
+    public function indexAction(SiteCredentialRepository $repository)
     {
         $this->isSiteCredentialsEnabled();
 
-        $credentials = $this->get(SiteCredentialRepository::class)->findByUser($this->getUser());
+        $credentials = $repository->findByUser($this->getUser());
 
         return $this->render('@WallabagCore/SiteCredential/index.html.twig', [
             'credentials' => $credentials,
@@ -57,16 +70,15 @@ class SiteCredentialController extends Controller
         $form->handleRequest($request);
 
         if ($form->isSubmitted() && $form->isValid()) {
-            $credential->setUsername($this->get(CryptoProxy::class)->crypt($credential->getUsername()));
-            $credential->setPassword($this->get(CryptoProxy::class)->crypt($credential->getPassword()));
+            $credential->setUsername($this->cryptoProxy->crypt($credential->getUsername()));
+            $credential->setPassword($this->cryptoProxy->crypt($credential->getPassword()));
 
-            $em = $this->get('doctrine')->getManager();
-            $em->persist($credential);
-            $em->flush();
+            $this->entityManager->persist($credential);
+            $this->entityManager->flush();
 
-            $this->get(SessionInterface::class)->getFlashBag()->add(
+            $this->addFlash(
                 'notice',
-                $this->get(TranslatorInterface::class)->trans('flashes.site_credential.notice.added', ['%host%' => $credential->getHost()])
+                $this->translator->trans('flashes.site_credential.notice.added', ['%host%' => $credential->getHost()])
             );
 
             return $this->redirectToRoute('site_credentials_index');
@@ -96,16 +108,15 @@ class SiteCredentialController extends Controller
         $editForm->handleRequest($request);
 
         if ($editForm->isSubmitted() && $editForm->isValid()) {
-            $siteCredential->setUsername($this->get(CryptoProxy::class)->crypt($siteCredential->getUsername()));
-            $siteCredential->setPassword($this->get(CryptoProxy::class)->crypt($siteCredential->getPassword()));
+            $siteCredential->setUsername($this->cryptoProxy->crypt($siteCredential->getUsername()));
+            $siteCredential->setPassword($this->cryptoProxy->crypt($siteCredential->getPassword()));
 
-            $em = $this->get('doctrine')->getManager();
-            $em->persist($siteCredential);
-            $em->flush();
+            $this->entityManager->persist($siteCredential);
+            $this->entityManager->flush();
 
-            $this->get(SessionInterface::class)->getFlashBag()->add(
+            $this->addFlash(
                 'notice',
-                $this->get(TranslatorInterface::class)->trans('flashes.site_credential.notice.updated', ['%host%' => $siteCredential->getHost()])
+                $this->translator->trans('flashes.site_credential.notice.updated', ['%host%' => $siteCredential->getHost()])
             );
 
             return $this->redirectToRoute('site_credentials_index');
@@ -135,14 +146,13 @@ class SiteCredentialController extends Controller
         $form->handleRequest($request);
 
         if ($form->isSubmitted() && $form->isValid()) {
-            $this->get(SessionInterface::class)->getFlashBag()->add(
+            $this->addFlash(
                 'notice',
-                $this->get(TranslatorInterface::class)->trans('flashes.site_credential.notice.deleted', ['%host%' => $siteCredential->getHost()])
+                $this->translator->trans('flashes.site_credential.notice.deleted', ['%host%' => $siteCredential->getHost()])
             );
 
-            $em = $this->get('doctrine')->getManager();
-            $em->remove($siteCredential);
-            $em->flush();
+            $this->entityManager->remove($siteCredential);
+            $this->entityManager->flush();
         }
 
         return $this->redirectToRoute('site_credentials_index');
@@ -153,7 +163,7 @@ class SiteCredentialController extends Controller
      */
     private function isSiteCredentialsEnabled()
     {
-        if (!$this->get(Config::class)->get('restricted_access')) {
+        if (!$this->craueConfig->get('restricted_access')) {
             throw $this->createNotFoundException('Feature "restricted_access" is disabled, controllers too.');
         }
     }

--- a/src/Wallabag/CoreBundle/Controller/StaticController.php
+++ b/src/Wallabag/CoreBundle/Controller/StaticController.php
@@ -12,7 +12,7 @@ class StaticController extends Controller
      */
     public function howtoAction()
     {
-        $addonsUrl = $this->container->getParameter('addons_url');
+        $addonsUrl = $this->getParameter('addons_url');
 
         return $this->render(
             '@WallabagCore/Static/howto.html.twig',

--- a/src/Wallabag/CoreBundle/Helper/EntriesExport.php
+++ b/src/Wallabag/CoreBundle/Helper/EntriesExport.php
@@ -9,7 +9,7 @@ use PHPePub\Core\EPub;
 use PHPePub\Core\Structure\OPF\DublinCore;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
-use Symfony\Component\Translation\TranslatorInterface;
+use Symfony\Contracts\Translation\TranslatorInterface;
 use Wallabag\CoreBundle\Entity\Entry;
 use Wallabag\UserBundle\Entity\User;
 

--- a/src/Wallabag/CoreBundle/ParamConverter/UsernameFeedTokenConverter.php
+++ b/src/Wallabag/CoreBundle/ParamConverter/UsernameFeedTokenConverter.php
@@ -77,6 +77,10 @@ class UsernameFeedTokenConverter implements ParamConverterInterface
         // Get actual entity manager for class
         $em = $this->registry->getManagerForClass($configuration->getClass());
 
+        if (null === $em) {
+            return false;
+        }
+
         /** @var UserRepository $userRepository */
         $userRepository = $em->getRepository($configuration->getClass());
 

--- a/src/Wallabag/CoreBundle/Twig/WallabagExtension.php
+++ b/src/Wallabag/CoreBundle/Twig/WallabagExtension.php
@@ -3,7 +3,7 @@
 namespace Wallabag\CoreBundle\Twig;
 
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
-use Symfony\Component\Translation\TranslatorInterface;
+use Symfony\Contracts\Translation\TranslatorInterface;
 use Twig\Extension\AbstractExtension;
 use Twig\Extension\GlobalsInterface;
 use Twig\TwigFilter;

--- a/src/Wallabag/ImportBundle/Controller/DeliciousController.php
+++ b/src/Wallabag/ImportBundle/Controller/DeliciousController.php
@@ -3,31 +3,40 @@
 namespace Wallabag\ImportBundle\Controller;
 
 use Craue\ConfigBundle\Util\Config;
-use Symfony\Bundle\FrameworkBundle\Controller\Controller;
+use OldSound\RabbitMqBundle\RabbitMq\Producer as RabbitMqProducer;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\HttpFoundation\Session\SessionInterface;
 use Symfony\Component\Routing\Annotation\Route;
-use Symfony\Component\Translation\TranslatorInterface;
+use Symfony\Contracts\Translation\TranslatorInterface;
 use Wallabag\ImportBundle\Form\Type\UploadImportType;
 use Wallabag\ImportBundle\Import\DeliciousImport;
+use Wallabag\ImportBundle\Redis\Producer as RedisProducer;
 
-class DeliciousController extends Controller
+class DeliciousController extends AbstractController
 {
+    private RabbitMqProducer $rabbitMqProducer;
+    private RedisProducer $redisProducer;
+
+    public function __construct(RabbitMqProducer $rabbitMqProducer, RedisProducer $redisProducer)
+    {
+        $this->rabbitMqProducer = $rabbitMqProducer;
+        $this->redisProducer = $redisProducer;
+    }
+
     /**
      * @Route("/delicious", name="import_delicious")
      */
-    public function indexAction(Request $request)
+    public function indexAction(Request $request, DeliciousImport $delicious, Config $craueConfig, TranslatorInterface $translator)
     {
         $form = $this->createForm(UploadImportType::class);
         $form->handleRequest($request);
 
-        $delicious = $this->get(DeliciousImport::class);
         $delicious->setUser($this->getUser());
 
-        if ($this->get(Config::class)->get('import_with_rabbitmq')) {
-            $delicious->setProducer($this->get('old_sound_rabbit_mq.import_delicious_producer'));
-        } elseif ($this->get(Config::class)->get('import_with_redis')) {
-            $delicious->setProducer($this->get('wallabag_import.producer.redis.delicious'));
+        if ($craueConfig->get('import_with_rabbitmq')) {
+            $delicious->setProducer($this->rabbitMqProducer);
+        } elseif ($craueConfig->get('import_with_redis')) {
+            $delicious->setProducer($this->redisProducer);
         }
 
         if ($form->isSubmitted() && $form->isValid()) {
@@ -45,13 +54,13 @@ class DeliciousController extends Controller
 
                 if (true === $res) {
                     $summary = $delicious->getSummary();
-                    $message = $this->get(TranslatorInterface::class)->trans('flashes.import.notice.summary', [
+                    $message = $translator->trans('flashes.import.notice.summary', [
                         '%imported%' => $summary['imported'],
                         '%skipped%' => $summary['skipped'],
                     ]);
 
                     if (0 < $summary['queued']) {
-                        $message = $this->get(TranslatorInterface::class)->trans('flashes.import.notice.summary_with_queue', [
+                        $message = $translator->trans('flashes.import.notice.summary_with_queue', [
                             '%queued%' => $summary['queued'],
                         ]);
                     }
@@ -59,18 +68,12 @@ class DeliciousController extends Controller
                     unlink($this->getParameter('wallabag_import.resource_dir') . '/' . $name);
                 }
 
-                $this->get(SessionInterface::class)->getFlashBag()->add(
-                    'notice',
-                    $message
-                );
+                $this->addFlash('notice', $message);
 
                 return $this->redirect($this->generateUrl('homepage'));
             }
 
-            $this->get(SessionInterface::class)->getFlashBag()->add(
-                'notice',
-                'flashes.import.notice.failed_on_file'
-            );
+            $this->addFlash('notice', 'flashes.import.notice.failed_on_file');
         }
 
         return $this->render('@WallabagImport/Delicious/index.html.twig', [

--- a/src/Wallabag/ImportBundle/Controller/FirefoxController.php
+++ b/src/Wallabag/ImportBundle/Controller/FirefoxController.php
@@ -3,18 +3,34 @@
 namespace Wallabag\ImportBundle\Controller;
 
 use Craue\ConfigBundle\Util\Config;
+use OldSound\RabbitMqBundle\RabbitMq\Producer as RabbitMqProducer;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Contracts\Translation\TranslatorInterface;
 use Wallabag\ImportBundle\Import\FirefoxImport;
+use Wallabag\ImportBundle\Redis\Producer as RedisProducer;
 
 class FirefoxController extends BrowserController
 {
+    private FirefoxImport $firefoxImport;
+    private Config $craueConfig;
+    private RabbitMqProducer $rabbitMqProducer;
+    private RedisProducer $redisProducer;
+
+    public function __construct(FirefoxImport $firefoxImport, Config $craueConfig, RabbitMqProducer $rabbitMqProducer, RedisProducer $redisProducer)
+    {
+        $this->firefoxImport = $firefoxImport;
+        $this->craueConfig = $craueConfig;
+        $this->rabbitMqProducer = $rabbitMqProducer;
+        $this->redisProducer = $redisProducer;
+    }
+
     /**
      * @Route("/firefox", name="import_firefox")
      */
-    public function indexAction(Request $request)
+    public function indexAction(Request $request, TranslatorInterface $translator)
     {
-        return parent::indexAction($request);
+        return parent::indexAction($request, $translator);
     }
 
     /**
@@ -22,15 +38,13 @@ class FirefoxController extends BrowserController
      */
     protected function getImportService()
     {
-        $service = $this->get(FirefoxImport::class);
-
-        if ($this->get(Config::class)->get('import_with_rabbitmq')) {
-            $service->setProducer($this->get('old_sound_rabbit_mq.import_firefox_producer'));
-        } elseif ($this->get(Config::class)->get('import_with_redis')) {
-            $service->setProducer($this->get('wallabag_import.producer.redis.firefox'));
+        if ($this->craueConfig->get('import_with_rabbitmq')) {
+            $this->firefoxImport->setProducer($this->rabbitMqProducer);
+        } elseif ($this->craueConfig->get('import_with_redis')) {
+            $this->firefoxImport->setProducer($this->redisProducer);
         }
 
-        return $service;
+        return $this->firefoxImport;
     }
 
     /**

--- a/src/Wallabag/ImportBundle/Controller/InstapaperController.php
+++ b/src/Wallabag/ImportBundle/Controller/InstapaperController.php
@@ -3,31 +3,40 @@
 namespace Wallabag\ImportBundle\Controller;
 
 use Craue\ConfigBundle\Util\Config;
-use Symfony\Bundle\FrameworkBundle\Controller\Controller;
+use OldSound\RabbitMqBundle\RabbitMq\Producer as RabbitMqProducer;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\HttpFoundation\Session\SessionInterface;
 use Symfony\Component\Routing\Annotation\Route;
-use Symfony\Component\Translation\TranslatorInterface;
+use Symfony\Contracts\Translation\TranslatorInterface;
 use Wallabag\ImportBundle\Form\Type\UploadImportType;
 use Wallabag\ImportBundle\Import\InstapaperImport;
+use Wallabag\ImportBundle\Redis\Producer as RedisProducer;
 
-class InstapaperController extends Controller
+class InstapaperController extends AbstractController
 {
+    private RabbitMqProducer $rabbitMqProducer;
+    private RedisProducer $redisProducer;
+
+    public function __construct(RabbitMqProducer $rabbitMqProducer, RedisProducer $redisProducer)
+    {
+        $this->rabbitMqProducer = $rabbitMqProducer;
+        $this->redisProducer = $redisProducer;
+    }
+
     /**
      * @Route("/instapaper", name="import_instapaper")
      */
-    public function indexAction(Request $request)
+    public function indexAction(Request $request, InstapaperImport $instapaper, Config $craueConfig, TranslatorInterface $translator)
     {
         $form = $this->createForm(UploadImportType::class);
         $form->handleRequest($request);
 
-        $instapaper = $this->get(InstapaperImport::class);
         $instapaper->setUser($this->getUser());
 
-        if ($this->get(Config::class)->get('import_with_rabbitmq')) {
-            $instapaper->setProducer($this->get('old_sound_rabbit_mq.import_instapaper_producer'));
-        } elseif ($this->get(Config::class)->get('import_with_redis')) {
-            $instapaper->setProducer($this->get('wallabag_import.producer.redis.instapaper'));
+        if ($craueConfig->get('import_with_rabbitmq')) {
+            $instapaper->setProducer($this->rabbitMqProducer);
+        } elseif ($craueConfig->get('import_with_redis')) {
+            $instapaper->setProducer($this->redisProducer);
         }
 
         if ($form->isSubmitted() && $form->isValid()) {
@@ -45,13 +54,13 @@ class InstapaperController extends Controller
 
                 if (true === $res) {
                     $summary = $instapaper->getSummary();
-                    $message = $this->get(TranslatorInterface::class)->trans('flashes.import.notice.summary', [
+                    $message = $translator->trans('flashes.import.notice.summary', [
                         '%imported%' => $summary['imported'],
                         '%skipped%' => $summary['skipped'],
                     ]);
 
                     if (0 < $summary['queued']) {
-                        $message = $this->get(TranslatorInterface::class)->trans('flashes.import.notice.summary_with_queue', [
+                        $message = $translator->trans('flashes.import.notice.summary_with_queue', [
                             '%queued%' => $summary['queued'],
                         ]);
                     }
@@ -59,18 +68,12 @@ class InstapaperController extends Controller
                     unlink($this->getParameter('wallabag_import.resource_dir') . '/' . $name);
                 }
 
-                $this->get(SessionInterface::class)->getFlashBag()->add(
-                    'notice',
-                    $message
-                );
+                $this->addFlash('notice', $message);
 
                 return $this->redirect($this->generateUrl('homepage'));
             }
 
-            $this->get(SessionInterface::class)->getFlashBag()->add(
-                'notice',
-                'flashes.import.notice.failed_on_file'
-            );
+            $this->addFlash('notice', 'flashes.import.notice.failed_on_file');
         }
 
         return $this->render('@WallabagImport/Instapaper/index.html.twig', [

--- a/src/Wallabag/ImportBundle/Controller/PinboardController.php
+++ b/src/Wallabag/ImportBundle/Controller/PinboardController.php
@@ -3,31 +3,40 @@
 namespace Wallabag\ImportBundle\Controller;
 
 use Craue\ConfigBundle\Util\Config;
-use Symfony\Bundle\FrameworkBundle\Controller\Controller;
+use OldSound\RabbitMqBundle\RabbitMq\Producer as RabbitMqProducer;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\HttpFoundation\Session\SessionInterface;
 use Symfony\Component\Routing\Annotation\Route;
-use Symfony\Component\Translation\TranslatorInterface;
+use Symfony\Contracts\Translation\TranslatorInterface;
 use Wallabag\ImportBundle\Form\Type\UploadImportType;
 use Wallabag\ImportBundle\Import\PinboardImport;
+use Wallabag\ImportBundle\Redis\Producer as RedisProducer;
 
-class PinboardController extends Controller
+class PinboardController extends AbstractController
 {
+    private RabbitMqProducer $rabbitMqProducer;
+    private RedisProducer $redisProducer;
+
+    public function __construct(RabbitMqProducer $rabbitMqProducer, RedisProducer $redisProducer)
+    {
+        $this->rabbitMqProducer = $rabbitMqProducer;
+        $this->redisProducer = $redisProducer;
+    }
+
     /**
      * @Route("/pinboard", name="import_pinboard")
      */
-    public function indexAction(Request $request)
+    public function indexAction(Request $request, PinboardImport $pinboard, Config $craueConfig, TranslatorInterface $translator)
     {
         $form = $this->createForm(UploadImportType::class);
         $form->handleRequest($request);
 
-        $pinboard = $this->get(PinboardImport::class);
         $pinboard->setUser($this->getUser());
 
-        if ($this->get(Config::class)->get('import_with_rabbitmq')) {
-            $pinboard->setProducer($this->get('old_sound_rabbit_mq.import_pinboard_producer'));
-        } elseif ($this->get(Config::class)->get('import_with_redis')) {
-            $pinboard->setProducer($this->get('wallabag_import.producer.redis.pinboard'));
+        if ($craueConfig->get('import_with_rabbitmq')) {
+            $pinboard->setProducer($this->rabbitMqProducer);
+        } elseif ($craueConfig->get('import_with_redis')) {
+            $pinboard->setProducer($this->redisProducer);
         }
 
         if ($form->isSubmitted() && $form->isValid()) {
@@ -45,13 +54,13 @@ class PinboardController extends Controller
 
                 if (true === $res) {
                     $summary = $pinboard->getSummary();
-                    $message = $this->get(TranslatorInterface::class)->trans('flashes.import.notice.summary', [
+                    $message = $translator->trans('flashes.import.notice.summary', [
                         '%imported%' => $summary['imported'],
                         '%skipped%' => $summary['skipped'],
                     ]);
 
                     if (0 < $summary['queued']) {
-                        $message = $this->get(TranslatorInterface::class)->trans('flashes.import.notice.summary_with_queue', [
+                        $message = $translator->trans('flashes.import.notice.summary_with_queue', [
                             '%queued%' => $summary['queued'],
                         ]);
                     }
@@ -59,18 +68,12 @@ class PinboardController extends Controller
                     unlink($this->getParameter('wallabag_import.resource_dir') . '/' . $name);
                 }
 
-                $this->get(SessionInterface::class)->getFlashBag()->add(
-                    'notice',
-                    $message
-                );
+                $this->addFlash('notice', $message);
 
                 return $this->redirect($this->generateUrl('homepage'));
             }
 
-            $this->get(SessionInterface::class)->getFlashBag()->add(
-                'notice',
-                'flashes.import.notice.failed_on_file'
-            );
+            $this->addFlash('notice', 'flashes.import.notice.failed_on_file');
         }
 
         return $this->render('@WallabagImport/Pinboard/index.html.twig', [

--- a/src/Wallabag/ImportBundle/Controller/PocketController.php
+++ b/src/Wallabag/ImportBundle/Controller/PocketController.php
@@ -3,23 +3,39 @@
 namespace Wallabag\ImportBundle\Controller;
 
 use Craue\ConfigBundle\Util\Config;
-use Symfony\Bundle\FrameworkBundle\Controller\Controller;
+use OldSound\RabbitMqBundle\RabbitMq\Producer as RabbitMqProducer;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Session\SessionInterface;
 use Symfony\Component\Routing\Annotation\Route;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
-use Symfony\Component\Translation\TranslatorInterface;
+use Symfony\Contracts\Translation\TranslatorInterface;
 use Wallabag\ImportBundle\Import\PocketImport;
+use Wallabag\ImportBundle\Redis\Producer as RedisProducer;
 
-class PocketController extends Controller
+class PocketController extends AbstractController
 {
+    private Config $craueConfig;
+    private RabbitMqProducer $rabbitMqProducer;
+    private RedisProducer $redisProducer;
+    private SessionInterface $session;
+
+    public function __construct(Config $craueConfig, RabbitMqProducer $rabbitMqProducer, RedisProducer $redisProducer, SessionInterface $session)
+    {
+        $this->craueConfig = $craueConfig;
+        $this->rabbitMqProducer = $rabbitMqProducer;
+        $this->redisProducer = $redisProducer;
+        $this->session = $session;
+    }
+
     /**
      * @Route("/pocket", name="import_pocket")
      */
-    public function indexAction()
+    public function indexAction(PocketImport $pocketImport)
     {
-        $pocket = $this->getPocketImportService();
+        $pocket = $this->getPocketImportService($pocketImport);
+
         $form = $this->createFormBuilder($pocket)
             ->add('mark_as_read', CheckboxType::class, [
                 'label' => 'import.form.mark_as_read_label',
@@ -28,7 +44,7 @@ class PocketController extends Controller
             ->getForm();
 
         return $this->render('@WallabagImport/Pocket/index.html.twig', [
-            'import' => $this->getPocketImportService(),
+            'import' => $pocket,
             'has_consumer_key' => '' === trim($this->getUser()->getConfig()->getPocketConsumerKey()) ? false : true,
             'form' => $form->createView(),
         ]);
@@ -37,13 +53,13 @@ class PocketController extends Controller
     /**
      * @Route("/pocket/auth", name="import_pocket_auth")
      */
-    public function authAction(Request $request)
+    public function authAction(Request $request, PocketImport $pocketImport)
     {
-        $requestToken = $this->getPocketImportService()
+        $requestToken = $this->getPocketImportService($pocketImport)
             ->getRequestToken($this->generateUrl('import', [], UrlGeneratorInterface::ABSOLUTE_URL));
 
         if (false === $requestToken) {
-            $this->get(SessionInterface::class)->getFlashBag()->add(
+            $this->addFlash(
                 'notice',
                 'flashes.import.notice.failed'
             );
@@ -53,9 +69,9 @@ class PocketController extends Controller
 
         $form = $request->request->get('form');
 
-        $this->get(SessionInterface::class)->set('import.pocket.code', $requestToken);
+        $this->session->set('import.pocket.code', $requestToken);
         if (null !== $form && \array_key_exists('mark_as_read', $form)) {
-            $this->get(SessionInterface::class)->set('mark_as_read', $form['mark_as_read']);
+            $this->session->set('mark_as_read', $form['mark_as_read']);
         }
 
         return $this->redirect(
@@ -67,62 +83,53 @@ class PocketController extends Controller
     /**
      * @Route("/pocket/callback", name="import_pocket_callback")
      */
-    public function callbackAction()
+    public function callbackAction(PocketImport $pocketImport, TranslatorInterface $translator)
     {
         $message = 'flashes.import.notice.failed';
-        $pocket = $this->getPocketImportService();
+        $pocket = $this->getPocketImportService($pocketImport);
 
-        $markAsRead = $this->get(SessionInterface::class)->get('mark_as_read');
-        $this->get(SessionInterface::class)->remove('mark_as_read');
+        $markAsRead = $this->session->get('mark_as_read');
+        $this->session->remove('mark_as_read');
 
         // something bad happend on pocket side
-        if (false === $pocket->authorize($this->get(SessionInterface::class)->get('import.pocket.code'))) {
-            $this->get(SessionInterface::class)->getFlashBag()->add(
-                'notice',
-                $message
-            );
+        if (false === $pocket->authorize($this->session->get('import.pocket.code'))) {
+            $this->addFlash('notice', $message);
 
             return $this->redirect($this->generateUrl('import_pocket'));
         }
 
         if (true === $pocket->setMarkAsRead($markAsRead)->import()) {
             $summary = $pocket->getSummary();
-            $message = $this->get(TranslatorInterface::class)->trans('flashes.import.notice.summary', [
+            $message = $translator->trans('flashes.import.notice.summary', [
                 '%imported%' => null !== $summary && \array_key_exists('imported', $summary) ? $summary['imported'] : 0,
                 '%skipped%' => null !== $summary && \array_key_exists('skipped', $summary) ? $summary['skipped'] : 0,
             ]);
 
             if (null !== $summary && \array_key_exists('queued', $summary) && 0 < $summary['queued']) {
-                $message = $this->get(TranslatorInterface::class)->trans('flashes.import.notice.summary_with_queue', [
+                $message = $translator->trans('flashes.import.notice.summary_with_queue', [
                     '%queued%' => $summary['queued'],
                 ]);
             }
         }
 
-        $this->get(SessionInterface::class)->getFlashBag()->add(
-            'notice',
-            $message
-        );
+        $this->addFlash('notice', $message);
 
         return $this->redirect($this->generateUrl('homepage'));
     }
 
     /**
      * Return Pocket Import Service with or without RabbitMQ enabled.
-     *
-     * @return PocketImport
      */
-    private function getPocketImportService()
+    private function getPocketImportService(PocketImport $pocketImport): PocketImport
     {
-        $pocket = $this->get(PocketImport::class);
-        $pocket->setUser($this->getUser());
+        $pocketImport->setUser($this->getUser());
 
-        if ($this->get(Config::class)->get('import_with_rabbitmq')) {
-            $pocket->setProducer($this->get('old_sound_rabbit_mq.import_pocket_producer'));
-        } elseif ($this->get(Config::class)->get('import_with_redis')) {
-            $pocket->setProducer($this->get('wallabag_import.producer.redis.pocket'));
+        if ($this->craueConfig->get('import_with_rabbitmq')) {
+            $pocketImport->setProducer($this->rabbitMqProducer);
+        } elseif ($this->craueConfig->get('import_with_redis')) {
+            $pocketImport->setProducer($this->redisProducer);
         }
 
-        return $pocket;
+        return $pocketImport;
     }
 }

--- a/src/Wallabag/ImportBundle/Controller/WallabagV1Controller.php
+++ b/src/Wallabag/ImportBundle/Controller/WallabagV1Controller.php
@@ -3,18 +3,34 @@
 namespace Wallabag\ImportBundle\Controller;
 
 use Craue\ConfigBundle\Util\Config;
+use OldSound\RabbitMqBundle\RabbitMq\Producer as RabbitMqProducer;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Contracts\Translation\TranslatorInterface;
 use Wallabag\ImportBundle\Import\WallabagV1Import;
+use Wallabag\ImportBundle\Redis\Producer as RedisProducer;
 
 class WallabagV1Controller extends WallabagController
 {
+    private WallabagV1Import $wallabagImport;
+    private Config $craueConfig;
+    private RabbitMqProducer $rabbitMqProducer;
+    private RedisProducer $redisProducer;
+
+    public function __construct(WallabagV1Import $wallabagImport, Config $craueConfig, RabbitMqProducer $rabbitMqProducer, RedisProducer $redisProducer)
+    {
+        $this->wallabagImport = $wallabagImport;
+        $this->craueConfig = $craueConfig;
+        $this->rabbitMqProducer = $rabbitMqProducer;
+        $this->redisProducer = $redisProducer;
+    }
+
     /**
      * @Route("/wallabag-v1", name="import_wallabag_v1")
      */
-    public function indexAction(Request $request)
+    public function indexAction(Request $request, TranslatorInterface $translator)
     {
-        return parent::indexAction($request);
+        return parent::indexAction($request, $translator);
     }
 
     /**
@@ -22,15 +38,13 @@ class WallabagV1Controller extends WallabagController
      */
     protected function getImportService()
     {
-        $service = $this->get(WallabagV1Import::class);
-
-        if ($this->get(Config::class)->get('import_with_rabbitmq')) {
-            $service->setProducer($this->get('old_sound_rabbit_mq.import_wallabag_v1_producer'));
-        } elseif ($this->get(Config::class)->get('import_with_redis')) {
-            $service->setProducer($this->get('wallabag_import.producer.redis.wallabag_v1'));
+        if ($this->craueConfig->get('import_with_rabbitmq')) {
+            $this->wallabagImport->setProducer($this->rabbitMqProducer);
+        } elseif ($this->craueConfig->get('import_with_redis')) {
+            $this->wallabagImport->setProducer($this->redisProducer);
         }
 
-        return $service;
+        return $this->wallabagImport;
     }
 
     /**

--- a/src/Wallabag/ImportBundle/Controller/WallabagV2Controller.php
+++ b/src/Wallabag/ImportBundle/Controller/WallabagV2Controller.php
@@ -3,18 +3,34 @@
 namespace Wallabag\ImportBundle\Controller;
 
 use Craue\ConfigBundle\Util\Config;
+use OldSound\RabbitMqBundle\RabbitMq\Producer as RabbitMqProducer;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Contracts\Translation\TranslatorInterface;
 use Wallabag\ImportBundle\Import\WallabagV2Import;
+use Wallabag\ImportBundle\Redis\Producer as RedisProducer;
 
 class WallabagV2Controller extends WallabagController
 {
+    private WallabagV2Import $wallabagImport;
+    private Config $craueConfig;
+    private RabbitMqProducer $rabbitMqProducer;
+    private RedisProducer $redisProducer;
+
+    public function __construct(WallabagV2Import $wallabagImport, Config $craueConfig, RabbitMqProducer $rabbitMqProducer, RedisProducer $redisProducer)
+    {
+        $this->wallabagImport = $wallabagImport;
+        $this->craueConfig = $craueConfig;
+        $this->rabbitMqProducer = $rabbitMqProducer;
+        $this->redisProducer = $redisProducer;
+    }
+
     /**
      * @Route("/wallabag-v2", name="import_wallabag_v2")
      */
-    public function indexAction(Request $request)
+    public function indexAction(Request $request, TranslatorInterface $translator)
     {
-        return parent::indexAction($request);
+        return parent::indexAction($request, $translator);
     }
 
     /**
@@ -22,15 +38,13 @@ class WallabagV2Controller extends WallabagController
      */
     protected function getImportService()
     {
-        $service = $this->get(WallabagV2Import::class);
-
-        if ($this->get(Config::class)->get('import_with_rabbitmq')) {
-            $service->setProducer($this->get('old_sound_rabbit_mq.import_wallabag_v2_producer'));
-        } elseif ($this->get(Config::class)->get('import_with_redis')) {
-            $service->setProducer($this->get('wallabag_import.producer.redis.wallabag_v2'));
+        if ($this->craueConfig->get('import_with_rabbitmq')) {
+            $this->wallabagImport->setProducer($this->rabbitMqProducer);
+        } elseif ($this->craueConfig->get('import_with_redis')) {
+            $this->wallabagImport->setProducer($this->redisProducer);
         }
 
-        return $service;
+        return $this->wallabagImport;
     }
 
     /**

--- a/src/Wallabag/UserBundle/Controller/ManageController.php
+++ b/src/Wallabag/UserBundle/Controller/ManageController.php
@@ -2,6 +2,7 @@
 
 namespace Wallabag\UserBundle\Controller;
 
+use Doctrine\ORM\EntityManagerInterface;
 use FOS\UserBundle\Event\UserEvent;
 use FOS\UserBundle\FOSUserEvents;
 use FOS\UserBundle\Model\UserManagerInterface;
@@ -9,33 +10,40 @@ use Pagerfanta\Doctrine\ORM\QueryAdapter as DoctrineORMAdapter;
 use Pagerfanta\Exception\OutOfRangeCurrentPageException;
 use Pagerfanta\Pagerfanta;
 use Scheb\TwoFactorBundle\Security\TwoFactor\Provider\Google\GoogleAuthenticatorInterface;
-use Symfony\Bundle\FrameworkBundle\Controller\Controller;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\Form\Form;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\HttpFoundation\Session\SessionInterface;
 use Symfony\Component\Routing\Annotation\Route;
-use Symfony\Component\Translation\TranslatorInterface;
+use Symfony\Contracts\Translation\TranslatorInterface;
 use Wallabag\UserBundle\Entity\User;
 use Wallabag\UserBundle\Form\NewUserType;
 use Wallabag\UserBundle\Form\SearchUserType;
 use Wallabag\UserBundle\Form\UserType;
+use Wallabag\UserBundle\Repository\UserRepository;
 
 /**
  * User controller.
  */
-class ManageController extends Controller
+class ManageController extends AbstractController
 {
+    private EntityManagerInterface $entityManager;
+    private TranslatorInterface $translator;
+
+    public function __construct(EntityManagerInterface $entityManager, TranslatorInterface $translator)
+    {
+        $this->entityManager = $entityManager;
+        $this->translator = $translator;
+    }
+
     /**
      * Creates a new User entity.
      *
      * @Route("/new", name="user_new", methods={"GET", "POST"})
      */
-    public function newAction(Request $request)
+    public function newAction(Request $request, UserManagerInterface $userManager, EventDispatcherInterface $eventDispatcher)
     {
-        $userManager = $this->container->get(UserManagerInterface::class);
-
         $user = $userManager->createUser();
         \assert($user instanceof User);
         // enable created user by default
@@ -49,11 +57,11 @@ class ManageController extends Controller
 
             // dispatch a created event so the associated config will be created
             $event = new UserEvent($user, $request);
-            $this->get(EventDispatcherInterface::class)->dispatch($event, FOSUserEvents::USER_CREATED);
+            $eventDispatcher->dispatch($event, FOSUserEvents::USER_CREATED);
 
-            $this->get(SessionInterface::class)->getFlashBag()->add(
+            $this->addFlash(
                 'notice',
-                $this->get(TranslatorInterface::class)->trans('flashes.user.notice.added', ['%username%' => $user->getUsername()])
+                $this->translator->trans('flashes.user.notice.added', ['%username%' => $user->getUsername()])
             );
 
             return $this->redirectToRoute('user_edit', ['id' => $user->getId()]);
@@ -70,10 +78,8 @@ class ManageController extends Controller
      *
      * @Route("/{id}/edit", name="user_edit", methods={"GET", "POST"})
      */
-    public function editAction(Request $request, User $user)
+    public function editAction(Request $request, User $user, UserManagerInterface $userManager, GoogleAuthenticatorInterface $googleAuthenticator)
     {
-        $userManager = $this->container->get(UserManagerInterface::class);
-
         $deleteForm = $this->createDeleteForm($user);
         $form = $this->createForm(UserType::class, $user);
         $form->handleRequest($request);
@@ -87,7 +93,7 @@ class ManageController extends Controller
             // handle creation / reset of the OTP secret if checkbox changed from the previous state
             if ($this->getParameter('twofactor_auth')) {
                 if (true === $form->get('googleTwoFactor')->getData() && false === $user->isGoogleAuthenticatorEnabled()) {
-                    $user->setGoogleAuthenticatorSecret($this->get(GoogleAuthenticatorInterface::class)->generateSecret());
+                    $user->setGoogleAuthenticatorSecret($googleAuthenticator->generateSecret());
                     $user->setEmailTwoFactor(false);
                 } elseif (false === $form->get('googleTwoFactor')->getData() && true === $user->isGoogleAuthenticatorEnabled()) {
                     $user->setGoogleAuthenticatorSecret(null);
@@ -96,9 +102,9 @@ class ManageController extends Controller
 
             $userManager->updateUser($user);
 
-            $this->get(SessionInterface::class)->getFlashBag()->add(
+            $this->addFlash(
                 'notice',
-                $this->get(TranslatorInterface::class)->trans('flashes.user.notice.updated', ['%username%' => $user->getUsername()])
+                $this->translator->trans('flashes.user.notice.updated', ['%username%' => $user->getUsername()])
             );
 
             return $this->redirectToRoute('user_edit', ['id' => $user->getId()]);
@@ -123,14 +129,13 @@ class ManageController extends Controller
         $form->handleRequest($request);
 
         if ($form->isSubmitted() && $form->isValid()) {
-            $this->get(SessionInterface::class)->getFlashBag()->add(
+            $this->addFlash(
                 'notice',
-                $this->get(TranslatorInterface::class)->trans('flashes.user.notice.deleted', ['%username%' => $user->getUsername()])
+                $this->translator->trans('flashes.user.notice.deleted', ['%username%' => $user->getUsername()])
             );
 
-            $em = $this->get('doctrine')->getManager();
-            $em->remove($user);
-            $em->flush();
+            $this->entityManager->remove($user);
+            $this->entityManager->flush();
         }
 
         return $this->redirectToRoute('user_index');
@@ -146,10 +151,9 @@ class ManageController extends Controller
      *
      * @return Response
      */
-    public function searchFormAction(Request $request, $page = 1)
+    public function searchFormAction(Request $request, UserRepository $userRepository, $page = 1)
     {
-        $em = $this->get('doctrine')->getManager();
-        $qb = $em->getRepository(User::class)->createQueryBuilder('u');
+        $qb = $userRepository->createQueryBuilder('u');
 
         $form = $this->createForm(SearchUserType::class);
         $form->handleRequest($request);
@@ -157,7 +161,7 @@ class ManageController extends Controller
         if ($form->isSubmitted() && $form->isValid()) {
             $searchTerm = (isset($request->get('search_user')['term']) ? $request->get('search_user')['term'] : '');
 
-            $qb = $em->getRepository(User::class)->getQueryBuilderForSearch($searchTerm);
+            $qb = $userRepository->getQueryBuilderForSearch($searchTerm);
         }
 
         $pagerAdapter = new DoctrineORMAdapter($qb->getQuery(), true, false);

--- a/tests/Wallabag/CoreBundle/Twig/WallabagExtensionTest.php
+++ b/tests/Wallabag/CoreBundle/Twig/WallabagExtensionTest.php
@@ -4,7 +4,7 @@ namespace Tests\Wallabag\CoreBundle\Twig;
 
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
-use Symfony\Component\Translation\TranslatorInterface;
+use Symfony\Contracts\Translation\TranslatorInterface;
 use Wallabag\CoreBundle\Repository\EntryRepository;
 use Wallabag\CoreBundle\Repository\TagRepository;
 use Wallabag\CoreBundle\Twig\WallabagExtension;


### PR DESCRIPTION
Mostly using autowiring to inject deps.
The only tricky part was for import because all producer use the same class and have a different alias. So we must write them down in the service definition, autowiring doesn't work in that case.

Usually:
- if a controller has a constructor, it means injected services are at least re-used once in actions
- otherwise, service are injected per action

~~Also remove custom controller to handle error (just adding template is enough).~~
☝️ reverted because of format error problem (requesting json format for a 404 from the api render a html page ...)