### PR TITLE
Move from transchoice to trans

### DIFF
--- a/src/Wallabag/CoreBundle/Resources/views/Entry/entries.html.twig
+++ b/src/Wallabag/CoreBundle/Resources/views/Entry/entries.html.twig
@@ -28,7 +28,7 @@
     <form name="form_mass_action" action="{{ path('mass_action') }}" method="post">
     <div class="results">
         <div class="nb-results">
-            {{ 'entry.list.number_on_the_page'|transchoice(entries.count) }}
+            {{ 'entry.list.number_on_the_page'|trans({'%count%': entries.count}) }}
             {% if entries.count > 0 %}
                 <a class="results-item" href="{{ path('switch_view_mode') }}"><i class="material-icons">{% if list_mode == 0 %}view_list{% else %}view_module{% endif %}</i></a>
             {% endif %}

--- a/src/Wallabag/CoreBundle/Resources/views/Entry/entry.html.twig
+++ b/src/Wallabag/CoreBundle/Resources/views/Entry/entry.html.twig
@@ -269,7 +269,7 @@
                     {% if entry.annotations|length %}
                         <li>
                             <i class="material-icons grey-text">comment</i>
-                            {{ 'entry.view.annotations_on_the_entry'|transchoice(entry.annotations|length) }}
+                            {{ 'entry.view.annotations_on_the_entry'|trans({'%count%': entry.annotations|length}) }}
                         </li>
                     {% endif %}
                     {% if entry.originUrl is not empty %}

--- a/src/Wallabag/CoreBundle/Resources/views/Tag/tags.html.twig
+++ b/src/Wallabag/CoreBundle/Resources/views/Tag/tags.html.twig
@@ -4,7 +4,7 @@
 
 {% block content %}
     <div class="results clearfix">
-        {{ 'tag.list.number_on_the_page'|transchoice(tags|length) }}
+        {{ 'tag.list.number_on_the_page'|trans({'%count%': tags|length}) }}
     </div>
 
     <div class="row">


### PR DESCRIPTION
> The `Templating\Helper\TranslatorHelper::transChoice()` method has been removed, use the `trans()` one instead with a `%count%` parameter.

from https://github.com/symfony/symfony/blob/4.4/UPGRADE-5.0.md#frameworkbundle