### PR TITLE
Feature: tagging rules reset

### DIFF
--- a/src/Controller/ConfigController.php
+++ b/src/Controller/ConfigController.php
@@ -576,7 +576,7 @@ class ConfigController extends AbstractController
                 $annotationRepository->removeAllByUserId($this->getUser()->getId());
                 break;
             case 'tagging_rules':
-                $taggingRuleRepository->removeAllTaggingRules($this->getConfig()->getId());
+                $taggingRuleRepository->removeAllByConfigId($this->getConfig()->getId());
                 break;
             case 'tags':
                 $this->removeAllTagsByUserId($this->getUser()->getId());

--- a/src/Controller/ConfigController.php
+++ b/src/Controller/ConfigController.php
@@ -561,11 +561,11 @@ class ConfigController extends AbstractController
     /**
      * Remove all annotations OR tags OR entries for the current user.
      *
-     * @Route("/reset/{type}", requirements={"id" = "annotations|tags|entries"}, name="config_reset", methods={"POST"})
+     * @Route("/reset/{type}", requirements={"id" = "annotations|tags|entries|tagging_rules"}, name="config_reset", methods={"POST"})
      *
      * @return RedirectResponse
      */
-    public function resetAction(Request $request, string $type, AnnotationRepository $annotationRepository, EntryRepository $entryRepository)
+    public function resetAction(Request $request, string $type, AnnotationRepository $annotationRepository, EntryRepository $entryRepository, TaggingRuleRepository $taggingRuleRepository)
     {
         if (!$this->isCsrfTokenValid('reset-area', $request->request->get('token'))) {
             throw $this->createAccessDeniedException('Bad CSRF token.');
@@ -574,6 +574,9 @@ class ConfigController extends AbstractController
         switch ($type) {
             case 'annotations':
                 $annotationRepository->removeAllByUserId($this->getUser()->getId());
+                break;
+            case 'tagging_rules':
+                $taggingRuleRepository->removeAllTaggingRules($this->getConfig()->getId());
                 break;
             case 'tags':
                 $this->removeAllTagsByUserId($this->getUser()->getId());

--- a/src/Repository/TaggingRuleRepository.php
+++ b/src/Repository/TaggingRuleRepository.php
@@ -14,12 +14,12 @@ class TaggingRuleRepository extends ServiceEntityRepository
     }
 
     /**
-     * Remove all tagging rule for a config.
+     * Remove all tagging rules for a config.
      * Used when a user wants to reset.
      *
      * @param int $configId
      */
-    public function removeAllTaggingRules($configId)
+    public function removeAllByConfigId($configId)
     {
         $this->getEntityManager()
             ->createQuery('DELETE FROM Wallabag\Entity\TaggingRule tr WHERE tr.config = :configId')

--- a/src/Repository/TaggingRuleRepository.php
+++ b/src/Repository/TaggingRuleRepository.php
@@ -12,4 +12,18 @@ class TaggingRuleRepository extends ServiceEntityRepository
     {
         parent::__construct($registry, TaggingRule::class);
     }
+
+    /**
+     * Remove all tagging rule for a config.
+     * Used when a user wants to reset.
+     *
+     * @param int $configId
+     */
+    public function removeAllTaggingRules($configId)
+    {
+        $this->getEntityManager()
+            ->createQuery('DELETE FROM Wallabag\Entity\TaggingRule tr WHERE tr.config = :configId')
+            ->setParameter(':configId', $configId)
+            ->execute();
+    }
 }

--- a/templates/Config/index.html.twig
+++ b/templates/Config/index.html.twig
@@ -640,6 +640,15 @@
                         <div class="row">
                             <h5>{{ 'config.reset.title'|trans }}</h5>
                             <p>{{ 'config.reset.description'|trans }}</p>
+                            {% if app.user.config.taggingRules is not empty %}
+                            <p>
+                                <form action="{{ path('config_reset', {type: 'tagging_rules'}) }}" method="post" onsubmit="return confirm('{{ 'config.reset.confirm'|trans|escape('js') }}')" name="reset-tagging-rules">
+                                    <input type="hidden" name="token" value="{{ csrf_token('reset-area') }}" />
+
+                                    <button class="waves-effect waves-light btn red" type="submit">{{ 'config.reset.tagging_rules'|trans }}</button>
+                                </form>
+                            </p>
+                            {% endif %}
                             <p>
                                 <form action="{{ path('config_reset', {type: 'annotations'}) }}" method="post" onsubmit="return confirm('{{ 'config.reset.confirm'|trans|escape('js') }}')" name="reset-annotations">
                                     <input type="hidden" name="token" value="{{ csrf_token('reset-area') }}" />

--- a/translations/messages.en.yml
+++ b/translations/messages.en.yml
@@ -138,6 +138,7 @@ config:
         description: By hitting buttons below you'll have ability to remove some information from your account. Be aware that these actions are IRREVERSIBLE.
         annotations: Remove ALL annotations
         tags: Remove ALL tags
+        tagging_rules: Remove ALL tagging rules
         entries: Remove ALL entries
         archived: Remove ALL archived entries
         confirm: Are you really sure? (THIS CAN'T BE UNDONE)
@@ -676,6 +677,7 @@ flashes:
             feed_token_revoked: 'Feed token revoked'
             annotations_reset: Annotations reset
             tags_reset: Tags reset
+            tagging_rules_reset: Tagging rules reset
             entries_reset: Entries reset
             archived_reset: Archived entries deleted
             otp_enabled: Two-factor authentication enabled

--- a/translations/messages.zh.yml
+++ b/translations/messages.zh.yml
@@ -140,6 +140,7 @@ config:
         title: '重置区（危险区域）'
         description: '一旦你点击这个按钮，你就可以移除你账号中的某些信息。请注意这些操作是不可撤销的。'
         annotations: "删除所有标注"
+        tagging_rules: "删除所有标签规则"
         tags: "删除所有标签"
         entries: "删除所有项目"
         archived: "删除所有已存档项目"
@@ -678,6 +679,7 @@ flashes:
             feed_token_revoked: '订阅源令牌已作废'
             annotations_reset: 标注已重置
             tags_reset: 标签已重置
+            tagging_rules_reset: 标签规则已重置
             entries_reset: 项目列表已重置
             archived_reset: 所有存档项目已删除
             otp_enabled: 两步验证已启用

--- a/translations/messages.zh_Hant.yml
+++ b/translations/messages.zh_Hant.yml
@@ -139,6 +139,7 @@ config:
         page_title: 雙重驗證
     reset:
         tags: 移除所有標籤
+        tagging_rules: 移除所有標籤規則
         title: 重設區域（危險地帶）
         entries: 移除所有條目
         archived: 移除所有已封存條目
@@ -671,6 +672,7 @@ flashes:
             entries_reset: 已重設條目
             archived_reset: 完成刪除已封存條目
             tags_reset: 已重設標籤
+            tagging_rules_reset: 已重設標籤規則
             annotations_reset: 已重設註釋
             tagging_rules_updated: 已更新標籤規則
             tagging_rules_deleted: 已刪除標籤規則


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Documentation | no
| Translation   | yes
| CHANGELOG.md  | no
| License       | MIT


<!--
Please list the issues your PR fixes using special keywords, see
https://help.github.com/articles/closing-issues-using-keywords/

Fixes #…
-->

Implements and closes #7520 

I put the reset tagging rules button in the reset area.

The button will only show up if the current user has tagging rules.

My first PR using PHP :smile:.Happy to make any changes.

<!--
- Please fill in this template according to the PR you're about to submit.
- Replace this comment by a description of what your PR is solving.
-->
