### PR TITLE
Bump annotator to 2.0.0-alpha.4

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -1378,8 +1378,8 @@ ajv@^8.0.0, ajv@^8.0.1, ajv@^8.9.0:
     uri-js "^4.2.2"
 
 annotator@wallabag/annotator#master:
-  version "2.0.0-alpha.3"
-  resolved "https://codeload.github.com/wallabag/annotator/tar.gz/3047fc22c83873efb10753187222cdb8cbb40d13"
+  version "2.0.0-alpha.4"
+  resolved "https://codeload.github.com/wallabag/annotator/tar.gz/082069d777ed0fe5080392e85675ef3a519c7886"
   dependencies:
     backbone-extend-standalone "^0.1.2"
     clean-css "^4.1.11"


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | 
| Documentation | no
| Translation   | no
| CHANGELOG.md  | no
| License       | MIT

Mostly cosmetic to avoid any yarn cache issue