### PR TITLE
Make tests use dev database config

### DIFF
--- a/app/AppKernel.php
+++ b/app/AppKernel.php
@@ -97,5 +97,47 @@ class AppKernel extends Kernel
             // $container->setParameter('container.dumper.inline_class_loader', true);
             $container->addObjectResource($this);
         });
+
+        $loader->load(function (ContainerBuilder $container) {
+            $this->processDatabaseParameters($container);
+
+            if ('test' === $container->getParameter('kernel.environment')) {
+                $this->processDatabaseParameters($container, true);
+            }
+        });
+    }
+
+    private function processDatabaseParameters(ContainerBuilder $container, bool $isTest = false)
+    {
+        $prefix = '';
+
+        if ($isTest) {
+            $prefix = 'test_';
+        }
+
+        switch ($container->getParameter($prefix . 'database_driver')) {
+            case 'pdo_mysql':
+                $scheme = 'mysql';
+                break;
+            case 'pdo_pgsql':
+                $scheme = 'pgsql';
+                break;
+            case 'pdo_sqlite':
+                $scheme = 'sqlite';
+                break;
+            default:
+                throw new \RuntimeException('Unsupported database driver: ' . $container->getParameter($prefix . 'database_driver'));
+        }
+
+        $container->setParameter($prefix . 'database_scheme', $scheme);
+
+        if ('sqlite' === $scheme) {
+            $container->setParameter($prefix . 'database_name', $container->getParameter($prefix . 'database_path'));
+        }
+
+        $container->setParameter($prefix . 'database_user', (string) $container->getParameter($prefix . 'database_user'));
+        $container->setParameter($prefix . 'database_password', (string) $container->getParameter($prefix . 'database_password'));
+        $container->setParameter($prefix . 'database_port', (string) $container->getParameter($prefix . 'database_port'));
+        $container->setParameter($prefix . 'database_socket', (string) $container->getParameter($prefix . 'database_socket'));
     }
 }

--- a/app/AppKernel.php
+++ b/app/AppKernel.php
@@ -100,22 +100,12 @@ class AppKernel extends Kernel
 
         $loader->load(function (ContainerBuilder $container) {
             $this->processDatabaseParameters($container);
-
-            if ('test' === $container->getParameter('kernel.environment')) {
-                $this->processDatabaseParameters($container, true);
-            }
         });
     }
 
-    private function processDatabaseParameters(ContainerBuilder $container, bool $isTest = false)
+    private function processDatabaseParameters(ContainerBuilder $container)
     {
-        $prefix = '';
-
-        if ($isTest) {
-            $prefix = 'test_';
-        }
-
-        switch ($container->getParameter($prefix . 'database_driver')) {
+        switch ($container->getParameter('database_driver')) {
             case 'pdo_mysql':
                 $scheme = 'mysql';
                 break;
@@ -126,18 +116,18 @@ class AppKernel extends Kernel
                 $scheme = 'sqlite';
                 break;
             default:
-                throw new \RuntimeException('Unsupported database driver: ' . $container->getParameter($prefix . 'database_driver'));
+                throw new \RuntimeException('Unsupported database driver: ' . $container->getParameter('database_driver'));
         }
 
-        $container->setParameter($prefix . 'database_scheme', $scheme);
+        $container->setParameter('database_scheme', $scheme);
 
         if ('sqlite' === $scheme) {
-            $container->setParameter($prefix . 'database_name', $container->getParameter($prefix . 'database_path'));
+            $container->setParameter('database_name', $container->getParameter('database_path'));
         }
 
-        $container->setParameter($prefix . 'database_user', (string) $container->getParameter($prefix . 'database_user'));
-        $container->setParameter($prefix . 'database_password', (string) $container->getParameter($prefix . 'database_password'));
-        $container->setParameter($prefix . 'database_port', (string) $container->getParameter($prefix . 'database_port'));
-        $container->setParameter($prefix . 'database_socket', (string) $container->getParameter($prefix . 'database_socket'));
+        $container->setParameter('database_user', (string) $container->getParameter('database_user'));
+        $container->setParameter('database_password', (string) $container->getParameter('database_password'));
+        $container->setParameter('database_port', (string) $container->getParameter('database_port'));
+        $container->setParameter('database_socket', (string) $container->getParameter('database_socket'));
     }
 }

--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -8,6 +8,7 @@ parameters:
     # Allows to use the live reload feature for changes in assets
     use_webpack_dev_server: false
     craue_config.cache_adapter.class: Craue\ConfigBundle\CacheAdapter\SymfonyCacheComponentAdapter
+    env(DATABASE_URL): '%database_scheme%://%database_user%:%database_password%@%database_host%:%database_port%/%database_name%?unix_socket=%database_socket%&charset=%database_charset%'
 
 framework:
     #esi:             ~
@@ -48,15 +49,7 @@ twig:
 # Doctrine Configuration
 doctrine:
     dbal:
-        driver: "%database_driver%"
-        host: "%database_host%"
-        port: "%database_port%"
-        dbname: "%database_name%"
-        user: "%database_user%"
-        password: "%database_password%"
-        charset: "%database_charset%"
-        path: "%database_path%"
-        unix_socket: "%database_socket%"
+        url: '%env(resolve:DATABASE_URL)%'
         types:
             json_array: Wallabag\CoreBundle\Doctrine\JsonArrayType
 

--- a/app/config/config_test.yml
+++ b/app/config/config_test.yml
@@ -3,6 +3,9 @@ imports:
     - { resource: parameters_test.yml }
     - { resource: services_test.yml }
 
+parameters:
+    fosuser_registration: true
+
 framework:
     test: ~
     session:

--- a/app/config/config_test.yml
+++ b/app/config/config_test.yml
@@ -4,6 +4,7 @@ imports:
     - { resource: services_test.yml }
 
 parameters:
+    env(TEST_DATABASE_URL): '%test_database_scheme%://%test_database_user%:%test_database_password%@%test_database_host%:%test_database_port%/%test_database_name%?unix_socket=%test_database_socket%&charset=%test_database_charset%'
     fosuser_registration: true
 
 framework:
@@ -23,15 +24,7 @@ web_profiler:
 
 doctrine:
     dbal:
-        driver: "%test_database_driver%"
-        host: "%test_database_host%"
-        port: "%test_database_port%"
-        dbname: "%test_database_name%"
-        user: "%test_database_user%"
-        password: "%test_database_password%"
-        charset: "%test_database_charset%"
-        path: "%env(TEST_DATABASE_PATH)%"
-        unix_socket: "%test_database_socket%"
+        url: '%env(resolve:TEST_DATABASE_URL)%'
 
     orm:
         metadata_cache_driver:

--- a/app/config/config_test.yml
+++ b/app/config/config_test.yml
@@ -4,7 +4,6 @@ imports:
     - { resource: services_test.yml }
 
 parameters:
-    env(TEST_DATABASE_URL): '%test_database_scheme%://%test_database_user%:%test_database_password%@%test_database_host%:%test_database_port%/%test_database_name%?unix_socket=%test_database_socket%&charset=%test_database_charset%'
     fosuser_registration: true
 
 framework:
@@ -24,7 +23,7 @@ web_profiler:
 
 doctrine:
     dbal:
-        url: '%env(resolve:TEST_DATABASE_URL)%'
+        dbname_suffix: '_test' # for MySQL and PostgreSQL
 
     orm:
         metadata_cache_driver:

--- a/app/config/config_test.yml
+++ b/app/config/config_test.yml
@@ -31,6 +31,7 @@ doctrine:
         password: "%test_database_password%"
         charset: "%test_database_charset%"
         path: "%env(TEST_DATABASE_PATH)%"
+        unix_socket: "%test_database_socket%"
 
     orm:
         metadata_cache_driver:

--- a/app/config/parameters_test.yml
+++ b/app/config/parameters_test.yml
@@ -1,11 +1,5 @@
 parameters:
-    test_database_driver: pdo_sqlite
-    test_database_host: 127.0.0.1
-    test_database_port: null
-    test_database_name: null
-    test_database_user: null
-    test_database_password: null
-    test_database_path: "%env(TEST_DATABASE_PATH)%"
+    # Using an environment variable in order to avoid the error "attempt to write a readonly database"
+    # when the schema is dropped then recreate
+    database_path: "%env(TEST_DATABASE_PATH)%"
     env(TEST_DATABASE_PATH): "%kernel.project_dir%/data/db/wallabag_test.sqlite"
-    test_database_socket: null
-    test_database_charset: utf8

--- a/app/config/parameters_test.yml
+++ b/app/config/parameters_test.yml
@@ -7,4 +7,5 @@ parameters:
     test_database_password: null
     test_database_path: "%env(TEST_DATABASE_PATH)%"
     env(TEST_DATABASE_PATH): "%kernel.project_dir%/data/db/wallabag_test.sqlite"
+    test_database_socket: null
     test_database_charset: utf8

--- a/app/config/parameters_test.yml
+++ b/app/config/parameters_test.yml
@@ -8,4 +8,3 @@ parameters:
     test_database_path: "%env(TEST_DATABASE_PATH)%"
     env(TEST_DATABASE_PATH): "%kernel.project_dir%/data/db/wallabag_test.sqlite"
     test_database_charset: utf8
-    fosuser_registration: true

--- a/app/config/tests/parameters_test.mysql.yml
+++ b/app/config/tests/parameters_test.mysql.yml
@@ -1,11 +1,2 @@
 parameters:
-    test_database_driver: pdo_mysql
-    test_database_host: 127.0.0.1
-    test_database_port: 3306
-    test_database_name: wallabag_test
-    test_database_user: root
-    test_database_password: root
-    test_database_path: ~
-    env(TEST_DATABASE_PATH): ~
-    test_database_socket: null
-    test_database_charset: utf8mb4
+    env(DATABASE_URL): mysql://root:root@127.0.0.1:3306/wallabag?charset=utf8mb4

--- a/app/config/tests/parameters_test.mysql.yml
+++ b/app/config/tests/parameters_test.mysql.yml
@@ -8,4 +8,3 @@ parameters:
     test_database_path: ~
     env(TEST_DATABASE_PATH): ~
     test_database_charset: utf8mb4
-    fosuser_registration: true

--- a/app/config/tests/parameters_test.mysql.yml
+++ b/app/config/tests/parameters_test.mysql.yml
@@ -7,4 +7,5 @@ parameters:
     test_database_password: root
     test_database_path: ~
     env(TEST_DATABASE_PATH): ~
+    test_database_socket: null
     test_database_charset: utf8mb4

--- a/app/config/tests/parameters_test.pgsql.yml
+++ b/app/config/tests/parameters_test.pgsql.yml
@@ -1,11 +1,2 @@
 parameters:
-    test_database_driver: pdo_pgsql
-    test_database_host: localhost
-    test_database_port:
-    test_database_name: wallabag_test
-    test_database_user: wallabag
-    test_database_password: wallabagrocks
-    test_database_path: ~
-    env(TEST_DATABASE_PATH): ~
-    test_database_socket: null
-    test_database_charset: utf8
+    env(DATABASE_URL): postgres://wallabag:wallabagrocks@localhost/wallabag?charset=utf8

--- a/app/config/tests/parameters_test.pgsql.yml
+++ b/app/config/tests/parameters_test.pgsql.yml
@@ -7,4 +7,5 @@ parameters:
     test_database_password: wallabagrocks
     test_database_path: ~
     env(TEST_DATABASE_PATH): ~
+    test_database_socket: null
     test_database_charset: utf8

--- a/app/config/tests/parameters_test.pgsql.yml
+++ b/app/config/tests/parameters_test.pgsql.yml
@@ -8,4 +8,3 @@ parameters:
     test_database_path: ~
     env(TEST_DATABASE_PATH): ~
     test_database_charset: utf8
-    fosuser_registration: true

--- a/app/config/tests/parameters_test.sqlite.yml
+++ b/app/config/tests/parameters_test.sqlite.yml
@@ -9,4 +9,5 @@ parameters:
     # when the schema is dropped then recreate
     test_database_path: "%env(TEST_DATABASE_PATH)%"
     env(TEST_DATABASE_PATH): "%kernel.project_dir%/data/db/wallabag_test.sqlite"
+    test_database_socket: null
     test_database_charset: utf8

--- a/app/config/tests/parameters_test.sqlite.yml
+++ b/app/config/tests/parameters_test.sqlite.yml
@@ -1,13 +1,5 @@
 parameters:
-    test_database_driver: pdo_sqlite
-    test_database_host: localhost
-    test_database_port:
-    test_database_name: ~
-    test_database_user: ~
-    test_database_password: ~
+    env(DATABASE_URL): sqlite://:@localhost/%env(TEST_DATABASE_PATH)%?charset=utf8
     # Using an environment variable in order to avoid the error "attempt to write a readonly database"
     # when the schema is dropped then recreate
-    test_database_path: "%env(TEST_DATABASE_PATH)%"
     env(TEST_DATABASE_PATH): "%kernel.project_dir%/data/db/wallabag_test.sqlite"
-    test_database_socket: null
-    test_database_charset: utf8

--- a/app/config/tests/parameters_test.sqlite.yml
+++ b/app/config/tests/parameters_test.sqlite.yml
@@ -10,4 +10,3 @@ parameters:
     test_database_path: "%env(TEST_DATABASE_PATH)%"
     env(TEST_DATABASE_PATH): "%kernel.project_dir%/data/db/wallabag_test.sqlite"
     test_database_charset: utf8
-    fosuser_registration: true


### PR DESCRIPTION
Benefits:
- easier testing on different databases locally
- prepare for the use of environment variables for configuration