### PR TITLE
Add annotations filter to entries API endpoint

### DIFF
--- a/src/Wallabag/ApiBundle/Controller/EntryRestController.php
+++ b/src/Wallabag/ApiBundle/Controller/EntryRestController.php
@@ -269,6 +269,16 @@ class EntryRestController extends WallabagRestController
      *             example="example.com",
      *         )
      *     ),
+     *     @OA\Parameter(
+     *         name="annotations",
+     *         in="query",
+     *         description="filter by entries with annotations. Use 1 for entries with annotations, 0 for entries without annotations. All entries by default",
+     *         required=false,
+     *         @OA\Schema(
+     *             type="integer",
+     *             enum={"1", "0"}
+     *         )
+     *     ),
      *     @OA\Response(
      *         response="200",
      *         description="Returned when successful"
@@ -294,6 +304,7 @@ class EntryRestController extends WallabagRestController
         $since = $request->query->get('since', 0);
         $detail = strtolower($request->query->get('detail', 'full'));
         $domainName = (null === $request->query->get('domain_name')) ? '' : (string) $request->query->get('domain_name');
+        $hasAnnotations = (null === $request->query->get('annotations')) ? null : (bool) $request->query->get('annotations');
 
         try {
             /** @var Pagerfanta $pager */
@@ -307,7 +318,8 @@ class EntryRestController extends WallabagRestController
                 $since,
                 $tags,
                 $detail,
-                $domainName
+                $domainName,
+                $hasAnnotations
             );
         } catch (\Exception $e) {
             throw new BadRequestHttpException($e->getMessage());
@@ -332,6 +344,7 @@ class EntryRestController extends WallabagRestController
                     'tags' => $tags,
                     'since' => $since,
                     'detail' => $detail,
+                    'annotations' => $hasAnnotations,
                 ],
                 true
             )

--- a/src/Wallabag/CoreBundle/Repository/EntryRepository.php
+++ b/src/Wallabag/CoreBundle/Repository/EntryRepository.php
@@ -266,14 +266,15 @@ class EntryRepository extends ServiceEntityRepository
      * @param string $order
      * @param int    $since
      * @param string $tags
-     * @param string $detail     'metadata' or 'full'. Include content field if 'full'
+     * @param string $detail         'metadata' or 'full'. Include content field if 'full'
      * @param string $domainName
+     * @param bool   $hasAnnotations
      *
      * @todo Breaking change: replace default detail=full by detail=metadata in a future version
      *
      * @return Pagerfanta
      */
-    public function findEntries($userId, $isArchived = null, $isStarred = null, $isPublic = null, $sort = 'created', $order = 'asc', $since = 0, $tags = '', $detail = 'full', $domainName = '')
+    public function findEntries($userId, $isArchived = null, $isStarred = null, $isPublic = null, $sort = 'created', $order = 'asc', $since = 0, $tags = '', $detail = 'full', $domainName = '', $hasAnnotations = null)
     {
         if (!\in_array(strtolower($detail), ['full', 'metadata'], true)) {
             throw new \Exception('Detail "' . $detail . '" parameter is wrong, allowed: full or metadata');
@@ -330,6 +331,16 @@ class EntryRepository extends ServiceEntityRepository
 
         if (\is_string($domainName) && '' !== $domainName) {
             $qb->andWhere('e.domainName = :domainName')->setParameter('domainName', $domainName);
+        }
+
+        if (null !== $hasAnnotations) {
+            if ($hasAnnotations) {
+                $qb->leftJoin('e.annotations', 'a')
+                   ->andWhere('a.id IS NOT NULL');
+            } else {
+                $qb->leftJoin('e.annotations', 'a')
+                   ->andWhere('a.id IS NULL');
+            }
         }
 
         if (!\in_array(strtolower($order), ['asc', 'desc'], true)) {


### PR DESCRIPTION
Implement a new filter parameter 'annotations' for the GET /api/entries endpoint that allows filtering entries based on whether they have annotations. When annotations=1, only entries with one or more annotations are returned. When annotations=0, only entries without annotations are returned. This feature enables users to easily find annotated content through the API.

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Documentation | yes
| Translation   | no
| CHANGELOG.md  | no
| License       | MIT

<!--
Please list the issues your PR fixes using special keywords, see
https://help.github.com/articles/closing-issues-using-keywords/

Fixes #…
-->

<!--
- Please fill in this template according to the PR you're about to submit.
- Replace this comment by a description of what your PR is solving.
-->
