### PR TITLE
Drop database if exists

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -38,7 +38,7 @@ prepare: clean ## Prepare database for testsuite
 ifdef DB
 	cp app/config/tests/parameters_test.$(DB).yml app/config/parameters_test.yml
 endif
-	-php bin/console doctrine:database:drop --force --env=test
+	php bin/console doctrine:database:drop --force --if-exists --env=test
 	php bin/console doctrine:database:create --env=test
 	php bin/console doctrine:migrations:migrate --no-interaction --env=test -vv
 

--- a/src/Wallabag/CoreBundle/Command/InstallCommand.php
+++ b/src/Wallabag/CoreBundle/Command/InstallCommand.php
@@ -202,7 +202,7 @@ class InstallCommand extends Command
             $this->io->text('Dropping database, creating database and schema, clearing the cache');
 
             $this
-                ->runCommand('doctrine:database:drop', ['--force' => true])
+                ->runCommand('doctrine:database:drop', ['--force' => true, '--if-exists' => true])
                 ->runCommand('doctrine:database:create')
                 ->runCommand('doctrine:migrations:migrate', ['--no-interaction' => true])
                 ->runCommand('cache:clear')
@@ -231,7 +231,7 @@ class InstallCommand extends Command
             $this->io->text('Dropping database, creating database and schema...');
 
             $this
-                ->runCommand('doctrine:database:drop', ['--force' => true])
+                ->runCommand('doctrine:database:drop', ['--force' => true, '--if-exists' => true])
                 ->runCommand('doctrine:database:create')
                 ->runCommand('doctrine:migrations:migrate', ['--no-interaction' => true])
             ;

--- a/tests/Wallabag/CoreBundle/Command/InstallCommandTest.php
+++ b/tests/Wallabag/CoreBundle/Command/InstallCommandTest.php
@@ -162,6 +162,7 @@ class InstallCommandTest extends WallabagCoreTestCase
         $command = $application->find('doctrine:database:drop');
         $command->run(new ArrayInput([
             '--force' => true,
+            '--if-exists' => true,
         ]), new NullOutput());
 
         // start a new application to avoid lagging connexion to pgsql
@@ -234,6 +235,7 @@ class InstallCommandTest extends WallabagCoreTestCase
         $command = $application->find('doctrine:database:drop');
         $command->run(new ArrayInput([
             '--force' => true,
+            '--if-exists' => true,
         ]), new NullOutput());
 
         $this->getTestClient()->getContainer()->get(ManagerRegistry::class)->getConnection()->close();


### PR DESCRIPTION
Just because it's safer and avoid to trigger an error, just in case :)