### PR TITLE
Fix installer when database not exists

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -153,7 +153,7 @@ jobs:
         run: "php bin/simple-phpunit -v"
 
   phpunit_no_database:
-    name: "PHP ${{ matrix.php }} using ${{ matrix.database }} who don't exist"
+    name: "PHP ${{ matrix.php }} using ${{ matrix.database }} without DB created"
     runs-on: "ubuntu-20.04"
     services:
       rabbitmq:
@@ -192,13 +192,14 @@ jobs:
         if: "${{ matrix.database == 'mysql' }}"
         run: |
           sudo systemctl start mysql.service
+
       - name: "Install dependencies with Composer"
         uses: "ramsey/composer-install@v2"
         with:
           composer-options: "--optimize-autoloader --prefer-dist"
 
       - name: "Install wallabag"
-        run: "make install ENV=test"
+        run: "php bin/console wallabag:install --env=test"
 
       - name: "Prepare fixtures"
         run: "make fixtures"

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -151,3 +151,57 @@ jobs:
 
       - name: "Run PHPUnit"
         run: "php bin/simple-phpunit -v"
+
+  phpunit_no_database:
+    name: "PHP ${{ matrix.php }} using ${{ matrix.database }} who don't exist"
+    runs-on: "ubuntu-20.04"
+    services:
+      rabbitmq:
+        image: rabbitmq:3-alpine
+        ports:
+          - 5672:5672
+      redis:
+        image: redis:6-alpine
+        ports:
+          - 6379:6379
+
+    strategy:
+      fail-fast: true
+      matrix:
+        php:
+          - "8.2"
+        database:
+          - "mysql"
+
+    steps:
+      - name: "Checkout"
+        uses: "actions/checkout@v3"
+        with:
+          fetch-depth: 2
+
+      - name: "Install PHP"
+        uses: "shivammathur/setup-php@v2"
+        with:
+          php-version: "${{ matrix.php }}"
+          coverage: none
+          tools: pecl
+          extensions: json, pdo, pdo_mysql, pdo_sqlite, pdo_pgsql, curl, imagick, pgsql, gd, tidy
+          ini-values: "date.timezone=Europe/Paris"
+
+      - name: "Setup MySQL"
+        if: "${{ matrix.database == 'mysql' }}"
+        run: |
+          sudo systemctl start mysql.service
+      - name: "Install dependencies with Composer"
+        uses: "ramsey/composer-install@v2"
+        with:
+          composer-options: "--optimize-autoloader --prefer-dist"
+
+      - name: "Install wallabag"
+        run: "make install ENV=test"
+
+      - name: "Prepare fixtures"
+        run: "make fixtures"
+
+      - name: "Run PHPUnit"
+        run: "php bin/simple-phpunit -v"

--- a/src/Wallabag/CoreBundle/Command/InstallCommand.php
+++ b/src/Wallabag/CoreBundle/Command/InstallCommand.php
@@ -372,23 +372,24 @@ class InstallCommand extends Command
     private function isDatabasePresent()
     {
         $connection = $this->entityManager->getConnection();
-        $databaseName = $connection->getDatabase();
 
         try {
-            $schemaManager = $connection->getSchemaManager();
+            $databaseName = $connection->getDatabase();
         } catch (\Exception $exception) {
             // mysql & sqlite
-            if (false !== strpos($exception->getMessage(), sprintf("Unknown database '%s'", $databaseName))) {
+            if (false !== strpos($exception->getMessage(), 'Unknown database')) {
                 return false;
             }
 
             // pgsql
-            if (false !== strpos($exception->getMessage(), sprintf('database "%s" does not exist', $databaseName))) {
+            if (false !== strpos($exception->getMessage(), 'does not exist')) {
                 return false;
             }
 
             throw $exception;
         }
+
+        $schemaManager = $connection->getSchemaManager();
 
         // custom verification for sqlite, since `getListDatabasesSQL` doesn't work for sqlite
         if ('sqlite' === $schemaManager->getDatabasePlatform()->getName()) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  |no
| BC breaks?    |no
| Deprecations? |no
| Tests pass?   | yes
| Documentation |no
| Translation   |no
| CHANGELOG.md  |no
| License       | MIT

I'd prefer have a regex to check the whole exception message. If someone wants to have a look on it. 

My PR is a pointer to the bug, we can improve it. 

I want to kill an other bug quickly https://github.com/wallabag/wallabag/issues/6659
