### PR TITLE
Use Graby's http headers configuration for the authentication request

### DIFF
--- a/src/SiteConfig/GrabySiteConfigBuilder.php
+++ b/src/SiteConfig/GrabySiteConfigBuilder.php
@@ -85,6 +85,7 @@ class GrabySiteConfigBuilder implements SiteConfigBuilder
             'notLoggedInXpath' => $config->not_logged_in_xpath ?: null,
             'username' => $credentials['username'],
             'password' => $credentials['password'],
+            'httpHeaders' => $config->http_header,
         ];
 
         $config = new SiteConfig($parameters);

--- a/src/SiteConfig/LoginFormAuthenticator.php
+++ b/src/SiteConfig/LoginFormAuthenticator.php
@@ -30,7 +30,7 @@ class LoginFormAuthenticator
             $siteConfig->getPasswordField() => $siteConfig->getPassword(),
         ] + $this->getExtraFields($siteConfig);
 
-        $this->browser->request('POST', $siteConfig->getLoginUri(), $postFields);
+        $this->browser->request('POST', $siteConfig->getLoginUri(), $postFields, [], $this->getHttpHeaders($siteConfig));
 
         return $this;
     }
@@ -71,6 +71,20 @@ class LoginFormAuthenticator
         }
 
         return \count($loggedIn) > 0;
+    }
+
+    /**
+     * Processes http_header(*) config, prepending HTTP_ string to the header's name.
+     * See : https://github.com/symfony/browser-kit/blob/5.4/AbstractBrowser.php#L349.
+     */
+    protected function getHttpHeaders(SiteConfig $siteConfig): array
+    {
+        $headers = [];
+        foreach ($siteConfig->getHttpHeaders() as $headerName => $headerValue) {
+            $headers["HTTP_$headerName"] = $headerValue;
+        }
+
+        return $headers;
     }
 
     /**

--- a/src/SiteConfig/SiteConfig.php
+++ b/src/SiteConfig/SiteConfig.php
@@ -71,6 +71,13 @@ class SiteConfig
     protected $password;
 
     /**
+     * Associative array of HTTP headers to send with the form.
+     *
+     * @var array
+     */
+    protected $httpHeaders = [];
+
+    /**
      * SiteConfig constructor. Sets the properties by name given a hash.
      *
      * @throws \InvalidArgumentException if a property doesn't exist
@@ -257,6 +264,18 @@ class SiteConfig
     public function setPassword($password)
     {
         $this->password = $password;
+
+        return $this;
+    }
+
+    public function getHttpHeaders(): array
+    {
+        return $this->httpHeaders;
+    }
+
+    public function setHttpHeaders(array $httpHeaders): self
+    {
+        $this->httpHeaders = $httpHeaders;
 
         return $this;
     }

--- a/tests/SiteConfig/SiteConfigTest.php
+++ b/tests/SiteConfig/SiteConfigTest.php
@@ -37,6 +37,9 @@ class SiteConfigTest extends TestCase
             ],
             'username' => 'johndoe',
             'password' => 'unkn0wn',
+            'httpHeaders' => [
+                'user-agent' => 'Wallabag (Guzzle/5)',
+            ],
         ]);
 
         $this->assertInstanceOf(SiteConfig::class, $config);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Documentation | no
| Translation   | no
| CHANGELOG.md  | no
| License       | MIT

This PR is related to https://github.com/wallabag/wallabag/issues/7878
Currently, if a user defines a User-Agent for a website Wallabag uses this User-Agent only to get the content, not for the authentication request.

This PR pass the HTTP headers defined for the website to the authentication request.