### PR TITLE
Fix XSS on username on share page

### DIFF
--- a/src/Wallabag/CoreBundle/Resources/views/themes/common/Entry/share.html.twig
+++ b/src/Wallabag/CoreBundle/Resources/views/themes/common/Entry/share.html.twig
@@ -28,7 +28,7 @@
         <header class="block">
             <h1>{{ entry.title|e|raw }}</h1>
             <a href="{{ entry.url|e }}" target="_blank" rel="noopener" title="{{ 'entry.view.original_article'|trans }} : {{ entry.title|e|raw }}" class="tool">{{ entry.domainName|removeWww }}</a>
-            <p class="shared-by">{{ "entry.public.shared_by_wallabag"|trans({'%wallabag_instance%': url('homepage'), '%username%': entry.user.username})|raw }}.</p>
+            <p class="shared-by">{{ "entry.public.shared_by_wallabag"|trans({'%wallabag_instance%': url('homepage'), '%username%': entry.user.username|escape})|raw }}.</p>
         </header>
         <article class="block">
             {{ entry.content | raw }}


### PR DESCRIPTION
Before:

<img width="464" alt="image" src="https://user-images.githubusercontent.com/62333/217340453-7865701d-5d59-40cf-bf82-16abc3aa2f92.png">


After:

<img width="520" alt="image" src="https://user-images.githubusercontent.com/62333/217340322-a5514ffa-4854-4bba-b796-4018f1fe2819.png">

Thanks to @gabriel-vernilo