### PR TITLE
Fix search when search term has useless space

### DIFF
--- a/src/Wallabag/CoreBundle/Controller/EntryController.php
+++ b/src/Wallabag/CoreBundle/Controller/EntryController.php
@@ -615,7 +615,7 @@ class EntryController extends AbstractController
      */
     private function showEntries($type, Request $request, $page)
     {
-        $searchTerm = (isset($request->get('search_entry')['term']) ? $request->get('search_entry')['term'] : '');
+        $searchTerm = (isset($request->get('search_entry')['term']) ? trim($request->get('search_entry')['term']) : '');
         $currentRoute = (null !== $request->query->get('currentRoute') ? $request->query->get('currentRoute') : '');
         $request->getSession()->set('prevUrl', $request->getRequestUri());
 

--- a/tests/Wallabag/CoreBundle/Controller/EntryControllerTest.php
+++ b/tests/Wallabag/CoreBundle/Controller/EntryControllerTest.php
@@ -1390,6 +1390,18 @@ class EntryControllerTest extends WallabagCoreTestCase
 
         $this->assertCount(4, $crawler->filter($this->entryDataTestAttribute));
 
+        // Add a check with useless spaces before and after the search term
+        $crawler = $client->request('GET', '/unread/list');
+
+        $form = $crawler->filter('form[name=search]')->form();
+        $data = [
+            'search_entry[term]' => '  title ',
+        ];
+
+        $crawler = $client->submit($form, $data);
+
+        $this->assertCount(4, $crawler->filter($this->entryDataTestAttribute));
+
         // Search on starred list
         $crawler = $client->request('GET', '/starred/list');
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  |no
| BC breaks?    |no
| Deprecations? |no
| Tests pass?   | yes
| Documentation | yes/no
| Translation   |no
| CHANGELOG.md  |no
| License       | MIT

Fix #4414. 