### PR TITLE
Fix duplicate tags creation when assigning search results to tag

### DIFF
--- a/src/Wallabag/CoreBundle/Controller/TagController.php
+++ b/src/Wallabag/CoreBundle/Controller/TagController.php
@@ -247,10 +247,15 @@ class TagController extends AbstractController
                 $filter
             );
 
-            $this->entityManager->persist($entry);
+            // check to avoid duplicate tags creation
+            foreach ($this->entityManager->getUnitOfWork()->getScheduledEntityInsertions() as $entity) {
+                if ($entity instanceof Tag && strtolower($entity->getLabel()) === strtolower($filter)) {
+                    continue 2;
+                }
+                $this->entityManager->persist($entry);
+            }
+            $this->entityManager->flush();
         }
-
-        $this->entityManager->flush();
 
         return $this->redirect($this->redirectHelper->to($request->headers->get('referer'), '', true));
     }

--- a/tests/Wallabag/CoreBundle/Controller/TagControllerTest.php
+++ b/tests/Wallabag/CoreBundle/Controller/TagControllerTest.php
@@ -560,5 +560,12 @@ class TagControllerTest extends WallabagCoreTestCase
 
             $this->assertContains('title', $tags);
         }
+
+        $tag = $client->getContainer()
+            ->get(EntityManagerInterface::class)
+            ->getRepository(Tag::class)
+            ->findByLabelsAndUser(['title'], $this->getLoggedInUserId());
+
+        $this->assertCount(1, $tag);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  |no
| BC breaks?    |no
| Deprecations? |no
| Tests pass?   | yes
| Documentation |no
| Translation   |no
| CHANGELOG.md  |no
| License       | MIT

Fixes #6330