### PR TITLE
Improve display of articles with annotations

### DIFF
--- a/assets/scss/_entries.scss
+++ b/assets/scss/_entries.scss
@@ -183,6 +183,12 @@
   display: none;
 }
 
+blockquote.annotations {
+  margin-top: 5px;
+  padding-left: 1rem;
+  border-left: 5px solid #00acc1;
+}
+
 footer {
   &.page-footer {
     margin-top: 10px;

--- a/templates/Entry/Card/_content.html.twig
+++ b/templates/Entry/Card/_content.html.twig
@@ -10,13 +10,17 @@
         {{ entry.title|striptags|default('entry.default_title'|trans)|raw }}
     {% endif %}
 
-    <div class="{{ subClass|default('original grey-text') }}">
-        <a href="{{ entry.url|e }}" target="_blank" title="{{ entry.domainName|removeWww }}" class="tool grey-text">{{ entry.domainName|removeWww }}</a>
-        {% if withMetadata is defined %}
-            {% include "Entry/_tags.html.twig" with {'tags': entry.tags|slice(0, 3), 'entryId': entry.id, 'listClass': ' hide-on-med-and-down'} only %}
-            <div class="reading-time grey-text">
-                <div class="card-reading-time">{% include "Entry/_reading_time.html.twig" with {'entry': entry} only %}</div>
-            </div>
-        {% endif %}
-    </div>
+    {% if currentRoute == 'annotated' %}
+        <blockquote class="annotations">{{ entry.annotations[0].text|u.truncate(80, '...') }}</blockquote>
+    {% else %}
+        <div class="{{ subClass|default('original grey-text') }}">
+            <a href="{{ entry.url|e }}" target="_blank" title="{{ entry.domainName|removeWww }}" class="tool grey-text">{{ entry.domainName|removeWww }}</a>
+            {% if withMetadata is defined %}
+                {% include "Entry/_tags.html.twig" with {'tags': entry.tags|slice(0, 3), 'entryId': entry.id, 'listClass': ' hide-on-med-and-down'} only %}
+                <div class="reading-time grey-text">
+                    <div class="card-reading-time">{% include "Entry/_reading_time.html.twig" with {'entry': entry} only %}</div>
+                </div>
+            {% endif %}
+        </div>
+    {% endif %}
 </div>

--- a/templates/Entry/_card_full_image.html.twig
+++ b/templates/Entry/_card_full_image.html.twig
@@ -16,7 +16,7 @@
                 {% endif %}
             {% endif %}
         </div>
-        {% include "Entry/Card/_content.html.twig" with {'entry': entry} only %}
+        {% include "Entry/Card/_content.html.twig" with {'entry': entry, 'currentRoute': currentRoute} only %}
     </div>
 
     {% include "Entry/_card_actions.html.twig" with {'entry': entry} only %}

--- a/templates/Entry/_card_list.html.twig
+++ b/templates/Entry/_card_list.html.twig
@@ -12,7 +12,7 @@
         {% endif %}
     </div>
     {% endif %}
-    {% include "Entry/Card/_content.html.twig" with {'entry': entry, 'withMetadata': true, 'subClass': 'metadata'} only %}
+    {% include "Entry/Card/_content.html.twig" with {'entry': entry, 'withMetadata': true, 'subClass': 'metadata', 'currentRoute': currentRoute} only %}
 
     {% set current_path = app.request.requesturi %}
 

--- a/templates/Entry/_card_preview.html.twig
+++ b/templates/Entry/_card_preview.html.twig
@@ -18,7 +18,7 @@
                 {% endif %}
             {% endif %}
         </div>
-        {% include "Entry/Card/_content.html.twig" with {'entry': entry, 'withPreview': true} only %}
+        {% include "Entry/Card/_content.html.twig" with {'entry': entry, 'withPreview': true, 'currentRoute': currentRoute} only %}
     </div>
 
     <div class="card-reveal">


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  |no
| BC breaks?    |no
| Deprecations? |no
| Tests pass?   | yes
| Documentation |no
| Translation   |no
| CHANGELOG.md  |no
| License       | MIT

On the "With annotations" view only, the app displays now the first words of the first annotation of each article. 

You can see below the screenshots of each view. 

<img width="778" alt="Capture d’écran 2025-06-12 à 19 56 09" src="https://github.com/user-attachments/assets/f702f263-d6d6-4612-8401-8fb21be60188" />
<img width="1097" alt="Capture d’écran 2025-06-12 à 19 56 17" src="https://github.com/user-attachments/assets/d32ee665-dc99-4ef3-9ba9-3ce38d41b76f" />
