### PR TITLE
fix(TaggingRule): allowed variable should match docs

### DIFF
--- a/src/Entity/TaggingRule.php
+++ b/src/Entity/TaggingRule.php
@@ -34,7 +34,7 @@ class TaggingRule implements RuleInterface
      * @Assert\NotBlank()
      * @Assert\Length(max=255)
      * @RulerZAssert\ValidRule(
-     *  allowed_variables={"title", "url", "isArchived", "isStared", "content", "language", "mimetype", "readingTime", "domainName"},
+     *  allowed_variables={"title", "url", "isArchived", "isStarred", "content", "language", "mimetype", "readingTime", "domainName"},
      *  allowed_operators={">", "<", ">=", "<=", "=", "is", "!=", "and", "not", "or", "matches", "notmatches"}
      * )
      * @ORM\Column(name="rule", type="string", nullable=false)


### PR DESCRIPTION
add missing 'r' here to allow creating tagging rules using the documented isStarred filter.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes/no
| Documentation | yes/no
| Translation   | no
| CHANGELOG.md  | yes/no
| License       | MIT

