### PR TITLE
pin the docker base image to bookworm - Fixes #8455

### DIFF
--- a/docker/php/Dockerfile
+++ b/docker/php/Dockerfile
@@ -7,7 +7,7 @@ ARG ENVSUBST_VERSION=v1.3.0
 # flag -ldflags "-s -w" produces a smaller executable
 RUN go install -ldflags "-s -w" -v github.com/a8m/envsubst/cmd/envsubst@${ENVSUBST_VERSION}
 
-FROM php:8.2-fpm AS rootless
+FROM php:8.2-fpm-bookworm AS rootless
 
 ARG DEBIAN_FRONTEND=noninteractive
 ARG NODE_VERSION=20


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  |no
| BC breaks?    |no
| Deprecations? |no
| Tests pass?   |yes (docker build + composer install)
| Documentation |no
| Translation   |no
| CHANGELOG.md  |no
| License       | MIT

Fixes #8455

Debian 13 (trixie) no longer ships the `software-properties-common`
package, which causes the dev `php` Docker image build to fail when
using the default `php:8.2-fpm` (now trixie-based) image.

This PR pins the Docker base image to the bookworm variant where this
package is still available, restoring the expected development
workflow described in CONTRIBUTING.md.

Testing performed:

* `docker compose build php` succeeds
* `docker compose run --rm php composer --version` works as expected

This is an interim solution to unblock contributors while a future
PR may migrate the dev image fully to trixie.
