### PR TITLE
Fix default DOMAIN_NAME to avoid Cross-Origin issues

### DIFF
--- a/docker/php/env.example
+++ b/docker/php/env.example
@@ -5,7 +5,7 @@ DATABASE_NAME=symfony
 DATABASE_USER=root
 DATABASE_PASSWORD=~
 DATABASE_PATH='"%kernel.project_dir%/data/db/wallabag.sqlite"'
-DOMAIN_NAME=http://localhost:8000
+DOMAIN_NAME=http://127.0.0.1:8000
 SECRET=ch4n63m31fy0uc4n
 PHP_SESSION_SAVE_PATH=redis://redis:6379?database=2
 PHP_SESSION_HANDLER=redis


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Documentation | no
| Translation   | no
| CHANGELOG.md  | no
| License       | MIT

Mainly to load fonts directly, before this there was a mismatch as localhost is not same as 127.0.0.1
This aligns with the URL provided in CONTRIBUTING.md