### PR TITLE
Make wallabag_url a Twig global

### DIFF
--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -60,6 +60,7 @@ twig:
     form_themes:
         - "@SpiriitFormFilter/Form/form_div_layout.html.twig"
     globals:
+        wallabag_url: '%domain_name%'
         registration_enabled: '%fosuser_registration%'
 
 # Doctrine Configuration

--- a/src/Controller/Api/DeveloperController.php
+++ b/src/Controller/Api/DeveloperController.php
@@ -103,8 +103,6 @@ class DeveloperController extends AbstractController
      */
     public function howtoFirstAppAction()
     {
-        return $this->render('Developer/howto_app.html.twig', [
-            'wallabag_url' => $this->getParameter('domain_name'),
-        ]);
+        return $this->render('Developer/howto_app.html.twig');
     }
 }

--- a/src/Controller/ConfigController.php
+++ b/src/Controller/ConfigController.php
@@ -257,7 +257,6 @@ class ConfigController extends AbstractController
                 'username' => $user->getUsername(),
                 'token' => $config->getFeedToken(),
             ],
-            'wallabag_url' => $this->getParameter('domain_name'),
             'enabled_users' => $userRepository->getSumEnabledUsers(),
         ]);
     }

--- a/src/Controller/FeedController.php
+++ b/src/Controller/FeedController.php
@@ -150,7 +150,6 @@ class FeedController extends AbstractController
                 'url' => $url,
                 'entries' => $entries,
                 'user' => $user->getUsername(),
-                'domainName' => $this->getParameter('domain_name'),
                 'version' => $this->getParameter('wallabag.version'),
                 'tag' => $tag->getSlug(),
                 'updated' => $this->prepareFeedUpdatedDate($entries, $sort),
@@ -231,7 +230,6 @@ class FeedController extends AbstractController
             'url' => $url,
             'entries' => $entries,
             'user' => $user->getUsername(),
-            'domainName' => $this->getParameter('domain_name'),
             'version' => $this->getParameter('wallabag.version'),
             'updated' => $this->prepareFeedUpdatedDate($entries),
         ], new Response('', 200, ['Content-Type' => 'application/atom+xml']));

--- a/src/Mailer/AuthCodeMailer.php
+++ b/src/Mailer/AuthCodeMailer.php
@@ -51,26 +51,17 @@ class AuthCodeMailer implements AuthCodeMailerInterface
     private $supportUrl;
 
     /**
-     * Url for the wallabag instance (only used for image in the HTML email template).
-     *
-     * @var string
-     */
-    private $wallabagUrl;
-
-    /**
      * @param string $senderEmail
      * @param string $senderName
      * @param string $supportUrl  wallabag support url
-     * @param string $wallabagUrl wallabag instance url
      */
-    public function __construct(MailerInterface $mailer, Environment $twig, $senderEmail, $senderName, $supportUrl, $wallabagUrl)
+    public function __construct(MailerInterface $mailer, Environment $twig, $senderEmail, $senderName, $supportUrl)
     {
         $this->mailer = $mailer;
         $this->twig = $twig;
         $this->senderEmail = $senderEmail;
         $this->senderName = $senderName;
         $this->supportUrl = $supportUrl;
-        $this->wallabagUrl = $wallabagUrl;
     }
 
     /**
@@ -85,7 +76,6 @@ class AuthCodeMailer implements AuthCodeMailerInterface
             'user' => $user->getName(),
             'code' => $user->getEmailAuthCode(),
             'support_url' => $this->supportUrl,
-            'wallabag_url' => $this->wallabagUrl,
         ]);
         $bodyText = $template->renderBlock('body_text', [
             'user' => $user->getName(),

--- a/templates/Entry/entries.xml.twig
+++ b/templates/Entry/entries.xml.twig
@@ -3,10 +3,10 @@
     {% if type != 'tag' %}
         <title>wallabag — {{ type }} feed</title>
         <subtitle type="html">Atom feed for {{ type }} entries</subtitle>
-        <id>wallabag:{{ domainName|removeScheme|removeWww }}:{{ user }}:{{ type }}</id>
+        <id>wallabag:{{ wallabag_url|removeScheme|removeWww }}:{{ user }}:{{ type }}</id>
         <link rel="alternate" type="text/html" href="{{ url(type) }}"/>
     {% else %}
-        <id>wallabag:{{ domainName|removeScheme|removeWww }}:{{ user }}:{{ type }}:{{ tag }}</id>
+        <id>wallabag:{{ wallabag_url|removeScheme|removeWww }}:{{ user }}:{{ type }}:{{ tag }}</id>
         <link rel="alternate" type="text/html" href="{{ url('tag_entries', {'slug': tag}) }}"/>
         <title>wallabag — {{ type }} {{ tag }} feed</title>
         <subtitle type="html">Atom feed for entries tagged with {{ tag }}</subtitle>
@@ -34,7 +34,7 @@
         <link rel="alternate" href="{{ entry.url }}"/>
         <link rel="via" type="text/html"
               href="{{ url('view', {'id': entry.id}) }}"/>
-        <id>wallabag:{{ domainName|removeScheme|removeWww }}:{{ user }}:entry:{{ entry.id }}</id>
+        <id>wallabag:{{ wallabag_url|removeScheme|removeWww }}:{{ user }}:entry:{{ entry.id }}</id>
         <updated>{{ entry.updatedAt|date('c') }}</updated>
         <published>{{ entry.createdAt|date('c') }}</published>
         {% for tag in entry.tags %}

--- a/tests/Mailer/AuthCodeMailerTest.php
+++ b/tests/Mailer/AuthCodeMailerTest.php
@@ -63,8 +63,7 @@ TWIG;
             $this->twig,
             'nobody@test.io',
             'wallabag test',
-            'http://0.0.0.0/support',
-            'http://0.0.0.0/'
+            'http://0.0.0.0/support'
         );
 
         $authCodeMailer->sendAuthCode($user);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Documentation | no
| Translation   | no
| CHANGELOG.md  | no
| License       | MIT

Extracted from #8012

Goal is to remove usages of `getParameter()` for parameters that are in `parameters.yml` to prepare using environment variables and passing values through configuration with `%env(...)%`