### PR TITLE
Fix database_path default value

### DIFF
--- a/docker/php/config/parameters.yml
+++ b/docker/php/config/parameters.yml
@@ -5,7 +5,7 @@ parameters:
     database_name: ${DATABASE_NAME:-symfony}
     database_user: ${DATABASE_USER:-root}
     database_password: ${DATABASE_PASSWORD:-~}
-    database_path: '${DATABASE_PATH:-"%kernel.project_dir%/data/db/wallabag.sqlite"}'
+    database_path: ${DATABASE_PATH:-"%kernel.project_dir%/data/db/wallabag.sqlite"}
     database_table_prefix: ${DATABASE_TABLE_PREFIX:-wallabag_}
     database_socket: null
     database_charset: ${DATABASE_CHARSET:-utf8}

--- a/docker/php/env.example
+++ b/docker/php/env.example
@@ -4,7 +4,7 @@ DATABASE_PORT=~
 DATABASE_NAME=symfony
 DATABASE_USER=root
 DATABASE_PASSWORD=~
-DATABASE_PATH="%kernel.project_dir%/data/db/wallabag.sqlite"
+DATABASE_PATH='"%kernel.project_dir%/data/db/wallabag.sqlite"'
 DOMAIN_NAME=http://localhost:8000
 SECRET=ch4n63m31fy0uc4n
 PHP_SESSION_SAVE_PATH=tcp://redis:6379?database=2


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Documentation | no
| Translation   | no
| CHANGELOG.md  | no
| License       | MIT

Before this change the generated value was `database_path: '"%kernel.project_dir%/data/db/wallabag.sqlite"'`, including the double quotes in the value