### PR TITLE
Add 'application/vnd.ms-excel' to allowed MIME types config

### DIFF
--- a/app/config/wallabag.yml
+++ b/app/config/wallabag.yml
@@ -175,5 +175,11 @@ parameters:
         - 'Montserrat'
         - 'OpenDyslexicRegular'
         - 'Oswald'
-    wallabag.allow_mimetypes: ['application/octet-stream', 'application/json', 'text/plain', 'text/csv', 'text/html']
+    wallabag.allow_mimetypes:
+        - 'application/octet-stream'
+        - 'application/json'
+        - 'text/plain'
+        - 'text/csv'
+        - 'text/html'
+        - 'application/vnd.ms-excel'
     wallabag.resource_dir: "%kernel.project_dir%/web/uploads/import"


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Documentation | no
| Translation   | no
| CHANGELOG.md  | no
| License       | MIT

This PR allows uploads of files with mime type of 'application/vnd.ms-excel'.

I ran into the same problem as was described #7685. Peeking around I found out, that my uploaded instapaper export gets a mime type (from `$file->getClientMimeType()` on line 47 in `\Wallabag\Controller\Import\InstapaperController::indexAction`) of `application/vnd.ms-excel` which is not mentioned in `wallabag.allow_mimetypes` config entry. 

Since this is a client mime type, this might possibly be a Windows (11?) only issue. 

This PR allows this mime type. After applying this change, Instapaper import works for me. I also tried to upload the csv attached to #7685 which also worked.

