### PR TITLE
Automate creation of Issues from TODO in code

### DIFF
--- a/.github/workflows/todo-registrar.yaml
+++ b/.github/workflows/todo-registrar.yaml
@@ -1,0 +1,56 @@
+name: TODO Registrar
+
+on:
+  push:
+    branches: [ "master" ]
+
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+
+jobs:
+  todo-registrar:
+    name: Register TODO
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Register TODOs
+        uses: Aeliot-Tm/todo-registrar-action@1.6.4
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          config: |
+            paths:
+              in: .
+              exclude:
+                - var
+                - vendor
+            process:
+              glueSameTickets: true
+              glueSequentialComments: true
+            registrar:
+              type: GitHub
+              options:
+                issue:
+                  addTagToLabels: true
+                  labels:
+                    - needs-review
+                    - tech-debt
+                  tagPrefix: tag-
+                  showContext: numbered
+                  contextTitle: "## Added in position:"
+                service:
+                  personalAccessToken: "%env(GITHUB_TOKEN)%"
+                  repository: "${{ github.repository }}"
+            tags:
+              - todo
+              - fixme
+          env_vars: |
+            GITHUB_TOKEN
+          new_branch_name: 'todo-registrar'


### PR DESCRIPTION
This PR configs the using of [TODO Registrar action](https://github.com/marketplace/actions/todo-registrar) for the creating of Issues from TODOs in the code. 

After the creation of Issues their numbers will be committed in code. And merge request will be created. It allows to manage them easily and to find related issues easily from the code perspective.
> **Note:** after the merging of PR with committed issues' numbers branch (`todo-registrar`) have to be removed! New issues creation will not start without it. It is done to prevent creation of issues duplicates.

[Permissions](https://github.com/marketplace/actions/todo-registrar#permissions) have to be configured for the proper work.