### PR TITLE
Move grouping deps in the right place

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,13 @@ updates:
     time: "04:00"
     timezone: Europe/Paris
   open-pull-requests-limit: 10
+  groups:
+    babel-dependencies:
+      patterns:
+        - "*babel*"
+    fontsource-dependencies:
+      patterns:
+        - "*fontsource*"
   ignore:
   - dependency-name: materialize-css
     versions:
@@ -18,17 +25,14 @@ updates:
     time: "04:00"
     timezone: Europe/Paris
   open-pull-requests-limit: 10
+  groups:
+    symfony-dependencies:
+      patterns:
+        - "*symfony*"
   reviewers:
   - j0k3r
   - tcitworld
   - Kdecherf
-  groups:
-    babel-dependencies:
-      patterns:
-        - "*babel*"
-    fontsource-dependencies:
-      patterns:
-        - "*fontsource*"
   ignore:
   - dependency-name: lcobucci/jwt
     versions:


### PR DESCRIPTION
I put npm grouped deps inside the composer section, which is why it wasn't working. I move it in the right place and also added one grouped deps for Symfony*