### PR TITLE
Add CODEOWNERS, fix deprecation

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Migrated rules from dependabot.yml
+composer.* @Kdecherf @j0k3r @yguedidi

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -35,10 +35,6 @@ updates:
     phpstan-dependencies:
       patterns:
         - "phpstan/*"
-  reviewers:
-  - j0k3r
-  - yguedidi
-  - Kdecherf
   ignore:
   - dependency-name: symfony/*
     update-types: [ "version-update:semver-major" ]


### PR DESCRIPTION
Fix deprecation on dependabot reviewers feature.

References:
- https://github.com/wallabag/wallabag/pull/8388#issuecomment-3148942621
- https://github.blog/changelog/2025-04-29-dependabot-reviewers-configuration-option-being-replaced-by-code-owners/
- https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | 
| Documentation | 
| Translation   | no
| CHANGELOG.md  | no
| License       | MIT