### PR TITLE
Define a custom user-agent for wallabag

### DIFF
--- a/app/config/parameters.yml.dist
+++ b/app/config/parameters.yml.dist
@@ -28,6 +28,8 @@ parameters:
 
     mailer_dsn: smtp://127.0.0.1
 
+    wallabag_user_agent: "Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/535.2 (KHTML, like Gecko) Chrome/15.0.874.92 Safari/535.2"
+
     locale: en
 
     # A secret key that's used to generate certain security-related tokens

--- a/app/config/services.yml
+++ b/app/config/services.yml
@@ -31,6 +31,7 @@ services:
             $supportUrl: '@=service(''craue_config'').get(''wallabag_support_url'')'
             $fonts: '%wallabag.fonts%'
             $defaultIgnoreOriginInstanceRules: '%wallabag.default_ignore_origin_instance_rules%'
+            $defaultUserAgent: "%wallabag.user_agent%"
 
     Wallabag\:
         resource: '../../src/*'
@@ -206,6 +207,8 @@ services:
             $config:
                 error_message: '%wallabag.fetching_error_message%'
                 error_message_title: '%wallabag.fetching_error_message_title%'
+                http_client:
+                    ua_browser: "%wallabag.user_agent%"
             $client: '@psr18.wallabag.client'
         calls:
             - [ setLogger, [ "@logger" ] ]

--- a/app/config/services.yml
+++ b/app/config/services.yml
@@ -31,7 +31,7 @@ services:
             $supportUrl: '@=service(''craue_config'').get(''wallabag_support_url'')'
             $fonts: '%wallabag.fonts%'
             $defaultIgnoreOriginInstanceRules: '%wallabag.default_ignore_origin_instance_rules%'
-            $defaultUserAgent: "%wallabag.user_agent%"
+            $defaultUserAgent: "%wallabag_user_agent%"
 
     Wallabag\:
         resource: '../../src/*'
@@ -208,7 +208,7 @@ services:
                 error_message: '%wallabag.fetching_error_message%'
                 error_message_title: '%wallabag.fetching_error_message_title%'
                 http_client:
-                    ua_browser: "%wallabag.user_agent%"
+                    ua_browser: "%wallabag_user_agent%"
             $client: '@psr18.wallabag.client'
         calls:
             - [ setLogger, [ "@logger" ] ]

--- a/app/config/wallabag.yml
+++ b/app/config/wallabag.yml
@@ -183,4 +183,3 @@ parameters:
         - 'text/html'
         - 'application/vnd.ms-excel'
     wallabag.resource_dir: "%kernel.project_dir%/web/uploads/import"
-    wallabag.user_agent: "Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/535.2 (KHTML, like Gecko) Chrome/15.0.874.92 Safari/535.2"

--- a/app/config/wallabag.yml
+++ b/app/config/wallabag.yml
@@ -183,3 +183,4 @@ parameters:
         - 'text/html'
         - 'application/vnd.ms-excel'
     wallabag.resource_dir: "%kernel.project_dir%/web/uploads/import"
+    wallabag.user_agent: "Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/535.2 (KHTML, like Gecko) Chrome/15.0.874.92 Safari/535.2"

--- a/src/SiteConfig/LoginFormAuthenticator.php
+++ b/src/SiteConfig/LoginFormAuthenticator.php
@@ -14,6 +14,7 @@ class LoginFormAuthenticator
     public function __construct(
         private readonly HttpBrowser $browser,
         AuthenticatorProvider $authenticatorProvider,
+        private readonly string $defaultUserAgent,
     ) {
         $this->expressionLanguage = new ExpressionLanguage(null, [$authenticatorProvider]);
     }
@@ -82,6 +83,10 @@ class LoginFormAuthenticator
         $headers = [];
         foreach ($siteConfig->getHttpHeaders() as $headerName => $headerValue) {
             $headers["HTTP_$headerName"] = $headerValue;
+        }
+
+        if (empty($headers['HTTP_user-agent'])) {
+            $headers['HTTP_user-agent'] = $this->defaultUserAgent;
         }
 
         return $headers;

--- a/tests/SiteConfig/LoginFormAuthenticatorTest.php
+++ b/tests/SiteConfig/LoginFormAuthenticatorTest.php
@@ -37,7 +37,7 @@ class LoginFormAuthenticatorTest extends TestCase
         $requestHtmlFunctionClient = new MockHttpClient([$requestHtmlFunctionResponse]);
         $authenticatorProvider = new AuthenticatorProvider($requestHtmlFunctionClient);
 
-        $auth = new LoginFormAuthenticator($browser, $authenticatorProvider);
+        $auth = new LoginFormAuthenticator($browser, $authenticatorProvider, 'Wallabag (Symfony HttpClient/5)');
 
         $res = $auth->login($siteConfig);
 
@@ -68,7 +68,7 @@ class LoginFormAuthenticatorTest extends TestCase
         $requestHtmlFunctionClient = new MockHttpClient([$requestHtmlFunctionResponse]);
         $authenticatorProvider = new AuthenticatorProvider($requestHtmlFunctionClient);
 
-        $auth = new LoginFormAuthenticator($browser, $authenticatorProvider);
+        $auth = new LoginFormAuthenticator($browser, $authenticatorProvider, 'Wallabag (Symfony HttpClient/5)');
 
         $res = $auth->login($siteConfig);
 
@@ -126,7 +126,7 @@ class LoginFormAuthenticatorTest extends TestCase
         ;
         $authenticatorProvider = new AuthenticatorProvider($requestHtmlFunctionClient);
 
-        $auth = new LoginFormAuthenticator($browser, $authenticatorProvider);
+        $auth = new LoginFormAuthenticator($browser, $authenticatorProvider, 'Wallabag (Symfony HttpClient/5)');
 
         $res = $auth->login($siteConfig);
 
@@ -151,7 +151,7 @@ class LoginFormAuthenticatorTest extends TestCase
         $requestHtmlFunctionClient = new MockHttpClient([$requestHtmlFunctionResponse]);
         $authenticatorProvider = new AuthenticatorProvider($requestHtmlFunctionClient);
 
-        $auth = new LoginFormAuthenticator($browser, $authenticatorProvider);
+        $auth = new LoginFormAuthenticator($browser, $authenticatorProvider, 'Wallabag (Symfony HttpClient/5)');
 
         $loginRequired = $auth->isLoginRequired($siteConfig, file_get_contents(__DIR__ . '/../fixtures/nextinpact-login.html'));
 
@@ -177,7 +177,7 @@ class LoginFormAuthenticatorTest extends TestCase
         $requestHtmlFunctionClient = new MockHttpClient([$requestHtmlFunctionResponse]);
         $authenticatorProvider = new AuthenticatorProvider($requestHtmlFunctionClient);
 
-        $auth = new LoginFormAuthenticator($browser, $authenticatorProvider);
+        $auth = new LoginFormAuthenticator($browser, $authenticatorProvider, 'Wallabag (Symfony HttpClient/5)');
 
         $loginRequired = $auth->isLoginRequired($siteConfig, file_get_contents(__DIR__ . '/../fixtures/nextinpact-article.html'));
 
@@ -235,7 +235,7 @@ class LoginFormAuthenticatorTest extends TestCase
         ;
         $authenticatorProvider = new AuthenticatorProvider($requestHtmlFunctionClient);
 
-        $auth = new LoginFormAuthenticator($browser, $authenticatorProvider);
+        $auth = new LoginFormAuthenticator($browser, $authenticatorProvider, 'Wallabag (Symfony HttpClient/5)');
 
         $res = $auth->login($siteConfig);
 


### PR DESCRIPTION
Hello,

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Documentation | no
| Translation   | no
| CHANGELOG.md  | no
| License       | MIT

This PR is related to #7878
The idea is to use a user-agent that describe the Wallabag instance so it's easier for websites to identify and allow the requests.
`Wallabag/%wallabag.version% (Guzzle/5 +%domain_name%)`

I wanted to fetch the Guzzle version from the composer lockfile but I don't know if we can do that.