### PR TITLE
restore pre-Atom behavior of linking directly to the article

### DIFF
--- a/templates/Entry/entries.xml.twig
+++ b/templates/Entry/entries.xml.twig
@@ -31,11 +31,9 @@
     {% for entry in entries %}
     <entry>
         <title><![CDATA[{{ entry.title|e }}]]></title>
-        <link href="{{ entry.url }}"/>
-        <link rel="alternate" type="text/html"
+        <link rel="alternate" href="{{ entry.url }}"/>
+        <link rel="via" type="text/html"
               href="{{ url('view', {'id': entry.id}) }}"/>
-        <link rel="via"
-              href="{{ entry.url }}"/>
         <id>wallabag:{{ domainName|removeScheme|removeWww }}:{{ user }}:entry:{{ entry.id }}</id>
         <updated>{{ entry.updatedAt|date('c') }}</updated>
         <published>{{ entry.createdAt|date('c') }}</published>


### PR DESCRIPTION
RFC4287 section 4.2.7.2 specifies that "rel=alternate" is effectively the default for the link element:

   If the "rel" attribute is not present, the link
   element MUST be interpreted as if the link relation type is
   "alternate".

So having a plain `<link>` and a `<link rel="alternate">` is kind of weird, *especially* if they point to different resources. So we just remove the plain entry and *replace* it with the rel=alternate, which is really the default here.

The sample Atom feeds in RFC4287 (section 1.1) do give an example *only* with `rel="alternate"`:

     <entry>
       <title>Atom draft-07 snapshot</title>
       <link rel="alternate" type="text/html"
        href="http://example.org/2005/04/02/atom"/>
       <link rel="enclosure" type="audio/mpeg" length="1337"
        href="http://example.org/audio/ph34r_my_podcast.mp3"/>

To refer to the actual Wallabag URL, we use the "via", which is defined in the RFC as:

   5.  The value "via" signifies that the IRI in the value of the href attribute identifies a resource that is the source of the information provided in the containing element.

I'm not sure how widely used that tag is, but I feel that the distinction between `rel="alternate"` is weird at best, and buggy (and certainly introducing unpleasantness in my usage) at worse.

Before:

```xml
<link href="{{ entry.url }}"/>
<link rel="alternate" type="text/html"
      href="{{ url('view', {'id': entry.id}) }}"/>
<link rel="via"
      href="{{ entry.url }}"/>
```

That is:

```xml
<link href="http://example.com/"/>
<link rel="alternate" type="text/html"
      href="http://wallabag.example.com/view/1"/>
<link rel="via"
      href="http://example.com/"/>
```

After:

```xml
<link rel="alternate" href="{{ entry.url }}"/>
<link rel="via" type="text/html"
      href="{{ url('view', {'id': entry.id}) }}"/>
```

That is:

```xml
<link rel="alternate" href="http://example.com"/>
<link rel="via" type="text/html"
      href="http://wallabag.example.com/view/1"/>
```
Closes: #7848

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | ???
| Deprecations? | no?
| Tests pass?   | ?
| Documentation | no
| Translation   | no
| CHANGELOG.md  | TODO?
| License       | MIT
