### PR TITLE
Fix dark theme auto-detection initialization order

### DIFF
--- a/assets/controllers/dark_theme_controller.js
+++ b/assets/controllers/dark_theme_controller.js
@@ -2,10 +2,10 @@ import { Controller } from '@hotwired/stimulus';
 
 export default class extends Controller {
   connect() {
-    this.#choose();
-
     this.mql = window.matchMedia('(prefers-color-scheme: dark)');
     this.mql.addEventListener('change', this.#choose.bind(this));
+
+    this.#choose();
   }
 
   useLight() {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Documentation | no
| Translation   | no
| CHANGELOG.md  | no
| License       | MIT

This fixes dark theme auto-detection on initial controller connect by creating the `matchMedia('(prefers-color-scheme: dark)')` handle before `#choose()` runs.

Without that initialization order, `#choose()` can read `this.mql` before it exists when no `theme` cookie is set, which breaks automatic dark mode detection.

Validation:
- `yarn eslint assets/controllers/dark_theme_controller.js`
- `yarn build:dev` reached `webpack compiled successfully`; in this environment it then exited because `webpack-notifier` could not open `/tmp/notifierPipe-*`
