### PR TITLE
Stop using get() directly on Request

### DIFF
--- a/src/Controller/Api/TagRestController.php
+++ b/src/Controller/Api/TagRestController.php
@@ -70,7 +70,7 @@ class TagRestController extends WallabagRestController
     public function deleteTagLabelAction(Request $request, TagRepository $tagRepository, EntryRepository $entryRepository)
     {
         $this->validateAuthentication();
-        $label = $request->get('tag', '');
+        $label = $request->request->get('tag', $request->query->get('tag', ''));
 
         $tags = $tagRepository->findByLabelsAndUser([$label], $this->getUser()->getId());
 
@@ -119,7 +119,7 @@ class TagRestController extends WallabagRestController
     {
         $this->validateAuthentication();
 
-        $tagsLabels = $request->get('tags', '');
+        $tagsLabels = $request->request->get('tags', $request->query->get('tags', ''));
 
         $tags = $tagRepository->findByLabelsAndUser(explode(',', $tagsLabels), $this->getUser()->getId());
 

--- a/src/Controller/ConfigController.php
+++ b/src/Controller/ConfigController.php
@@ -411,7 +411,7 @@ class ConfigController extends AbstractController
 
         $isValid = $googleAuthenticator->checkCode(
             $this->getUser(),
-            $request->get('_auth_code')
+            $request->request->get('_auth_code')
         );
 
         if (true === $isValid) {

--- a/src/Controller/EntryController.php
+++ b/src/Controller/EntryController.php
@@ -221,7 +221,7 @@ class EntryController extends AbstractController
     public function addEntryViaBookmarkletAction(Request $request)
     {
         $entry = new Entry($this->getUser());
-        $entry->setUrl($request->get('url'));
+        $entry->setUrl($request->query->get('url'));
 
         if (false === $this->checkIfEntryAlreadyExists($entry)) {
             $this->updateEntry($entry);
@@ -623,7 +623,7 @@ class EntryController extends AbstractController
      */
     private function showEntries($type, Request $request, $page)
     {
-        $searchTerm = (isset($request->get('search_entry')['term']) ? trim($request->get('search_entry')['term']) : '');
+        $searchTerm = (isset($request->query->get('search_entry')['term']) ? trim($request->query->get('search_entry')['term']) : '');
         $currentRoute = (null !== $request->query->get('currentRoute') ? $request->query->get('currentRoute') : '');
 
         $formOptions = [];

--- a/src/Controller/ExportController.php
+++ b/src/Controller/ExportController.php
@@ -69,7 +69,7 @@ class ExportController extends AbstractController
         if ('same_domain' === $category) {
             $entries = $entryRepository->getBuilderForSameDomainByUser(
                 $this->getUser()->getId(),
-                $request->get('entry')
+                $request->query->get('entry')
             )->getQuery()
              ->getResult();
 
@@ -84,7 +84,7 @@ class ExportController extends AbstractController
 
             $title = 'Tag ' . $tag->getLabel();
         } elseif ('search' === $category) {
-            $searchTerm = (isset($request->get('search_entry')['term']) ? $request->get('search_entry')['term'] : '');
+            $searchTerm = (isset($request->query->get('search_entry')['term']) ? $request->query->get('search_entry')['term'] : '');
             $currentRoute = (null !== $request->query->get('currentRoute') ? $request->query->get('currentRoute') : '');
 
             $entries = $entryRepository->getBuilderForSearchByUser(

--- a/src/Controller/TagController.php
+++ b/src/Controller/TagController.php
@@ -155,7 +155,7 @@ class TagController extends AbstractController
             $entries->setCurrentPage($page);
         } catch (OutOfRangeCurrentPageException $e) {
             if ($page > 1) {
-                return $this->redirect($this->generateUrl($request->get('_route'), [
+                return $this->redirect($this->generateUrl($request->attributes->get('_route'), [
                     'slug' => $tag->getSlug(),
                     'page' => $entries->getNbPages(),
                 ]), 302);

--- a/src/Controller/UserController.php
+++ b/src/Controller/UserController.php
@@ -161,7 +161,7 @@ class UserController extends AbstractController
         $form->handleRequest($request);
 
         if ($form->isSubmitted() && $form->isValid()) {
-            $searchTerm = (isset($request->get('search_user')['term']) ? $request->get('search_user')['term'] : '');
+            $searchTerm = (isset($request->query->get('search_user')['term']) ? $request->query->get('search_user')['term'] : '');
 
             $qb = $userRepository->getQueryBuilderForSearch($searchTerm);
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | yes
| Tests pass?   | yes
| Documentation | no
| Translation   | no
| CHANGELOG.md  | no
| License       | MIT

since Symfony 5.4 we must use explicit input sources
