### PR TITLE
Make database dependent commands lazy

### DIFF
--- a/app/config/services.yml
+++ b/app/config/services.yml
@@ -268,9 +268,23 @@ services:
         arguments:
             $baseFolder: "%kernel.project_dir%/web/assets/images"
 
+    Wallabag\CoreBundle\Command\CleanDownloadedImagesCommand:
+        tags:
+            - { name: console.command, command: 'wallabag:clean-downloaded-images' }
+
+    Wallabag\CoreBundle\Command\CleanDuplicatesCommand:
+        tags:
+            - { name: console.command, command: 'wallabag:clean-duplicates' }
+
     Wallabag\CoreBundle\Command\ExportCommand:
         arguments:
             $projectDir: '%kernel.project_dir%'
+        tags:
+            - { name: console.command, command: 'wallabag:export' }
+
+    Wallabag\CoreBundle\Command\GenerateUrlHashesCommand:
+        tags:
+            - { name: console.command, command: 'wallabag:generate-hashed-urls' }
 
     Wallabag\CoreBundle\Command\InstallCommand:
         arguments:
@@ -278,6 +292,26 @@ services:
             $databaseName: '%database_name%'
             $defaultSettings: '%wallabag_core.default_internal_settings%'
             $defaultIgnoreOriginInstanceRules: '%wallabag_core.default_ignore_origin_instance_rules%'
+
+    Wallabag\CoreBundle\Command\ListUserCommand:
+        tags:
+            - { name: console.command, command: 'wallabag:user:list' }
+
+    Wallabag\CoreBundle\Command\ReloadEntryCommand:
+        tags:
+            - { name: console.command, command: 'wallabag:entry:reload' }
+
+    Wallabag\CoreBundle\Command\ShowUserCommand:
+        tags:
+            - { name: console.command, command: 'wallabag:user:show' }
+
+    Wallabag\CoreBundle\Command\TagAllCommand:
+        tags:
+            - { name: console.command, command: 'wallabag:tag:all' }
+
+    Wallabag\ImportBundle\Command\ImportCommand:
+        tags:
+            - { name: console.command, command: 'wallabag:import' }
 
     wallabag_core.entry.download_images.client:
         alias: 'httplug.client.wallabag_core.entry.download_images'


### PR DESCRIPTION
No more database connection errors on first composer install! 🎉 

Before: https://github.com/wallabag/wallabag/actions/runs/7303332338/job/19903631251#step:7:392
![image](https://github.com/wallabag/wallabag/assets/1480128/06182dad-16c1-484a-9597-3363c83efbd1)

After: https://github.com/wallabag/wallabag/actions/runs/7332455594/job/19966621958?pr=7142#step:7:390
![image](https://github.com/wallabag/wallabag/assets/1480128/1d122f9a-0839-4813-890b-9c96437efb8b)
