### PR TITLE
[FIX] round reading time in export

### DIFF
--- a/src/Wallabag/CoreBundle/Helper/EntriesExport.php
+++ b/src/Wallabag/CoreBundle/Helper/EntriesExport.php
@@ -210,7 +210,7 @@ class EntriesExport
                 $publishedDate = $entry->getPublishedAt()->format('Y-m-d');
             }
 
-            $readingTime = $entry->getReadingTime() / $user->getConfig()->getReadingSpeed() * 200;
+            $readingTime = round($entry->getReadingTime() / $user->getConfig()->getReadingSpeed() * 200);
 
             $titlepage = $content_start .
                 '<h1>' . $entry->getTitle() . '</h1>' .


### PR DESCRIPTION
Before this commit, the exported entry (pdf, epub,...) could look like:

> Estimated reading time:
> 2.6666666666667 min

Now it will be:
> Estimated reading time
> 3 min

![Screenshot from 2023-05-24 17-08-32](https://github.com/wallabag/wallabag/assets/564822/76d72269-59dd-41e5-ba69-4d16defffcfa)


| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | ?
| Deprecations? | no
| Tests pass?   | :crossed_fingers: 
| Documentation | no
| Translation   | no
| CHANGELOG.md  | no
| License       | MIT
