### PR TITLE
Ensure the kernel is shut down before calling createClient

### DIFF
--- a/tests/Wallabag/CoreBundle/WallabagCoreTestCase.php
+++ b/tests/Wallabag/CoreBundle/WallabagCoreTestCase.php
@@ -22,6 +22,8 @@ abstract class WallabagCoreTestCase extends WebTestCase
 
     protected function setUp(): void
     {
+        static::ensureKernelShutdown();
+
         parent::setUp();
 
         $this->client = static::createClient();
@@ -29,6 +31,8 @@ abstract class WallabagCoreTestCase extends WebTestCase
 
     public function getNewClient()
     {
+        static::ensureKernelShutdown();
+
         return $this->client = static::createClient();
     }
 


### PR DESCRIPTION
> Calling `WebTestCase::createClient()` while a kernel has been booted now throws an exception, ensure the kernel is shut down before calling the method

from https://github.com/symfony/symfony/blob/4.4/UPGRADE-5.0.md#frameworkbundle

remove ~9 direct depreciation, see from [2119](https://github.com/wallabag/wallabag/actions/runs/5743870218/job/15569056118#step:10:130) to [2110](https://github.com/wallabag/wallabag/actions/runs/5776682512/job/15656061556?pr=6803#step:10:130) for example