### PR TITLE
Identify platforms by their class

### DIFF
--- a/app/DoctrineMigrations/Version20160401000000.php
+++ b/app/DoctrineMigrations/Version20160401000000.php
@@ -2,6 +2,9 @@
 
 namespace Application\Migrations;
 
+use Doctrine\DBAL\Platforms\MySQLPlatform;
+use Doctrine\DBAL\Platforms\PostgreSQLPlatform;
+use Doctrine\DBAL\Platforms\SqlitePlatform;
 use Doctrine\DBAL\Schema\Schema;
 use Wallabag\CoreBundle\Doctrine\WallabagMigration;
 
@@ -14,8 +17,10 @@ class Version20160401000000 extends WallabagMigration
     {
         $this->skipIf($schema->hasTable($this->getTable('entry')), 'Database already initialized');
 
-        switch ($this->connection->getDatabasePlatform()->getName()) {
-            case 'sqlite':
+        $platform = $this->connection->getDatabasePlatform();
+
+        switch (true) {
+            case $platform instanceof SqlitePlatform:
                 $sql = <<<SQL
 CREATE TABLE {$this->getTable('craue_config_setting')} (name VARCHAR(255) NOT NULL, value VARCHAR(255) DEFAULT NULL, section VARCHAR(255) DEFAULT NULL, PRIMARY KEY(name));
 CREATE UNIQUE INDEX UNIQ_5D9649505E237E06 ON {$this->getTable('craue_config_setting')} (name);
@@ -58,7 +63,7 @@ SQL
                 }
 
                 break;
-            case 'mysql':
+            case $platform instanceof MySQLPlatform:
                 $sql = <<<SQL
 CREATE TABLE {$this->getTable('craue_config_setting')} (name VARCHAR(255) NOT NULL, value VARCHAR(255) DEFAULT NULL, section VARCHAR(255) DEFAULT NULL, UNIQUE INDEX UNIQ_5D9649505E237E06 (name), PRIMARY KEY(name)) DEFAULT CHARACTER SET utf8 COLLATE utf8_unicode_ci ENGINE = InnoDB;
 CREATE TABLE {$this->getTable('entry')} (id INT AUTO_INCREMENT NOT NULL, user_id INT DEFAULT NULL, title LONGTEXT DEFAULT NULL, url LONGTEXT DEFAULT NULL, is_archived TINYINT(1) NOT NULL, is_starred TINYINT(1) NOT NULL, content LONGTEXT DEFAULT NULL, created_at DATETIME NOT NULL, updated_at DATETIME NOT NULL, mimetype LONGTEXT DEFAULT NULL, language LONGTEXT DEFAULT NULL, reading_time INT DEFAULT NULL, domain_name LONGTEXT DEFAULT NULL, preview_picture LONGTEXT DEFAULT NULL, is_public TINYINT(1) DEFAULT '0', INDEX IDX_F4D18282A76ED395 (user_id), PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8 COLLATE utf8_unicode_ci ENGINE = InnoDB;
@@ -91,7 +96,7 @@ SQL
                     $this->addSql($query);
                 }
                 break;
-            case 'postgresql':
+            case $platform instanceof PostgreSQLPlatform:
                 $sql = <<<SQL
 CREATE TABLE {$this->getTable('craue_config_setting')} (name VARCHAR(255) NOT NULL, value VARCHAR(255) DEFAULT NULL, section VARCHAR(255) DEFAULT NULL, PRIMARY KEY(name));
 CREATE UNIQUE INDEX UNIQ_5D9649505E237E06 ON {$this->getTable('craue_config_setting')} (name);

--- a/app/DoctrineMigrations/Version20160812120952.php
+++ b/app/DoctrineMigrations/Version20160812120952.php
@@ -2,6 +2,7 @@
 
 namespace Application\Migrations;
 
+use Doctrine\DBAL\Platforms\SqlitePlatform;
 use Doctrine\DBAL\Schema\Schema;
 use Wallabag\CoreBundle\Doctrine\WallabagMigration;
 
@@ -15,7 +16,7 @@ class Version20160812120952 extends WallabagMigration
         $clientsTable = $schema->getTable($this->getTable('oauth2_clients'));
         $this->skipIf($clientsTable->hasColumn('name'), 'It seems that you already played this migration.');
 
-        if ('sqlite' === $this->connection->getDatabasePlatform()->getName()) {
+        if ($this->connection->getDatabasePlatform() instanceof SqlitePlatform) {
             // Can't use $clientsTable->addColumn('name', 'blob');
             // because of the error:
             // SQLSTATE[HY000]: General error: 1 Cannot add a NOT NULL column with default value NULL
@@ -35,7 +36,7 @@ class Version20160812120952 extends WallabagMigration
     {
         $clientsTable = $schema->getTable($this->getTable('oauth2_clients'));
 
-        if ('sqlite' === $this->connection->getDatabasePlatform()->getName()) {
+        if ($this->connection->getDatabasePlatform() instanceof SqlitePlatform) {
             $databaseTablePrefix = $this->container->getParameter('database_table_prefix');
             $this->addSql('DROP INDEX IDX_635D765EA76ED395');
             $this->addSql('CREATE TEMPORARY TABLE __temp__' . $databaseTablePrefix . 'oauth2_clients AS SELECT id, random_id, redirect_uris, secret, allowed_grant_types FROM ' . $databaseTablePrefix . 'oauth2_clients');

--- a/app/DoctrineMigrations/Version20161022134138.php
+++ b/app/DoctrineMigrations/Version20161022134138.php
@@ -2,6 +2,7 @@
 
 namespace Application\Migrations;
 
+use Doctrine\DBAL\Platforms\MySQLPlatform;
 use Doctrine\DBAL\Schema\Schema;
 use Wallabag\CoreBundle\Doctrine\WallabagMigration;
 
@@ -12,7 +13,7 @@ class Version20161022134138 extends WallabagMigration
 {
     public function up(Schema $schema): void
     {
-        $this->skipIf('mysql' !== $this->connection->getDatabasePlatform()->getName(), 'This migration only apply to MySQL');
+        $this->skipIf(!$this->connection->getDatabasePlatform() instanceof MySQLPlatform, 'This migration only apply to MySQL');
 
         $this->addSql('ALTER DATABASE `' . $this->connection->getParams()['dbname'] . '` CHARACTER SET = utf8mb4 COLLATE = utf8mb4_unicode_ci;');
 
@@ -40,7 +41,7 @@ class Version20161022134138 extends WallabagMigration
 
     public function down(Schema $schema): void
     {
-        $this->skipIf('mysql' !== $this->connection->getDatabasePlatform()->getName(), 'This migration only apply to MySQL');
+        $this->skipIf(!$this->connection->getDatabasePlatform() instanceof MySQLPlatform, 'This migration only apply to MySQL');
 
         $this->addSql('ALTER DATABASE `' . $this->connection->getParams()['dbname'] . '` CHARACTER SET = utf8 COLLATE = utf8_unicode_ci;');
 

--- a/app/DoctrineMigrations/Version20161024212538.php
+++ b/app/DoctrineMigrations/Version20161024212538.php
@@ -2,6 +2,7 @@
 
 namespace Application\Migrations;
 
+use Doctrine\DBAL\Platforms\SqlitePlatform;
 use Doctrine\DBAL\Schema\Schema;
 use Wallabag\CoreBundle\Doctrine\WallabagMigration;
 
@@ -37,7 +38,7 @@ class Version20161024212538 extends WallabagMigration
 
         $clientsTable->dropColumn('user_id', 'integer');
 
-        if ('sqlite' !== $this->connection->getDatabasePlatform()->getName()) {
+        if (!$this->connection->getDatabasePlatform() instanceof SqlitePlatform) {
             $clientsTable->removeForeignKey($this->constraintName);
         }
     }

--- a/app/DoctrineMigrations/Version20161214094402.php
+++ b/app/DoctrineMigrations/Version20161214094402.php
@@ -2,6 +2,9 @@
 
 namespace Application\Migrations;
 
+use Doctrine\DBAL\Platforms\MySQLPlatform;
+use Doctrine\DBAL\Platforms\PostgreSQLPlatform;
+use Doctrine\DBAL\Platforms\SqlitePlatform;
 use Doctrine\DBAL\Schema\Schema;
 use Wallabag\CoreBundle\Doctrine\WallabagMigration;
 
@@ -16,18 +19,20 @@ class Version20161214094402 extends WallabagMigration
 
         $this->skipIf($entryTable->hasColumn('uid'), 'It seems that you already played this migration.');
 
-        switch ($this->connection->getDatabasePlatform()->getName()) {
-            case 'sqlite':
+        $platform = $this->connection->getDatabasePlatform();
+
+        switch (true) {
+            case $platform instanceof SqlitePlatform:
                 $this->addSql('CREATE TEMPORARY TABLE __temp__wallabag_entry AS SELECT id, user_id, uuid, title, url, is_archived, is_starred, content, created_at, updated_at, mimetype, language, reading_time, domain_name, preview_picture, is_public FROM ' . $this->getTable('entry'));
                 $this->addSql('DROP TABLE ' . $this->getTable('entry'));
                 $this->addSql('CREATE TABLE ' . $this->getTable('entry') . ' (id INTEGER NOT NULL, user_id INTEGER DEFAULT NULL, uid CLOB DEFAULT NULL COLLATE BINARY, title CLOB DEFAULT NULL COLLATE BINARY, url CLOB DEFAULT NULL COLLATE BINARY, is_archived BOOLEAN NOT NULL, is_starred BOOLEAN NOT NULL, content CLOB DEFAULT NULL COLLATE BINARY, created_at DATETIME NOT NULL, updated_at DATETIME NOT NULL, mimetype CLOB DEFAULT NULL COLLATE BINARY, language CLOB DEFAULT NULL COLLATE BINARY, reading_time INTEGER DEFAULT NULL, domain_name CLOB DEFAULT NULL COLLATE BINARY, preview_picture CLOB DEFAULT NULL COLLATE BINARY, is_public BOOLEAN DEFAULT "0", PRIMARY KEY(id));');
                 $this->addSql('INSERT INTO ' . $this->getTable('entry') . ' (id, user_id, uid, title, url, is_archived, is_starred, content, created_at, updated_at, mimetype, language, reading_time, domain_name, preview_picture, is_public) SELECT id, user_id, uuid, title, url, is_archived, is_starred, content, created_at, updated_at, mimetype, language, reading_time, domain_name, preview_picture, is_public FROM __temp__wallabag_entry;');
                 $this->addSql('DROP TABLE __temp__wallabag_entry');
                 break;
-            case 'mysql':
+            case $platform instanceof MySQLPlatform:
                 $this->addSql('ALTER TABLE ' . $this->getTable('entry') . ' CHANGE uuid uid VARCHAR(23)');
                 break;
-            case 'postgresql':
+            case $platform instanceof PostgreSQLPlatform:
                 $this->addSql('ALTER TABLE ' . $this->getTable('entry') . ' RENAME uuid TO uid');
         }
     }
@@ -38,14 +43,16 @@ class Version20161214094402 extends WallabagMigration
 
         $this->skipIf($entryTable->hasColumn('uuid'), 'It seems that you already played this migration.');
 
-        switch ($this->connection->getDatabasePlatform()->getName()) {
-            case 'sqlite':
+        $platform = $this->connection->getDatabasePlatform();
+
+        switch (true) {
+            case $platform instanceof SqlitePlatform:
                 throw new SkipMigrationException('Too complex ...');
                 break;
-            case 'mysql':
+            case $platform instanceof MySQLPlatform:
                 $this->addSql('ALTER TABLE ' . $this->getTable('entry') . ' CHANGE uid uuid VARCHAR(23)');
                 break;
-            case 'postgresql':
+            case $platform instanceof PostgreSQLPlatform:
                 $this->addSql('ALTER TABLE ' . $this->getTable('entry') . ' RENAME uid TO uuid');
         }
     }

--- a/app/DoctrineMigrations/Version20170501115751.php
+++ b/app/DoctrineMigrations/Version20170501115751.php
@@ -2,6 +2,7 @@
 
 namespace Application\Migrations;
 
+use Doctrine\DBAL\Platforms\PostgreSQLPlatform;
 use Doctrine\DBAL\Schema\Schema;
 use Wallabag\CoreBundle\Doctrine\WallabagMigration;
 
@@ -25,7 +26,7 @@ class Version20170501115751 extends WallabagMigration
         $table->setPrimaryKey(['id']);
         $table->addForeignKeyConstraint($this->getTable('user'), ['user_id'], ['id'], [], 'fk_user');
 
-        if ('postgresql' === $this->connection->getDatabasePlatform()->getName()) {
+        if ($this->connection->getDatabasePlatform() instanceof PostgreSQLPlatform) {
             $schema->dropSequence('site_credential_id_seq');
             $schema->createSequence('site_credential_id_seq');
         }

--- a/app/DoctrineMigrations/Version20170510082609.php
+++ b/app/DoctrineMigrations/Version20170510082609.php
@@ -2,6 +2,7 @@
 
 namespace Application\Migrations;
 
+use Doctrine\DBAL\Platforms\MySQLPlatform;
 use Doctrine\DBAL\Schema\Schema;
 use Wallabag\CoreBundle\Doctrine\WallabagMigration;
 
@@ -19,7 +20,7 @@ class Version20170510082609 extends WallabagMigration
 
     public function up(Schema $schema): void
     {
-        $this->skipIf('mysql' !== $this->connection->getDatabasePlatform()->getName(), 'This migration only apply to MySQL');
+        $this->skipIf(!$this->connection->getDatabasePlatform() instanceof MySQLPlatform, 'This migration only apply to MySQL');
 
         foreach ($this->fields as $field) {
             $this->addSql('ALTER TABLE ' . $this->getTable('user') . ' CHANGE ' . $field . ' ' . $field . ' VARCHAR(180) NOT NULL;');
@@ -28,7 +29,7 @@ class Version20170510082609 extends WallabagMigration
 
     public function down(Schema $schema): void
     {
-        $this->skipIf('mysql' !== $this->connection->getDatabasePlatform()->getName(), 'This migration only apply to MySQL');
+        $this->skipIf(!$this->connection->getDatabasePlatform() instanceof MySQLPlatform, 'This migration only apply to MySQL');
 
         foreach ($this->fields as $field) {
             $this->addSql('ALTER TABLE ' . $this->getTable('user') . ' CHANGE ' . $field . ' ' . $field . ' VARCHAR(255) NOT NULL;');

--- a/app/DoctrineMigrations/Version20170511211659.php
+++ b/app/DoctrineMigrations/Version20170511211659.php
@@ -3,6 +3,9 @@
 namespace Application\Migrations;
 
 use Doctrine\DBAL\Migrations\SkipMigrationException;
+use Doctrine\DBAL\Platforms\MySQLPlatform;
+use Doctrine\DBAL\Platforms\PostgreSQLPlatform;
+use Doctrine\DBAL\Platforms\SqlitePlatform;
 use Doctrine\DBAL\Schema\Schema;
 use Wallabag\CoreBundle\Doctrine\WallabagMigration;
 
@@ -13,8 +16,10 @@ class Version20170511211659 extends WallabagMigration
 {
     public function up(Schema $schema): void
     {
-        switch ($this->connection->getDatabasePlatform()->getName()) {
-            case 'sqlite':
+        $platform = $this->connection->getDatabasePlatform();
+
+        switch (true) {
+            case $platform instanceof SqlitePlatform:
                 $annotationTableName = $this->getTable('annotation', true);
                 $userTableName = $this->getTable('user', true);
                 $entryTableName = $this->getTable('entry', true);
@@ -53,10 +58,10 @@ EOD
                 );
                 $this->addSql('DROP TABLE __temp__wallabag_annotation');
                 break;
-            case 'mysql':
+            case $platform instanceof MySQLPlatform:
                 $this->addSql('ALTER TABLE ' . $this->getTable('annotation') . ' MODIFY quote TEXT NOT NULL');
                 break;
-            case 'postgresql':
+            case $platform instanceof PostgreSQLPlatform:
                 $this->addSql('ALTER TABLE ' . $this->getTable('annotation') . ' ALTER COLUMN quote TYPE TEXT');
                 break;
         }
@@ -66,14 +71,16 @@ EOD
     {
         $tableName = $this->getTable('annotation');
 
-        switch ($this->connection->getDatabasePlatform()->getName()) {
-            case 'sqlite':
+        $platform = $this->connection->getDatabasePlatform();
+
+        switch (true) {
+            case $platform instanceof SqlitePlatform:
                 throw new SkipMigrationException('Too complex ...');
                 break;
-            case 'mysql':
+            case $platform instanceof MySQLPlatform:
                 $this->addSql('ALTER TABLE ' . $tableName . ' MODIFY quote VARCHAR(255) NOT NULL');
                 break;
-            case 'postgresql':
+            case $platform instanceof PostgreSQLPlatform:
                 $this->addSql('ALTER TABLE ' . $tableName . ' ALTER COLUMN quote TYPE VARCHAR(255)');
                 break;
         }

--- a/app/DoctrineMigrations/Version20170719231144.php
+++ b/app/DoctrineMigrations/Version20170719231144.php
@@ -2,6 +2,7 @@
 
 namespace Application\Migrations;
 
+use Doctrine\DBAL\Platforms\SqlitePlatform;
 use Doctrine\DBAL\Schema\Schema;
 use Wallabag\CoreBundle\Doctrine\WallabagMigration;
 
@@ -12,7 +13,7 @@ class Version20170719231144 extends WallabagMigration
 {
     public function up(Schema $schema): void
     {
-        $this->skipIf('sqlite' === $this->connection->getDatabasePlatform()->getName(), 'Migration can only be executed safely on \'mysql\' or \'postgresql\'.');
+        $this->skipIf($this->connection->getDatabasePlatform() instanceof SqlitePlatform, 'Migration can only be executed safely on \'mysql\' or \'postgresql\'.');
 
         // Find tags which need to be merged
         $dupTags = $this->connection->query('

--- a/app/DoctrineMigrations/Version20171008195606.php
+++ b/app/DoctrineMigrations/Version20171008195606.php
@@ -2,6 +2,9 @@
 
 namespace Application\Migrations;
 
+use Doctrine\DBAL\Platforms\MySQLPlatform;
+use Doctrine\DBAL\Platforms\PostgreSQLPlatform;
+use Doctrine\DBAL\Platforms\SqlitePlatform;
 use Doctrine\DBAL\Schema\Schema;
 use Wallabag\CoreBundle\Doctrine\WallabagMigration;
 
@@ -12,14 +15,16 @@ class Version20171008195606 extends WallabagMigration
 {
     public function up(Schema $schema): void
     {
-        $this->skipIf('sqlite' === $this->connection->getDatabasePlatform()->getName(), 'Migration can only be executed safely on \'mysql\' or \'postgresql\'.');
+        $platform = $this->connection->getDatabasePlatform();
 
-        switch ($this->connection->getDatabasePlatform()->getName()) {
-            case 'mysql':
+        $this->skipIf($platform instanceof SqlitePlatform, 'Migration can only be executed safely on \'mysql\' or \'postgresql\'.');
+
+        switch (true) {
+            case $platform instanceof MySQLPlatform:
                 $this->addSql('UPDATE ' . $this->getTable('entry') . ' SET reading_time = 0 WHERE reading_time IS NULL;');
                 $this->addSql('ALTER TABLE ' . $this->getTable('entry') . ' CHANGE reading_time reading_time INT(11) NOT NULL;');
                 break;
-            case 'postgresql':
+            case $platform instanceof PostgreSQLPlatform:
                 $this->addSql('UPDATE ' . $this->getTable('entry') . ' SET reading_time = 0 WHERE reading_time IS NULL;');
                 $this->addSql('ALTER TABLE ' . $this->getTable('entry') . ' ALTER COLUMN reading_time SET NOT NULL;');
                 break;
@@ -28,13 +33,15 @@ class Version20171008195606 extends WallabagMigration
 
     public function down(Schema $schema): void
     {
-        $this->skipIf('sqlite' === $this->connection->getDatabasePlatform()->getName(), 'Migration can only be executed safely on \'mysql\' or \'postgresql\'.');
+        $platform = $this->connection->getDatabasePlatform();
 
-        switch ($this->connection->getDatabasePlatform()->getName()) {
-            case 'mysql':
+        $this->skipIf($platform instanceof SqlitePlatform, 'Migration can only be executed safely on \'mysql\' or \'postgresql\'.');
+
+        switch (true) {
+            case $platform instanceof MySQLPlatform:
                 $this->addSql('ALTER TABLE ' . $this->getTable('entry') . ' CHANGE reading_time reading_time INT(11);');
                 break;
-            case 'postgresql':
+            case $platform instanceof PostgreSQLPlatform:
                 $this->addSql('ALTER TABLE ' . $this->getTable('entry') . ' ALTER COLUMN reading_time DROP NOT NULL;');
                 break;
         }

--- a/app/DoctrineMigrations/Version20181128203230.php
+++ b/app/DoctrineMigrations/Version20181128203230.php
@@ -2,6 +2,7 @@
 
 namespace Application\Migrations;
 
+use Doctrine\DBAL\Platforms\MySQLPlatform;
 use Doctrine\DBAL\Schema\Schema;
 use Wallabag\CoreBundle\Doctrine\WallabagMigration;
 
@@ -12,7 +13,7 @@ class Version20181128203230 extends WallabagMigration
 {
     public function up(Schema $schema): void
     {
-        $this->skipIf('mysql' !== $this->connection->getDatabasePlatform()->getName(), 'This migration can only be applied on \'mysql\'.');
+        $this->skipIf(!$this->connection->getDatabasePlatform() instanceof MySQLPlatform, 'This migration can only be applied on \'mysql\'.');
 
         $this->addSql('ALTER TABLE ' . $this->getTable('oauth2_access_tokens') . ' CHANGE `token` `token` varchar(191) NOT NULL');
         $this->addSql('ALTER TABLE ' . $this->getTable('oauth2_access_tokens') . ' CHANGE `scope` `scope` varchar(191)');
@@ -27,7 +28,7 @@ class Version20181128203230 extends WallabagMigration
 
     public function down(Schema $schema): void
     {
-        $this->skipIf('mysql' !== $this->connection->getDatabasePlatform()->getName(), 'This migration can only be applied on \'mysql\'.');
+        $this->skipIf(!$this->connection->getDatabasePlatform() instanceof MySQLPlatform, 'This migration can only be applied on \'mysql\'.');
 
         $this->addSql('ALTER TABLE ' . $this->getTable('oauth2_access_tokens') . ' CHANGE `token` `token` varchar(255) NOT NULL');
         $this->addSql('ALTER TABLE ' . $this->getTable('oauth2_access_tokens') . ' CHANGE `scope` `scope` varchar(255)');

--- a/app/DoctrineMigrations/Version20181202073750.php
+++ b/app/DoctrineMigrations/Version20181202073750.php
@@ -2,6 +2,9 @@
 
 namespace Application\Migrations;
 
+use Doctrine\DBAL\Platforms\MySQLPlatform;
+use Doctrine\DBAL\Platforms\PostgreSQLPlatform;
+use Doctrine\DBAL\Platforms\SqlitePlatform;
 use Doctrine\DBAL\Schema\Schema;
 use Wallabag\CoreBundle\Doctrine\WallabagMigration;
 
@@ -12,8 +15,10 @@ final class Version20181202073750 extends WallabagMigration
 {
     public function up(Schema $schema): void
     {
-        switch ($this->connection->getDatabasePlatform()->getName()) {
-            case 'sqlite':
+        $platform = $this->connection->getDatabasePlatform();
+
+        switch (true) {
+            case $platform instanceof SqlitePlatform:
                 $this->addSql('DROP INDEX UNIQ_1D63E7E5C05FB297');
                 $this->addSql('DROP INDEX UNIQ_1D63E7E5A0D96FBF');
                 $this->addSql('DROP INDEX UNIQ_1D63E7E592FC23A8');
@@ -28,13 +33,13 @@ final class Version20181202073750 extends WallabagMigration
                 $this->addSql('CREATE UNIQUE INDEX UNIQ_1D63E7E5A0D96FBF ON ' . $this->getTable('user', true) . ' (email_canonical)');
                 $this->addSql('CREATE UNIQUE INDEX UNIQ_1D63E7E592FC23A8 ON ' . $this->getTable('user', true) . ' (username_canonical)');
                 break;
-            case 'mysql':
+            case $platform instanceof MySQLPlatform:
                 $this->addSql('ALTER TABLE ' . $this->getTable('user') . ' ADD googleAuthenticatorSecret VARCHAR(191) DEFAULT NULL');
                 $this->addSql('ALTER TABLE ' . $this->getTable('user') . ' CHANGE twoFactorAuthentication emailTwoFactor BOOLEAN NOT NULL');
                 $this->addSql('ALTER TABLE ' . $this->getTable('user') . ' DROP trusted');
                 $this->addSql('ALTER TABLE ' . $this->getTable('user') . ' ADD backupCodes LONGTEXT DEFAULT NULL COMMENT \'(DC2Type:json_array)\'');
                 break;
-            case 'postgresql':
+            case $platform instanceof PostgreSQLPlatform:
                 $this->addSql('ALTER TABLE ' . $this->getTable('user') . ' ADD googleAuthenticatorSecret VARCHAR(191) DEFAULT NULL');
                 $this->addSql('ALTER TABLE ' . $this->getTable('user') . ' RENAME COLUMN twofactorauthentication TO emailTwoFactor');
                 $this->addSql('ALTER TABLE ' . $this->getTable('user') . ' DROP trusted');
@@ -45,8 +50,10 @@ final class Version20181202073750 extends WallabagMigration
 
     public function down(Schema $schema): void
     {
-        switch ($this->connection->getDatabasePlatform()->getName()) {
-            case 'sqlite':
+        $platform = $this->connection->getDatabasePlatform();
+
+        switch (true) {
+            case $platform instanceof SqlitePlatform:
                 $this->addSql('DROP INDEX UNIQ_1D63E7E592FC23A8');
                 $this->addSql('DROP INDEX UNIQ_1D63E7E5A0D96FBF');
                 $this->addSql('DROP INDEX UNIQ_1D63E7E5C05FB297');
@@ -59,13 +66,13 @@ final class Version20181202073750 extends WallabagMigration
                 $this->addSql('CREATE UNIQUE INDEX UNIQ_1D63E7E5A0D96FBF ON "' . $this->getTable('user', true) . '" (email_canonical)');
                 $this->addSql('CREATE UNIQUE INDEX UNIQ_1D63E7E5C05FB297 ON "' . $this->getTable('user', true) . '" (confirmation_token)');
                 break;
-            case 'mysql':
+            case $platform instanceof MySQLPlatform:
                 $this->addSql('ALTER TABLE `' . $this->getTable('user') . '` DROP googleAuthenticatorSecret');
                 $this->addSql('ALTER TABLE `' . $this->getTable('user') . '` CHANGE emailtwofactor twoFactorAuthentication BOOLEAN NOT NULL');
                 $this->addSql('ALTER TABLE `' . $this->getTable('user') . '` ADD trusted TEXT DEFAULT NULL');
                 $this->addSql('ALTER TABLE `' . $this->getTable('user') . '` DROP backupCodes');
                 break;
-            case 'postgresql':
+            case $platform instanceof PostgreSQLPlatform:
                 $this->addSql('ALTER TABLE ' . $this->getTable('user') . ' DROP googleAuthenticatorSecret');
                 $this->addSql('ALTER TABLE ' . $this->getTable('user') . ' RENAME COLUMN emailTwoFactor TO twofactorauthentication');
                 $this->addSql('ALTER TABLE ' . $this->getTable('user') . ' ADD trusted TEXT DEFAULT NULL');

--- a/app/DoctrineMigrations/Version20190425115043.php
+++ b/app/DoctrineMigrations/Version20190425115043.php
@@ -2,6 +2,9 @@
 
 namespace Application\Migrations;
 
+use Doctrine\DBAL\Platforms\MySQLPlatform;
+use Doctrine\DBAL\Platforms\PostgreSQLPlatform;
+use Doctrine\DBAL\Platforms\SqlitePlatform;
 use Doctrine\DBAL\Schema\Schema;
 use Wallabag\CoreBundle\Doctrine\WallabagMigration;
 
@@ -12,8 +15,10 @@ final class Version20190425115043 extends WallabagMigration
 {
     public function up(Schema $schema): void
     {
-        switch ($this->connection->getDatabasePlatform()->getName()) {
-            case 'sqlite':
+        $platform = $this->connection->getDatabasePlatform();
+
+        switch (true) {
+            case $platform instanceof SqlitePlatform:
                 $this->addSql('DROP INDEX UNIQ_87E64C53A76ED395');
                 $this->addSql('CREATE TEMPORARY TABLE __temp__' . $this->getTable('config', true) . ' AS SELECT id, user_id, theme, items_per_page, language, rss_token, rss_limit, reading_speed, pocket_consumer_key, action_mark_as_read, list_mode FROM ' . $this->getTable('config', true));
                 $this->addSql('DROP TABLE ' . $this->getTable('config', true));
@@ -22,11 +27,11 @@ final class Version20190425115043 extends WallabagMigration
                 $this->addSql('DROP TABLE __temp__' . $this->getTable('config', true));
                 $this->addSql('CREATE UNIQUE INDEX UNIQ_87E64C53A76ED395 ON ' . $this->getTable('config', true) . ' (user_id)');
                 break;
-            case 'mysql':
+            case $platform instanceof MySQLPlatform:
                 $this->addSql('ALTER TABLE ' . $this->getTable('config') . ' CHANGE rss_token feed_token VARCHAR(255) DEFAULT NULL');
                 $this->addSql('ALTER TABLE ' . $this->getTable('config') . ' CHANGE rss_limit feed_limit INT DEFAULT NULL');
                 break;
-            case 'postgresql':
+            case $platform instanceof PostgreSQLPlatform:
                 $this->addSql('ALTER TABLE ' . $this->getTable('config') . ' RENAME COLUMN rss_token TO feed_token');
                 $this->addSql('ALTER TABLE ' . $this->getTable('config') . ' RENAME COLUMN rss_limit TO feed_limit');
                 break;
@@ -35,8 +40,10 @@ final class Version20190425115043 extends WallabagMigration
 
     public function down(Schema $schema): void
     {
-        switch ($this->connection->getDatabasePlatform()->getName()) {
-            case 'sqlite':
+        $platform = $this->connection->getDatabasePlatform();
+
+        switch (true) {
+            case $platform instanceof SqlitePlatform:
                 $this->addSql('DROP INDEX UNIQ_87E64C53A76ED395');
                 $this->addSql('CREATE TEMPORARY TABLE __temp__' . $this->getTable('config', true) . ' AS SELECT id, user_id, theme, items_per_page, language, feed_token, feed_limit, reading_speed, pocket_consumer_key, action_mark_as_read, list_mode FROM "' . $this->getTable('config', true) . '"');
                 $this->addSql('DROP TABLE "' . $this->getTable('config', true) . '"');
@@ -45,11 +52,11 @@ final class Version20190425115043 extends WallabagMigration
                 $this->addSql('DROP TABLE __temp__' . $this->getTable('config', true));
                 $this->addSql('CREATE UNIQUE INDEX UNIQ_87E64C53A76ED395 ON "' . $this->getTable('config', true) . '" (user_id)');
                 break;
-            case 'mysql':
+            case $platform instanceof MySQLPlatform:
                 $this->addSql('ALTER TABLE ' . $this->getTable('config') . ' CHANGE feed_token rss_token');
                 $this->addSql('ALTER TABLE ' . $this->getTable('config') . ' CHANGE feed_limit rss_limit');
                 break;
-            case 'postgresql':
+            case $platform instanceof PostgreSQLPlatform:
                 $this->addSql('ALTER TABLE ' . $this->getTable('config') . ' RENAME COLUMN feed_token TO rss_token');
                 $this->addSql('ALTER TABLE ' . $this->getTable('config') . ' RENAME COLUMN feed_limit TO rss_limit');
                 break;

--- a/app/DoctrineMigrations/Version20190510141130.php
+++ b/app/DoctrineMigrations/Version20190510141130.php
@@ -3,6 +3,9 @@
 namespace Application\Migrations;
 
 use Doctrine\DBAL\Migrations\SkipMigrationException;
+use Doctrine\DBAL\Platforms\MySQLPlatform;
+use Doctrine\DBAL\Platforms\PostgreSQLPlatform;
+use Doctrine\DBAL\Platforms\SqlitePlatform;
 use Doctrine\DBAL\Schema\Schema;
 use Wallabag\CoreBundle\Doctrine\WallabagMigration;
 
@@ -17,8 +20,10 @@ final class Version20190510141130 extends WallabagMigration
 {
     public function up(Schema $schema): void
     {
-        switch ($this->connection->getDatabasePlatform()->getName()) {
-            case 'sqlite':
+        $platform = $this->connection->getDatabasePlatform();
+
+        switch (true) {
+            case $platform instanceof SqlitePlatform:
                 $this->addSql('DROP INDEX IDX_368A4209A76ED395');
                 $this->addSql('DROP INDEX IDX_368A420919EB6921');
                 $this->addSql('DROP INDEX UNIQ_368A42095F37A13B');
@@ -60,7 +65,7 @@ final class Version20190510141130 extends WallabagMigration
                 $this->addSql('CREATE INDEX IDX_EE52E3FAA76ED395 ON ' . $this->getTable('oauth2_auth_codes', true) . ' (user_id)');
                 $this->addSql('CREATE INDEX IDX_EE52E3FA19EB6921 ON ' . $this->getTable('oauth2_auth_codes', true) . ' (client_id)');
                 break;
-            case 'mysql':
+            case $platform instanceof MySQLPlatform:
                 $this->addSql('ALTER TABLE ' . $this->getTable('oauth2_access_tokens') . ' DROP FOREIGN KEY FK_368A4209A76ED395');
                 $this->addSql('ALTER TABLE ' . $this->getTable('oauth2_access_tokens') . ' ADD CONSTRAINT FK_368A4209A76ED395 FOREIGN KEY (user_id) REFERENCES ' . $this->getTable('user') . ' (id) ON DELETE CASCADE');
 
@@ -75,7 +80,7 @@ final class Version20190510141130 extends WallabagMigration
                 $this->addSql('ALTER TABLE ' . $this->getTable('oauth2_auth_codes') . ' DROP FOREIGN KEY FK_EE52E3FAA76ED395');
                 $this->addSql('ALTER TABLE ' . $this->getTable('oauth2_auth_codes') . ' ADD CONSTRAINT FK_EE52E3FAA76ED395 FOREIGN KEY (user_id) REFERENCES ' . $this->getTable('user') . ' (id) ON DELETE CASCADE');
                 break;
-            case 'postgresql':
+            case $platform instanceof PostgreSQLPlatform:
                 $this->addSql('ALTER TABLE ' . $this->getTable('oauth2_access_tokens') . ' DROP CONSTRAINT FK_368A4209A76ED395');
                 $this->addSql('ALTER TABLE ' . $this->getTable('oauth2_access_tokens') . ' ADD CONSTRAINT FK_368A4209A76ED395 FOREIGN KEY (user_id) REFERENCES ' . $this->getTable('user') . ' (id) ON DELETE CASCADE NOT DEFERRABLE INITIALLY IMMEDIATE');
 

--- a/app/DoctrineMigrations/Version20190511165128.php
+++ b/app/DoctrineMigrations/Version20190511165128.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Application\Migrations;
 
+use Doctrine\DBAL\Platforms\MySQLPlatform;
 use Doctrine\DBAL\Schema\Schema;
 use Wallabag\CoreBundle\Doctrine\WallabagMigration;
 
@@ -14,7 +15,7 @@ final class Version20190511165128 extends WallabagMigration
 {
     public function up(Schema $schema): void
     {
-        $this->skipIf('mysql' !== $this->connection->getDatabasePlatform()->getName(), 'This migration only apply to MySQL');
+        $this->skipIf(!$this->connection->getDatabasePlatform() instanceof MySQLPlatform, 'This migration only apply to MySQL');
 
         $this->addSql('ALTER TABLE ' . $this->getTable('tag') . ' CHANGE `label` `label` longtext CHARACTER SET utf8mb4 COLLATE utf8mb4_bin;');
         $this->addSql('ALTER TABLE ' . $this->getTable('tag') . ' CHANGE `slug` `slug` VARCHAR(128) CHARACTER SET utf8mb4 COLLATE utf8mb4_bin;');
@@ -22,7 +23,7 @@ final class Version20190511165128 extends WallabagMigration
 
     public function down(Schema $schema): void
     {
-        $this->skipIf('mysql' !== $this->connection->getDatabasePlatform()->getName(), 'This migration only apply to MySQL');
+        $this->skipIf(!$this->connection->getDatabasePlatform() instanceof MySQLPlatform, 'This migration only apply to MySQL');
 
         $this->addSql('ALTER TABLE ' . $this->getTable('tag') . ' CHANGE `slug` `slug` VARCHAR(128) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;');
         $this->addSql('ALTER TABLE ' . $this->getTable('tag') . ' CHANGE `label` `label` longtext CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;');

--- a/app/DoctrineMigrations/Version20190619093534.php
+++ b/app/DoctrineMigrations/Version20190619093534.php
@@ -2,6 +2,7 @@
 
 namespace Application\Migrations;
 
+use Doctrine\DBAL\Platforms\SqlitePlatform;
 use Doctrine\DBAL\Schema\Schema;
 use Wallabag\CoreBundle\Doctrine\WallabagMigration;
 
@@ -14,7 +15,7 @@ final class Version20190619093534 extends WallabagMigration
     public function up(Schema $schema): void
     {
         // this up() migration is auto-generated, please modify it to your needs
-        $this->skipIf('sqlite' !== $this->connection->getDatabasePlatform()->getName(), 'Migration can only be executed safely on \'sqlite\'.');
+        $this->skipIf(!$this->connection->getDatabasePlatform() instanceof SqlitePlatform, 'Migration can only be executed safely on \'sqlite\'.');
 
         $this->addSql('UPDATE ' . $this->getTable('entry', true) . ' SET reading_time = 0 WHERE reading_time IS NULL;');
 
@@ -42,7 +43,7 @@ final class Version20190619093534 extends WallabagMigration
     public function down(Schema $schema): void
     {
         // this down() migration is auto-generated, please modify it to your needs
-        $this->skipIf('sqlite' !== $this->connection->getDatabasePlatform()->getName(), 'Migration can only be executed safely on \'sqlite\'.');
+        $this->skipIf(!$this->connection->getDatabasePlatform() instanceof SqlitePlatform, 'Migration can only be executed safely on \'sqlite\'.');
 
         $this->addSql('DROP INDEX IDX_F4D18282A76ED395');
         $this->addSql('DROP INDEX created_at');

--- a/app/DoctrineMigrations/Version20190806130304.php
+++ b/app/DoctrineMigrations/Version20190806130304.php
@@ -2,6 +2,9 @@
 
 namespace Application\Migrations;
 
+use Doctrine\DBAL\Platforms\MySQLPlatform;
+use Doctrine\DBAL\Platforms\PostgreSQLPlatform;
+use Doctrine\DBAL\Platforms\SqlitePlatform;
 use Doctrine\DBAL\Schema\Schema;
 use Wallabag\CoreBundle\Doctrine\WallabagMigration;
 
@@ -18,8 +21,10 @@ final class Version20190806130304 extends WallabagMigration
 {
     public function up(Schema $schema): void
     {
-        switch ($this->connection->getDatabasePlatform()->getName()) {
-            case 'sqlite':
+        $platform = $this->connection->getDatabasePlatform();
+
+        switch (true) {
+            case $platform instanceof SqlitePlatform:
                 $this->addSql('DROP INDEX uid');
                 $this->addSql('DROP INDEX created_at');
                 $this->addSql('DROP INDEX hashed_url_user_id');
@@ -44,7 +49,7 @@ final class Version20190806130304 extends WallabagMigration
                 $this->addSql('CREATE INDEX tag_label ON ' . $this->getTable('tag', true) . ' (label)');
                 $this->addSql('CREATE INDEX config_feed_token ON ' . $this->getTable('config', true) . ' (feed_token)');
                 break;
-            case 'mysql':
+            case $platform instanceof MySQLPlatform:
                 $this->addSql('ALTER TABLE ' . $this->getTable('entry') . ' MODIFY language VARCHAR(20) DEFAULT NULL');
                 $this->addSql('CREATE INDEX user_language ON ' . $this->getTable('entry') . ' (language, user_id)');
                 $this->addSql('CREATE INDEX user_archived ON ' . $this->getTable('entry') . ' (user_id, is_archived, archived_at)');
@@ -53,7 +58,7 @@ final class Version20190806130304 extends WallabagMigration
                 $this->addSql('CREATE INDEX tag_label ON ' . $this->getTable('tag') . ' (label (255))');
                 $this->addSql('CREATE INDEX config_feed_token ON ' . $this->getTable('config') . ' (feed_token (255))');
                 break;
-            case 'postgresql':
+            case $platform instanceof PostgreSQLPlatform:
                 $this->addSql('ALTER TABLE ' . $this->getTable('entry') . ' ALTER language TYPE VARCHAR(20)');
                 $this->addSql('CREATE INDEX user_language ON ' . $this->getTable('entry') . ' (language, user_id)');
                 $this->addSql('CREATE INDEX user_archived ON ' . $this->getTable('entry') . ' (user_id, is_archived, archived_at)');
@@ -67,8 +72,10 @@ final class Version20190806130304 extends WallabagMigration
 
     public function down(Schema $schema): void
     {
-        switch ($this->connection->getDatabasePlatform()->getName()) {
-            case 'sqlite':
+        $platform = $this->connection->getDatabasePlatform();
+
+        switch (true) {
+            case $platform instanceof SqlitePlatform:
                 $this->addSql('DROP INDEX IDX_F4D18282A76ED395');
                 $this->addSql('DROP INDEX created_at');
                 $this->addSql('DROP INDEX uid');
@@ -93,7 +100,7 @@ final class Version20190806130304 extends WallabagMigration
                 $this->addSql('CREATE INDEX hashed_url_user_id ON ' . $this->getTable('entry', true) . ' (user_id, hashed_url)');
                 $this->addSql('CREATE INDEX hashed_given_url_user_id ON ' . $this->getTable('entry', true) . ' (user_id, hashed_given_url)');
                 break;
-            case 'mysql':
+            case $platform instanceof MySQLPlatform:
                 $this->addSql('ALTER TABLE ' . $this->getTable('entry') . ' MODIFY language LONGTEXT DEFAULT NULL');
                 $this->addSql('DROP INDEX user_language ON ' . $this->getTable('entry'));
                 $this->addSql('DROP INDEX user_archived ON ' . $this->getTable('entry'));
@@ -102,7 +109,7 @@ final class Version20190806130304 extends WallabagMigration
                 $this->addSql('DROP INDEX tag_label ON ' . $this->getTable('tag'));
                 $this->addSql('DROP INDEX config_feed_token ON ' . $this->getTable('config'));
                 break;
-            case 'postgresql':
+            case $platform instanceof PostgreSQLPlatform:
                 $this->addSql('ALTER TABLE ' . $this->getTable('entry') . ' ALTER language TYPE TEXT');
                 $this->addSql('DROP INDEX user_language ON ' . $this->getTable('entry'));
                 $this->addSql('DROP INDEX user_archived ON ' . $this->getTable('entry'));

--- a/app/DoctrineMigrations/Version20190808124957.php
+++ b/app/DoctrineMigrations/Version20190808124957.php
@@ -2,6 +2,9 @@
 
 namespace Application\Migrations;
 
+use Doctrine\DBAL\Platforms\MySQLPlatform;
+use Doctrine\DBAL\Platforms\PostgreSQLPlatform;
+use Doctrine\DBAL\Platforms\SqlitePlatform;
 use Doctrine\DBAL\Schema\Schema;
 use Wallabag\CoreBundle\Doctrine\WallabagMigration;
 
@@ -12,14 +15,16 @@ final class Version20190808124957 extends WallabagMigration
 {
     public function up(Schema $schema): void
     {
-        switch ($this->connection->getDatabasePlatform()->getName()) {
-            case 'sqlite':
+        $platform = $this->connection->getDatabasePlatform();
+
+        switch (true) {
+            case $platform instanceof SqlitePlatform:
                 $this->addSql('ALTER TABLE ' . $this->getTable('craue_config_setting', true) . ' RENAME TO ' . $this->getTable('internal_setting', true));
                 break;
-            case 'mysql':
+            case $platform instanceof MySQLPlatform:
                 $this->addSql('ALTER TABLE ' . $this->getTable('craue_config_setting') . ' RENAME ' . $this->getTable('internal_setting'));
                 break;
-            case 'postgresql':
+            case $platform instanceof PostgreSQLPlatform:
                 $this->addSql('ALTER TABLE ' . $this->getTable('craue_config_setting') . ' RENAME TO ' . $this->getTable('internal_setting'));
                 break;
         }
@@ -27,14 +32,16 @@ final class Version20190808124957 extends WallabagMigration
 
     public function down(Schema $schema): void
     {
-        switch ($this->connection->getDatabasePlatform()->getName()) {
-            case 'sqlite':
+        $platform = $this->connection->getDatabasePlatform();
+
+        switch (true) {
+            case $platform instanceof SqlitePlatform:
                 $this->addSql('ALTER TABLE ' . $this->getTable('internal_setting', true) . ' RENAME TO ' . $this->getTable('craue_config_setting', true));
                 break;
-            case 'mysql':
+            case $platform instanceof MySQLPlatform:
                 $this->addSql('ALTER TABLE ' . $this->getTable('internal_setting') . ' RENAME ' . $this->getTable('craue_config_setting'));
                 break;
-            case 'postgresql':
+            case $platform instanceof PostgreSQLPlatform:
                 $this->addSql('ALTER TABLE ' . $this->getTable('internal_setting') . ' RENAME TO ' . $this->getTable('craue_config_setting'));
                 break;
         }

--- a/app/DoctrineMigrations/Version20190826204730.php
+++ b/app/DoctrineMigrations/Version20190826204730.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Application\Migrations;
 
+use Doctrine\DBAL\Platforms\PostgreSQLPlatform;
 use Doctrine\DBAL\Schema\Schema;
 use Wallabag\CoreBundle\Doctrine\WallabagMigration;
 
@@ -23,7 +24,7 @@ final class Version20190826204730 extends WallabagMigration
             $userTable->setPrimaryKey(['id']);
             $userTable->addForeignKeyConstraint($this->getTable('config'), ['config_id'], ['id'], [], 'fk_config');
 
-            if ('postgresql' === $this->connection->getDatabasePlatform()->getName()) {
+            if ($this->connection->getDatabasePlatform() instanceof PostgreSQLPlatform) {
                 $schema->dropSequence('ignore_origin_user_rule_id_seq');
                 $schema->createSequence('ignore_origin_user_rule_id_seq');
             }
@@ -35,7 +36,7 @@ final class Version20190826204730 extends WallabagMigration
             $instanceTable->addColumn('rule', 'string', ['length' => 255]);
             $instanceTable->setPrimaryKey(['id']);
 
-            if ('postgresql' === $this->connection->getDatabasePlatform()->getName()) {
+            if ($this->connection->getDatabasePlatform() instanceof PostgreSQLPlatform) {
                 $schema->dropSequence('ignore_origin_instance_rule_id_seq');
                 $schema->createSequence('ignore_origin_instance_rule_id_seq');
             }

--- a/app/DoctrineMigrations/Version20221221092957.php
+++ b/app/DoctrineMigrations/Version20221221092957.php
@@ -2,6 +2,9 @@
 
 namespace Application\Migrations;
 
+use Doctrine\DBAL\Platforms\MySQLPlatform;
+use Doctrine\DBAL\Platforms\PostgreSQLPlatform;
+use Doctrine\DBAL\Platforms\SqlitePlatform;
 use Doctrine\DBAL\Schema\Schema;
 use Wallabag\CoreBundle\Doctrine\WallabagMigration;
 
@@ -13,8 +16,10 @@ final class Version20221221092957 extends WallabagMigration
     public function up(Schema $schema): void
     {
         $userTable = $this->getTable('user');
-        switch ($this->connection->getDatabasePlatform()->getName()) {
-            case 'sqlite':
+        $platform = $this->connection->getDatabasePlatform();
+
+        switch (true) {
+            case $platform instanceof SqlitePlatform:
                 $this->addSql('CREATE TEMPORARY TABLE __temp__wallabag_user AS SELECT id, username, username_canonical, email, email_canonical, enabled, password, last_login, password_requested_at, name, created_at, updated_at, authCode, emailTwoFactor, salt, confirmation_token, roles, googleAuthenticatorSecret, backupCodes FROM ' . $userTable);
                 $this->addSql('DROP TABLE ' . $userTable);
                 $this->addSql('CREATE TABLE ' . $userTable . ' (id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, username VARCHAR(180) NOT NULL, username_canonical VARCHAR(180) NOT NULL, email VARCHAR(180) NOT NULL, email_canonical VARCHAR(180) NOT NULL, enabled BOOLEAN NOT NULL, salt VARCHAR(255) DEFAULT NULL, password VARCHAR(255) NOT NULL, last_login DATETIME DEFAULT NULL, confirmation_token VARCHAR(180) DEFAULT NULL, password_requested_at DATETIME DEFAULT NULL, roles CLOB NOT NULL --(DC2Type:array)
@@ -26,10 +31,10 @@ final class Version20221221092957 extends WallabagMigration
                 $this->addSql('CREATE UNIQUE INDEX UNIQ_1D63E7E5A0D96FBF ON ' . $userTable . ' (email_canonical)');
                 $this->addSql('CREATE UNIQUE INDEX UNIQ_1D63E7E5C05FB297 ON ' . $userTable . ' (confirmation_token)');
                 break;
-            case 'mysql':
+            case $platform instanceof MySQLPlatform:
                 $this->addSql('ALTER TABLE ' . $userTable . ' CHANGE backupCodes backupCodes JSON DEFAULT NULL');
                 break;
-            case 'postgresql':
+            case $platform instanceof PostgreSQLPlatform:
                 $this->addSql('ALTER TABLE ' . $userTable . ' ALTER backupcodes TYPE JSON USING backupcodes::json');
                 break;
         }
@@ -38,8 +43,10 @@ final class Version20221221092957 extends WallabagMigration
     public function down(Schema $schema): void
     {
         $userTable = $this->getTable('user');
-        switch ($this->connection->getDatabasePlatform()->getName()) {
-            case 'sqlite':
+        $platform = $this->connection->getDatabasePlatform();
+
+        switch (true) {
+            case $platform instanceof SqlitePlatform:
                 $this->addSql('CREATE TEMPORARY TABLE __temp__wallabag_user AS SELECT id, username, username_canonical, email, email_canonical, enabled, salt, password, last_login, confirmation_token, password_requested_at, roles, name, created_at, updated_at, authCode, googleAuthenticatorSecret, backupCodes, emailTwoFactor FROM ' . $userTable);
                 $this->addSql('DROP TABLE ' . $userTable);
                 $this->addSql('CREATE TABLE ' . $userTable . ' (id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, username VARCHAR(180) NOT NULL, username_canonical VARCHAR(180) NOT NULL, email VARCHAR(180) NOT NULL, email_canonical VARCHAR(180) NOT NULL, enabled BOOLEAN NOT NULL, salt VARCHAR(255) DEFAULT NULL, password VARCHAR(255) NOT NULL, last_login DATETIME DEFAULT NULL, confirmation_token VARCHAR(180) DEFAULT NULL, password_requested_at DATETIME DEFAULT NULL, roles CLOB NOT NULL --(DC2Type:array)
@@ -51,10 +58,10 @@ final class Version20221221092957 extends WallabagMigration
                 $this->addSql('CREATE UNIQUE INDEX UNIQ_1D63E7E5A0D96FBF ON ' . $userTable . ' (email_canonical)');
                 $this->addSql('CREATE UNIQUE INDEX UNIQ_1D63E7E5C05FB297 ON ' . $userTable . ' (confirmation_token)');
                 break;
-            case 'mysql':
+            case $platform instanceof MySQLPlatform:
                 $this->addSql('ALTER TABLE ' . $userTable . ' CHANGE backupCodes backupCodes JSON DEFAULT NULL COMMENT \'(DC2Type:json_array)\'');
                 break;
-            case 'postgresql':
+            case $platform instanceof PostgreSQLPlatform:
                 $this->addSql('ALTER TABLE ' . $userTable . ' ALTER backupCodes TYPE TEXT');
                 break;
         }

--- a/src/Wallabag/CoreBundle/Command/InstallCommand.php
+++ b/src/Wallabag/CoreBundle/Command/InstallCommand.php
@@ -4,6 +4,9 @@ namespace Wallabag\CoreBundle\Command;
 
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Exception\DriverException;
+use Doctrine\DBAL\Platforms\MySQLPlatform;
+use Doctrine\DBAL\Platforms\PostgreSQLPlatform;
+use Doctrine\DBAL\Platforms\SqlitePlatform;
 use Doctrine\ORM\EntityManagerInterface;
 use FOS\UserBundle\Event\UserEvent;
 use FOS\UserBundle\FOSUserEvents;
@@ -138,7 +141,7 @@ class InstallCommand extends Command
         $help = '';
 
         // now check if MySQL isn't too old to handle utf8mb4
-        if ($conn->isConnected() && 'mysql' === $conn->getDatabasePlatform()->getName()) {
+        if ($conn->isConnected() && $conn->getDatabasePlatform() instanceof MySQLPlatform) {
             $version = $conn->query('select version()')->fetchOne();
             $minimalVersion = '5.5.4';
 
@@ -150,7 +153,7 @@ class InstallCommand extends Command
         }
 
         // testing if PostgreSQL > 9.1
-        if ($conn->isConnected() && 'postgresql' === $conn->getDatabasePlatform()->getName()) {
+        if ($conn->isConnected() && $conn->getDatabasePlatform() instanceof PostgreSQLPlatform) {
             // return version should be like "PostgreSQL 9.5.4 on x86_64-apple-darwin15.6.0, compiled by Apple LLVM version 8.0.0 (clang-800.0.38), 64-bit"
             $version = $conn->query('SELECT version();')->fetchOne();
 
@@ -391,7 +394,7 @@ class InstallCommand extends Command
         }
 
         // custom verification for sqlite, since `getListDatabasesSQL` doesn't work for sqlite
-        if ('sqlite' === $schemaManager->getDatabasePlatform()->getName()) {
+        if ($connection->getDatabasePlatform() instanceof SqlitePlatform) {
             $params = $connection->getParams();
 
             if (isset($params['path']) && file_exists($params['path'])) {

--- a/src/Wallabag/CoreBundle/Doctrine/WallabagMigration.php
+++ b/src/Wallabag/CoreBundle/Doctrine/WallabagMigration.php
@@ -2,6 +2,7 @@
 
 namespace Wallabag\CoreBundle\Doctrine;
 
+use Doctrine\DBAL\Platforms\PostgreSQLPlatform;
 use Doctrine\DBAL\Schema\Schema;
 use Doctrine\Migrations\AbstractMigration;
 use Symfony\Component\DependencyInjection\ContainerAwareInterface;
@@ -49,7 +50,7 @@ abstract class WallabagMigration extends AbstractMigration implements ContainerA
         }
 
         // escape table name is handled using " on postgresql
-        if ('postgresql' === $this->connection->getDatabasePlatform()->getName()) {
+        if ($this->connection->getDatabasePlatform() instanceof PostgreSQLPlatform) {
             return '"' . $table . '"';
         }
 


### PR DESCRIPTION
> Relying on the name of the platform is discouraged. To identify the platform, use its class name.

from https://github.com/doctrine/dbal/blob/3.6.x/UPGRADE.md#deprecated-abstractplatformgetname

remove ~177 direct depreciation, see from [2119](https://github.com/wallabag/wallabag/actions/runs/5743870218/job/15569056118#step:10:130) to [1942](https://github.com/wallabag/wallabag/actions/runs/5771991202/job/15646498327?pr=6799#step:10:130) for example