### PR TITLE
Fix `database_path` in Docker env

### DIFF
--- a/docker/php/Dockerfile
+++ b/docker/php/Dockerfile
@@ -53,7 +53,7 @@ RUN docker-php-ext-install -j "$(nproc)" \
 
 RUN pecl install redis; \
     pecl install imagick; \
-    pecl install xdebug; \
+    pecl install xdebug-3.1.6; \
     docker-php-ext-enable \
         redis \
         imagick \

--- a/docker/php/config/parameters.yml
+++ b/docker/php/config/parameters.yml
@@ -6,7 +6,7 @@ parameters:
     database_name: ${DATABASE_NAME:-symfony}
     database_user: ${DATABASE_USER:-root}
     database_password: ${DATABASE_PASSWORD:-~}
-    database_path: ${DATABASE_PATH:-"%kernel.root_dir%/data/db/wallabag.sqlite"}
+    database_path: '${DATABASE_PATH:-"%kernel.root_dir%/data/db/wallabag.sqlite"}'
     database_table_prefix: wallabag_
     database_socket: null
     database_charset: ${DATABASE_CHARSET:-utf8}
@@ -14,15 +14,9 @@ parameters:
     domain_name: ${DOMAIN_NAME:-https://www.example.com}
     server_name: ${SERVER_NAME:-"Your wallabag instance"}
 
-    mailer_transport:  ${MAILER_TRANSPORT:-smtp}
-    mailer_user:       ${MAILER_USER:-~}
-    mailer_password:   ${MAILER_PASSWORD:-~}
-    mailer_host:       ${MAILER_HOST:-127.0.0.1}
-    mailer_port:       ${MAILER_PORT:-25}
-    mailer_encryption: ${MAILER_ENCRYPTION:-~}
-    mailer_auth_mode:  ${MAILER_AUTH_MODE:-~}
+    mailer_dsn: ${MAILER_DSN:-"smtp://127.0.0.1"}
 
-    locale:            ${LOCALE:-en}
+    locale: ${LOCALE:-en}
 
     # A secret key that's used to generate certain security-related tokens
     secret: ${SECRET:-~}


### PR DESCRIPTION
Also, add `mailer_dsn` and limit xdebug to allow installation of PHP < 8

- `database_path` is related to https://github.com/wallabag/wallabag/pull/6099
- `mailer_dsn` is related to https://github.com/wallabag/wallabag/pull/6150

Should fix #6173