### PR TITLE
wallassets folder added to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,7 +29,7 @@ web/uploads/
 !/web/bundles/.gitkeep
 /web/assets/images/*
 !web/assets/images/.gitkeep
-/web/wallassets/*.dev.js
+/web/wallassets/*
 
 # Build
 /app/build


### PR DESCRIPTION
If I get it correctly, the assets are generated during the release process so we should avoid the `wallassets` folder to be commited again. ping @yguedidi 