### PR TITLE
Update instapaper import

### DIFF
--- a/src/Import/InstapaperImport.php
+++ b/src/Import/InstapaperImport.php
@@ -74,7 +74,7 @@ class InstapaperImport extends AbstractImport
             if ($hasNewFormat && !empty($data[5])) {
                 // New format: Tags column exists and contains JSON array
                 $parsedTags = json_decode($data[5], true);
-                if (is_array($parsedTags) && !empty($parsedTags)) {
+                if (\is_array($parsedTags) && !empty($parsedTags)) {
                     $tags = $parsedTags;
                 }
             } elseif (!$hasNewFormat && false === \in_array($data[3], ['Archive', 'Unread', 'Starred'], true)) {

--- a/tests/fixtures/Import/instapaper-export-new.csv
+++ b/tests/fixtures/Import/instapaper-export-new.csv
@@ -1,0 +1,5 @@
+URL,Title,Selection,Folder,Timestamp,Tags
+https://www.liberation.fr/societe/police-justice/cours-dassises-on-efface-le-peuple-dun-processus-judiciaire-dont-il-est-pourtant-le-coeur-battant-20210414_FYUNIZENHRGHZLAZEKSMKZYEPI/,Cours d'assises : «On efface le peuple d'un processus judiciaire dont il est pourtant le cœur battant»,,Unread,1700000000,"[]"
+https://redditblog.com/2016/09/20/amp-and-reactredux/,AMP and React+Redux: Why Not?,,Archive,1700000001,"[""react"",""javascript""]"
+https://medium.com/@the_minh/why-foursquare-swarm-is-still-my-favourite-social-network-e38228493e6c,Why Foursquare / Swarm is still my favourite social network,,Starred,1700000002,"[""social""]"
+https://www.20minutes.fr/high-tech/2077615-20170531-quoi-exactement-tweet-covfefe-donald-trump-persiste-signe,"Dis donc Donald Trump, c'est quoi exactement «covfefe»?",,Unread,1700000003,"[""politics"",""twitter"",""news""]"


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      |yes
| New feature?  |no
| BC breaks?    |no
| Deprecations? |no
| Tests pass?   | yes
| Documentation |no
| Translation   |no
| CHANGELOG.md  |no
| License       | MIT

This PR updates the Instapaper importer to support the newer CSV export format while keeping full backward compatibility with the existing 4-column format.

Instapaper now exports CSVs with 6 columns:

- Old format: `URL,Title,Selection,Folder`
- New format (as of at least 2025-11-20): `URL,Title,Selection,Folder,Timestamp,Tags`
  - where `Tags` is a JSON array (e.g. `["programming","go","security"]`).

This PR:

- Detects whether the imported file is in the old or new format.
- For the **new format**, parses the JSON `Tags` column and assigns those tags to the entry.
- For the **old format**, keeps the existing behavior of turning the `Folder` into a tag, except when it is one of the status folders (`Unread`, `Archive`, `Starred`).
- Uses the `Timestamp` column (Unix epoch) to set `Entry::createdAt` when available, preserving the original Instapaper creation time.
- Stores the current user’s ID before `em->clear()` and reattaches the `User` entity via `getReference()` in `parseEntry()`, ensuring `findByUrlAndUserId()` always has a valid user and avoiding issues when the user entity has been detached.
- Adds unit tests and a new CSV fixture (`instapaper-export-new.csv`) to cover the new export format and tag assignment behavior.

No BC breaks: existing Instapaper exports in the old 4-column format continue to work as before.