### PR TITLE
Remove `twofactor_auth` parameter

### DIFF
--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -201,15 +201,15 @@ scheb_two_factor:
         lifetime: 2592000
 
     backup_codes:
-        enabled: "%twofactor_auth%"
+        enabled: true
 
     google:
-        enabled: "%twofactor_auth%"
+        enabled: true
         issuer: "%server_name%"
         template: "@WallabagUser/Authentication/form.html.twig"
 
     email:
-        enabled: "%twofactor_auth%"
+        enabled: true
         sender_email: "%twofactor_sender%"
         digits: 6
         template: "@WallabagUser/Authentication/form.html.twig"

--- a/app/config/parameters.yml.dist
+++ b/app/config/parameters.yml.dist
@@ -34,7 +34,6 @@ parameters:
     secret: CHANGE_ME_TO_SOMETHING_SECRET_AND_RANDOM
 
     # two factor stuff
-    twofactor_auth: true
     twofactor_sender: no-reply@wallabag.org
 
     # fosuser stuff

--- a/docker/php/config/parameters.yml
+++ b/docker/php/config/parameters.yml
@@ -22,7 +22,6 @@ parameters:
     secret: ${SECRET:-~}
 
     # two factor stuff
-    twofactor_auth: ${TWOFACTOR_AUTH:-true}
     twofactor_sender: ${TWOFACTOR_SENDER:-no-reply@wallabag.org}
 
     # fosuser stuff

--- a/src/Wallabag/CoreBundle/Controller/ConfigController.php
+++ b/src/Wallabag/CoreBundle/Controller/ConfigController.php
@@ -246,7 +246,6 @@ class ConfigController extends AbstractController
                 'username' => $user->getUsername(),
                 'token' => $config->getFeedToken(),
             ],
-            'twofactor_auth' => $this->getParameter('twofactor_auth'),
             'wallabag_url' => $this->getParameter('domain_name'),
             'enabled_users' => $userRepository->getSumEnabledUsers(),
         ]);
@@ -259,10 +258,6 @@ class ConfigController extends AbstractController
      */
     public function disableOtpEmailAction()
     {
-        if (!$this->getParameter('twofactor_auth')) {
-            return $this->createNotFoundException('two_factor not enabled');
-        }
-
         $user = $this->getUser();
         $user->setEmailTwoFactor(false);
 
@@ -283,10 +278,6 @@ class ConfigController extends AbstractController
      */
     public function otpEmailAction()
     {
-        if (!$this->getParameter('twofactor_auth')) {
-            return $this->createNotFoundException('two_factor not enabled');
-        }
-
         $user = $this->getUser();
 
         $user->setGoogleAuthenticatorSecret(null);
@@ -310,10 +301,6 @@ class ConfigController extends AbstractController
      */
     public function disableOtpAppAction()
     {
-        if (!$this->getParameter('twofactor_auth')) {
-            return $this->createNotFoundException('two_factor not enabled');
-        }
-
         $user = $this->getUser();
 
         $user->setGoogleAuthenticatorSecret('');
@@ -336,10 +323,6 @@ class ConfigController extends AbstractController
      */
     public function otpAppAction(GoogleAuthenticatorInterface $googleAuthenticator)
     {
-        if (!$this->getParameter('twofactor_auth')) {
-            return $this->createNotFoundException('two_factor not enabled');
-        }
-
         $user = $this->getUser();
         $secret = $googleAuthenticator->generateSecret();
 
@@ -377,10 +360,6 @@ class ConfigController extends AbstractController
      */
     public function otpAppCancelAction()
     {
-        if (!$this->getParameter('twofactor_auth')) {
-            return $this->createNotFoundException('two_factor not enabled');
-        }
-
         $user = $this->getUser();
         $user->setGoogleAuthenticatorSecret(null);
         $user->setBackupCodes(null);

--- a/src/Wallabag/CoreBundle/Resources/views/Config/index.html.twig
+++ b/src/Wallabag/CoreBundle/Resources/views/Config/index.html.twig
@@ -209,38 +209,36 @@
 
                             {{ form_widget(form.user.save, {'attr': {'class': 'btn waves-effect waves-light'}}) }}
 
-                            {% if twofactor_auth %}
-                                <br/>
-                                <br/>
-                                <div class="row">
-                                    <h5>{{ 'config.otp.page_title'|trans }}</h5>
+                            <br/>
+                            <br/>
+                            <div class="row">
+                                <h5>{{ 'config.otp.page_title'|trans }}</h5>
 
-                                    <p>{{ 'config.form_user.two_factor_description'|trans }}</p>
+                                <p>{{ 'config.form_user.two_factor_description'|trans }}</p>
 
-                                    <table>
-                                        <thead>
-                                            <tr>
-                                                <th>{{ 'config.form_user.two_factor.table_method'|trans }}</th>
-                                                <th>{{ 'config.form_user.two_factor.table_state'|trans }}</th>
-                                                <th>{{ 'config.form_user.two_factor.table_action'|trans }}</th>
-                                            </tr>
-                                        </thead>
+                                <table>
+                                    <thead>
+                                        <tr>
+                                            <th>{{ 'config.form_user.two_factor.table_method'|trans }}</th>
+                                            <th>{{ 'config.form_user.two_factor.table_state'|trans }}</th>
+                                            <th>{{ 'config.form_user.two_factor.table_action'|trans }}</th>
+                                        </tr>
+                                    </thead>
 
-                                        <tbody>
-                                            <tr>
-                                                <td>{{ 'config.form_user.two_factor.emailTwoFactor_label'|trans }}</td>
-                                                <td>{% if app.user.isEmailTwoFactor %}<b>{{ 'config.form_user.two_factor.state_enabled'|trans }}</b>{% else %}{{ 'config.form_user.two_factor.state_disabled'|trans }}{% endif %}</td>
-                                                <td><a href="{{ path('config_otp_email') }}" class="waves-effect waves-light btn{% if app.user.isEmailTwoFactor %} disabled{% endif %}">{{ 'config.form_user.two_factor.action_email'|trans }}</a> {% if app.user.isEmailTwoFactor %}<a href="{{ path('disable_otp_email') }}" class="waves-effect waves-light btn red">Disable</a>{% endif %}</td>
-                                            </tr>
-                                            <tr>
-                                                <td>{{ 'config.form_user.two_factor.googleTwoFactor_label'|trans }}</td>
-                                                <td>{% if app.user.isGoogleTwoFactor %}<b>{{ 'config.form_user.two_factor.state_enabled'|trans }}</b>{% else %}{{ 'config.form_user.two_factor.state_disabled'|trans }}{% endif %}</td>
-                                                <td><a href="{{ path('config_otp_app') }}" class="waves-effect waves-light btn{% if app.user.isGoogleTwoFactor %} disabled{% endif %}">{{ 'config.form_user.two_factor.action_app'|trans }}</a> {% if app.user.isGoogleTwoFactor %}<a href="{{ path('disable_otp_app') }}" class="waves-effect waves-light btn red">Disable</a>{% endif %}</td>
-                                            </tr>
-                                        </tbody>
-                                    </table>
-                                </div>
-                            {% endif %}
+                                    <tbody>
+                                        <tr>
+                                            <td>{{ 'config.form_user.two_factor.emailTwoFactor_label'|trans }}</td>
+                                            <td>{% if app.user.isEmailTwoFactor %}<b>{{ 'config.form_user.two_factor.state_enabled'|trans }}</b>{% else %}{{ 'config.form_user.two_factor.state_disabled'|trans }}{% endif %}</td>
+                                            <td><a href="{{ path('config_otp_email') }}" class="waves-effect waves-light btn{% if app.user.isEmailTwoFactor %} disabled{% endif %}">{{ 'config.form_user.two_factor.action_email'|trans }}</a> {% if app.user.isEmailTwoFactor %}<a href="{{ path('disable_otp_email') }}" class="waves-effect waves-light btn red">Disable</a>{% endif %}</td>
+                                        </tr>
+                                        <tr>
+                                            <td>{{ 'config.form_user.two_factor.googleTwoFactor_label'|trans }}</td>
+                                            <td>{% if app.user.isGoogleTwoFactor %}<b>{{ 'config.form_user.two_factor.state_enabled'|trans }}</b>{% else %}{{ 'config.form_user.two_factor.state_disabled'|trans }}{% endif %}</td>
+                                            <td><a href="{{ path('config_otp_app') }}" class="waves-effect waves-light btn{% if app.user.isGoogleTwoFactor %} disabled{% endif %}">{{ 'config.form_user.two_factor.action_app'|trans }}</a> {% if app.user.isGoogleTwoFactor %}<a href="{{ path('disable_otp_app') }}" class="waves-effect waves-light btn red">Disable</a>{% endif %}</td>
+                                        </tr>
+                                    </tbody>
+                                </table>
+                            </div>
                             {{ form_widget(form.user._token) }}
                         </form>
                     </div>

--- a/src/Wallabag/UserBundle/Controller/ManageController.php
+++ b/src/Wallabag/UserBundle/Controller/ManageController.php
@@ -85,19 +85,17 @@ class ManageController extends AbstractController
         $form->handleRequest($request);
 
         // `googleTwoFactor` isn't a field within the User entity, we need to define it's value in a different way
-        if ($this->getParameter('twofactor_auth') && true === $user->isGoogleAuthenticatorEnabled() && false === $form->isSubmitted()) {
+        if (true === $user->isGoogleAuthenticatorEnabled() && false === $form->isSubmitted()) {
             $form->get('googleTwoFactor')->setData(true);
         }
 
         if ($form->isSubmitted() && $form->isValid()) {
             // handle creation / reset of the OTP secret if checkbox changed from the previous state
-            if ($this->getParameter('twofactor_auth')) {
-                if (true === $form->get('googleTwoFactor')->getData() && false === $user->isGoogleAuthenticatorEnabled()) {
-                    $user->setGoogleAuthenticatorSecret($googleAuthenticator->generateSecret());
-                    $user->setEmailTwoFactor(false);
-                } elseif (false === $form->get('googleTwoFactor')->getData() && true === $user->isGoogleAuthenticatorEnabled()) {
-                    $user->setGoogleAuthenticatorSecret(null);
-                }
+            if (true === $form->get('googleTwoFactor')->getData() && false === $user->isGoogleAuthenticatorEnabled()) {
+                $user->setGoogleAuthenticatorSecret($googleAuthenticator->generateSecret());
+                $user->setEmailTwoFactor(false);
+            } elseif (false === $form->get('googleTwoFactor')->getData() && true === $user->isGoogleAuthenticatorEnabled()) {
+                $user->setGoogleAuthenticatorSecret(null);
             }
 
             $userManager->updateUser($user);
@@ -114,7 +112,6 @@ class ManageController extends AbstractController
             'user' => $user,
             'edit_form' => $form->createView(),
             'delete_form' => $deleteForm->createView(),
-            'twofactor_auth' => $this->getParameter('twofactor_auth'),
         ]);
     }
 

--- a/src/Wallabag/UserBundle/Resources/views/Manage/edit.html.twig
+++ b/src/Wallabag/UserBundle/Resources/views/Manage/edit.html.twig
@@ -47,7 +47,6 @@
                                     </div>
                                 </div>
 
-                                {% if twofactor_auth %}
                                 <div class="row">
                                     <div class="input-field col s12">
                                         {{ form_widget(edit_form.emailTwoFactor) }}
@@ -60,7 +59,6 @@
                                         {{ form_errors(edit_form.googleTwoFactor) }}
                                     </div>
                                 </div>
-                                {% endif %}
 
                                 <br/>
 

--- a/tests/Wallabag/CoreBundle/Controller/SecurityControllerTest.php
+++ b/tests/Wallabag/CoreBundle/Controller/SecurityControllerTest.php
@@ -32,12 +32,6 @@ class SecurityControllerTest extends WallabagCoreTestCase
     {
         $client = $this->getTestClient();
 
-        if (!$client->getContainer()->getParameter('twofactor_auth')) {
-            $this->markTestSkipped('twofactor_auth is not enabled.');
-
-            return;
-        }
-
         $client->followRedirects();
 
         $em = $client->getContainer()->get(EntityManagerInterface::class);
@@ -64,12 +58,6 @@ class SecurityControllerTest extends WallabagCoreTestCase
     public function testLoginWith2FactorGoogle()
     {
         $client = $this->getTestClient();
-
-        if (!$client->getContainer()->getParameter('twofactor_auth')) {
-            $this->markTestSkipped('twofactor_auth is not enabled.');
-
-            return;
-        }
 
         $client->followRedirects();
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Documentation |no
| Translation   | no
| CHANGELOG.md  |no
| License       | MIT

Fix #6649

