### PR TITLE
Add IsGranted to EntryRestController

### DIFF
--- a/src/Controller/Api/WallabagRestController.php
+++ b/src/Controller/Api/WallabagRestController.php
@@ -102,22 +102,6 @@ class WallabagRestController extends AbstractFOSRestController
     }
 
     /**
-     * Validate that the first id is equal to the second one.
-     * If not, throw exception. It means a user try to access information from an other user.
-     *
-     * @param int $requestUserId User id from the requested source
-     */
-    protected function validateUserAccess($requestUserId)
-    {
-        $user = $this->tokenStorage->getToken()->getUser();
-        \assert($user instanceof User);
-
-        if ($requestUserId !== $user->getId()) {
-            throw $this->createAccessDeniedException('Access forbidden. Entry user id: ' . $requestUserId . ', logged user id: ' . $user->getId());
-        }
-    }
-
-    /**
      * Shortcut to send data serialized in json.
      *
      * @return JsonResponse

--- a/src/Security/Voter/EntryVoter.php
+++ b/src/Security/Voter/EntryVoter.php
@@ -20,6 +20,7 @@ class EntryVoter extends Voter
     public const DELETE = 'DELETE';
     public const LIST_ANNOTATIONS = 'LIST_ANNOTATIONS';
     public const CREATE_ANNOTATIONS = 'CREATE_ANNOTATIONS';
+    public const LIST_TAGS = 'LIST_TAGS';
     public const TAG = 'TAG';
     public const UNTAG = 'UNTAG';
 
@@ -29,7 +30,7 @@ class EntryVoter extends Voter
             return false;
         }
 
-        if (!\in_array($attribute, [self::VIEW, self::EDIT, self::RELOAD, self::STAR, self::ARCHIVE, self::SHARE, self::UNSHARE, self::EXPORT, self::DELETE, self::LIST_ANNOTATIONS, self::CREATE_ANNOTATIONS, self::TAG, self::UNTAG], true)) {
+        if (!\in_array($attribute, [self::VIEW, self::EDIT, self::RELOAD, self::STAR, self::ARCHIVE, self::SHARE, self::UNSHARE, self::EXPORT, self::DELETE, self::LIST_ANNOTATIONS, self::CREATE_ANNOTATIONS, self::LIST_TAGS, self::TAG, self::UNTAG], true)) {
             return false;
         }
 
@@ -58,6 +59,7 @@ class EntryVoter extends Voter
             case self::DELETE:
             case self::LIST_ANNOTATIONS:
             case self::CREATE_ANNOTATIONS:
+            case self::LIST_TAGS:
             case self::TAG:
             case self::UNTAG:
                 return $user === $subject->getUser();

--- a/src/Security/Voter/MainVoter.php
+++ b/src/Security/Voter/MainVoter.php
@@ -13,8 +13,10 @@ class MainVoter extends Voter
     public const EDIT_ENTRIES = 'EDIT_ENTRIES';
     public const EXPORT_ENTRIES = 'EXPORT_ENTRIES';
     public const IMPORT_ENTRIES = 'IMPORT_ENTRIES';
+    public const DELETE_ENTRIES = 'DELETE_ENTRIES';
     public const LIST_TAGS = 'LIST_TAGS';
     public const CREATE_TAGS = 'CREATE_TAGS';
+    public const DELETE_TAGS = 'DELETE_TAGS';
     public const LIST_SITE_CREDENTIALS = 'LIST_SITE_CREDENTIALS';
     public const CREATE_SITE_CREDENTIALS = 'CREATE_SITE_CREDENTIALS';
     public const EDIT_CONFIG = 'EDIT_CONFIG';
@@ -32,7 +34,7 @@ class MainVoter extends Voter
             return false;
         }
 
-        if (!\in_array($attribute, [self::LIST_ENTRIES, self::CREATE_ENTRIES, self::EDIT_ENTRIES, self::EXPORT_ENTRIES, self::IMPORT_ENTRIES, self::LIST_TAGS, self::CREATE_TAGS, self::LIST_SITE_CREDENTIALS, self::CREATE_SITE_CREDENTIALS, self::EDIT_CONFIG], true)) {
+        if (!\in_array($attribute, [self::LIST_ENTRIES, self::CREATE_ENTRIES, self::EDIT_ENTRIES, self::EXPORT_ENTRIES, self::IMPORT_ENTRIES, self::DELETE_ENTRIES, self::LIST_TAGS, self::CREATE_TAGS, self::DELETE_TAGS, self::LIST_SITE_CREDENTIALS, self::CREATE_SITE_CREDENTIALS, self::EDIT_CONFIG], true)) {
             return false;
         }
 
@@ -47,8 +49,10 @@ class MainVoter extends Voter
             case self::EDIT_ENTRIES:
             case self::EXPORT_ENTRIES:
             case self::IMPORT_ENTRIES:
+            case self::DELETE_ENTRIES:
             case self::LIST_TAGS:
             case self::CREATE_TAGS:
+            case self::DELETE_TAGS:
             case self::LIST_SITE_CREDENTIALS:
             case self::CREATE_SITE_CREDENTIALS:
             case self::EDIT_CONFIG:

--- a/tests/Controller/Api/EntryRestControllerTest.php
+++ b/tests/Controller/Api/EntryRestControllerTest.php
@@ -541,7 +541,7 @@ class EntryRestControllerTest extends WallabagApiTestCase
         $em->persist($entry);
         $em->flush();
 
-        $em->clear();
+        $this->client = $this->createAuthorizedClient();
 
         $e = [
             'title' => $entry->getTitle(),
@@ -574,7 +574,7 @@ class EntryRestControllerTest extends WallabagApiTestCase
         $em->persist($entry);
         $em->flush();
 
-        $em->clear();
+        $this->client = $this->createAuthorizedClient();
 
         $id = $entry->getId();
 
@@ -666,7 +666,8 @@ class EntryRestControllerTest extends WallabagApiTestCase
         $entry->addTag((new Tag())->setLabel('apple'));
         $em->persist($entry);
         $em->flush();
-        $em->clear();
+
+        $this->client = $this->createAuthorizedClient();
 
         $this->client->request('POST', '/api/entries.json', [
             'url' => 'https://www.20minutes.fr/sport/jo_2024/4095122-20240712-jo-paris-2024-saut-ange-bombe-comment-anne-hidalgo-va-plonger-seine-si-fait-vraiment',
@@ -1361,7 +1362,7 @@ class EntryRestControllerTest extends WallabagApiTestCase
         $em->persist($entry);
         $em->flush();
 
-        $em->clear();
+        $this->client = $this->createAuthorizedClient();
 
         $list = [
             [
@@ -1425,7 +1426,9 @@ class EntryRestControllerTest extends WallabagApiTestCase
         $em->persist((new Entry($em->getReference(User::class, $this->getUserId())))->setUrl('http://0.0.0.0/test-entry1'));
 
         $em->flush();
-        $em->clear();
+
+        $this->client = $this->createAuthorizedClient();
+
         $list = [
             'http://0.0.0.0/test-entry1',
             'http://0.0.0.0/test-entry-not-exist',
@@ -1487,7 +1490,8 @@ class EntryRestControllerTest extends WallabagApiTestCase
         $entry->setPublishedAt(new \DateTime('2017-06-26T07:46:02+0200'));
         $em->persist($entry);
         $em->flush();
-        $em->clear();
+
+        $this->client = $this->createAuthorizedClient();
 
         $this->client->request('POST', '/api/entries.json', [
             'url' => 'https://www.lemonde.fr/m-perso/article/2017/06/25/antoine-de-caunes-je-veux-avoir-le-droit-de-tatonner_5150728_4497916.html',

--- a/tests/Controller/Api/EntryRestControllerTest.php
+++ b/tests/Controller/Api/EntryRestControllerTest.php
@@ -6,7 +6,6 @@ use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Component\DependencyInjection\Container;
 use Wallabag\Entity\Entry;
 use Wallabag\Entity\Tag;
-use Wallabag\Entity\User;
 use Wallabag\Helper\ContentProxy;
 
 class EntryRestControllerTest extends WallabagApiTestCase
@@ -535,7 +534,7 @@ class EntryRestControllerTest extends WallabagApiTestCase
     public function testDeleteEntry()
     {
         $em = $this->client->getContainer()->get(EntityManagerInterface::class);
-        $entry = new Entry($em->getReference(User::class, 1));
+        $entry = new Entry($this->user);
         $entry->setUrl('http://0.0.0.0/test-delete-entry');
         $entry->setTitle('Test delete entry');
         $em->persist($entry);
@@ -569,7 +568,7 @@ class EntryRestControllerTest extends WallabagApiTestCase
     public function testDeleteEntryExpectId()
     {
         $em = $this->client->getContainer()->get(EntityManagerInterface::class);
-        $entry = new Entry($em->getReference(User::class, 1));
+        $entry = new Entry($this->user);
         $entry->setUrl('http://0.0.0.0/test-delete-entry-id');
         $em->persist($entry);
         $em->flush();
@@ -659,7 +658,7 @@ class EntryRestControllerTest extends WallabagApiTestCase
     public function testPostSameEntry()
     {
         $em = $this->client->getContainer()->get(EntityManagerInterface::class);
-        $entry = new Entry($em->getReference(User::class, $this->getUserId()));
+        $entry = new Entry($this->user);
         $entry->setUrl('https://www.20minutes.fr/sport/jo_2024/4095122-20240712-jo-paris-2024-saut-ange-bombe-comment-anne-hidalgo-va-plonger-seine-si-fait-vraiment');
         $entry->setArchived(true);
         $entry->addTag((new Tag())->setLabel('google'));
@@ -1355,7 +1354,7 @@ class EntryRestControllerTest extends WallabagApiTestCase
     public function testDeleteEntriesTagsListAction()
     {
         $em = $this->client->getContainer()->get(EntityManagerInterface::class);
-        $entry = new Entry($em->getReference(User::class, $this->getUserId()));
+        $entry = new Entry($this->user);
         $entry->setUrl('http://0.0.0.0/test-entry');
         $entry->addTag((new Tag())->setLabel('foo-tag'));
         $entry->addTag((new Tag())->setLabel('bar-tag'));
@@ -1423,7 +1422,7 @@ class EntryRestControllerTest extends WallabagApiTestCase
     public function testDeleteEntriesListAction()
     {
         $em = $this->client->getContainer()->get(EntityManagerInterface::class);
-        $em->persist((new Entry($em->getReference(User::class, $this->getUserId())))->setUrl('http://0.0.0.0/test-entry1'));
+        $em->persist((new Entry($this->user))->setUrl('http://0.0.0.0/test-entry1'));
 
         $em->flush();
 
@@ -1483,7 +1482,7 @@ class EntryRestControllerTest extends WallabagApiTestCase
     public function testRePostEntryAndReUsePublishedAt()
     {
         $em = $this->client->getContainer()->get(EntityManagerInterface::class);
-        $entry = new Entry($em->getReference(User::class, $this->getUserId()));
+        $entry = new Entry($this->user);
         $entry->setTitle('Antoine de Caunes : « Je veux avoir le droit de tâtonner »');
         $entry->setContent('hihi');
         $entry->setUrl('https://www.lemonde.fr/m-perso/article/2017/06/25/antoine-de-caunes-je-veux-avoir-le-droit-de-tatonner_5150728_4497916.html');

--- a/tests/Controller/Api/TagRestControllerTest.php
+++ b/tests/Controller/Api/TagRestControllerTest.php
@@ -49,7 +49,8 @@ class TagRestControllerTest extends WallabagApiTestCase
 
         $em->persist($entry);
         $em->flush();
-        $em->clear();
+
+        $this->client = $this->createAuthorizedClient();
 
         $this->client->request('DELETE', '/api/tags/' . $tag->getId() . '.json');
 

--- a/tests/Controller/ConfigControllerTest.php
+++ b/tests/Controller/ConfigControllerTest.php
@@ -80,7 +80,8 @@ class ConfigControllerTest extends WallabagTestCase
         $this->getEntityManager()->persist($entry);
 
         $this->getEntityManager()->flush();
-        $this->getEntityManager()->clear();
+
+        $client = $this->getTestClient();
 
         $crawler = $client->request('GET', '/unread/list');
         $form = $crawler->filter('button[id=submit-filter]')->form();

--- a/tests/Controller/EntryControllerTest.php
+++ b/tests/Controller/EntryControllerTest.php
@@ -538,7 +538,8 @@ class EntryControllerTest extends WallabagTestCase
         $entry->setContent('');
         $this->getEntityManager()->persist($entry);
         $this->getEntityManager()->flush();
-        $this->getEntityManager()->clear();
+
+        $client = $this->getTestClient();
 
         $client->request('GET', '/reload/' . $entry->getId());
 
@@ -670,7 +671,8 @@ class EntryControllerTest extends WallabagTestCase
         $entry->setUrl($this->url);
         $this->getEntityManager()->persist($entry);
         $this->getEntityManager()->flush();
-        $this->getEntityManager()->clear();
+
+        $client = $this->getTestClient();
 
         $client->request('GET', '/archive/' . $entry->getId());
 
@@ -693,7 +695,8 @@ class EntryControllerTest extends WallabagTestCase
         $entry->setUrl($this->url);
         $this->getEntityManager()->persist($entry);
         $this->getEntityManager()->flush();
-        $this->getEntityManager()->clear();
+
+        $client = $this->getTestClient();
 
         $client->request('GET', '/star/' . $entry->getId());
 
@@ -1200,7 +1203,8 @@ class EntryControllerTest extends WallabagTestCase
         $content->setUrl($this->url);
         $this->getEntityManager()->persist($content);
         $this->getEntityManager()->flush();
-        $this->getEntityManager()->clear();
+
+        $client = $this->getTestClient();
 
         // no uid
         $client->request('GET', '/share/' . $content->getUid());
@@ -1791,7 +1795,8 @@ class EntryControllerTest extends WallabagTestCase
         $this->getEntityManager()->persist($entry3);
 
         $this->getEntityManager()->flush();
-        $this->getEntityManager()->clear();
+
+        $client = $this->getTestClient();
 
         $entries = [];
         $entries[] = $entry1->getId();

--- a/tests/Controller/TagControllerTest.php
+++ b/tests/Controller/TagControllerTest.php
@@ -35,7 +35,8 @@ class TagControllerTest extends WallabagTestCase
         $entry->setUrl('http://0.0.0.0/foo');
         $this->getEntityManager()->persist($entry);
         $this->getEntityManager()->flush();
-        $this->getEntityManager()->clear();
+
+        $client = $this->getTestClient();
 
         $crawler = $client->request('GET', '/view/' . $entry->getId());
 
@@ -120,7 +121,8 @@ class TagControllerTest extends WallabagTestCase
         $entry->addTag($tag);
         $this->getEntityManager()->persist($entry);
         $this->getEntityManager()->flush();
-        $this->getEntityManager()->clear();
+
+        $client = $this->getTestClient();
 
         // We make a first request to set an history and test redirection after tag deletion
         $crawler = $client->request('GET', '/view/' . $entry->getId());
@@ -166,7 +168,8 @@ class TagControllerTest extends WallabagTestCase
         $entry2->addTag($tag);
         $this->getEntityManager()->persist($entry2);
         $this->getEntityManager()->flush();
-        $this->getEntityManager()->clear();
+
+        $client = $this->getTestClient();
 
         $crawler = $client->request('GET', '/tag/list');
         $link = $crawler->filter('a[id="delete-' . $tag->getSlug() . '"]')->link();
@@ -254,7 +257,8 @@ class TagControllerTest extends WallabagTestCase
         $this->getEntityManager()->persist($entry2);
 
         $this->getEntityManager()->flush();
-        $this->getEntityManager()->clear();
+
+        $client = $this->getTestClient();
 
         // We make a first request to set an history and test redirection after tag deletion
         $crawler = $client->request('GET', '/tag/list');
@@ -321,7 +325,8 @@ class TagControllerTest extends WallabagTestCase
         $this->getEntityManager()->persist($entry);
 
         $this->getEntityManager()->flush();
-        $this->getEntityManager()->clear();
+
+        $client = $this->getTestClient();
 
         // We make a first request to set an history and test redirection after tag deletion
         $crawler = $client->request('GET', '/tag/list');
@@ -376,7 +381,8 @@ class TagControllerTest extends WallabagTestCase
         $this->getEntityManager()->persist($entry);
 
         $this->getEntityManager()->flush();
-        $this->getEntityManager()->clear();
+
+        $client = $this->getTestClient();
 
         // We make a first request to set an history and test redirection after tag deletion
         $crawler = $client->request('GET', '/tag/list');
@@ -446,7 +452,8 @@ class TagControllerTest extends WallabagTestCase
         $this->getEntityManager()->persist($entry2);
 
         $this->getEntityManager()->flush();
-        $this->getEntityManager()->clear();
+
+        $client = $this->getTestClient();
 
         // We make a first request to set an history and test redirection after tag deletion
         $crawler = $client->request('GET', '/tag/list');
@@ -496,7 +503,8 @@ class TagControllerTest extends WallabagTestCase
         $entry->setUrl('http://0.0.0.0/tag-caché');
         $this->getEntityManager()->persist($entry);
         $this->getEntityManager()->flush();
-        $this->getEntityManager()->clear();
+
+        $client = $this->getTestClient();
 
         $crawler = $client->request('GET', '/view/' . $entry->getId());
 

--- a/tests/Security/Voter/EntryVoterTest.php
+++ b/tests/Security/Voter/EntryVoterTest.php
@@ -189,6 +189,20 @@ class EntryVoterTest extends TestCase
         $this->assertSame(VoterInterface::ACCESS_GRANTED, $this->entryVoter->vote($this->token, $this->entry, [EntryVoter::CREATE_ANNOTATIONS]));
     }
 
+    public function testVoteReturnsDeniedForNonEntryUserListTags(): void
+    {
+        $this->token->method('getUser')->willReturn(new User());
+
+        $this->assertSame(VoterInterface::ACCESS_DENIED, $this->entryVoter->vote($this->token, $this->entry, [EntryVoter::LIST_TAGS]));
+    }
+
+    public function testVoteReturnsGrantedForEntryUserListTags(): void
+    {
+        $this->token->method('getUser')->willReturn($this->user);
+
+        $this->assertSame(VoterInterface::ACCESS_GRANTED, $this->entryVoter->vote($this->token, $this->entry, [EntryVoter::LIST_TAGS]));
+    }
+
     public function testVoteReturnsDeniedForNonEntryUserTag(): void
     {
         $this->token->method('getUser')->willReturn(new User());

--- a/tests/Security/Voter/MainVoterTest.php
+++ b/tests/Security/Voter/MainVoterTest.php
@@ -112,6 +112,20 @@ class MainVoterTest extends TestCase
         $this->assertSame(VoterInterface::ACCESS_GRANTED, $this->mainVoter->vote($this->token, null, [MainVoter::IMPORT_ENTRIES]));
     }
 
+    public function testVoteReturnsDeniedForNonUserDeleteEntries(): void
+    {
+        $this->security->method('isGranted')->with('ROLE_USER')->willReturn(false);
+
+        $this->assertSame(VoterInterface::ACCESS_DENIED, $this->mainVoter->vote($this->token, null, [MainVoter::DELETE_ENTRIES]));
+    }
+
+    public function testVoteReturnsGrantedForUserDeleteEntries(): void
+    {
+        $this->security->method('isGranted')->with('ROLE_USER')->willReturn(true);
+
+        $this->assertSame(VoterInterface::ACCESS_GRANTED, $this->mainVoter->vote($this->token, null, [MainVoter::DELETE_ENTRIES]));
+    }
+
     public function testVoteReturnsDeniedForNonUserListTags(): void
     {
         $this->security->method('isGranted')->with('ROLE_USER')->willReturn(false);
@@ -138,6 +152,20 @@ class MainVoterTest extends TestCase
         $this->security->method('isGranted')->with('ROLE_USER')->willReturn(true);
 
         $this->assertSame(VoterInterface::ACCESS_GRANTED, $this->mainVoter->vote($this->token, null, [MainVoter::CREATE_TAGS]));
+    }
+
+    public function testVoteReturnsDeniedForNonUserDeleteTags(): void
+    {
+        $this->security->method('isGranted')->with('ROLE_USER')->willReturn(false);
+
+        $this->assertSame(VoterInterface::ACCESS_DENIED, $this->mainVoter->vote($this->token, null, [MainVoter::DELETE_TAGS]));
+    }
+
+    public function testVoteReturnsGrantedForUserDeleteTags(): void
+    {
+        $this->security->method('isGranted')->with('ROLE_USER')->willReturn(true);
+
+        $this->assertSame(VoterInterface::ACCESS_GRANTED, $this->mainVoter->vote($this->token, null, [MainVoter::DELETE_TAGS]));
     }
 
     public function testVoteReturnsDeniedForNonUserListSiteCredentials(): void


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Documentation | no
| Translation   | no
| CHANGELOG.md  | no
| License       | MIT

More precise security.

Replacing the entity manager clear by creating a new client is needed because without it tests about deleting an entry failed.
It's because of the clear, the user entity instance that is inside the entry and the one used in security became different instances, so the `===` check on user in EntryVoter failed.