### PR TITLE
Fix async browser import with nested children

### DIFF
--- a/src/Consumer/AbstractConsumer.php
+++ b/src/Consumer/AbstractConsumer.php
@@ -46,14 +46,14 @@ abstract class AbstractConsumer
 
         $this->import->setUser($user);
 
+        $entry = $this->import->parseEntry($storedEntry);
+
         if (false === $this->import->validateEntry($storedEntry)) {
             $this->logger->warning('Entry is invalid', ['entry' => $storedEntry]);
 
             // return true to skip message
             return true;
         }
-
-        $entry = $this->import->parseEntry($storedEntry);
 
         if (null === $entry) {
             $this->logger->warning('Entry already exists', ['entry' => $storedEntry]);


### PR DESCRIPTION
The `parseEntry` function recurses into children and dispatches their processing. However, validate will reject any entry that does not have a url e.g. parents.

We need to call parseEntries before so that the processing of children is dispatched, otherwise nothing is imported.