### PR TITLE
Fix tests namespaces

### DIFF
--- a/tests/Security/Voter/AnnotationVoterTest.php
+++ b/tests/Security/Voter/AnnotationVoterTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Security\Voter;
+namespace Tests\Wallabag\Security\Voter;
 
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;

--- a/tests/Security/Voter/EntryVoterTest.php
+++ b/tests/Security/Voter/EntryVoterTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Security\Voter;
+namespace Tests\Wallabag\Security\Voter;
 
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;

--- a/tests/Security/Voter/IgnoreOriginInstanceRuleVoterTest.php
+++ b/tests/Security/Voter/IgnoreOriginInstanceRuleVoterTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Security\Voter;
+namespace Tests\Wallabag\Security\Voter;
 
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;

--- a/tests/Security/Voter/MainVoterTest.php
+++ b/tests/Security/Voter/MainVoterTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Security\Voter;
+namespace Tests\Wallabag\Security\Voter;
 
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;

--- a/tests/Security/Voter/SiteCredentialVoterTest.php
+++ b/tests/Security/Voter/SiteCredentialVoterTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Security\Voter;
+namespace Tests\Wallabag\Security\Voter;
 
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Documentation | no
| Translation   | no
| CHANGELOG.md  | no
| License       | MIT

I think PHPStorm didn't detect well the namespace when I created those files