### PR TITLE
Add confirmation before reload entry

### DIFF
--- a/src/Wallabag/CoreBundle/Resources/views/Entry/entry.html.twig
+++ b/src/Wallabag/CoreBundle/Resources/views/Entry/entry.html.twig
@@ -54,7 +54,7 @@
         </li>
 
         <li class="bold">
-            <a class="waves-effect collapsible-header" title="{{ 'entry.view.left_menu.re_fetch_content'|trans }}" href="{{ path('reload_entry', {'id': entry.id}) }}" id="reload">
+            <a class="waves-effect collapsible-header" onclick="return confirm('{{ 'entry.confirm.reload'|trans|escape('js') }}')" title="{{ 'entry.view.left_menu.re_fetch_content'|trans }}" href="{{ path('reload_entry', {'id': entry.id}) }}" id="reload">
                 <i class="material-icons small">refresh</i>
                 <span>{{ 'entry.view.left_menu.re_fetch_content'|trans }}</span>
             </a>

--- a/translations/messages.en.yml
+++ b/translations/messages.en.yml
@@ -320,6 +320,7 @@ entry:
         delete: Are you sure you want to remove that article?
         delete_tag: Are you sure you want to remove that tag from that article?
         delete_entries: Are you sure you want to remove these articles?
+        reload: Are you sure you want to reload that article?
     metadata:
         reading_time: Estimated reading time
         reading_time_minutes_short: '%readingTime% min'


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes, kind of
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Documentation | no
| Translation   | yes
| CHANGELOG.md  | no
| License       | MIT

As the "delete an article" feature, and because reload an article can be a mistake (for example: I have an archive of an article, this article is no more available on the internet and I misclick on "reload this article"), I think it's good to add a confirmation. 
