### PR TITLE
Resolve self depreciation

### DIFF
--- a/src/Wallabag/CoreBundle/Command/UpdatePicturesPathCommand.php
+++ b/src/Wallabag/CoreBundle/Command/UpdatePicturesPathCommand.php
@@ -46,11 +46,15 @@ class UpdatePicturesPathCommand extends Command
         $io->text('Retrieve existing entries');
         $i = 1;
         foreach ($query->toIterable() as $entry) {
-            $content = str_replace($oldUrl, $this->wallabagUrl, $entry->getContent());
-            $entry->setContent($content);
+            $content = $entry->getContent();
+            if (null !== $content) {
+                $entry->setContent(str_replace($oldUrl, $this->wallabagUrl, $content));
+            }
 
-            $previewPicture = str_replace($oldUrl, $this->wallabagUrl, $entry->getPreviewPicture());
-            $entry->setPreviewPicture($previewPicture);
+            $previewPicture = $entry->getPreviewPicture();
+            if (null !== $previewPicture) {
+                $entry->setPreviewPicture(str_replace($oldUrl, $this->wallabagUrl, $previewPicture));
+            }
 
             if (0 === ($i % 20)) {
                 $this->entityManager->flush();

--- a/src/Wallabag/CoreBundle/Controller/EntryController.php
+++ b/src/Wallabag/CoreBundle/Controller/EntryController.php
@@ -518,7 +518,7 @@ class EntryController extends AbstractController
         );
 
         // don't redirect user to the deleted entry (check that the referer doesn't end with the same url)
-        $prev = $request->getSession()->get('prevUrl');
+        $prev = $request->getSession()->get('prevUrl', '');
         $to = (1 !== preg_match('#' . $url . '$#i', $prev) ? $prev : null);
 
         $redirectUrl = $this->redirectHelper->to($to);

--- a/src/Wallabag/CoreBundle/Controller/TagController.php
+++ b/src/Wallabag/CoreBundle/Controller/TagController.php
@@ -45,7 +45,7 @@ class TagController extends AbstractController
         $form = $this->createForm(NewTagType::class, new Tag());
         $form->handleRequest($request);
 
-        $tags = $form->get('label')->getData();
+        $tags = $form->get('label')->getData() ?? '';
         $tagsExploded = explode(',', $tags);
 
         // avoid too much tag to be added

--- a/src/Wallabag/CoreBundle/DataFixtures/EntryFixtures.php
+++ b/src/Wallabag/CoreBundle/DataFixtures/EntryFixtures.php
@@ -17,6 +17,8 @@ class EntryFixtures extends Fixture implements DependentFixtureInterface
      */
     public function load(ObjectManager $manager): void
     {
+        $now = new \DateTime();
+
         $entries = [
             'entry1' => [
                 'user' => 'admin-user',
@@ -72,7 +74,7 @@ class EntryFixtures extends Fixture implements DependentFixtureInterface
                 'content' => 'This is my content /o/',
                 'language' => 'fr',
                 'starred' => true,
-                'starred_at' => new \DateTime(),
+                'starred_at' => $now,
                 'preview' => 'http://0.0.0.0/image.jpg',
             ],
             'entry6' => [
@@ -85,6 +87,7 @@ class EntryFixtures extends Fixture implements DependentFixtureInterface
                 'content' => 'This is my content /o/',
                 'language' => 'de',
                 'archived' => true,
+                'archived_at' => $now,
                 'tags' => ['bar-tag'],
                 'is_not_parsed' => true,
             ],
@@ -120,6 +123,10 @@ class EntryFixtures extends Fixture implements DependentFixtureInterface
 
             if (isset($item['archived'])) {
                 $entry->setArchived($item['archived']);
+            }
+
+            if (isset($item['archived_at'])) {
+                $entry->setArchivedAt($item['archived_at']);
             }
 
             if (isset($item['preview'])) {

--- a/src/Wallabag/CoreBundle/DataFixtures/EntryFixtures.php
+++ b/src/Wallabag/CoreBundle/DataFixtures/EntryFixtures.php
@@ -72,6 +72,7 @@ class EntryFixtures extends Fixture implements DependentFixtureInterface
                 'content' => 'This is my content /o/',
                 'language' => 'fr',
                 'starred' => true,
+                'starred_at' => new \DateTime(),
                 'preview' => 'http://0.0.0.0/image.jpg',
             ],
             'entry6' => [
@@ -111,6 +112,10 @@ class EntryFixtures extends Fixture implements DependentFixtureInterface
 
             if (isset($item['starred'])) {
                 $entry->setStarred($item['starred']);
+            }
+
+            if (isset($item['starred_at'])) {
+                $entry->setStarredAt($item['starred_at']);
             }
 
             if (isset($item['archived'])) {

--- a/src/Wallabag/CoreBundle/Form/Type/EntryFilterType.php
+++ b/src/Wallabag/CoreBundle/Form/Type/EntryFilterType.php
@@ -94,7 +94,7 @@ class EntryFilterType extends AbstractType
             ->add('domainName', TextFilterType::class, [
                 'apply_filter' => function (QueryInterface $filterQuery, $field, $values) {
                     $value = $values['value'];
-                    if (\strlen($value) <= 2 || empty($value)) {
+                    if (empty($value) || \strlen($value) <= 2) {
                         return false;
                     }
                     $expression = $filterQuery->getExpr()->like($field, $filterQuery->getExpr()->lower($filterQuery->getExpr()->literal('%' . $value . '%')));

--- a/src/Wallabag/CoreBundle/Twig/WallabagExtension.php
+++ b/src/Wallabag/CoreBundle/Twig/WallabagExtension.php
@@ -58,11 +58,19 @@ class WallabagExtension extends AbstractExtension implements GlobalsInterface
 
     public function removeWww($url)
     {
+        if (!\is_string($url)) {
+            return $url;
+        }
+
         return preg_replace('/^www\./i', '', $url);
     }
 
     public function removeScheme($url)
     {
+        if (!\is_string($url)) {
+            return $url;
+        }
+
         return preg_replace('#^https?://#i', '', $url);
     }
 

--- a/tests/Wallabag/ApiBundle/Controller/EntryRestControllerTest.php
+++ b/tests/Wallabag/ApiBundle/Controller/EntryRestControllerTest.php
@@ -1065,7 +1065,7 @@ class EntryRestControllerTest extends WallabagApiTestCase
         $content = json_decode($this->client->getResponse()->getContent(), true);
 
         $this->assertSame(1, $content['is_starred']);
-        $this->assertGreaterThanOrEqual($now->getTimestamp(), (new \DateTime($content['starred_at']))->getTimestamp());
+        $this->assertGreaterThanOrEqual((new \DateTime($content['starred_at']))->getTimestamp(), $now->getTimestamp());
     }
 
     public function dataForEntriesExistWithUrl()

--- a/tests/Wallabag/ApiBundle/Controller/EntryRestControllerTest.php
+++ b/tests/Wallabag/ApiBundle/Controller/EntryRestControllerTest.php
@@ -1022,6 +1022,7 @@ class EntryRestControllerTest extends WallabagApiTestCase
 
     public function testSaveIsArchivedAfterPatch()
     {
+        $now = new \DateTime();
         $entry = $this->client->getContainer()
             ->get(EntityManagerInterface::class)
             ->getRepository(Entry::class)
@@ -1043,6 +1044,7 @@ class EntryRestControllerTest extends WallabagApiTestCase
 
         $this->assertSame(1, $content['is_archived']);
         $this->assertSame($previousTitle . '++', $content['title']);
+        $this->assertGreaterThanOrEqual((new \DateTime($content['archived_at']))->getTimestamp(), $now->getTimestamp());
     }
 
     public function testSaveIsStarredAfterPatch()
@@ -1056,6 +1058,9 @@ class EntryRestControllerTest extends WallabagApiTestCase
         if (!$entry) {
             $this->markTestSkipped('No content found in db.');
         }
+
+        $previousTitle = $entry->getTitle();
+
         $this->client->request('PATCH', '/api/entries/' . $entry->getId() . '.json', [
             'title' => $entry->getTitle() . '++',
         ]);
@@ -1065,6 +1070,7 @@ class EntryRestControllerTest extends WallabagApiTestCase
         $content = json_decode($this->client->getResponse()->getContent(), true);
 
         $this->assertSame(1, $content['is_starred']);
+        $this->assertSame($previousTitle . '++', $content['title']);
         $this->assertGreaterThanOrEqual((new \DateTime($content['starred_at']))->getTimestamp(), $now->getTimestamp());
     }
 

--- a/tests/Wallabag/CoreBundle/Twig/WallabagExtensionTest.php
+++ b/tests/Wallabag/CoreBundle/Twig/WallabagExtensionTest.php
@@ -59,6 +59,7 @@ class WallabagExtensionTest extends TestCase
         $this->assertSame('lemonde.fr', $extension->removeScheme('lemonde.fr'));
         $this->assertSame('gist.github.com', $extension->removeScheme('gist.github.com'));
         $this->assertSame('gist.github.com', $extension->removeScheme('https://gist.github.com'));
+        $this->assertSame('gist.github.com', $extension->removeScheme('http://gist.github.com'));
     }
 
     public function testRemoveSchemeAndWww()
@@ -82,8 +83,10 @@ class WallabagExtensionTest extends TestCase
         $extension = new WallabagExtension($entryRepository, $tagRepository, $tokenStorage, 0, $translator, '');
 
         $this->assertSame('lemonde.fr', $extension->removeSchemeAndWww('www.lemonde.fr'));
+        $this->assertSame('lemonde.fr', $extension->removeSchemeAndWww('http://www.lemonde.fr'));
         $this->assertSame('lemonde.fr', $extension->removeSchemeAndWww('http://lemonde.fr'));
         $this->assertSame('lemonde.fr', $extension->removeSchemeAndWww('https://www.lemonde.fr'));
+        $this->assertSame('lemonde.fr', $extension->removeSchemeAndWww('https://lemonde.fr'));
         $this->assertSame('gist.github.com', $extension->removeSchemeAndWww('https://gist.github.com'));
         $this->assertSame('ftp://gist.github.com', $extension->removeSchemeAndWww('ftp://gist.github.com'));
     }


### PR DESCRIPTION
All self depreciation notices were about accepting null in some functions is deprecated.
And it looks like there was a bug in entry PATCH action tests that made them pass why not working as expected