### PR TITLE
Skip migration if the table was already renamed

### DIFF
--- a/app/DoctrineMigrations/Version20170606155640.php
+++ b/app/DoctrineMigrations/Version20170606155640.php
@@ -13,6 +13,8 @@ class Version20170606155640 extends WallabagMigration
 {
     public function up(Schema $schema): void
     {
+        $this->skipIf(!$schema->hasTable($this->getTable('craue_config_setting')), 'Table already renamed');
+
         $apiUserRegistration = $this->container
             ->get('doctrine.orm.default_entity_manager')
             ->getConnection()


### PR DESCRIPTION
Doctrine 3.5 reruns skipped migrations when invoking doctrine:migrations:migrate. This causes this migration to rerun and it errors since craue_config_setting table gets renamed in Version20190808124957.php to internal_setting table.

Fixes #6660

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes/no
| Documentation | no
| Translation   | no
| CHANGELOG.md  | no
| License       | MIT
