### PR TITLE
Fix reading time computation for short entries

### DIFF
--- a/templates/Entry/_reading_time.html.twig
+++ b/templates/Entry/_reading_time.html.twig
@@ -1,6 +1,6 @@
 {% set reading_time = entry.readingTime / app.user.config.readingSpeed * 200 %}
 <i class="material-icons grey-text">timer</i>
-{% if reading_time > 0 %}
+{% if reading_time|round > 0 %}
     <span>{{ 'entry.list.reading_time_minutes_short'|trans({'%readingTime%': reading_time|round}) }}</span>
 {% else %}
     <span>{{ 'entry.list.reading_time_less_one_minute_short'|trans|raw }}</span>


### PR DESCRIPTION
Time computation for short entries may give incorrect results with reading speed > 400.

Reading speed = 420
Reading time = 1 min
Displayed reading time = 0 min

With this change this will be correctly displayed as 1 min also in this case

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Documentation | no
| Translation   | no
| CHANGELOG.md  | no
| License       | MIT

<!--
Please list the issues your PR fixes using special keywords, see
https://help.github.com/articles/closing-issues-using-keywords/

-->
Fixes #1831
<!--
- Please fill in this template according to the PR you're about to submit.
- Replace this comment by a description of what your PR is solving.
-->
