### PR TITLE
Fix deprecation

### DIFF
--- a/src/Wallabag/CoreBundle/Controller/ConfigController.php
+++ b/src/Wallabag/CoreBundle/Controller/ConfigController.php
@@ -668,7 +668,7 @@ class ConfigController extends AbstractController
      */
     public function setLocaleAction(Request $request, ValidatorInterface $validator, $language = null)
     {
-        $errors = $validator->validate($language, (new LocaleConstraint()));
+        $errors = $validator->validate($language, (new LocaleConstraint(['canonicalize' => true])));
 
         if (0 === \count($errors)) {
             $request->getSession()->set('_locale', $language);

--- a/src/Wallabag/CoreBundle/Helper/ContentProxy.php
+++ b/src/Wallabag/CoreBundle/Helper/ContentProxy.php
@@ -98,7 +98,7 @@ class ContentProxy
 
         $errors = $this->validator->validate(
             $value,
-            (new LocaleConstraint())
+            (new LocaleConstraint(['canonicalize' => true]))
         );
 
         if (0 === \count($errors)) {

--- a/tests/Wallabag/ApiBundle/Controller/ConfigRestControllerTest.php
+++ b/tests/Wallabag/ApiBundle/Controller/ConfigRestControllerTest.php
@@ -31,7 +31,7 @@ class ConfigRestControllerTest extends WallabagApiTestCase
 
     public function testGetConfigWithoutAuthentication()
     {
-        $client = static::createClient();
+        $client = $this->createUnauthorizedClient();
         $client->request('GET', '/api/config.json');
         $this->assertSame(401, $client->getResponse()->getStatusCode());
 

--- a/tests/Wallabag/ApiBundle/Controller/UserRestControllerTest.php
+++ b/tests/Wallabag/ApiBundle/Controller/UserRestControllerTest.php
@@ -30,7 +30,7 @@ class UserRestControllerTest extends WallabagApiTestCase
 
     public function testGetUserWithoutAuthentication()
     {
-        $client = static::createClient();
+        $client = $this->createUnauthorizedClient();
         $client->request('GET', '/api/user.json');
         $this->assertSame(401, $client->getResponse()->getStatusCode());
 
@@ -80,7 +80,7 @@ class UserRestControllerTest extends WallabagApiTestCase
     public function testCreateNewUserWithoutAuthentication()
     {
         // create a new client instead of using $this->client to be sure client isn't authenticated
-        $client = static::createClient();
+        $client = $this->createUnauthorizedClient();
         $client->getContainer()->get(Config::class)->set('api_user_registration', 1);
         $client->request('PUT', '/api/user.json', [
             'username' => 'google',
@@ -115,7 +115,7 @@ class UserRestControllerTest extends WallabagApiTestCase
 
     public function testCreateNewUserWithExistingEmail()
     {
-        $client = static::createClient();
+        $client = $this->createUnauthorizedClient();
         $client->getContainer()->get(Config::class)->set('api_user_registration', 1);
         $client->request('PUT', '/api/user.json', [
             'username' => 'admin',
@@ -144,7 +144,7 @@ class UserRestControllerTest extends WallabagApiTestCase
 
     public function testCreateNewUserWithTooShortPassword()
     {
-        $client = static::createClient();
+        $client = $this->createUnauthorizedClient();
         $client->getContainer()->get(Config::class)->set('api_user_registration', 1);
         $client->request('PUT', '/api/user.json', [
             'username' => 'facebook',
@@ -168,7 +168,7 @@ class UserRestControllerTest extends WallabagApiTestCase
 
     public function testCreateNewUserWhenRegistrationIsDisabled()
     {
-        $client = static::createClient();
+        $client = $this->createUnauthorizedClient();
         $client->request('PUT', '/api/user.json', [
             'username' => 'facebook',
             'password' => 'face',

--- a/tests/Wallabag/ApiBundle/Controller/WallabagRestControllerTest.php
+++ b/tests/Wallabag/ApiBundle/Controller/WallabagRestControllerTest.php
@@ -10,7 +10,7 @@ class WallabagRestControllerTest extends WallabagApiTestCase
     public function testGetVersion()
     {
         // create a new client instead of using $this->client to be sure client isn't authenticated
-        $client = static::createClient();
+        $client = $this->createUnauthorizedClient();
         $client->request('GET', '/api/version');
 
         $this->assertSame(200, $client->getResponse()->getStatusCode());
@@ -23,7 +23,7 @@ class WallabagRestControllerTest extends WallabagApiTestCase
     public function testGetInfo()
     {
         // create a new client instead of using $this->client to be sure client isn't authenticated
-        $client = static::createClient();
+        $client = $this->createUnauthorizedClient();
         $client->request('GET', '/api/info');
 
         $this->assertSame(200, $client->getResponse()->getStatusCode());
@@ -40,7 +40,7 @@ class WallabagRestControllerTest extends WallabagApiTestCase
     public function testAllowedRegistration()
     {
         // create a new client instead of using $this->client to be sure client isn't authenticated
-        $client = static::createClient();
+        $client = $this->createUnauthorizedClient();
 
         if (!$client->getContainer()->getParameter('fosuser_registration')) {
             $this->markTestSkipped('fosuser_registration is not enabled.');

--- a/tests/Wallabag/ApiBundle/WallabagApiTestCase.php
+++ b/tests/Wallabag/ApiBundle/WallabagApiTestCase.php
@@ -34,9 +34,19 @@ abstract class WallabagApiTestCase extends WebTestCase
     /**
      * @return KernelBrowser
      */
+    protected function createUnauthorizedClient()
+    {
+        static::ensureKernelShutdown();
+
+        return static::createClient();
+    }
+
+    /**
+     * @return KernelBrowser
+     */
     protected function createAuthorizedClient()
     {
-        $client = static::createClient();
+        $client = $this->createUnauthorizedClient();
         $container = $client->getContainer();
 
         /** @var UserManager $userManager */

--- a/tests/Wallabag/CoreBundle/Command/InstallCommandTest.php
+++ b/tests/Wallabag/CoreBundle/Command/InstallCommandTest.php
@@ -76,7 +76,7 @@ class InstallCommandTest extends WallabagCoreTestCase
         } else {
             // Create a new client to avoid the error:
             // Transaction commit failed because the transaction has been marked for rollback only.
-            $client = static::createClient();
+            $client = $this->getNewClient();
             $this->resetDatabase($client);
         }
 

--- a/tests/Wallabag/CoreBundle/WallabagCoreTestCase.php
+++ b/tests/Wallabag/CoreBundle/WallabagCoreTestCase.php
@@ -71,7 +71,7 @@ abstract class WallabagCoreTestCase extends WebTestCase
          * [Doctrine\DBAL\ConnectionException]
          * Transaction commit failed because the transaction has been marked for rollback only.
          */
-        $this->client = static::createClient();
+        $this->client = $this->getNewClient();
     }
 
     public function getEntityManager()


### PR DESCRIPTION
Move from [176](https://github.com/wallabag/wallabag/actions/runs/7298018512/job/19888237846#step:10:107) direct deprecation notices to [73](https://github.com/wallabag/wallabag/actions/runs/7320835512/job/19940459396#step:10:104) on PHP 8.1 with sqlite!

72 are from Doctrine and I think it's OK to keep them for now.
The last on is about `Symfony\Component\DomCrawler\Crawler::text()` and it's OK to keep it also as we don't need whitespace normalization in [that single usage in tests](https://github.com/wallabag/wallabag/blob/master/tests/Wallabag/CoreBundle/Controller/EntryControllerTest.php#L594-L595).

Find below the remaining 73.

```
Remaining direct deprecation notices (73)

  44x: Method Doctrine\ORM\Event\LifecycleEventArgs::getEntity() is deprecated and will be removed in Doctrine ORM 3.0. Use getObject() instead. (LifecycleEventArgs.php:49 called by SQLiteCascadeDeleteSubscriber.php:43, https://github.com/doctrine/orm/issues/9875, package doctrine/orm)
    4x in TagRestControllerTest::testDeleteTagsByLabel from Tests\Wallabag\ApiBundle\Controller
    3x in ConfigControllerTest::testDeleteAccount from Tests\Wallabag\CoreBundle\Controller
    2x in AnnotationControllerTest::testEditAnnotation from Tests\Wallabag\AnnotationBundle\Controller
    2x in AnnotationControllerTest::testDeleteAnnotation from Tests\Wallabag\AnnotationBundle\Controller
    2x in TagRestControllerTest::testDeleteTagByLabel from Tests\Wallabag\ApiBundle\Controller
    ...

  12x: Subscribing to postConnect events is deprecated. Implement a middleware instead. (Connection.php:391 called by Connection.php:452, https://github.com/doctrine/dbal/issues/5784, package doctrine/dbal)
    6x in InstallCommandTest::setUp from Tests\Wallabag\CoreBundle\Command
    1x in InstallCommandTest::testRunInstallCommand from Tests\Wallabag\CoreBundle\Command
    1x in InstallCommandTest::testRunInstallCommandWithReset from Tests\Wallabag\CoreBundle\Command
    1x in InstallCommandTest::testRunInstallCommandWithDatabaseRemoved from Tests\Wallabag\CoreBundle\Command
    1x in InstallCommandTest::testRunInstallCommandChooseResetSchema from Tests\Wallabag\CoreBundle\Command
    ...

  5x: Public access to Connection::connect() is deprecated. (Connection.php:369 called by InstallCommand.php:126, https://github.com/doctrine/dbal/issues/4966, package doctrine/dbal)
    1x in InstallCommandTest::testRunInstallCommand from Tests\Wallabag\CoreBundle\Command
    1x in InstallCommandTest::testRunInstallCommandWithReset from Tests\Wallabag\CoreBundle\Command
    1x in InstallCommandTest::testRunInstallCommandChooseResetSchema from Tests\Wallabag\CoreBundle\Command
    1x in InstallCommandTest::testRunInstallCommandChooseNothing from Tests\Wallabag\CoreBundle\Command
    1x in InstallCommandTest::testRunInstallCommandNoInteraction from Tests\Wallabag\CoreBundle\Command

  4x: Connection::getSchemaManager() is deprecated, use Connection::createSchemaManager() instead. (Connection.php:1700 called by InstallCommand.php:381, https://github.com/doctrine/dbal/issues/4515, package doctrine/dbal)
    1x in InstallCommandTest::testRunInstallCommand from Tests\Wallabag\CoreBundle\Command
    1x in InstallCommandTest::testRunInstallCommandChooseResetSchema from Tests\Wallabag\CoreBundle\Command
    1x in InstallCommandTest::testRunInstallCommandChooseNothing from Tests\Wallabag\CoreBundle\Command
    1x in InstallCommandTest::testRunInstallCommandNoInteraction from Tests\Wallabag\CoreBundle\Command

  3x: Connection::getSchemaManager() is deprecated, use Connection::createSchemaManager() instead. (Connection.php:1700 called by InstallCommand.php:424, https://github.com/doctrine/dbal/issues/4515, package doctrine/dbal)
    1x in InstallCommandTest::testRunInstallCommandChooseResetSchema from Tests\Wallabag\CoreBundle\Command
    1x in InstallCommandTest::testRunInstallCommandChooseNothing from Tests\Wallabag\CoreBundle\Command
    1x in InstallCommandTest::testRunInstallCommandNoInteraction from Tests\Wallabag\CoreBundle\Command

  3x: Doctrine\DBAL\Configuration::setSQLLogger is deprecated, use setMiddlewares() and Logging\Middleware instead. (Configuration.php:87 called by ImportCommand.php:102, https://github.com/doctrine/dbal/pull/4967, package doctrine/dbal)
    1x in ImportCommandTest::testRunImportCommandWithWrongUsername from Tests\Wallabag\ImportBundle\Command
    1x in ImportCommandTest::testRunImportCommand from Tests\Wallabag\ImportBundle\Command
    1x in ImportCommandTest::testRunImportCommandWithUserId from Tests\Wallabag\ImportBundle\Command

  1x: Subscribing to postConnect events is deprecated. Implement a middleware instead. (Connection.php:391 called by InstallCommand.php:126, https://github.com/doctrine/dbal/issues/5784, package doctrine/dbal)
    1x in InstallCommandTest::testRunInstallCommandChooseNothing from Tests\Wallabag\CoreBundle\Command

  1x: "Symfony\Component\DomCrawler\Crawler::text()" will normalize whitespaces by default in Symfony 5.0, set the second "$normalizeWhitespace" argument to false to retrieve the non-normalized version of the text.
    1x in EntryControllerTest::testEditUpdate from Tests\Wallabag\CoreBundle\Controller
```

Symfony 5 is around the corner! 🙂 