### PR TITLE
fix: inappropriate handling of escaped query arguments

### DIFF
--- a/src/Controller/Api/EntryRestController.php
+++ b/src/Controller/Api/EntryRestController.php
@@ -1289,7 +1289,7 @@ class EntryRestController extends WallabagRestController
     {
         $this->validateAuthentication();
 
-        $urls = json_decode(urldecode($request->query->get('list', '[]')));
+        $list = json_decode(urldecode($request->query->get('list', '[]')));
 
         if (empty($list)) {
             return $this->sendResponse([]);
@@ -1356,7 +1356,7 @@ class EntryRestController extends WallabagRestController
     {
         $this->validateAuthentication();
 
-        $urls = json_decode(urldecode($request->query->get('list', '[]')));
+        $list = json_decode(urldecode($request->query->get('list', '[]')));
 
         if (empty($list)) {
             return $this->sendResponse([]);

--- a/src/Controller/Api/EntryRestController.php
+++ b/src/Controller/Api/EntryRestController.php
@@ -477,7 +477,7 @@ class EntryRestController extends WallabagRestController
     {
         $this->validateAuthentication();
 
-        $urls = json_decode($request->query->get('urls', []));
+        $urls = json_decode(urldecode($request->query->get('urls', '[]')));
 
         if (empty($urls)) {
             return $this->sendResponse([]);
@@ -487,6 +487,7 @@ class EntryRestController extends WallabagRestController
 
         // handle multiple urls
         foreach ($urls as $key => $url) {
+            $url = $url->url;
             $entry = $entryRepository->findByUrlAndUserId(
                 $url,
                 $this->getUser()->getId()
@@ -537,7 +538,7 @@ class EntryRestController extends WallabagRestController
     {
         $this->validateAuthentication();
 
-        $urls = json_decode($request->query->get('urls', []));
+        $urls = json_decode(urldecode($request->query->get('urls', '[]')));
 
         $limit = $this->getParameter('wallabag.api_limit_mass_actions');
 
@@ -552,6 +553,7 @@ class EntryRestController extends WallabagRestController
 
         // handle multiple urls
         foreach ($urls as $key => $url) {
+            $url = $url->url;
             $entry = $entryRepository->findByUrlAndUserId(
                 $url,
                 $this->getUser()->getId()
@@ -1287,7 +1289,7 @@ class EntryRestController extends WallabagRestController
     {
         $this->validateAuthentication();
 
-        $list = json_decode($request->query->get('list', []));
+        $urls = json_decode(urldecode($request->query->get('list', '[]')));
 
         if (empty($list)) {
             return $this->sendResponse([]);
@@ -1354,7 +1356,7 @@ class EntryRestController extends WallabagRestController
     {
         $this->validateAuthentication();
 
-        $list = json_decode($request->query->get('list', []));
+        $urls = json_decode(urldecode($request->query->get('list', '[]')));
 
         if (empty($list)) {
             return $this->sendResponse([]);

--- a/tests/Controller/Api/EntryRestControllerTest.php
+++ b/tests/Controller/Api/EntryRestControllerTest.php
@@ -1323,7 +1323,7 @@ class EntryRestControllerTest extends WallabagApiTestCase
 
     public function testPostEntriesTagsListActionNoList()
     {
-        $this->client->request('POST', '/api/entries/tags/lists?list=' . json_encode([]));
+        $this->client->request('POST', '/api/entries/tags/lists?list=' . urlencode(json_encode([])));
 
         $this->assertSame(200, $this->client->getResponse()->getStatusCode());
 
@@ -1391,7 +1391,7 @@ class EntryRestControllerTest extends WallabagApiTestCase
 
     public function testPostEntriesListActionWithNoUrls()
     {
-        $this->client->request('POST', '/api/entries/lists?urls=' . json_encode([]));
+        $this->client->request('POST', '/api/entries/lists?urls=' . urlencode(json_encode([])));
 
         $this->assertSame(200, $this->client->getResponse()->getStatusCode());
 
@@ -1452,7 +1452,7 @@ class EntryRestControllerTest extends WallabagApiTestCase
             'http://0.0.0.0/entry1',
         ];
 
-        $this->client->request('POST', '/api/entries/lists?urls=' . json_encode($list));
+        $this->client->request('POST', '/api/entries/lists?urls=' . urlencode(json_encode($list)));
 
         $this->assertSame(400, $this->client->getResponse()->getStatusCode());
         $this->assertStringContainsString('API limit reached', $this->client->getResponse()->getContent());

--- a/tests/Controller/Api/EntryRestControllerTest.php
+++ b/tests/Controller/Api/EntryRestControllerTest.php
@@ -1304,7 +1304,7 @@ class EntryRestControllerTest extends WallabagApiTestCase
             ],
         ];
 
-        $this->client->request('POST', '/api/entries/tags/lists?list=' . json_encode($list));
+        $this->client->request('POST', '/api/entries/tags/lists?list=' . urlencode(json_encode($list)));
 
         $this->assertSame(200, $this->client->getResponse()->getStatusCode());
 
@@ -1351,7 +1351,7 @@ class EntryRestControllerTest extends WallabagApiTestCase
             ],
         ];
 
-        $this->client->request('DELETE', '/api/entries/tags/list?list=' . json_encode($list));
+        $this->client->request('DELETE', '/api/entries/tags/list?list=' . urlencode(json_encode($list)));
         $this->assertSame(200, $this->client->getResponse()->getStatusCode());
 
         $entry = $em->getRepository(Entry::class)->find($entry->getId());
@@ -1376,7 +1376,7 @@ class EntryRestControllerTest extends WallabagApiTestCase
             'http://0.0.0.0/entry2',
         ];
 
-        $this->client->request('POST', '/api/entries/lists?urls=' . json_encode($list));
+        $this->client->request('POST', '/api/entries/lists?urls=' . urlencode(json_encode($list)));
 
         $this->assertSame(200, $this->client->getResponse()->getStatusCode());
 
@@ -1412,7 +1412,7 @@ class EntryRestControllerTest extends WallabagApiTestCase
             'http://0.0.0.0/test-entry-not-exist',
         ];
 
-        $this->client->request('DELETE', '/api/entries/list?urls=' . json_encode($list));
+        $this->client->request('DELETE', '/api/entries/list?urls=' . urlencode(json_encode($list)));
 
         $this->assertSame(200, $this->client->getResponse()->getStatusCode());
 


### PR DESCRIPTION
The list(s) endpoints receive a JSON encoded list of URLs as a query
param. Because it's a query param, it's escaped, so the `json_decode`
method can't decode it without first calling `urldecode`.
Also, the `POST` versions were accessing the elments as if they were the
strings, rather than objects of the shape `{'url':'<url>'}`.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | yes/no
| BC breaks?    | yes/no
| Deprecations? | yes/no
| Tests pass?   | yes/no
| Documentation | yes/no
| Translation   | yes/no
| CHANGELOG.md  | yes/no
| License       | MIT

Fixes #6928
Tested locally on my instance. I hope the CI will catch any pieces lost in translation :)
