### PR TITLE
Fix default support URL

### DIFF
--- a/app/config/wallabag.yml
+++ b/app/config/wallabag.yml
@@ -144,7 +144,7 @@ parameters:
             section: misc
         -
             name: wallabag_support_url
-            value: https://www.wallabag.org/pages/support.html
+            value: https://github.com/wallabag/wallabag/issues/new/choose
             section: misc
         -
             name: api_user_registration


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  |no
| BC breaks?    |no
| Deprecations? |no
| Tests pass?   | yes
| Documentation |no
| Translation   |no
| CHANGELOG.md  |no
| License       | MIT

The previous URL is down. 
