### PR TITLE
Use constructor injection for registration parameter

### DIFF
--- a/src/Controller/Api/UserRestController.php
+++ b/src/Controller/Api/UserRestController.php
@@ -104,7 +104,7 @@ class UserRestController extends WallabagRestController
      */
     public function putUserAction(Request $request, Config $craueConfig, UserManagerInterface $userManager, EntityManagerInterface $entityManager, EventDispatcherInterface $eventDispatcher)
     {
-        if (!$this->getParameter('fosuser_registration') || !$craueConfig->get('api_user_registration')) {
+        if (!$this->registrationEnabled || !$craueConfig->get('api_user_registration')) {
             $json = $this->serializer->serialize(['error' => "Server doesn't allow registrations"], 'json');
 
             return (new JsonResponse())

--- a/src/Controller/Api/WallabagRestController.php
+++ b/src/Controller/Api/WallabagRestController.php
@@ -26,14 +26,16 @@ class WallabagRestController extends AbstractFOSRestController
     protected AuthorizationCheckerInterface $authorizationChecker;
     protected TokenStorageInterface $tokenStorage;
     protected TranslatorInterface $translator;
+    protected bool $registrationEnabled;
 
-    public function __construct(EntityManagerInterface $entityManager, SerializerInterface $serializer, AuthorizationCheckerInterface $authorizationChecker, TokenStorageInterface $tokenStorage, TranslatorInterface $translator)
+    public function __construct(EntityManagerInterface $entityManager, SerializerInterface $serializer, AuthorizationCheckerInterface $authorizationChecker, TokenStorageInterface $tokenStorage, TranslatorInterface $translator, bool $registrationEnabled)
     {
         $this->entityManager = $entityManager;
         $this->serializer = $serializer;
         $this->authorizationChecker = $authorizationChecker;
         $this->tokenStorage = $tokenStorage;
         $this->translator = $translator;
+        $this->registrationEnabled = $registrationEnabled;
     }
 
     /**
@@ -86,7 +88,7 @@ class WallabagRestController extends AbstractFOSRestController
     {
         $info = new ApplicationInfo(
             $this->getParameter('wallabag.version'),
-            $this->getParameter('fosuser_registration') && $craueConfig->get('api_user_registration'),
+            $this->registrationEnabled && $craueConfig->get('api_user_registration'),
         );
 
         return (new JsonResponse())->setJson($this->serializer->serialize($info, 'json'));


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Documentation | no
| Translation   | no
| CHANGELOG.md  | no
| License       | MIT

Extracted from #8012

Goal is to remove usages of `getParameter()` for parameters that are in `parameters.yml` to prepare using environment variables and passing values through configuration with `%env(...)%`