### PR TITLE
Make AuthenticatorProvider use Symfony HTTP Client

### DIFF
--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -45,6 +45,8 @@ framework:
                 headers:
                     Content-Type: 'application/json'
                     X-Accept: 'application/json'
+            request_html_function.client:
+                scope: '.*'
 
 # Twig Configuration
 twig:

--- a/app/config/services.yml
+++ b/app/config/services.yml
@@ -34,7 +34,7 @@ services:
 
     Wallabag\:
         resource: '../../src/*'
-        exclude: ['../../src/{Consumer,Controller,Entity,ExpressionLanguage,DataFixtures,Redis}', '../../src/Event/*Event.php']
+        exclude: ['../../src/{Consumer,Controller,Entity,DataFixtures,Redis}', '../../src/Event/*Event.php']
 
     # controllers are imported separately to make sure services can be injected
     # as action arguments even if you don't extend any base controller class

--- a/src/ExpressionLanguage/AuthenticatorProvider.php
+++ b/src/ExpressionLanguage/AuthenticatorProvider.php
@@ -2,21 +2,18 @@
 
 namespace Wallabag\ExpressionLanguage;
 
-use GuzzleHttp\ClientInterface;
 use Symfony\Component\DomCrawler\Crawler;
 use Symfony\Component\ExpressionLanguage\ExpressionFunction;
 use Symfony\Component\ExpressionLanguage\ExpressionFunctionProviderInterface;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
 
 class AuthenticatorProvider implements ExpressionFunctionProviderInterface
 {
-    /**
-     * @var ClientInterface
-     */
-    private $guzzle;
+    private HttpClientInterface $requestHtmlFunctionClient;
 
-    public function __construct(ClientInterface $guzzle)
+    public function __construct(HttpClientInterface $requestHtmlFunctionClient)
     {
-        $this->guzzle = $guzzle;
+        $this->requestHtmlFunctionClient = $requestHtmlFunctionClient;
     }
 
     public function getFunctions(): array
@@ -38,7 +35,7 @@ class AuthenticatorProvider implements ExpressionFunctionProviderInterface
                 throw new \Exception('Not supported');
             },
             function (array $arguments, $uri) {
-                return $this->guzzle->get($uri, $options)->getBody();
+                return $this->requestHtmlFunctionClient->request('GET', $uri)->getContent();
             }
         );
     }

--- a/src/ExpressionLanguage/AuthenticatorProvider.php
+++ b/src/ExpressionLanguage/AuthenticatorProvider.php
@@ -37,7 +37,7 @@ class AuthenticatorProvider implements ExpressionFunctionProviderInterface
             function () {
                 throw new \Exception('Not supported');
             },
-            function (array $arguments, $uri, array $options = []) {
+            function (array $arguments, $uri) {
                 return $this->guzzle->get($uri, $options)->getBody();
             }
         );

--- a/src/SiteConfig/LoginFormAuthenticator.php
+++ b/src/SiteConfig/LoginFormAuthenticator.php
@@ -10,11 +10,11 @@ use Wallabag\ExpressionLanguage\AuthenticatorProvider;
 
 class LoginFormAuthenticator
 {
-    private AuthenticatorProvider $authenticatorProvider;
+    private ExpressionLanguage $expressionLanguage;
 
     public function __construct(AuthenticatorProvider $authenticatorProvider)
     {
-        $this->authenticatorProvider = $authenticatorProvider;
+        $this->expressionLanguage = new ExpressionLanguage(null, [$authenticatorProvider]);
     }
 
     /**
@@ -90,8 +90,7 @@ class LoginFormAuthenticator
 
         foreach ($siteConfig->getExtraFields() as $fieldName => $fieldValue) {
             if ('@=' === substr($fieldValue, 0, 2)) {
-                $expressionLanguage = $this->getExpressionLanguage();
-                $fieldValue = $expressionLanguage->evaluate(
+                $fieldValue = $this->expressionLanguage->evaluate(
                     substr($fieldValue, 2),
                     [
                         'config' => $siteConfig,
@@ -103,16 +102,5 @@ class LoginFormAuthenticator
         }
 
         return $extraFields;
-    }
-
-    /**
-     * @return ExpressionLanguage
-     */
-    private function getExpressionLanguage()
-    {
-        return new ExpressionLanguage(
-            null,
-            [$this->authenticatorProvider]
-        );
     }
 }

--- a/src/SiteConfig/LoginFormAuthenticator.php
+++ b/src/SiteConfig/LoginFormAuthenticator.php
@@ -10,6 +10,13 @@ use Wallabag\ExpressionLanguage\AuthenticatorProvider;
 
 class LoginFormAuthenticator
 {
+    private AuthenticatorProvider $authenticatorProvider;
+
+    public function __construct(AuthenticatorProvider $authenticatorProvider)
+    {
+        $this->authenticatorProvider = $authenticatorProvider;
+    }
+
     /**
      * Logs the configured user on the given Guzzle client.
      *
@@ -20,7 +27,7 @@ class LoginFormAuthenticator
         $postFields = [
             $siteConfig->getUsernameField() => $siteConfig->getUsername(),
             $siteConfig->getPasswordField() => $siteConfig->getPassword(),
-        ] + $this->getExtraFields($siteConfig, $guzzle);
+        ] + $this->getExtraFields($siteConfig);
 
         $guzzle->post(
             $siteConfig->getLoginUri(),
@@ -77,13 +84,13 @@ class LoginFormAuthenticator
      *
      * @return array
      */
-    private function getExtraFields(SiteConfig $siteConfig, ClientInterface $guzzle)
+    private function getExtraFields(SiteConfig $siteConfig)
     {
         $extraFields = [];
 
         foreach ($siteConfig->getExtraFields() as $fieldName => $fieldValue) {
             if ('@=' === substr($fieldValue, 0, 2)) {
-                $expressionLanguage = $this->getExpressionLanguage($guzzle);
+                $expressionLanguage = $this->getExpressionLanguage();
                 $fieldValue = $expressionLanguage->evaluate(
                     substr($fieldValue, 2),
                     [
@@ -101,11 +108,11 @@ class LoginFormAuthenticator
     /**
      * @return ExpressionLanguage
      */
-    private function getExpressionLanguage(ClientInterface $guzzle)
+    private function getExpressionLanguage()
     {
         return new ExpressionLanguage(
             null,
-            [new AuthenticatorProvider($guzzle)]
+            [$this->authenticatorProvider]
         );
     }
 }

--- a/tests/SiteConfig/LoginFormAuthenticatorTest.php
+++ b/tests/SiteConfig/LoginFormAuthenticatorTest.php
@@ -7,6 +7,9 @@ use GuzzleHttp\Message\Response;
 use GuzzleHttp\Stream\Stream;
 use GuzzleHttp\Subscriber\Mock;
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpClient\MockHttpClient;
+use Symfony\Component\HttpClient\Response\MockResponse;
+use Wallabag\ExpressionLanguage\AuthenticatorProvider;
 use Wallabag\SiteConfig\LoginFormAuthenticator;
 use Wallabag\SiteConfig\SiteConfig;
 
@@ -22,6 +25,8 @@ class LoginFormAuthenticatorTest extends TestCase
         $guzzle = new Client();
         $guzzle->getEmitter()->attach(new Mock([$response]));
 
+        $mockHttpClient = new MockHttpClient([new MockResponse('', ['http_code' => 200, 'response_headers' => ['content-type' => 'text/html']])]);
+
         $siteConfig = new SiteConfig([
             'host' => 'example.com',
             'loginUri' => 'http://example.com/login',
@@ -35,7 +40,8 @@ class LoginFormAuthenticatorTest extends TestCase
             'password' => 'unkn0wn',
         ]);
 
-        $auth = new LoginFormAuthenticator();
+        $authenticatorProvider = new AuthenticatorProvider($mockHttpClient);
+        $auth = new LoginFormAuthenticator($authenticatorProvider);
         $res = $auth->login($siteConfig, $guzzle);
 
         $this->assertInstanceOf(LoginFormAuthenticator::class, $res);
@@ -51,6 +57,8 @@ class LoginFormAuthenticatorTest extends TestCase
         $guzzle = new Client();
         $guzzle->getEmitter()->attach(new Mock([$response, $response]));
 
+        $mockHttpClient = new MockHttpClient([new MockResponse('<html></html>', ['http_code' => 200, 'response_headers' => ['content-type' => 'text/html']])]);
+
         $siteConfig = new SiteConfig([
             'host' => 'example.com',
             'loginUri' => 'http://example.com/login',
@@ -65,7 +73,8 @@ class LoginFormAuthenticatorTest extends TestCase
             'password' => 'unkn0wn',
         ]);
 
-        $auth = new LoginFormAuthenticator();
+        $authenticatorProvider = new AuthenticatorProvider($mockHttpClient);
+        $auth = new LoginFormAuthenticator($authenticatorProvider);
         $res = $auth->login($siteConfig, $guzzle);
 
         $this->assertInstanceOf(LoginFormAuthenticator::class, $res);
@@ -85,6 +94,8 @@ class LoginFormAuthenticatorTest extends TestCase
         $response->expects($this->any())
             ->method('getStatusCode')
             ->willReturn(200);
+
+        $mockHttpClient = new MockHttpClient([new MockResponse(file_get_contents(__DIR__ . '/../fixtures/aoc.media.html'), ['http_code' => 200, 'response_headers' => ['content-type' => 'text/html']])]);
 
         $client = $this->getMockBuilder(Client::class)
             ->disableOriginalConstructor()
@@ -128,7 +139,8 @@ class LoginFormAuthenticatorTest extends TestCase
             'password' => 'unkn0wn',
         ]);
 
-        $auth = new LoginFormAuthenticator();
+        $authenticatorProvider = new AuthenticatorProvider($mockHttpClient);
+        $auth = new LoginFormAuthenticator($authenticatorProvider);
         $res = $auth->login($siteConfig, $client);
 
         $this->assertInstanceOf(LoginFormAuthenticator::class, $res);
@@ -147,6 +159,8 @@ class LoginFormAuthenticatorTest extends TestCase
         $response->expects($this->any())
             ->method('getStatusCode')
             ->willReturn(200);
+
+        $mockHttpClient = new MockHttpClient([new MockResponse(file_get_contents(__DIR__ . '/../fixtures/nextinpact-login.html'), ['http_code' => 200, 'response_headers' => ['content-type' => 'text/html']])]);
 
         $client = $this->getMockBuilder(Client::class)
             ->disableOriginalConstructor()
@@ -194,7 +208,8 @@ class LoginFormAuthenticatorTest extends TestCase
             'password' => 'unkn0wn',
         ]);
 
-        $auth = new LoginFormAuthenticator();
+        $authenticatorProvider = new AuthenticatorProvider($mockHttpClient);
+        $auth = new LoginFormAuthenticator($authenticatorProvider);
         $res = $auth->login($siteConfig, $client);
 
         $this->assertInstanceOf(LoginFormAuthenticator::class, $res);
@@ -210,7 +225,10 @@ class LoginFormAuthenticatorTest extends TestCase
             'password' => 'unkn0wn',
         ]);
 
-        $auth = new LoginFormAuthenticator();
+        $mockHttpClient = new MockHttpClient();
+
+        $authenticatorProvider = new AuthenticatorProvider($mockHttpClient);
+        $auth = new LoginFormAuthenticator($authenticatorProvider);
         $loginRequired = $auth->isLoginRequired($siteConfig, file_get_contents(__DIR__ . '/../fixtures/nextinpact-login.html'));
 
         $this->assertFalse($loginRequired);
@@ -227,7 +245,10 @@ class LoginFormAuthenticatorTest extends TestCase
             'notLoggedInXpath' => '//h2[@class="title_reserve_article"]',
         ]);
 
-        $auth = new LoginFormAuthenticator();
+        $mockHttpClient = new MockHttpClient();
+
+        $authenticatorProvider = new AuthenticatorProvider($mockHttpClient);
+        $auth = new LoginFormAuthenticator($authenticatorProvider);
         $loginRequired = $auth->isLoginRequired($siteConfig, file_get_contents(__DIR__ . '/../fixtures/nextinpact-article.html'));
 
         $this->assertTrue($loginRequired);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Documentation | no
| Translation   | no
| CHANGELOG.md  | no
| License       | MIT

The `request_html` is used only in login context, so no need for authentication cookie from the cookie jar, we can safely use Symfony HTTP Client there.
Also, among all site configs using `request_html` function, only the URL is passed as parameter, so I removed the support for passing Guzzle options to it.