### PR TITLE
Avoid non-validated OTP to be enabled

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -57,5 +57,5 @@ parameters:
 
         -
             message: "#^Method FOS\\\\UserBundle\\\\Model\\\\UserManagerInterface\\:\\:updateUser()#"
-            count: 6
+            count: 7
             path: src/Wallabag/CoreBundle/Controller/ConfigController.php

--- a/src/Wallabag/CoreBundle/Controller/ConfigController.php
+++ b/src/Wallabag/CoreBundle/Controller/ConfigController.php
@@ -402,12 +402,14 @@ class ConfigController extends AbstractController
             throw new BadRequestHttpException('Bad CSRF token.');
         }
 
+        $user = $this->getUser();
+
         $isValid = $googleAuthenticator->checkCode(
-            $this->getUser(),
+            $user,
             $request->get('_auth_code')
         );
 
-        if (true === $isValid) {
+        if ($isValid) {
             $this->addFlash(
                 'notice',
                 'flashes.config.notice.otp_enabled'
@@ -417,14 +419,14 @@ class ConfigController extends AbstractController
         }
 
         $this->addFlash(
-            'two_factor',
-            'scheb_two_factor.code_invalid'
+            'notice',
+            'flashes.config.notice.otp_code_invalid'
         );
 
-        $this->addFlash(
-            'notice',
-            'scheb_two_factor.code_invalid'
-        );
+        $user->setGoogleAuthenticatorSecret(null);
+        $user->setBackupCodes(null);
+
+        $this->userManager->updateUser($user, true);
 
         return $this->redirect($this->generateUrl('config') . '#set3');
     }

--- a/src/Wallabag/CoreBundle/Resources/views/Config/otp_app.html.twig
+++ b/src/Wallabag/CoreBundle/Resources/views/Config/otp_app.html.twig
@@ -45,7 +45,7 @@
                                     <div class="row">
                                         <div class="input-field col s12">
                                             <label for="_auth_code">{{ "auth_code"|trans({}, 'SchebTwoFactorBundle') }}</label>
-                                            <input id="_auth_code" type="text" autocomplete="off" name="_auth_code" />
+                                            <input id="_auth_code" type="text" autocomplete="off" name="_auth_code" required="required" />
                                         </div>
                                     </div>
                                 </div>

--- a/translations/messages.en.yml
+++ b/translations/messages.en.yml
@@ -668,6 +668,7 @@ flashes:
             archived_reset: Archived entries deleted
             otp_enabled: Two-factor authentication enabled
             otp_disabled: Two-factor authentication disabled
+            otp_code_invalid: Invalid two-factor authentication code
             tagging_rules_imported: Tagging rules imported
             tagging_rules_not_imported: Error while importing tagging rules
             ignore_origin_rules_deleted: 'Ignore origin rule deleted'


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | dunno
| Documentation | no
| Translation   | yes
| CHANGELOG.md  | no
| License       | MIT

Might fix #8138 (or at least provide a workaround)