### PR TITLE
Update Dockerfile

### DIFF
--- a/docker/php/Dockerfile
+++ b/docker/php/Dockerfile
@@ -18,8 +18,7 @@ RUN apt-get update \
       curl \
       gnupg \
       lsb-release \
-      openssl \
-      software-properties-common
+      openssl
 
 RUN curl -fsSL https://deb.nodesource.com/setup_${NODE_VERSION}.x | bash -
 


### PR DESCRIPTION
Bug fix:
- Unable to locate package software-properties-common on Debian Trixie docker image build


```
$ docker compose build php --no-cache
...
 > [rootless  2/15] RUN apt-get update     && apt-get install -y       ca-certificates       curl       gnupg       lsb-release       openssl       software-properties-common:
0.173 Get:3 http://deb.debian.org/debian-security trixie-security InRelease [43.4 kB]
0.196 Get:4 http://deb.debian.org/debian trixie/main arm64 Packages [9605 kB]
0.827 Get:5 http://deb.debian.org/debian trixie-updates/main arm64 Packages [5404 B]
0.840 Get:6 http://deb.debian.org/debian-security trixie-security/main arm64 Packages [46.4 kB]
1.403 Fetched 9747 kB in 1s (7383 kB/s)
1.403 Reading package lists...
1.695 Reading package lists...
2.018 Building dependency tree...
2.165 Reading state information...
2.181 E: Unable to locate package software-properties-common
```