### PR TITLE
Remove legacy translation in CraueConfigBundle

### DIFF
--- a/translations/CraueConfigBundle.de.yml
+++ b/translations/CraueConfigBundle.de.yml
@@ -18,7 +18,6 @@ share_twitter: Freigabe für Twitter aktivieren
 share_unmark: Freigabe für Unmark.it aktivieren
 show_printlink: Link anzeigen, um den Inhalt auszudrucken
 wallabag_support_url: Support-URL für wallabag
-wallabag_url: URL von *deiner* wallabag-Instanz
 entry: Artikel
 export: Export
 import: Import

--- a/translations/CraueConfigBundle.ru.yml
+++ b/translations/CraueConfigBundle.ru.yml
@@ -18,7 +18,6 @@ share_twitter: "Включить возможность поделиться в 
 share_unmark: "Включить возможность поделиться в Unmark.it"
 show_printlink: "Отображать ссылки в версии для печати"
 wallabag_support_url: "Поддержка URL для wallabag"
-wallabag_url: "URL *вашего* wallabag сервиса"
 entry: "запись"
 export: "экспорт"
 import: "импорт"


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Documentation | no
| Translation   | yes
| CHANGELOG.md  | no
| License       | MIT

Extracted from #8012

I don't know if this will be added back when sync'ing with Weblate