### PR TITLE
include wallabag_user_agent in the docker parameters.yml

### DIFF
--- a/docker/php/config/parameters.yml
+++ b/docker/php/config/parameters.yml
@@ -15,6 +15,8 @@ parameters:
 
     mailer_dsn: ${MAILER_DSN:-"smtp://127.0.0.1"}
 
+    wallabag_user_agent: "${WALLABAG_USER_AGENT:-Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/535.2 (KHTML, like Gecko) Chrome/15.0.874.92 Safari/535.2}"
+
     locale: ${LOCALE:-en}
 
     # A secret key that's used to generate certain security-related tokens


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  |no
| BC breaks?    |no
| Deprecations? |no
| Tests pass?   | yes
| Documentation |no
| Translation   |no
| CHANGELOG.md  |no
| License       | MIT

This fixes an issue with the Docker development workflow. `entrypoint.sh` regenerates
`app/config/parameters.yml` from a template on container start. The template at
`docker/php/config/parameters.yml` was missing the newer `wallabag_user_agent` parameter
(added in 2.7.0), which exists in `app/config/parameters.yml.dist`.

This caused the following problems during development:
- `composer install` repeatedly prompts for the missing parameter
- `bin/console wallabag:install` fails with `You have requested a non-existent parameter "wallabag_user_agent"`
- `docker compose up -d` overwrites the file and removes the parameter again

This PR adds the missing parameter to the Docker config template with a default matching the
upstream documentation, restoring a smooth development experience with Docker.
