### PR TITLE
Use lighter PDF file in Pinboard tests

### DIFF
--- a/tests/Controller/Import/PinboardControllerTest.php
+++ b/tests/Controller/Import/PinboardControllerTest.php
@@ -162,7 +162,7 @@ class PinboardControllerTest extends WallabagCoreTestCase
             ->get(EntityManagerInterface::class)
             ->getRepository(Entry::class)
             ->findByUrlAndUserId(
-                'https://ilia.ws/files/nginx_torontophpug.pdf',
+                'https://www.w3.org/WAI/ER/tests/xhtml/testfiles/resources/pdf/dummy.pdf',
                 $this->getLoggedInUserId()
             );
 

--- a/tests/fixtures/Import/pinboard_export
+++ b/tests/fixtures/Import/pinboard_export
@@ -22,14 +22,14 @@
     "tags": "varnish PHP"
   },
   {
-    "href": "https://ilia.ws/files/nginx_torontophpug.pdf",
-    "description": "Nginx Tricks for PHP Developers",
+    "href": "https://www.w3.org/WAI/ER/tests/xhtml/testfiles/resources/pdf/dummy.pdf",
+    "description": "Dummy PDF file",
     "extended": "",
     "meta": "9adbb5c4ca6760e335b920800d88c70a",
     "hash": "0189bb08f8bd0122c6544bed4624c546",
     "time": "2016-10-05T07:11:27Z",
     "shared": "yes",
     "toread": "no",
-    "tags": "nginx PHP best_practice"
+    "tags": "dummy PDF file"
   }
 ]


### PR DESCRIPTION
From [4m04s](https://github.com/wallabag/wallabag/actions/runs/8018668664) on latest master CI run to now [3m14s](https://github.com/wallabag/wallabag/actions/runs/8027642340): ~ -50s