### PR TITLE
Fix/dark mode disabled url

### DIFF
--- a/app/Resources/static/themes/material/css/dark_theme.scss
+++ b/app/Resources/static/themes/material/css/dark_theme.scss
@@ -131,6 +131,10 @@
     color: #abb2bf;
   }
 
+  input[type="url"]:not(.browser-default):disabled {
+    color: #9e9e9e;
+  }
+
   .input-field.nav-panel-add.disabled,
   .input-field.nav-panel-add.disabled input {
     background-color: transparent;

--- a/app/Resources/static/themes/material/css/dark_theme.scss
+++ b/app/Resources/static/themes/material/css/dark_theme.scss
@@ -85,6 +85,7 @@
     background-color: #2f2f2f;
   }
 
+  .mass-action-tags .mass-action-tags-input.mass-action-tags-input,
   .side-nav li:not(.logo) > a:hover,
   .side-nav .collapsible-header:hover,
   .side-nav.fixed .collapsible-header:hover {


### PR DESCRIPTION
Fix #7127
Wrong color for edit URL with dark mode enabled:
![wallabag-fix-url-edit-dark-mode](https://github.com/wallabag/wallabag/assets/582666/f1c24225-db8c-4ecd-9c2e-69c786ab1502)

And a fix for the add tags input with dark mode enabled:
![wallabag-fix-add-tags-dark-mode](https://github.com/wallabag/wallabag/assets/582666/76ac0bcc-ea05-48da-8e14-6f36d7408dfc)
