### PR TITLE
Replace hardcoded title truncate with CSS text-overflow

### DIFF
--- a/assets/scss/_cards.scss
+++ b/assets/scss/_cards.scss
@@ -154,6 +154,15 @@ a.original:not(.waves-effect) {
   }
 }
 
+.card .card-content .card-title,
+.card-stacked .card-content .card-title {
+  display: -webkit-box;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
+}
+
 .card-entry-labels li,
 .card-tag-labels li {
   margin: 10px 10px 10px auto;

--- a/templates/Entry/Card/_content.html.twig
+++ b/templates/Entry/Card/_content.html.twig
@@ -4,10 +4,10 @@
     {% endif %}
     {% if is_granted('VIEW', entry) %}
         <a href="{{ path('view', {'id': entry.id}) }}" title="{{ entry.title|striptags|e('html_attr') }}" class="card-title dot-ellipsis dot-resize-update">
-            {{ entry.title|striptags|u.truncate(80, '…', false)|default('entry.default_title'|trans)|raw }}
+            {{ entry.title|striptags|default('entry.default_title'|trans)|raw }}
         </a>
     {% else %}
-        {{ entry.title|striptags|u.truncate(80, '…', false)|default('entry.default_title'|trans)|raw }}
+        {{ entry.title|striptags|default('entry.default_title'|trans)|raw }}
     {% endif %}
 
     <div class="{{ subClass|default('original grey-text') }}">


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | 
| Documentation | no
| Translation   | no
| CHANGELOG.md  | no
| License       | MIT


This PR replaces the hard-coded title truncate at 80 chars with a dynamic text-overflow ellipsis using CSS.
This cuts the title on client-side and shows an ellipsis if it exceeds two lines.

We can change to 3 lines for the card view if it seems too short.

<details>

<summary>Screenshots of the changes before and after</summary>

## Before the change

### Mobile-view list
![2025-04-13-142640_359x501](https://github.com/user-attachments/assets/a79214cb-b6e2-465f-8fd5-34c3df7a7f2b)

### Mobile-view card
![2025-04-13-143209_357x542](https://github.com/user-attachments/assets/f3c65e6d-0833-4e04-8d1d-8f25eb466c44)

### Desktop-view list
![2025-04-13-142651_801x406](https://github.com/user-attachments/assets/4ffe5556-1518-4327-ade3-6ba767e003e3)

### Desktop-view card
![2025-04-13-143153_428x530](https://github.com/user-attachments/assets/cca3b4bf-3bf0-4c6f-ac0d-3da06c77e46b)

## After the change

### Mobile-view list
![2025-04-13-143524_357x523](https://github.com/user-attachments/assets/09c11388-7919-4f40-ae2e-f0fb77086002)

### Mobile-view card
![2025-04-13-143557_362x509](https://github.com/user-attachments/assets/a37fe729-5304-41ea-841f-332f4ba9dcc3)

### Desktop-view list
![2025-04-13-143535_765x419](https://github.com/user-attachments/assets/4884f072-c09b-4af3-903c-01b6e951108a)

### Desktop-view card
![2025-04-13-143544_397x442](https://github.com/user-attachments/assets/b07551d1-8b28-42a7-8f62-d18db4a90e64)

</details>