### PR TITLE
Restored lazy connections for RabbitMQ

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -148,3 +148,57 @@ jobs:
 
       - name: "Run PHPUnit"
         run: "php bin/phpunit -v"
+
+  phpunit-without-rmq-redis:
+    name: "PHP ${{ matrix.php }} using ${{ matrix.database }} without Rabbit & Redis"
+    runs-on: "ubuntu-20.04"
+
+    strategy:
+      fail-fast: false
+      matrix:
+        php:
+          - "8.3"
+        database:
+          - "sqlite"
+          - "mysql"
+          - "pgsql"
+
+    steps:
+      - name: "Checkout"
+        uses: "actions/checkout@v4"
+        with:
+          fetch-depth: 2
+
+      - name: "Install PHP"
+        uses: "shivammathur/setup-php@v2"
+        with:
+          php-version: "${{ matrix.php }}"
+          coverage: none
+          tools: pecl
+          extensions: json, pdo, pdo_mysql, pdo_sqlite, pdo_pgsql, curl, imagick, pgsql, gd, tidy
+          ini-values: "date.timezone=Europe/Paris"
+
+      - name: "Setup MySQL"
+        if: "${{ matrix.database == 'mysql' }}"
+        run: |
+          sudo systemctl start mysql.service
+          sudo mysql -u root -proot -h 127.0.0.1 -e "CREATE DATABASE wallabag_test"
+
+      - name: "Setup PostgreSQL"
+        if: "${{ matrix.database == 'pgsql' }}"
+        run: |
+          sudo systemctl start postgresql
+          sudo -u postgres psql -d template1 -c "CREATE USER wallabag WITH PASSWORD 'wallabagrocks' CREATEDB"
+          createdb -h localhost -p 5432 -U wallabag wallabag_test
+          pg_isready -d wallabag_test -h localhost -p 5432 -U wallabag
+
+      - name: "Install dependencies with Composer"
+        uses: "ramsey/composer-install@v3"
+        with:
+          composer-options: "--optimize-autoloader --prefer-dist"
+
+      - name: "Prepare database configuration"
+        run: cp app/config/tests/parameters_test.${{ matrix.database }}.yml app/config/parameters_test.yml
+
+      - name: "Run PHPUnit"
+        run: "php bin/phpunit -v"

--- a/app/config/services_rabbit.yml
+++ b/app/config/services_rabbit.yml
@@ -6,6 +6,7 @@ services:
         public: true
 
     Wallabag\Consumer\RabbitMQConsumerTotalProxy:
+        lazy: true
         arguments:
             $pocketConsumer: '@old_sound_rabbit_mq.import_pocket_consumer'
             $readabilityConsumer: '@old_sound_rabbit_mq.import_readability_consumer'


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    |no
| Deprecations? | no
| Tests pass?   | yes
| Documentation | no
| Translation   | no
| CHANGELOG.md  | yes/no
| License       | MIT

Should fix https://github.com/wallabag/wallabag/issues/7762

The bug was introduced here: https://github.com/wallabag/wallabag/commit/423f2f792d57386defce3369b8e780f1aac0b428 in this huge PR: https://github.com/wallabag/wallabag/pull/7137

RabbitMqBundle doesn't support lazy services, but in the documentation, it's written: `but you can set lazy: true in your connection configuration to avoid unnecessary connections to your message broker in every request`
I think that this setting is necessary for us, when the RabbitMQ server is not up. 

Our testsuite didn't warn us, because our testsuite environment installs a RabbitMQ server.
That's why I duplicated the workflow (and I removed RabbitMQ and Redis dependencies), but I don't know if it's the good way. 