### PR TITLE
Add "gl" language to wallabag.yml

### DIFF
--- a/app/config/wallabag.yml
+++ b/app/config/wallabag.yml
@@ -23,6 +23,7 @@ parameters:
         hr: 'Hrvatski'
         cs: 'Čeština'
         el: 'Ελληνικά'
+        gl: 'Galego'
     wallabag.items_on_page: 12
     wallabag.language: '%locale%'
     wallabag.feed_limit: 50


### PR DESCRIPTION
Galician language (gl) option is not in the drop down menu but available to use. I have manually tested this on my install and works fine letting users select galician language.

| Q             | A
| ------------- | ---
| Bug fix?  |    yes
| New feature?  no
| Translation   | yes
| CHANGELOG.md  | yes/no
| License       | MIT

