### PR TITLE
Fix RSS feed_route not set

### DIFF
--- a/src/Wallabag/CoreBundle/Resources/views/Entry/_feed_link.html.twig
+++ b/src/Wallabag/CoreBundle/Resources/views/Entry/_feed_link.html.twig
@@ -9,4 +9,6 @@
     {% set feed_route = feed_route ~ '_feed' %}
     {% set slug = null %}
 {% endif %}
-<a rel="alternate" type="application/atom+xml" href="{{ path(feed_route, {'username': app.user.username, 'token': app.user.config.feedToken, 'slug': slug}) }}" class="results-item"><i class="material-icons">rss_feed</i></a>
+{% if feed_route %}
+    <a rel="alternate" type="application/atom+xml" href="{{ path(feed_route, {'username': app.user.username, 'token': app.user.config.feedToken, 'slug': slug}) }}" class="results-item"><i class="material-icons">rss_feed</i></a>
+{% endif %}


### PR DESCRIPTION
I made some changes earlier and didn't think about other routes using this. So here is the code to fix this error:
```
 request.CRITICAL: Uncaught PHP Exception Twig\Error\RuntimeError: "An exception has been thrown during the rendering of a template ("Unable to generate a URL for the named route ".fr" as such route does not exist.")." at /var/www/wallabag/src/Wallabag/CoreBundle/Resources/views/Entry/_feed_link.html.twig line 12 {"exception":"[object] (Twig\\Error\\RuntimeError(code: 0): An exception has been thrown during the rendering of a template (\"Unable to generate a URL for the named route \".fr\" as such route does not exist.\"). at /var/www/wallabag/src/Wallabag/CoreBundle/Resources/views/Entry/_feed_link.html.twig:12, Symfony\\Component\\Routing\\Exception\\RouteNotFoundException(code: 0): Unable to generate a URL for the named route \".fr\" as such route does not exist. at /var/www/wallabag/vendor/symfony/symfony/src/Symfony/Component/Routing/Generator/CompiledUrlGenerator.php:50)"} []
```