### PR TITLE
Make ImportController extends AbstractController

### DIFF
--- a/src/Wallabag/ImportBundle/Controller/ImportController.php
+++ b/src/Wallabag/ImportBundle/Controller/ImportController.php
@@ -4,13 +4,13 @@ namespace Wallabag\ImportBundle\Controller;
 
 use Craue\ConfigBundle\Util\Config;
 use Predis\Client;
-use Symfony\Bundle\FrameworkBundle\Controller\Controller;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\Routing\Annotation\Route;
 use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
 use Wallabag\ImportBundle\Consumer\RabbitMQConsumerTotalProxy;
 use Wallabag\ImportBundle\Import\ImportChain;
 
-class ImportController extends Controller
+class ImportController extends AbstractController
 {
     private RabbitMQConsumerTotalProxy $rabbitMQConsumerTotalProxy;
 


### PR DESCRIPTION
> Removed `Symfony\Bundle\FrameworkBundle\Controller\Controller`. Use `Symfony\Bundle\FrameworkBundle\Controller\AbstractController` instead.

from https://github.com/symfony/symfony/blob/4.4/UPGRADE-5.0.md#frameworkbundle