### PR TITLE
Fix failing randomly test

### DIFF
--- a/tests/Wallabag/CoreBundle/Controller/FeedControllerTest.php
+++ b/tests/Wallabag/CoreBundle/Controller/FeedControllerTest.php
@@ -237,13 +237,17 @@ class FeedControllerTest extends WallabagCoreTestCase
         $entry1->setCreatedAt($day1);
         $entry4->setCreatedAt($day2);
 
-        $property = (new \ReflectionObject($entry1))->getProperty('updatedAt');
-        $property->setAccessible(true);
-        $property->setValue($entry1, $day4);
-
         $property = (new \ReflectionObject($entry4))->getProperty('updatedAt');
         $property->setAccessible(true);
         $property->setValue($entry4, $day3);
+
+        // We have to flush and sleep here to be sure that $entry1 and $entry4 have different updatedAt values
+        $em->flush();
+        sleep(2);
+
+        $property = (new \ReflectionObject($entry1))->getProperty('updatedAt');
+        $property->setAccessible(true);
+        $property->setValue($entry1, $day4);
 
         $em->flush();
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes 🤞 
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes 🤞 
| Documentation | no
| Translation   | no
| CHANGELOG.md  | no
| License       | MIT

We need to persist object and add a sleep call to be sure that the 2 objects have different `updatedAt` values. 

In fact, in this test, `$day3` and `$day4` are useless because these dates are not keeped: as we persist objects, the `updatedAt` field is updated with current date. 