### PR TITLE
Make migrations noop instead of skipping

### DIFF
--- a/app/DoctrineMigrations/Version20161001072726.php
+++ b/app/DoctrineMigrations/Version20161001072726.php
@@ -18,7 +18,11 @@ class Version20161001072726 extends WallabagMigration
     {
         $platform = $this->connection->getDatabasePlatform();
 
-        $this->skipIf($platform instanceof SqlitePlatform, 'Migration can only be executed safely on \'mysql\' or \'postgresql\'.');
+        if ($platform instanceof SqlitePlatform) {
+            $this->write('Migration can only be executed safely on \'mysql\' or \'postgresql\'.');
+
+            return;
+        }
 
         // remove all FK from entry_tag
         switch (true) {

--- a/app/DoctrineMigrations/Version20161022134138.php
+++ b/app/DoctrineMigrations/Version20161022134138.php
@@ -13,7 +13,11 @@ class Version20161022134138 extends WallabagMigration
 {
     public function up(Schema $schema): void
     {
-        $this->skipIf(!$this->connection->getDatabasePlatform() instanceof MySQLPlatform, 'This migration only apply to MySQL');
+        if (!$this->connection->getDatabasePlatform() instanceof MySQLPlatform) {
+            $this->write('This migration only apply to MySQL');
+
+            return;
+        }
 
         $this->addSql('ALTER DATABASE `' . $this->connection->getParams()['dbname'] . '` CHARACTER SET = utf8mb4 COLLATE = utf8mb4_unicode_ci;');
 
@@ -41,7 +45,11 @@ class Version20161022134138 extends WallabagMigration
 
     public function down(Schema $schema): void
     {
-        $this->skipIf(!$this->connection->getDatabasePlatform() instanceof MySQLPlatform, 'This migration only apply to MySQL');
+        if (!$this->connection->getDatabasePlatform() instanceof MySQLPlatform) {
+            $this->write('This migration only apply to MySQL');
+
+            return;
+        }
 
         $this->addSql('ALTER DATABASE `' . $this->connection->getParams()['dbname'] . '` CHARACTER SET = utf8 COLLATE = utf8_unicode_ci;');
 

--- a/app/DoctrineMigrations/Version20170510082609.php
+++ b/app/DoctrineMigrations/Version20170510082609.php
@@ -20,7 +20,11 @@ class Version20170510082609 extends WallabagMigration
 
     public function up(Schema $schema): void
     {
-        $this->skipIf(!$this->connection->getDatabasePlatform() instanceof MySQLPlatform, 'This migration only apply to MySQL');
+        if (!$this->connection->getDatabasePlatform() instanceof MySQLPlatform) {
+            $this->write('This migration only apply to MySQL');
+
+            return;
+        }
 
         foreach ($this->fields as $field) {
             $this->addSql('ALTER TABLE ' . $this->getTable('user') . ' CHANGE ' . $field . ' ' . $field . ' VARCHAR(180) NOT NULL;');
@@ -29,7 +33,11 @@ class Version20170510082609 extends WallabagMigration
 
     public function down(Schema $schema): void
     {
-        $this->skipIf(!$this->connection->getDatabasePlatform() instanceof MySQLPlatform, 'This migration only apply to MySQL');
+        if (!$this->connection->getDatabasePlatform() instanceof MySQLPlatform) {
+            $this->write('This migration only apply to MySQL');
+
+            return;
+        }
 
         foreach ($this->fields as $field) {
             $this->addSql('ALTER TABLE ' . $this->getTable('user') . ' CHANGE ' . $field . ' ' . $field . ' VARCHAR(255) NOT NULL;');

--- a/app/DoctrineMigrations/Version20170719231144.php
+++ b/app/DoctrineMigrations/Version20170719231144.php
@@ -13,7 +13,11 @@ class Version20170719231144 extends WallabagMigration
 {
     public function up(Schema $schema): void
     {
-        $this->skipIf($this->connection->getDatabasePlatform() instanceof SqlitePlatform, 'Migration can only be executed safely on \'mysql\' or \'postgresql\'.');
+        if ($this->connection->getDatabasePlatform() instanceof SqlitePlatform) {
+            $this->write('Migration can only be executed safely on \'mysql\' or \'postgresql\'.');
+
+            return;
+        }
 
         // Find tags which need to be merged
         $dupTags = $this->connection->query('

--- a/app/DoctrineMigrations/Version20171008195606.php
+++ b/app/DoctrineMigrations/Version20171008195606.php
@@ -17,7 +17,11 @@ class Version20171008195606 extends WallabagMigration
     {
         $platform = $this->connection->getDatabasePlatform();
 
-        $this->skipIf($platform instanceof SqlitePlatform, 'Migration can only be executed safely on \'mysql\' or \'postgresql\'.');
+        if ($platform instanceof SqlitePlatform) {
+            $this->write('Migration can only be executed safely on \'mysql\' or \'postgresql\'.');
+
+            return;
+        }
 
         switch (true) {
             case $platform instanceof MySQLPlatform:
@@ -35,7 +39,11 @@ class Version20171008195606 extends WallabagMigration
     {
         $platform = $this->connection->getDatabasePlatform();
 
-        $this->skipIf($platform instanceof SqlitePlatform, 'Migration can only be executed safely on \'mysql\' or \'postgresql\'.');
+        if ($platform instanceof SqlitePlatform) {
+            $this->write('Migration can only be executed safely on \'mysql\' or \'postgresql\'.');
+
+            return;
+        }
 
         switch (true) {
             case $platform instanceof MySQLPlatform:

--- a/app/DoctrineMigrations/Version20181128203230.php
+++ b/app/DoctrineMigrations/Version20181128203230.php
@@ -13,7 +13,11 @@ class Version20181128203230 extends WallabagMigration
 {
     public function up(Schema $schema): void
     {
-        $this->skipIf(!$this->connection->getDatabasePlatform() instanceof MySQLPlatform, 'This migration can only be applied on \'mysql\'.');
+        if (!$this->connection->getDatabasePlatform() instanceof MySQLPlatform) {
+            $this->write('This migration can only be applied on \'mysql\'.');
+
+            return;
+        }
 
         $this->addSql('ALTER TABLE ' . $this->getTable('oauth2_access_tokens') . ' CHANGE `token` `token` varchar(191) NOT NULL');
         $this->addSql('ALTER TABLE ' . $this->getTable('oauth2_access_tokens') . ' CHANGE `scope` `scope` varchar(191)');
@@ -28,7 +32,11 @@ class Version20181128203230 extends WallabagMigration
 
     public function down(Schema $schema): void
     {
-        $this->skipIf(!$this->connection->getDatabasePlatform() instanceof MySQLPlatform, 'This migration can only be applied on \'mysql\'.');
+        if (!$this->connection->getDatabasePlatform() instanceof MySQLPlatform) {
+            $this->write('This migration can only be applied on \'mysql\'.');
+
+            return;
+        }
 
         $this->addSql('ALTER TABLE ' . $this->getTable('oauth2_access_tokens') . ' CHANGE `token` `token` varchar(255) NOT NULL');
         $this->addSql('ALTER TABLE ' . $this->getTable('oauth2_access_tokens') . ' CHANGE `scope` `scope` varchar(255)');

--- a/app/DoctrineMigrations/Version20190511165128.php
+++ b/app/DoctrineMigrations/Version20190511165128.php
@@ -15,7 +15,11 @@ final class Version20190511165128 extends WallabagMigration
 {
     public function up(Schema $schema): void
     {
-        $this->skipIf(!$this->connection->getDatabasePlatform() instanceof MySQLPlatform, 'This migration only apply to MySQL');
+        if (!$this->connection->getDatabasePlatform() instanceof MySQLPlatform) {
+            $this->write('This migration only apply to MySQL');
+
+            return;
+        }
 
         $this->addSql('ALTER TABLE ' . $this->getTable('tag') . ' CHANGE `label` `label` longtext CHARACTER SET utf8mb4 COLLATE utf8mb4_bin;');
         $this->addSql('ALTER TABLE ' . $this->getTable('tag') . ' CHANGE `slug` `slug` VARCHAR(128) CHARACTER SET utf8mb4 COLLATE utf8mb4_bin;');
@@ -23,7 +27,11 @@ final class Version20190511165128 extends WallabagMigration
 
     public function down(Schema $schema): void
     {
-        $this->skipIf(!$this->connection->getDatabasePlatform() instanceof MySQLPlatform, 'This migration only apply to MySQL');
+        if (!$this->connection->getDatabasePlatform() instanceof MySQLPlatform) {
+            $this->write('This migration only apply to MySQL');
+
+            return;
+        }
 
         $this->addSql('ALTER TABLE ' . $this->getTable('tag') . ' CHANGE `slug` `slug` VARCHAR(128) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;');
         $this->addSql('ALTER TABLE ' . $this->getTable('tag') . ' CHANGE `label` `label` longtext CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;');

--- a/app/DoctrineMigrations/Version20190619093534.php
+++ b/app/DoctrineMigrations/Version20190619093534.php
@@ -15,7 +15,11 @@ final class Version20190619093534 extends WallabagMigration
     public function up(Schema $schema): void
     {
         // this up() migration is auto-generated, please modify it to your needs
-        $this->skipIf(!$this->connection->getDatabasePlatform() instanceof SqlitePlatform, 'Migration can only be executed safely on \'sqlite\'.');
+        if (!$this->connection->getDatabasePlatform() instanceof SqlitePlatform) {
+            $this->write('Migration can only be executed safely on \'sqlite\'.');
+
+            return;
+        }
 
         $this->addSql('UPDATE ' . $this->getTable('entry', true) . ' SET reading_time = 0 WHERE reading_time IS NULL;');
 
@@ -43,7 +47,11 @@ final class Version20190619093534 extends WallabagMigration
     public function down(Schema $schema): void
     {
         // this down() migration is auto-generated, please modify it to your needs
-        $this->skipIf(!$this->connection->getDatabasePlatform() instanceof SqlitePlatform, 'Migration can only be executed safely on \'sqlite\'.');
+        if (!$this->connection->getDatabasePlatform() instanceof SqlitePlatform) {
+            $this->write('Migration can only be executed safely on \'sqlite\'.');
+
+            return;
+        }
 
         $this->addSql('DROP INDEX IDX_F4D18282A76ED395');
         $this->addSql('DROP INDEX created_at');


### PR DESCRIPTION
Benefit is that those migrations will actually execute but doing nothing, and this avoid keeping them as "pending" migrations to be executed.
This helps not having the message "you have not run migrations" when using migration diff.
And migration status will show no not run migrations :)