### PR TITLE
Force secure cookie on HTTPS connection

### DIFF
--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -29,6 +29,7 @@ framework:
         # handler_id set to null will use default session handler from php.ini
         handler_id: session.handler.native_file
         save_path: "%kernel.project_dir%/var/sessions/%kernel.environment%"
+        cookie_secure: auto
     fragments: ~
     http_method_override: true
     assets: ~


### PR DESCRIPTION
Cookie will be set as `secure` when the connection will be on HTTPS otherwise the cookie will be defined as `secure: false`.

I used `mkcert` to  test it locally.

<img width="1114" alt="image" src="https://github.com/wallabag/wallabag/assets/62333/c39306a2-ef07-40be-8161-472c533ef110">

See:
- https://symfony.com/doc/4.4/reference/configuration/framework.html#cookie-secure
- [CWE-614: Sensitive Cookie in HTTPS Session Without 'Secure' Attribute ](https://cwe.mitre.org/data/definitions/614.html)