### PR TITLE
Fix public folder for Symfony 4+

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -161,7 +161,8 @@
     "extra": {
         "incenteev-parameters": {
             "file": "app/config/parameters.yml"
-        }
+        },
+        "public-dir": "web"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes/no
| Documentation | no
| Translation   | no
| CHANGELOG.md  | no
| License       | MIT

Symfony 4 introduced a new structure, web has been renamed public.

~~This fix is maybe a breaking change, we could maybe customize `public-dir` while waiting for flex migration~~

Finally fix https://github.com/wallabag/wallabag/issues/6173