### PR TITLE
Prefetch content ISO to fetch URL content

### DIFF
--- a/src/Helper/ContentProxy.php
+++ b/src/Helper/ContentProxy.php
@@ -44,21 +44,31 @@ class ContentProxy
     {
         $this->graby->toggleImgNoReferrer(true);
         if (!empty($content['html'])) {
+            $this->graby->setContentAsPrefetched($content['html']);
             $content['html'] = $this->graby->cleanupHtml($content['html'], $url);
         }
 
-        if ((empty($content) || false === $this->validateContent($content)) && false === $disableContentUpdate) {
-            $fetchedContent = $this->graby->fetchContent($url);
+        if (false === $disableContentUpdate) {
+            $fetchedContent = array_filter($this->graby->fetchContent($url), static function ($value, $key) {
+                if ('html' === $key) {
+                    return true;
+                }
 
-            $fetchedContent['title'] = $this->sanitizeContentTitle(
-                $fetchedContent['title'],
-                $fetchedContent['headers']['content-type'] ?? ''
-            );
+                return $value;
+            }, \ARRAY_FILTER_USE_BOTH);
+
+            $title = $content['title'] ?? $fetchedContent['title'] ?? null;
+            if ($title) {
+                $fetchedContent['title'] = $this->sanitizeContentTitle(
+                    $title,
+                    $fetchedContent['headers']['content-type'] ?? ''
+                );
+            }
 
             // when content is imported, we have information in $content
             // in case fetching content goes bad, we'll keep the imported information instead of overriding them
-            if (empty($content) || $fetchedContent['html'] !== $this->fetchingErrorMessage) {
-                $content = $fetchedContent;
+            if ($fetchedContent['html'] !== $this->fetchingErrorMessage) {
+                $content = array_merge($fetchedContent, $content);
             }
         }
 
@@ -390,15 +400,5 @@ class ContentProxy
                 $entry->setUrl($url);
                 break;
         }
-    }
-
-    /**
-     * Validate that the given content has at least a title, an html and a url.
-     *
-     * @return bool true if valid otherwise false
-     */
-    private function validateContent(array $content)
-    {
-        return !empty($content['title']) && !empty($content['html']) && !empty($content['url']);
     }
 }

--- a/tests/functional/Controller/Import/WallabagV1ControllerTest.php
+++ b/tests/functional/Controller/Import/WallabagV1ControllerTest.php
@@ -124,7 +124,7 @@ class WallabagV1ControllerTest extends WallabagTestCase
         $this->assertStringContainsString('flashes.import.notice.summary', $body[0]);
 
         $this->assertInstanceOf(Entry::class, $content);
-        $this->assertEmpty($content->getMimetype(), 'Mimetype for http://www.framablog.org is empty');
+        $this->assertSame($content->getMimetype(), 'text/html', 'Mimetype for http://www.framablog.org is empty');
         $this->assertSame($content->getPreviewPicture(), 'http://www.framablog.org/public/_img/framablog/wallaby_baby.jpg');
         $this->assertEmpty($content->getLanguage(), 'Language for http://www.framablog.org is empty');
 

--- a/tests/unit/Helper/ContentProxyTest.php
+++ b/tests/unit/Helper/ContentProxyTest.php
@@ -640,6 +640,69 @@ class ContentProxyTest extends TestCase
         $this->assertFalse($entry->isNotParsed());
     }
 
+    public function testWithPrefetchedContent(): void
+    {
+        $tagger = $this->getTaggerMock();
+        $tagger->expects($this->once())
+            ->method('tag');
+
+        $ruleBasedIgnoreOriginProcessor = $this->getRuleBasedIgnoreOriginProcessorMock();
+
+        $html = <<<'HTML'
+        <!DOCTYPE html>
+        <html lang="fr">
+            <head>
+                <meta charset="utf-8">
+                <title>Amazing article ‒ wallabag test</title>
+                <meta name="author" content="wallabag user"/>
+                <meta property="og:image" content="http://1.1.1.1/avatar.jpg" />
+                <meta property="og:image:secure_url" content="http://1.1.1.1/avatar.jpg" />
+                <meta property="article:published_time" content="2025-03-20T17:30:00+00:00" />
+                <meta property="article:modified_time" content="2025-04-02T10:43:04+00:00" />
+                <meta name="twitter:image" content="http://1.1.1.1/avatar.jpg" />
+            </head>
+
+            <body>
+                <h1>Amazing article</h1>
+                <p>An amazing article to test wallabag. An amazing article to test wallabag. An amazing article to test wallabag. An amazing article to test wallabag. An amazing article to test wallabag.</p>
+            </body>
+        </html>
+        HTML;
+        $proxy = new ContentProxy(new Graby(), $tagger, $ruleBasedIgnoreOriginProcessor, $this->getValidator(), $this->getLogger(), $this->fetchingErrorMessage);
+        $entry = new Entry(new User());
+        $proxy->updateEntry(
+            $entry,
+            'http://1.1.1.1',
+            [
+                'html' => $html,
+                'title' => 'Amazing article ‒ wallabag test',
+                'url' => 'http://1.1.1.1',
+                'language' => 'fr',
+                'status' => '200',
+                'headers' => [
+                    'content-type' => 'text/html',
+                ],
+            ]
+        );
+
+        $content = <<<'CONTENT'
+        Amazing article ‒ wallabag test
+        <p>An amazing article to test wallabag. An amazing article to test wallabag. An amazing article to test wallabag. An amazing article to test wallabag. An amazing article to test wallabag.</p>
+        CONTENT;
+
+        $this->assertSame(['wallabag user'], $entry->getPublishedBy());
+        $this->assertSame('2025-03-20 17:30:00', $entry->getPublishedAt()->format('Y-m-d H:i:s'));
+        $this->assertSame($content, $entry->getContent());
+        $this->assertSame('http://1.1.1.1', $entry->getUrl());
+        $this->assertSame('Amazing article ‒ wallabag test', $entry->getTitle());
+        $this->assertSame('http://1.1.1.1/avatar.jpg', $entry->getPreviewPicture());
+        $this->assertSame('text/html', $entry->getMimetype());
+        $this->assertSame('fr', $entry->getLanguage());
+        $this->assertSame('200', $entry->getHttpStatus());
+        $this->assertSame('1.1.1.1', $entry->getDomainName());
+        $this->assertFalse($entry->isNotParsed());
+    }
+
     public function testWithImageAsContent(): void
     {
         $tagger = $this->getTaggerMock();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Documentation | no
| Translation   | no
| CHANGELOG.md  | no
| License       | MIT

Trying to be ISO when we are submitting the content from an external source (wallabagger for instance) using Graby `setContentAsPrefetched`. At the moment, the external content is not processed as a normal submitted URL.
