### PR TITLE
Add command to clean pictures path when changing instance URL

### DIFF
--- a/src/Wallabag/CoreBundle/Command/UpdatePicturesPathCommand.php
+++ b/src/Wallabag/CoreBundle/Command/UpdatePicturesPathCommand.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace Wallabag\CoreBundle\Command;
+
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+use Wallabag\CoreBundle\Repository\EntryRepository;
+
+class UpdatePicturesPathCommand extends Command
+{
+    private EntityManagerInterface $entityManager;
+    private EntryRepository $entryRepository;
+    private string $wallabagUrl;
+
+    public function __construct(EntityManagerInterface $entityManager, EntryRepository $entryRepository, $wallabagUrl)
+    {
+        $this->entityManager = $entityManager;
+        $this->entryRepository = $entryRepository;
+        $this->wallabagUrl = $wallabagUrl;
+        parent::__construct();
+    }
+
+    protected function configure()
+    {
+        $this
+            ->setName('wallabag:update-pictures-path')
+            ->setDescription('Update the path of the pictures for each entry when you changed your wallabag instance URL.')
+            ->addArgument(
+                'old-url',
+                InputArgument::REQUIRED,
+                'URL to replace'
+            );
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $io = new SymfonyStyle($input, $output);
+
+        $oldUrl = $input->getArgument('old-url');
+
+        $query = $this->entryRepository->createQueryBuilder('e')->getQuery();
+        $io->text('Retrieve existing entries');
+        $i = 1;
+        foreach ($query->toIterable() as $entry) {
+            $content = str_replace($oldUrl, $this->wallabagUrl, $entry->getContent());
+            $entry->setContent($content);
+
+            $previewPicture = str_replace($oldUrl, $this->wallabagUrl, $entry->getPreviewPicture());
+            $entry->setPreviewPicture($previewPicture);
+
+            if (0 === ($i % 20)) {
+                $this->entityManager->flush();
+            }
+            ++$i;
+        }
+        $this->entityManager->flush();
+
+        $io->success('Finished updating.');
+
+        return 0;
+    }
+}

--- a/tests/Wallabag/CoreBundle/Command/UpdatePicturesPathCommandTest.php
+++ b/tests/Wallabag/CoreBundle/Command/UpdatePicturesPathCommandTest.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace Tests\Wallabag\CoreBundle\Command;
+
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Bundle\FrameworkBundle\Console\Application;
+use Symfony\Component\Console\Exception\RuntimeException;
+use Symfony\Component\Console\Tester\CommandTester;
+use Tests\Wallabag\CoreBundle\WallabagCoreTestCase;
+use Wallabag\CoreBundle\Entity\Entry;
+
+class UpdatePicturesPathCommandTest extends WallabagCoreTestCase
+{
+    public function testRunUpdatePicturesPathCommandWithoutOldURL()
+    {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Not enough arguments (missing: "old-url")');
+        $application = new Application($this->getTestClient()->getKernel());
+
+        $command = $application->find('wallabag:update-pictures-path');
+
+        $tester = new CommandTester($command);
+        $tester->execute([]);
+    }
+
+    public function testRunGenerateUrlHashesCommandForUser()
+    {
+        $application = new Application($this->getTestClient()->getKernel());
+        $this->logInAs('admin');
+
+        $url = 'https://wallabag.org/news/20230620-new-release-wallabag-260/';
+
+        $command = $application->find('wallabag:update-pictures-path');
+
+        $client = $this->getTestClient();
+        $em = $client->getContainer()->get(EntityManagerInterface::class);
+        $entry = new Entry($this->getLoggedInUser());
+        $entry->setUrl($url);
+        $entry->setPreviewPicture('https://old-url.test/mypicture.jpg');
+        $entry->setContent('my great article with a picture <img src="https://old-url.test/mypicture.jpg" />');
+        $em->persist($entry);
+        $em->flush();
+
+        $tester = new CommandTester($command);
+        $tester->execute([
+            'old-url' => 'https://old-url.test',
+        ]);
+
+        $this->assertStringContainsString('Finished updating.', $tester->getDisplay());
+
+        $entry = $em->getRepository(Entry::class)->findOneByUrl($url);
+        $this->assertSame($entry->getPreviewPicture(), $client->getContainer()->getParameter('domain_name') . '/mypicture.jpg');
+
+        $query = $em->createQuery('DELETE FROM Wallabag\CoreBundle\Entity\Entry e WHERE e.url = :url');
+        $query->setParameter('url', $url);
+        $query->execute();
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    |no
| Deprecations? |no
| Tests pass?   | yes/no
| Documentation |no
| Translation   |no
| CHANGELOG.md  |no
| License       | MIT

Should fix #2852. 

Tests missing. 