### PR TITLE
Fix #8642 long tag words on mobile

### DIFF
--- a/assets/scss/_article.scss
+++ b/assets/scss/_article.scss
@@ -138,6 +138,7 @@
       .tags {
         display: flex;
         margin: 0;
+        flex-wrap: wrap;
         align-items: center;
         gap: 5px;
       }
@@ -147,9 +148,8 @@
       display: flex;
       margin: 0;
       padding: 0;
-      height: 25px;
+      height: auto;
       line-height: 25px;
-      align-items: center;
       background-color: transparent;
 
       a,
@@ -166,14 +166,23 @@
     .chip-label {
         padding-left: 10px;
         padding-right: 5px;
+        word-break: break-word;
+        hyphens: auto;
         background-color: #9e9e9e;
         border-radius: 6px 0 0 6px;
     }
 
+    .chip-action-form {
+        display: contents;
+    }
+
     .chip-action {
+      display: flex;
       padding: 0 5px;
       background-color: #868686;
       border-radius: 0 6px 6px 0;
+      justify-content: center;
+      align-items: center;
     }
 
     .chip-label,
@@ -258,7 +267,6 @@
   }
 
   #article .entry-info .chip {
-    height: 32px;
     line-height: 32px;
   }
 

--- a/templates/Entry/_tags.html.twig
+++ b/templates/Entry/_tags.html.twig
@@ -5,7 +5,7 @@
                 <a class="chip-label" href="{{ path('tag_entries', {'slug': tag.slug}) }}">{{ tag.label }}</a>
                 {% if withRemove is defined and withRemove == true and is_granted('DELETE', tag) %}
                     {% set current_path = path(app.request.attributes.get('_route'), app.request.attributes.get('_route_params')) %}
-                    <form action="{{ path('remove_tag', {'entry': entryId, 'tag': tag.id, redirect: current_path}) }}" method="post">
+                    <form action="{{ path('remove_tag', {'entry': entryId, 'tag': tag.id, redirect: current_path}) }}" method="post" class="chip-action-form">
                         <input type="hidden" name="token" value="{{ csrf_token('remove-tag') }}"/>
 
                         <button type="submit" class="btn-link chip-action" onclick="return confirm('{{ 'entry.confirm.delete_tag'|trans|escape('js') }}')">


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Documentation | no
| Translation   | no
| CHANGELOG.md  | no
| License       | MIT

Hi there!
Fixes the long tags issue #8642 . Should be backported to 2.6.

Have a nice day.

Before

<img width="417" height="937" alt="wallabag-tags-before" src="https://github.com/user-attachments/assets/d6bf2d11-bffc-4e02-b5a0-9b4c1dc48bf2" />

After when there is space (tags break to a new line)

<img width="380" height="854" alt="wallabag-tags-after-wrapped" src="https://github.com/user-attachments/assets/2cb9cca7-1286-48ea-99a0-ad6e103a52e6" />

After when there is no space (word break)

<img width="238" height="854" alt="wallabag-tags-after-word-break" src="https://github.com/user-attachments/assets/0fedd521-66d7-422b-83f5-a4450f166cca" />