### PR TITLE
Fix images downloading with numeric HTML entity

### DIFF
--- a/src/Wallabag/CoreBundle/Helper/DownloadImages.php
+++ b/src/Wallabag/CoreBundle/Helper/DownloadImages.php
@@ -86,12 +86,14 @@ class DownloadImages
                 continue;
             }
 
-            // if image contains "&" and we can't find it in the html it might be because it's encoded as &amp;
-            if (false !== stripos($image, '&') && false === stripos($html, $image)) {
-                $image = str_replace('&', '&amp;', $image);
-            }
-
             $html = str_replace($image, $newImage, $html);
+            // if image contains "&" and we can't find it in the html it might be because it's encoded as &amp; or unicode
+            if (false !== stripos($image, '&') && false === stripos($html, $image)) {
+                $imageAmp = str_replace('&', '&amp;', $image);
+                $html = str_replace($imageAmp, $newImage, $html);
+                $imageUnicode = str_replace('&', '&#038;', $image);
+                $html = str_replace($imageUnicode, $newImage, $html);
+            }
         }
 
         return $html;

--- a/tests/Wallabag/CoreBundle/Helper/DownloadImagesTest.php
+++ b/tests/Wallabag/CoreBundle/Helper/DownloadImagesTest.php
@@ -184,6 +184,23 @@ class DownloadImagesTest extends TestCase
         $this->assertStringNotContainsString('f_auto,q_auto', $res, 'Image srcset attribute were not replaced');
     }
 
+    public function testProcessImageWithNumericHtmlEntitySeparator()
+    {
+        $httpMockClient = new HttpMockClient();
+        $httpMockClient->addResponse(new Response(200, ['content-type' => 'image/jpeg'], file_get_contents(__DIR__ . '/../fixtures/image-no-content-type.jpg')));
+        $httpMockClient->addResponse(new Response(200, ['content-type' => 'image/jpeg'], file_get_contents(__DIR__ . '/../fixtures/image-no-content-type.jpg')));
+        $httpMockClient->addResponse(new Response(200, ['content-type' => 'image/jpeg'], file_get_contents(__DIR__ . '/../fixtures/image-no-content-type.jpg')));
+
+        $logHandler = new TestHandler();
+        $logger = new Logger('test', [$logHandler]);
+
+        $download = new DownloadImages($httpMockClient, sys_get_temp_dir() . '/wallabag_test', 'http://wallabag.io/', $logger);
+        // wordpress.com sites using &#038; as an &amp; alternative
+        $res = $download->processHtml(123, '<img srcset="https://example.com/20191204_133626-scaled.jpg?strip=info&#038;w=600&#038;ssl=1 600w,https://example.com/20191204_133626-scaled.jpg?strip=info&#038;w=900&#038;ssl=1 900w" src="https://example.com/20191204_133626-scaled.jpg?ssl=1"/>', 'https://example.com/about/');
+
+        $this->assertStringNotContainsString('https://example.com', $res, 'Image srcset attribute were not replaced');
+    }
+
     public function testProcessImageWithNullPath()
     {
         $httpMockClient = new HttpMockClient();


### PR DESCRIPTION
Images with numerical entities (`&#038;` instead of `&amp;`) were not downloaded. I encountered this issue on wordpress.com websites.