### PR TITLE
Fix Sass mixed declaration depreciation notices

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -9,7 +9,7 @@ indent_size = 4
 trim_trailing_whitespace = true
 insert_final_newline = true
 
-[*.{js,css}]
+[*.{js,css,scss}]
 indent_style = space
 indent_size = 2
 

--- a/assets/material/css/cards.scss
+++ b/assets/material/css/cards.scss
@@ -268,9 +268,11 @@ a.original:not(.waves-effect) {
     }
 
     @include mixin-reading-time {
-      padding: 0 5px;
-      flex-wrap: wrap;
-      margin-left: auto;
+      & {
+        padding: 0 5px;
+        flex-wrap: wrap;
+        margin-left: auto;
+      }
 
       i.material-icons {
         font-size: 20px;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | yes
| Tests pass?   | yes
| Documentation | no
| Translation   | no
| CHANGELOG.md  | no
| License       | MIT

When running yarn here the new deprecation notices:

```
WARNING in ./assets/material/css/index.scss (./node_modules/css-loader/dist/cjs.js??ruleSet[1].rules[1].use[1]!./node_modules/postcss-loader/dist/cjs.js??ruleSet[1].rules[1].use[2]!./node_modules/sass-loader/dist/cjs.js!./assets/material/css/index.scss)
Module Warning (from ./node_modules/sass-loader/dist/cjs.js):
Deprecation Warning on line 270, column 6 of file:///var/www/html/assets/material/css/cards.scss:270:6:
Sass's behavior for declarations that appear after nested
rules will be changing to match the behavior specified by CSS in an upcoming
version. To keep the existing behavior, move the declaration above the nested
rule. To opt into the new behavior, wrap the declaration in `& {}`.

More info: https://sass-lang.com/d/mixed-decls

270 |       padding: 0 5px;


assets/material/css/cards.scss 271:7  @content
assets/material/css/cards.scss 25:5   mixin-reading-time()
assets/material/css/cards.scss 270:5  @import
assets/material/css/index.scss 5:9    root stylesheet

 @ ./assets/material/css/index.scss 8:6-257 20:17-24 24:0-227 24:0-227 25:22-29 25:33-47 25:50-64
 @ ./assets/material/index.js 24:0-26

WARNING in ./assets/material/css/index.scss (./node_modules/css-loader/dist/cjs.js??ruleSet[1].rules[1].use[1]!./node_modules/postcss-loader/dist/cjs.js??ruleSet[1].rules[1].use[2]!./node_modules/sass-loader/dist/cjs.js!./assets/material/css/index.scss)
Module Warning (from ./node_modules/sass-loader/dist/cjs.js):
Deprecation Warning on line 271, column 6 of file:///var/www/html/assets/material/css/cards.scss:271:6:
Sass's behavior for declarations that appear after nested
rules will be changing to match the behavior specified by CSS in an upcoming
version. To keep the existing behavior, move the declaration above the nested
rule. To opt into the new behavior, wrap the declaration in `& {}`.

More info: https://sass-lang.com/d/mixed-decls

271 |       flex-wrap: wrap;


assets/material/css/cards.scss 272:7  @content
assets/material/css/cards.scss 25:5   mixin-reading-time()
assets/material/css/cards.scss 270:5  @import
assets/material/css/index.scss 5:9    root stylesheet

 @ ./assets/material/css/index.scss 8:6-257 20:17-24 24:0-227 24:0-227 25:22-29 25:33-47 25:50-64
 @ ./assets/material/index.js 24:0-26

WARNING in ./assets/material/css/index.scss (./node_modules/css-loader/dist/cjs.js??ruleSet[1].rules[1].use[1]!./node_modules/postcss-loader/dist/cjs.js??ruleSet[1].rules[1].use[2]!./node_modules/sass-loader/dist/cjs.js!./assets/material/css/index.scss)
Module Warning (from ./node_modules/sass-loader/dist/cjs.js):
Deprecation Warning on line 272, column 6 of file:///var/www/html/assets/material/css/cards.scss:272:6:
Sass's behavior for declarations that appear after nested
rules will be changing to match the behavior specified by CSS in an upcoming
version. To keep the existing behavior, move the declaration above the nested
rule. To opt into the new behavior, wrap the declaration in `& {}`.

More info: https://sass-lang.com/d/mixed-decls

272 |       margin-left: auto;


assets/material/css/cards.scss 273:7  @content
assets/material/css/cards.scss 25:5   mixin-reading-time()
assets/material/css/cards.scss 270:5  @import
assets/material/css/index.scss 5:9    root stylesheet

 @ ./assets/material/css/index.scss 8:6-257 20:17-24 24:0-227 24:0-227 25:22-29 25:33-47 25:50-64
 @ ./assets/material/index.js 24:0-26
```

Fixed the way that is proposed in https://sass-lang.com/d/mixed-decls
