### PR TITLE
Fix some deprecation notices

### DIFF
--- a/fixtures/AnnotationFixtures.php
+++ b/fixtures/AnnotationFixtures.php
@@ -11,7 +11,7 @@ use Wallabag\Entity\User;
 
 class AnnotationFixtures extends Fixture implements DependentFixtureInterface
 {
-    public function load(ObjectManager $manager)
+    public function load(ObjectManager $manager): void
     {
         $annotation1 = new Annotation($this->getReference('admin-user', User::class));
         $annotation1->setEntry($this->getReference('entry1', Entry::class));

--- a/fixtures/UserFixtures.php
+++ b/fixtures/UserFixtures.php
@@ -8,7 +8,7 @@ use Wallabag\Entity\User;
 
 class UserFixtures extends Fixture
 {
-    public function load(ObjectManager $manager)
+    public function load(ObjectManager $manager): void
     {
         $userAdmin = new User();
         $userAdmin->setName('Big boss');

--- a/src/Command/CleanDownloadedImagesCommand.php
+++ b/src/Command/CleanDownloadedImagesCommand.php
@@ -38,7 +38,7 @@ class CleanDownloadedImagesCommand extends Command
             );
     }
 
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $io = new SymfonyStyle($input, $output);
 

--- a/src/Command/CleanDuplicatesCommand.php
+++ b/src/Command/CleanDuplicatesCommand.php
@@ -45,7 +45,7 @@ class CleanDuplicatesCommand extends Command
             );
     }
 
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $this->io = new SymfonyStyle($input, $output);
 

--- a/src/Command/ExportCommand.php
+++ b/src/Command/ExportCommand.php
@@ -49,7 +49,7 @@ class ExportCommand extends Command
         ;
     }
 
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $io = new SymfonyStyle($input, $output);
 

--- a/src/Command/GenerateUrlHashesCommand.php
+++ b/src/Command/GenerateUrlHashesCommand.php
@@ -39,7 +39,7 @@ class GenerateUrlHashesCommand extends Command
             ->addArgument('username', InputArgument::OPTIONAL, 'User to process entries');
     }
 
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $this->output = $output;
 

--- a/src/Command/Import/ImportCommand.php
+++ b/src/Command/Import/ImportCommand.php
@@ -97,7 +97,7 @@ class ImportCommand extends Command
         ;
     }
 
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $output->writeln('Start : ' . (new \DateTime())->format('d-m-Y G:i:s') . ' ---');
 

--- a/src/Command/Import/ImportCommand.php
+++ b/src/Command/Import/ImportCommand.php
@@ -125,7 +125,6 @@ class ImportCommand extends Command
         // Authenticate user for paywalled websites
         $token = new UsernamePasswordToken(
             $entityUser,
-            null,
             'main',
             $entityUser->getRoles());
 

--- a/src/Command/Import/RedisWorkerCommand.php
+++ b/src/Command/Import/RedisWorkerCommand.php
@@ -33,7 +33,7 @@ class RedisWorkerCommand extends Command
         ;
     }
 
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $output->writeln('Worker started at: ' . (new \DateTime())->format('d-m-Y G:i:s'));
         $output->writeln('Waiting for message ...');

--- a/src/Command/InstallCommand.php
+++ b/src/Command/InstallCommand.php
@@ -70,7 +70,7 @@ class InstallCommand extends Command
         ;
     }
 
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $this->defaultInput = $input;
 

--- a/src/Command/ListUserCommand.php
+++ b/src/Command/ListUserCommand.php
@@ -33,7 +33,7 @@ class ListUserCommand extends Command
         ;
     }
 
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $io = new SymfonyStyle($input, $output);
 

--- a/src/Command/ReloadEntryCommand.php
+++ b/src/Command/ReloadEntryCommand.php
@@ -51,7 +51,7 @@ class ReloadEntryCommand extends Command
             );
     }
 
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $io = new SymfonyStyle($input, $output);
 

--- a/src/Command/ShowUserCommand.php
+++ b/src/Command/ShowUserCommand.php
@@ -37,7 +37,7 @@ class ShowUserCommand extends Command
             );
     }
 
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $this->io = new SymfonyStyle($input, $output);
 

--- a/src/Command/TagAllCommand.php
+++ b/src/Command/TagAllCommand.php
@@ -42,7 +42,7 @@ class TagAllCommand extends Command
         ;
     }
 
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $io = new SymfonyStyle($input, $output);
 

--- a/src/Command/UpdatePicturesPathCommand.php
+++ b/src/Command/UpdatePicturesPathCommand.php
@@ -37,7 +37,7 @@ class UpdatePicturesPathCommand extends Command
             );
     }
 
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $io = new SymfonyStyle($input, $output);
 

--- a/src/Controller/Api/EntryRestController.php
+++ b/src/Controller/Api/EntryRestController.php
@@ -314,7 +314,7 @@ class EntryRestController extends WallabagRestController
         $order = strtolower($request->query->get('order', 'desc'));
         $page = (int) $request->query->get('page', 1);
         $perPage = (int) $request->query->get('perPage', 30);
-        $tags = \is_array($request->query->get('tags')) ? '' : (string) $request->query->get('tags', '');
+        $tags = \is_array($request->query->all()['tags'] ?? '') ? '' : (string) $request->query->get('tags', '');
         $since = $request->query->get('since', 0);
         $detail = strtolower($request->query->get('detail', 'full'));
         $domainName = (null === $request->query->get('domain_name')) ? '' : (string) $request->query->get('domain_name');
@@ -477,7 +477,7 @@ class EntryRestController extends WallabagRestController
     {
         $this->validateAuthentication();
 
-        $urls = json_decode($request->query->get('urls', []));
+        $urls = json_decode($request->query->get('urls', '[]'));
 
         if (empty($urls)) {
             return $this->sendResponse([]);
@@ -537,7 +537,7 @@ class EntryRestController extends WallabagRestController
     {
         $this->validateAuthentication();
 
-        $urls = json_decode($request->query->get('urls', []));
+        $urls = json_decode($request->query->get('urls', '[]'));
 
         $limit = $this->getParameter('wallabag.api_limit_mass_actions');
 
@@ -1287,7 +1287,7 @@ class EntryRestController extends WallabagRestController
     {
         $this->validateAuthentication();
 
-        $list = json_decode($request->query->get('list', []));
+        $list = json_decode($request->query->get('list', '[]'));
 
         if (empty($list)) {
             return $this->sendResponse([]);
@@ -1354,7 +1354,7 @@ class EntryRestController extends WallabagRestController
     {
         $this->validateAuthentication();
 
-        $list = json_decode($request->query->get('list', []));
+        $list = json_decode($request->query->get('list', '[]'));
 
         if (empty($list)) {
             return $this->sendResponse([]);
@@ -1413,7 +1413,7 @@ class EntryRestController extends WallabagRestController
     {
         return [
             'title' => $request->request->get('title'),
-            'tags' => $request->request->get('tags', []),
+            'tags' => $request->request->get('tags', ''),
             'isArchived' => $request->request->get('archive'),
             'isStarred' => $request->request->get('starred'),
             'isPublic' => $request->request->get('public'),
@@ -1421,7 +1421,7 @@ class EntryRestController extends WallabagRestController
             'language' => $request->request->get('language'),
             'picture' => $request->request->get('preview_picture'),
             'publishedAt' => $request->request->get('published_at'),
-            'authors' => $request->request->get('authors', ''),
+            'authors' => $request->request->all()['authors'] ?? '',
             'origin_url' => $request->request->get('origin_url', ''),
         ];
     }

--- a/src/Controller/Api/TaggingRuleRestController.php
+++ b/src/Controller/Api/TaggingRuleRestController.php
@@ -37,7 +37,7 @@ class TaggingRuleRestController extends WallabagRestController
             SerializationContext::create()->setGroups(['export_tagging_rule'])
         );
 
-        return Response::create(
+        return new Response(
             $data,
             200,
             [

--- a/src/Controller/ConfigController.php
+++ b/src/Controller/ConfigController.php
@@ -700,7 +700,7 @@ class ConfigController extends AbstractController
             SerializationContext::create()->setGroups(['export_tagging_rule'])
         );
 
-        return Response::create(
+        return new Response(
             $data,
             200,
             [

--- a/src/Controller/EntryController.php
+++ b/src/Controller/EntryController.php
@@ -625,6 +625,7 @@ class EntryController extends AbstractController
     {
         $searchTerm = (isset($request->get('search_entry')['term']) ? trim($request->get('search_entry')['term']) : '');
         $currentRoute = (null !== $request->query->get('currentRoute') ? $request->query->get('currentRoute') : '');
+        $currentEntryId = $request->attributes->getInt('id');
 
         $formOptions = [];
 
@@ -651,7 +652,7 @@ class EntryController extends AbstractController
                 $formOptions['filter_unread'] = true;
                 break;
             case 'same-domain':
-                $qb = $this->entryRepository->getBuilderForSameDomainByUser($this->getUser()->getId(), $request->get('id'));
+                $qb = $this->entryRepository->getBuilderForSameDomainByUser($this->getUser()->getId(), $currentEntryId);
                 break;
             case 'all':
                 $qb = $this->entryRepository->getBuilderForAllByUser($this->getUser()->getId());
@@ -664,7 +665,7 @@ class EntryController extends AbstractController
 
         if ($request->query->has($form->getName())) {
             // manually bind values from the request
-            $form->submit($request->query->get($form->getName()));
+            $form->submit($request->query->all($form->getName()));
 
             // build the query from the given form object
             $this->filterBuilderUpdater->addFilterConditions($form, $qb);

--- a/src/Doctrine/JsonArrayType.php
+++ b/src/Doctrine/JsonArrayType.php
@@ -25,12 +25,12 @@ class JsonArrayType extends JsonType
         return json_decode($value, true);
     }
 
-    public function getName()
+    public function getName(): string
     {
         return 'json_array';
     }
 
-    public function requiresSQLCommentHint(AbstractPlatform $platform)
+    public function requiresSQLCommentHint(AbstractPlatform $platform): bool
     {
         return true;
     }

--- a/src/Event/Listener/AuthenticationFailureListener.php
+++ b/src/Event/Listener/AuthenticationFailureListener.php
@@ -30,7 +30,7 @@ class AuthenticationFailureListener implements EventSubscriberInterface
      */
     public function onAuthenticationFailure()
     {
-        $request = $this->requestStack->getMasterRequest();
+        $request = $this->requestStack->getMainRequest();
 
         $this->logger->error('Authentication failure for user "' . $request->request->get('_username') . '", from IP "' . $request->getClientIp() . '", with UA: "' . $request->server->get('HTTP_USER_AGENT') . '".');
     }

--- a/src/Event/Listener/AuthenticationFailureListener.php
+++ b/src/Event/Listener/AuthenticationFailureListener.php
@@ -18,7 +18,7 @@ class AuthenticationFailureListener implements EventSubscriberInterface
         $this->logger = $logger;
     }
 
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         return [
             AuthenticationEvents::AUTHENTICATION_FAILURE => 'onAuthenticationFailure',

--- a/src/Event/Listener/CreateConfigListener.php
+++ b/src/Event/Listener/CreateConfigListener.php
@@ -38,7 +38,7 @@ class CreateConfigListener implements EventSubscriberInterface
         $this->displayThumbnails = $displayThumbnails;
     }
 
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         return [
             // when a user register using the normal form

--- a/src/Event/Listener/CreateConfigListener.php
+++ b/src/Event/Listener/CreateConfigListener.php
@@ -53,8 +53,8 @@ class CreateConfigListener implements EventSubscriberInterface
     {
         $language = $this->language;
 
-        if ($this->requestStack->getMasterRequest()) {
-            $session = $this->requestStack->getMasterRequest()->getSession();
+        if ($this->requestStack->getMainRequest()) {
+            $session = $this->requestStack->getMainRequest()->getSession();
             $language = $session->get('_locale', $this->language);
         }
 

--- a/src/Event/Listener/LocaleListener.php
+++ b/src/Event/Listener/LocaleListener.php
@@ -34,7 +34,7 @@ class LocaleListener implements EventSubscriberInterface
         }
     }
 
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         return [
             // must be registered before the default Locale listener

--- a/src/Event/Listener/PasswordResettingListener.php
+++ b/src/Event/Listener/PasswordResettingListener.php
@@ -22,7 +22,7 @@ class PasswordResettingListener implements EventSubscriberInterface
         $this->router = $router;
     }
 
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         return [
             FOSUserEvents::RESETTING_RESET_SUCCESS => 'onPasswordResettingSuccess',

--- a/src/Event/Listener/RegistrationListener.php
+++ b/src/Event/Listener/RegistrationListener.php
@@ -26,7 +26,7 @@ class RegistrationListener implements EventSubscriberInterface
         $this->urlGenerator = $urlGenerator;
     }
 
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         return [
             FOSUserEvents::REGISTRATION_INITIALIZE => 'onRegistrationInitialize',

--- a/src/Event/Subscriber/DownloadImagesSubscriber.php
+++ b/src/Event/Subscriber/DownloadImagesSubscriber.php
@@ -25,7 +25,7 @@ class DownloadImagesSubscriber implements EventSubscriberInterface
         $this->logger = $logger;
     }
 
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         return [
             EntrySavedEvent::NAME => 'onEntrySaved',

--- a/src/Event/Subscriber/GenerateCustomCSSSubscriber.php
+++ b/src/Event/Subscriber/GenerateCustomCSSSubscriber.php
@@ -18,7 +18,7 @@ class GenerateCustomCSSSubscriber implements EventSubscriberInterface
         $this->compiler = $compiler;
     }
 
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         return [
             ConfigUpdatedEvent::NAME => 'onConfigUpdated',

--- a/src/Event/Subscriber/SchemaAdapterSubscriber.php
+++ b/src/Event/Subscriber/SchemaAdapterSubscriber.php
@@ -15,7 +15,7 @@ class SchemaAdapterSubscriber implements EventSubscriber
         $this->databaseTablePrefix = $databaseTablePrefix;
     }
 
-    public function getSubscribedEvents()
+    public function getSubscribedEvents(): array
     {
         return ['postGenerateSchema'];
     }

--- a/src/Event/Subscriber/TablePrefixSubscriber.php
+++ b/src/Event/Subscriber/TablePrefixSubscriber.php
@@ -25,7 +25,7 @@ class TablePrefixSubscriber implements EventSubscriber
         $this->tablePrefix = (string) $tablePrefix;
     }
 
-    public function getSubscribedEvents()
+    public function getSubscribedEvents(): array
     {
         return ['loadClassMetadata'];
     }

--- a/src/Form/Type/Api/ClientType.php
+++ b/src/Form/Type/Api/ClientType.php
@@ -45,7 +45,7 @@ class ClientType extends AbstractType
         ]);
     }
 
-    public function getBlockPrefix()
+    public function getBlockPrefix(): string
     {
         return 'client';
     }

--- a/src/Form/Type/ChangePasswordType.php
+++ b/src/Form/Type/ChangePasswordType.php
@@ -41,7 +41,7 @@ class ChangePasswordType extends AbstractType
         ;
     }
 
-    public function getBlockPrefix()
+    public function getBlockPrefix(): string
     {
         return 'change_passwd';
     }

--- a/src/Form/Type/ConfigType.php
+++ b/src/Form/Type/ConfigType.php
@@ -104,7 +104,7 @@ class ConfigType extends AbstractType
         ]);
     }
 
-    public function getBlockPrefix()
+    public function getBlockPrefix(): string
     {
         return 'config';
     }

--- a/src/Form/Type/EditEntryType.php
+++ b/src/Form/Type/EditEntryType.php
@@ -44,7 +44,7 @@ class EditEntryType extends AbstractType
         ]);
     }
 
-    public function getBlockPrefix()
+    public function getBlockPrefix(): string
     {
         return 'entry';
     }

--- a/src/Form/Type/EntryFilterType.php
+++ b/src/Form/Type/EntryFilterType.php
@@ -197,7 +197,7 @@ class EntryFilterType extends AbstractType
         ;
     }
 
-    public function getBlockPrefix()
+    public function getBlockPrefix(): string
     {
         return 'entry_filter';
     }

--- a/src/Form/Type/FeedType.php
+++ b/src/Form/Type/FeedType.php
@@ -30,7 +30,7 @@ class FeedType extends AbstractType
         ]);
     }
 
-    public function getBlockPrefix()
+    public function getBlockPrefix(): string
     {
         return 'feed_config';
     }

--- a/src/Form/Type/IgnoreOriginInstanceRuleType.php
+++ b/src/Form/Type/IgnoreOriginInstanceRuleType.php
@@ -31,7 +31,7 @@ class IgnoreOriginInstanceRuleType extends AbstractType
         ]);
     }
 
-    public function getBlockPrefix()
+    public function getBlockPrefix(): string
     {
         return 'ignore_origin_instance_rule';
     }

--- a/src/Form/Type/IgnoreOriginUserRuleType.php
+++ b/src/Form/Type/IgnoreOriginUserRuleType.php
@@ -31,7 +31,7 @@ class IgnoreOriginUserRuleType extends AbstractType
         ]);
     }
 
-    public function getBlockPrefix()
+    public function getBlockPrefix(): string
     {
         return 'ignore_origin_user_rule';
     }

--- a/src/Form/Type/NewEntryType.php
+++ b/src/Form/Type/NewEntryType.php
@@ -28,7 +28,7 @@ class NewEntryType extends AbstractType
         ]);
     }
 
-    public function getBlockPrefix()
+    public function getBlockPrefix(): string
     {
         return 'entry';
     }

--- a/src/Form/Type/NewTagType.php
+++ b/src/Form/Type/NewTagType.php
@@ -37,7 +37,7 @@ class NewTagType extends AbstractType
         ]);
     }
 
-    public function getBlockPrefix()
+    public function getBlockPrefix(): string
     {
         return 'tag';
     }

--- a/src/Form/Type/NewUserType.php
+++ b/src/Form/Type/NewUserType.php
@@ -53,7 +53,7 @@ class NewUserType extends AbstractType
         ]);
     }
 
-    public function getBlockPrefix()
+    public function getBlockPrefix(): string
     {
         return 'new_user';
     }

--- a/src/Form/Type/RenameTagType.php
+++ b/src/Form/Type/RenameTagType.php
@@ -29,7 +29,7 @@ class RenameTagType extends AbstractType
         ]);
     }
 
-    public function getBlockPrefix()
+    public function getBlockPrefix(): string
     {
         return 'tag';
     }

--- a/src/Form/Type/SiteCredentialType.php
+++ b/src/Form/Type/SiteCredentialType.php
@@ -38,7 +38,7 @@ class SiteCredentialType extends AbstractType
         ]);
     }
 
-    public function getBlockPrefix()
+    public function getBlockPrefix(): string
     {
         return 'site_credential';
     }

--- a/src/Form/Type/TaggingRuleImportType.php
+++ b/src/Form/Type/TaggingRuleImportType.php
@@ -22,7 +22,7 @@ class TaggingRuleImportType extends AbstractType
         ;
     }
 
-    public function getBlockPrefix()
+    public function getBlockPrefix(): string
     {
         return 'upload_tagging_rule_file';
     }

--- a/src/Form/Type/TaggingRuleType.php
+++ b/src/Form/Type/TaggingRuleType.php
@@ -40,7 +40,7 @@ class TaggingRuleType extends AbstractType
         ]);
     }
 
-    public function getBlockPrefix()
+    public function getBlockPrefix(): string
     {
         return 'tagging_rule';
     }

--- a/src/Form/Type/UploadImportType.php
+++ b/src/Form/Type/UploadImportType.php
@@ -27,7 +27,7 @@ class UploadImportType extends AbstractType
         ;
     }
 
-    public function getBlockPrefix()
+    public function getBlockPrefix(): string
     {
         return 'upload_import_file';
     }

--- a/src/Form/Type/UserInformationType.php
+++ b/src/Form/Type/UserInformationType.php
@@ -30,7 +30,7 @@ class UserInformationType extends AbstractType
         ;
     }
 
-    public function getParent()
+    public function getParent(): ?string
     {
         return RegistrationFormType::class;
     }
@@ -42,7 +42,7 @@ class UserInformationType extends AbstractType
         ]);
     }
 
-    public function getBlockPrefix()
+    public function getBlockPrefix(): string
     {
         return 'update_user';
     }

--- a/src/Helper/EntriesExport.php
+++ b/src/Helper/EntriesExport.php
@@ -234,7 +234,7 @@ class EntriesExport
         $hash = sha1(\sprintf('%s:%s', $this->wallabagUrl, implode(',', $entryIds)));
         $book->setIdentifier(\sprintf('urn:wallabag:%s', $hash), EPub::IDENTIFIER_URI);
 
-        return Response::create(
+        return new Response(
             $book->getBook(),
             200,
             [
@@ -309,7 +309,7 @@ class EntriesExport
         // set image scale factor
         $pdf->setImageScale(PDF_IMAGE_SCALE_RATIO);
 
-        return Response::create(
+        return new Response(
             $pdf->Output('', 'S'),
             200,
             [
@@ -354,7 +354,7 @@ class EntriesExport
         $output = stream_get_contents($handle);
         fclose($handle);
 
-        return Response::create(
+        return new Response(
             $output,
             200,
             [
@@ -370,7 +370,7 @@ class EntriesExport
      */
     private function produceJson(): Response
     {
-        return Response::create(
+        return new Response(
             $this->prepareSerializingContent('json'),
             200,
             [
@@ -386,7 +386,7 @@ class EntriesExport
      */
     private function produceXml(): Response
     {
-        return Response::create(
+        return new Response(
             $this->prepareSerializingContent('xml'),
             200,
             [
@@ -410,7 +410,7 @@ class EntriesExport
             $content .= $html->getText();
         }
 
-        return Response::create(
+        return new Response(
             $content,
             200,
             [
@@ -433,7 +433,7 @@ class EntriesExport
             $content .= $converter->convert('<h1>' . $entry->getTitle() . '</h1>' . $entry->getContent());
         }
 
-        return Response::create(
+        return new Response(
             $content,
             200,
             [

--- a/src/Import/AbstractImport.php
+++ b/src/Import/AbstractImport.php
@@ -37,7 +37,7 @@ abstract class AbstractImport implements ImportInterface
         $this->eventDispatcher = $eventDispatcher;
     }
 
-    public function setLogger(LoggerInterface $logger)
+    public function setLogger(LoggerInterface $logger): void
     {
         $this->logger = $logger;
     }

--- a/src/Operator/PHP/Matches.php
+++ b/src/Operator/PHP/Matches.php
@@ -16,6 +16,10 @@ class Matches
 {
     public function __invoke($subject, $pattern)
     {
+        if (null === $subject) {
+            return false;
+        }
+
         return false !== stripos($subject, $pattern);
     }
 }

--- a/src/Operator/PHP/NotMatches.php
+++ b/src/Operator/PHP/NotMatches.php
@@ -16,6 +16,10 @@ class NotMatches
 {
     public function __invoke($subject, $pattern)
     {
+        if (null === $subject) {
+            return true;
+        }
+
         return false === stripos($subject, $pattern);
     }
 }

--- a/src/ParamConverter/UsernameFeedTokenConverter.php
+++ b/src/ParamConverter/UsernameFeedTokenConverter.php
@@ -33,7 +33,7 @@ class UsernameFeedTokenConverter implements ParamConverterInterface
      *
      * Check, if object supported by our converter
      */
-    public function supports(ParamConverter $configuration)
+    public function supports(ParamConverter $configuration): bool
     {
         // If there is no manager, this means that only Doctrine DBAL is configured
         // In this case we can do nothing and just return
@@ -65,7 +65,7 @@ class UsernameFeedTokenConverter implements ParamConverterInterface
      * @throws \InvalidArgumentException When route attributes are missing
      * @throws NotFoundHttpException     When object not found
      */
-    public function apply(Request $request, ParamConverter $configuration)
+    public function apply(Request $request, ParamConverter $configuration): bool
     {
         $username = $request->attributes->get('username');
         $feedToken = $request->attributes->get('token');

--- a/src/Repository/Api/ClientRepository.php
+++ b/src/Repository/Api/ClientRepository.php
@@ -16,7 +16,7 @@ class ClientRepository extends ServiceEntityRepository
         parent::__construct($registry, Client::class);
     }
 
-    public function findOneBy(array $criteria, ?array $orderBy = null)
+    public function findOneBy(array $criteria, ?array $orderBy = null): ?object
     {
         if (!empty($criteria['id'])) {
             // cast client id to be an integer to avoid postgres error:

--- a/src/Twig/WallabagExtension.php
+++ b/src/Twig/WallabagExtension.php
@@ -36,7 +36,7 @@ class WallabagExtension extends AbstractExtension implements GlobalsInterface
         return [];
     }
 
-    public function getFilters()
+    public function getFilters(): array
     {
         return [
             new TwigFilter('removeWww', [$this, 'removeWww']),
@@ -45,7 +45,7 @@ class WallabagExtension extends AbstractExtension implements GlobalsInterface
         ];
     }
 
-    public function getFunctions()
+    public function getFunctions(): array
     {
         return [
             new TwigFunction('count_entries', [$this, 'countEntries']),

--- a/tests/Event/Listener/CreateConfigListenerTest.php
+++ b/tests/Event/Listener/CreateConfigListenerTest.php
@@ -48,7 +48,7 @@ class CreateConfigListenerTest extends TestCase
         $this->dispatcher->addSubscriber($this->listener);
 
         $this->request = Request::create('/');
-        $this->response = Response::create();
+        $this->response = new Response();
     }
 
     public function testWithValidUser()

--- a/tests/Event/Listener/UserLocaleListenerTest.php
+++ b/tests/Event/Listener/UserLocaleListenerTest.php
@@ -27,7 +27,7 @@ class UserLocaleListenerTest extends TestCase
 
         $user->setConfig($config);
 
-        $userToken = new UsernamePasswordToken($user, '', 'test');
+        $userToken = new UsernamePasswordToken($user, 'test');
         $request = Request::create('/');
         $event = new InteractiveLoginEvent($request, $userToken);
 
@@ -48,7 +48,7 @@ class UserLocaleListenerTest extends TestCase
 
         $user->setConfig($config);
 
-        $userToken = new UsernamePasswordToken($user, '', 'test');
+        $userToken = new UsernamePasswordToken($user, 'test');
         $request = Request::create('/');
         $event = new InteractiveLoginEvent($request, $userToken);
 
@@ -71,7 +71,7 @@ class UserLocaleListenerTest extends TestCase
 
         $user->setConfig($config);
 
-        $userToken = new UsernamePasswordToken($user, '', 'test');
+        $userToken = new UsernamePasswordToken($user, 'test');
         $request = Request::create('/');
         $event = new InteractiveLoginEvent($request, $userToken);
 

--- a/tests/Helper/RedirectTest.php
+++ b/tests/Helper/RedirectTest.php
@@ -53,7 +53,7 @@ class RedirectTest extends TestCase
 
         $this->user->setConfig($config);
 
-        $this->token = new UsernamePasswordToken($this->user, 'password', 'key');
+        $this->token = new UsernamePasswordToken($this->user, 'key');
         $tokenStorage = new TokenStorage();
         $tokenStorage->setToken($this->token);
 

--- a/tests/SiteConfig/GrabySiteConfigBuilderTest.php
+++ b/tests/SiteConfig/GrabySiteConfigBuilderTest.php
@@ -55,7 +55,7 @@ class GrabySiteConfigBuilderTest extends WallabagTestCase
             ->method('getId')
             ->willReturn(1);
 
-        $token = new UsernamePasswordToken($user, 'pass', 'provider');
+        $token = new UsernamePasswordToken($user, 'provider');
 
         $tokenStorage = new TokenStorage();
         $tokenStorage->setToken($token);
@@ -114,7 +114,7 @@ class GrabySiteConfigBuilderTest extends WallabagTestCase
             ->method('getId')
             ->willReturn(1);
 
-        $token = new UsernamePasswordToken($user, 'pass', 'provider');
+        $token = new UsernamePasswordToken($user, 'provider');
 
         $tokenStorage = new TokenStorage();
         $tokenStorage->setToken($token);
@@ -173,7 +173,7 @@ class GrabySiteConfigBuilderTest extends WallabagTestCase
             ->method('getId')
             ->willReturn(1);
 
-        $token = new UsernamePasswordToken($user, 'pass', 'provider');
+        $token = new UsernamePasswordToken($user, 'provider');
 
         $tokenStorage = new TokenStorage();
         $tokenStorage->setToken($token);
@@ -291,7 +291,7 @@ class GrabySiteConfigBuilderTest extends WallabagTestCase
             ->method('getId')
             ->willReturn(1);
 
-        $token = new UsernamePasswordToken($user, 'pass', 'provider');
+        $token = new UsernamePasswordToken($user, 'provider');
 
         $tokenStorage = new TokenStorage();
         $tokenStorage->setToken($token);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | yes
| Tests pass?   | yes
| Documentation | no
| Translation   | no
| CHANGELOG.md  | no
| License       | MIT

Remaining 2 self deprecation notices require PHP 8

```
Remaining self deprecation notices (2)

  1x: Method "Doctrine\DBAL\Types\Type::convertToPHPValue()" might add "mixed" as a native return type declaration in the future. Do the same in child class "Wallabag\Doctrine\JsonArrayType" now to avoid errors or add an explicit @return annotation to suppress this message.
    1x in CleanDuplicatesCommandTest::testRunCleanDuplicates from Tests\Wallabag\Command

  1x: Method "OldSound\RabbitMqBundle\RabbitMq\ConsumerInterface::execute()" might add "int|bool" as a native return type declaration in the future. Do the same in implementation "Wallabag\Consumer\AMQPEntryConsumer" now to avoid errors or add an explicit @return annotation to suppress this message.
    1x in AMQPEntryConsumerTest::testMessageOk from Tests\Wallabag\Consumer
```
