### PR TITLE
Fix symfony pattern for dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -28,7 +28,7 @@ updates:
   groups:
     symfony-dependencies:
       patterns:
-        - "*symfony*"
+        - "symfony/*"
   reviewers:
   - j0k3r
   - tcitworld


### PR DESCRIPTION
`*symfony*` matches to much deps (ie `phpstan-symfony`, see https://github.com/wallabag/wallabag/pull/7004) which aren't related to Symfony release. `symfony/*` will properly match Symfony release better.