### PR TITLE
feat(locale): Add Korean to the list of available languages

### DIFF
--- a/app/config/wallabag.yml
+++ b/app/config/wallabag.yml
@@ -18,6 +18,7 @@ parameters:
         pt: 'Português'
         ru: 'Русский'
         ja: '日本語'
+        ko: '한국어'
         zh: '简体中文'
         uk: 'Українська'
         hr: 'Hrvatski'


### PR DESCRIPTION
This pull request enables the Korean (한국어) language option in the user settings.

The translation files for Korean are already present in the repository, but the language was not configured in `parameters.wallabag.languages`, making it impossible for users to select. This change adds the necessary configuration line.

Fixes #8427

| Q             | A   |
|---------------|-----|
| Bug fix?      | yes |
| New feature?  | no  |
| BC breaks?    | no  |
| Deprecations? | no  |
| Tests pass?   | yes |
| Documentation | no  |
| Translation   | no  |
| CHANGELOG.md  | yes |
| License       | MIT |