### PR TITLE
Fix deprecated null tag parameter

### DIFF
--- a/src/Wallabag/CoreBundle/Controller/TagController.php
+++ b/src/Wallabag/CoreBundle/Controller/TagController.php
@@ -45,7 +45,7 @@ class TagController extends AbstractController
         $form = $this->createForm(NewTagType::class, new Tag());
         $form->handleRequest($request);
 
-        $tags = $form->get('label')->getData();
+        $tags = $form->get('label')->getData() ?? '';
         $tagsExploded = explode(',', $tags);
 
         // avoid too much tag to be added


### PR DESCRIPTION
Fix PHP8.1+ deprecation:
````
Got error '
PHP message: PHP Deprecated:  explode(): Passing null to parameter #2 ($string) of type string is deprecated in /var/www/wallabag/src/Wallabag/CoreBundle/Controller/TagController.php on line 49
PHP message: PHP Deprecated:  strlen(): Passing null to parameter #1 ($string) of type string is deprecated in /var/www/wallabag/src/Wallabag/CoreBundle/Controller/TagController.php on line 52'
````