### PR TITLE
Rename tests namespace to Wallabag\Tests

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -214,8 +214,8 @@
     },
     "autoload-dev": {
         "psr-4": {
-            "Tests\\Wallabag\\": "tests/",
-            "Wallabag\\DataFixtures\\": "fixtures/"
+            "Wallabag\\DataFixtures\\": "fixtures/",
+            "Wallabag\\Tests\\": "tests/"
         },
         "files": [
             "tests/functions.php"

--- a/tests/Command/CleanDuplicatesCommandTest.php
+++ b/tests/Command/CleanDuplicatesCommandTest.php
@@ -1,13 +1,13 @@
 <?php
 
-namespace Tests\Wallabag\Command;
+namespace Wallabag\Tests\Command;
 
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Bundle\FrameworkBundle\Console\Application;
 use Symfony\Component\Console\Tester\CommandTester;
-use Tests\Wallabag\WallabagTestCase;
 use Wallabag\Entity\Entry;
 use Wallabag\Entity\User;
+use Wallabag\Tests\WallabagTestCase;
 
 class CleanDuplicatesCommandTest extends WallabagTestCase
 {

--- a/tests/Command/ExportCommandTest.php
+++ b/tests/Command/ExportCommandTest.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace Tests\Wallabag\Command;
+namespace Wallabag\Tests\Command;
 
 use Symfony\Bundle\FrameworkBundle\Console\Application;
 use Symfony\Component\Console\Exception\RuntimeException;
 use Symfony\Component\Console\Tester\CommandTester;
-use Tests\Wallabag\WallabagTestCase;
+use Wallabag\Tests\WallabagTestCase;
 
 class ExportCommandTest extends WallabagTestCase
 {

--- a/tests/Command/GenerateUrlHashesCommandTest.php
+++ b/tests/Command/GenerateUrlHashesCommandTest.php
@@ -1,13 +1,13 @@
 <?php
 
-namespace Tests\Wallabag\Command;
+namespace Wallabag\Tests\Command;
 
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Bundle\FrameworkBundle\Console\Application;
 use Symfony\Component\Console\Tester\CommandTester;
-use Tests\Wallabag\WallabagTestCase;
 use Wallabag\Entity\Entry;
 use Wallabag\Entity\User;
+use Wallabag\Tests\WallabagTestCase;
 
 class GenerateUrlHashesCommandTest extends WallabagTestCase
 {

--- a/tests/Command/Import/ImportCommandTest.php
+++ b/tests/Command/Import/ImportCommandTest.php
@@ -1,13 +1,13 @@
 <?php
 
-namespace Tests\Wallabag\Command\Import;
+namespace Wallabag\Tests\Command\Import;
 
 use Doctrine\ORM\NoResultException;
 use Symfony\Bundle\FrameworkBundle\Console\Application;
 use Symfony\Component\Config\Definition\Exception\Exception;
 use Symfony\Component\Console\Exception\RuntimeException;
 use Symfony\Component\Console\Tester\CommandTester;
-use Tests\Wallabag\WallabagTestCase;
+use Wallabag\Tests\WallabagTestCase;
 
 class ImportCommandTest extends WallabagTestCase
 {

--- a/tests/Command/Import/RedisWorkerCommandTest.php
+++ b/tests/Command/Import/RedisWorkerCommandTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Tests\Wallabag\Command\Import;
+namespace Wallabag\Tests\Command\Import;
 
 use M6Web\Component\RedisMock\RedisMockFactory;
 use Predis\Client;
@@ -8,7 +8,7 @@ use Symfony\Bundle\FrameworkBundle\Console\Application;
 use Symfony\Component\Config\Definition\Exception\Exception;
 use Symfony\Component\Console\Exception\RuntimeException;
 use Symfony\Component\Console\Tester\CommandTester;
-use Tests\Wallabag\WallabagTestCase;
+use Wallabag\Tests\WallabagTestCase;
 
 class RedisWorkerCommandTest extends WallabagTestCase
 {

--- a/tests/Command/Import/UrlCommandTest.php
+++ b/tests/Command/Import/UrlCommandTest.php
@@ -1,14 +1,14 @@
 <?php
 
-namespace Tests\Wallabag\Command\Import;
+namespace Wallabag\Tests\Command\Import;
 
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\NoResultException;
 use Symfony\Bundle\FrameworkBundle\Console\Application;
 use Symfony\Component\Console\Exception\RuntimeException;
 use Symfony\Component\Console\Tester\CommandTester;
-use Tests\Wallabag\WallabagTestCase;
 use Wallabag\Entity\Entry;
+use Wallabag\Tests\WallabagTestCase;
 
 class UrlCommandTest extends WallabagTestCase
 {

--- a/tests/Command/InstallCommandTest.php
+++ b/tests/Command/InstallCommandTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Tests\Wallabag\Command;
+namespace Wallabag\Tests\Command;
 
 use DAMA\DoctrineTestBundle\Doctrine\DBAL\StaticDriver;
 use Doctrine\DBAL\Connection;
@@ -14,8 +14,8 @@ use Symfony\Component\Console\Command\LazyCommand;
 use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Output\NullOutput;
 use Symfony\Component\Console\Tester\CommandTester;
-use Tests\Wallabag\WallabagTestCase;
 use Wallabag\Command\InstallCommand;
+use Wallabag\Tests\WallabagTestCase;
 
 class InstallCommandTest extends WallabagTestCase
 {

--- a/tests/Command/ListUserCommandTest.php
+++ b/tests/Command/ListUserCommandTest.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace Tests\Wallabag\Command;
+namespace Wallabag\Tests\Command;
 
 use Symfony\Bundle\FrameworkBundle\Console\Application;
 use Symfony\Component\Console\Tester\CommandTester;
-use Tests\Wallabag\WallabagTestCase;
+use Wallabag\Tests\WallabagTestCase;
 
 class ListUserCommandTest extends WallabagTestCase
 {

--- a/tests/Command/ReloadEntryCommandTest.php
+++ b/tests/Command/ReloadEntryCommandTest.php
@@ -1,13 +1,13 @@
 <?php
 
-namespace Tests\Wallabag\Command;
+namespace Wallabag\Tests\Command;
 
 use Symfony\Bundle\FrameworkBundle\Console\Application;
 use Symfony\Component\Console\Tester\CommandTester;
-use Tests\Wallabag\WallabagTestCase;
 use Wallabag\Entity\Entry;
 use Wallabag\Repository\EntryRepository;
 use Wallabag\Repository\UserRepository;
+use Wallabag\Tests\WallabagTestCase;
 
 class ReloadEntryCommandTest extends WallabagTestCase
 {

--- a/tests/Command/ShowUserCommandTest.php
+++ b/tests/Command/ShowUserCommandTest.php
@@ -1,13 +1,13 @@
 <?php
 
-namespace Tests\Wallabag\Command;
+namespace Wallabag\Tests\Command;
 
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Bundle\FrameworkBundle\Console\Application;
 use Symfony\Component\Console\Exception\RuntimeException;
 use Symfony\Component\Console\Tester\CommandTester;
-use Tests\Wallabag\WallabagTestCase;
 use Wallabag\Entity\User;
+use Wallabag\Tests\WallabagTestCase;
 
 class ShowUserCommandTest extends WallabagTestCase
 {

--- a/tests/Command/TagAllCommandTest.php
+++ b/tests/Command/TagAllCommandTest.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace Tests\Wallabag\Command;
+namespace Wallabag\Tests\Command;
 
 use Symfony\Bundle\FrameworkBundle\Console\Application;
 use Symfony\Component\Console\Exception\RuntimeException;
 use Symfony\Component\Console\Tester\CommandTester;
-use Tests\Wallabag\WallabagTestCase;
+use Wallabag\Tests\WallabagTestCase;
 
 class TagAllCommandTest extends WallabagTestCase
 {

--- a/tests/Command/UpdatePicturesPathCommandTest.php
+++ b/tests/Command/UpdatePicturesPathCommandTest.php
@@ -1,13 +1,13 @@
 <?php
 
-namespace Tests\Wallabag\Command;
+namespace Wallabag\Tests\Command;
 
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Bundle\FrameworkBundle\Console\Application;
 use Symfony\Component\Console\Exception\RuntimeException;
 use Symfony\Component\Console\Tester\CommandTester;
-use Tests\Wallabag\WallabagTestCase;
 use Wallabag\Entity\Entry;
+use Wallabag\Tests\WallabagTestCase;
 
 class UpdatePicturesPathCommandTest extends WallabagTestCase
 {

--- a/tests/Consumer/AMQPEntryConsumerTest.php
+++ b/tests/Consumer/AMQPEntryConsumerTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Tests\Wallabag\Consumer;
+namespace Wallabag\Tests\Consumer;
 
 use Doctrine\ORM\EntityManager;
 use PhpAmqpLib\Message\AMQPMessage;

--- a/tests/Consumer/RedisEntryConsumerTest.php
+++ b/tests/Consumer/RedisEntryConsumerTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Tests\Wallabag\Consumer;
+namespace Wallabag\Tests\Consumer;
 
 use Doctrine\ORM\EntityManager;
 use PHPUnit\Framework\TestCase;

--- a/tests/Controller/AnnotationControllerTest.php
+++ b/tests/Controller/AnnotationControllerTest.php
@@ -1,13 +1,13 @@
 <?php
 
-namespace Tests\Wallabag\Controller;
+namespace Wallabag\Tests\Controller;
 
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Bundle\FrameworkBundle\KernelBrowser;
-use Tests\Wallabag\WallabagTestCase;
 use Wallabag\Entity\Annotation;
 use Wallabag\Entity\Entry;
 use Wallabag\Entity\User;
+use Wallabag\Tests\WallabagTestCase;
 
 class AnnotationControllerTest extends WallabagTestCase
 {

--- a/tests/Controller/Api/ConfigRestControllerTest.php
+++ b/tests/Controller/Api/ConfigRestControllerTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Tests\Wallabag\Controller\Api;
+namespace Wallabag\Tests\Controller\Api;
 
 class ConfigRestControllerTest extends WallabagApiTestCase
 {

--- a/tests/Controller/Api/DeveloperControllerTest.php
+++ b/tests/Controller/Api/DeveloperControllerTest.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace Tests\Wallabag\Controller\Api;
+namespace Wallabag\Tests\Controller\Api;
 
 use Doctrine\ORM\EntityManagerInterface;
-use Tests\Wallabag\WallabagTestCase;
 use Wallabag\Entity\Api\Client;
 use Wallabag\Entity\User;
+use Wallabag\Tests\WallabagTestCase;
 
 class DeveloperControllerTest extends WallabagTestCase
 {

--- a/tests/Controller/Api/EntryRestControllerTest.php
+++ b/tests/Controller/Api/EntryRestControllerTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Tests\Wallabag\Controller\Api;
+namespace Wallabag\Tests\Controller\Api;
 
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Component\DependencyInjection\Container;

--- a/tests/Controller/Api/SearchRestControllerTest.php
+++ b/tests/Controller/Api/SearchRestControllerTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Tests\Wallabag\Controller\Api;
+namespace Wallabag\Tests\Controller\Api;
 
 class SearchRestControllerTest extends WallabagApiTestCase
 {

--- a/tests/Controller/Api/TagRestControllerTest.php
+++ b/tests/Controller/Api/TagRestControllerTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Tests\Wallabag\Controller\Api;
+namespace Wallabag\Tests\Controller\Api;
 
 use Doctrine\ORM\EntityManagerInterface;
 use Wallabag\Entity\Entry;

--- a/tests/Controller/Api/TaggingRuleRestControllerTest.php
+++ b/tests/Controller/Api/TaggingRuleRestControllerTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Tests\Wallabag\Controller\Api;
+namespace Wallabag\Tests\Controller\Api;
 
 class TaggingRuleRestControllerTest extends WallabagApiTestCase
 {

--- a/tests/Controller/Api/UserRestControllerTest.php
+++ b/tests/Controller/Api/UserRestControllerTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Tests\Wallabag\Controller\Api;
+namespace Wallabag\Tests\Controller\Api;
 
 use Craue\ConfigBundle\Util\Config;
 

--- a/tests/Controller/Api/WallabagApiTestCase.php
+++ b/tests/Controller/Api/WallabagApiTestCase.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Tests\Wallabag\Controller\Api;
+namespace Wallabag\Tests\Controller\Api;
 
 use Doctrine\ORM\EntityManagerInterface;
 use FOS\UserBundle\Model\UserManager;

--- a/tests/Controller/Api/WallabagRestControllerTest.php
+++ b/tests/Controller/Api/WallabagRestControllerTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Tests\Wallabag\Controller\Api;
+namespace Wallabag\Tests\Controller\Api;
 
 use Craue\ConfigBundle\Util\Config;
 

--- a/tests/Controller/ConfigControllerTest.php
+++ b/tests/Controller/ConfigControllerTest.php
@@ -1,13 +1,12 @@
 <?php
 
-namespace Tests\Wallabag\Controller;
+namespace Wallabag\Tests\Controller;
 
 use Doctrine\ORM\EntityManagerInterface;
 use Scheb\TwoFactorBundle\Security\TwoFactor\Provider\Google\GoogleAuthenticatorInterface;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
 use Symfony\Component\HttpFoundation\Session\SessionInterface;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
-use Tests\Wallabag\WallabagTestCase;
 use Wallabag\Entity\Annotation;
 use Wallabag\Entity\Config as ConfigEntity;
 use Wallabag\Entity\Entry;
@@ -15,6 +14,7 @@ use Wallabag\Entity\IgnoreOriginUserRule;
 use Wallabag\Entity\Tag;
 use Wallabag\Entity\TaggingRule;
 use Wallabag\Entity\User;
+use Wallabag\Tests\WallabagTestCase;
 
 class ConfigControllerTest extends WallabagTestCase
 {

--- a/tests/Controller/EntryControllerTest.php
+++ b/tests/Controller/EntryControllerTest.php
@@ -1,11 +1,10 @@
 <?php
 
-namespace Tests\Wallabag\Controller;
+namespace Wallabag\Tests\Controller;
 
 use Craue\ConfigBundle\Util\Config;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
-use Tests\Wallabag\WallabagTestCase;
 use Wallabag\Entity\Annotation;
 use Wallabag\Entity\Config as ConfigEntity;
 use Wallabag\Entity\Entry;
@@ -14,6 +13,7 @@ use Wallabag\Entity\Tag;
 use Wallabag\Entity\User;
 use Wallabag\Helper\ContentProxy;
 use Wallabag\Helper\CryptoProxy;
+use Wallabag\Tests\WallabagTestCase;
 
 class EntryControllerTest extends WallabagTestCase
 {

--- a/tests/Controller/ExportControllerTest.php
+++ b/tests/Controller/ExportControllerTest.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace Tests\Wallabag\Controller;
+namespace Wallabag\Tests\Controller;
 
 use Doctrine\ORM\EntityManagerInterface;
-use Tests\Wallabag\WallabagTestCase;
 use Wallabag\Entity\Entry;
 use Wallabag\Repository\UserRepository;
+use Wallabag\Tests\WallabagTestCase;
 
 class ExportControllerTest extends WallabagTestCase
 {

--- a/tests/Controller/FeedControllerTest.php
+++ b/tests/Controller/FeedControllerTest.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace Tests\Wallabag\Controller;
+namespace Wallabag\Tests\Controller;
 
 use Doctrine\ORM\EntityManagerInterface;
-use Tests\Wallabag\WallabagTestCase;
 use Wallabag\Entity\Entry;
 use Wallabag\Entity\User;
+use Wallabag\Tests\WallabagTestCase;
 
 class FeedControllerTest extends WallabagTestCase
 {

--- a/tests/Controller/IgnoreOriginInstanceRuleControllerTest.php
+++ b/tests/Controller/IgnoreOriginInstanceRuleControllerTest.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace Tests\Wallabag\Controller;
+namespace Wallabag\Tests\Controller;
 
-use Tests\Wallabag\WallabagTestCase;
+use Wallabag\Tests\WallabagTestCase;
 
 class IgnoreOriginInstanceRuleControllerTest extends WallabagTestCase
 {

--- a/tests/Controller/Import/ChromeControllerTest.php
+++ b/tests/Controller/Import/ChromeControllerTest.php
@@ -1,13 +1,13 @@
 <?php
 
-namespace Tests\Wallabag\Controller\Import;
+namespace Wallabag\Tests\Controller\Import;
 
 use Craue\ConfigBundle\Util\Config;
 use Doctrine\ORM\EntityManagerInterface;
 use Predis\Client;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
-use Tests\Wallabag\WallabagTestCase;
 use Wallabag\Entity\Entry;
+use Wallabag\Tests\WallabagTestCase;
 
 class ChromeControllerTest extends WallabagTestCase
 {

--- a/tests/Controller/Import/DeliciousControllerTest.php
+++ b/tests/Controller/Import/DeliciousControllerTest.php
@@ -1,13 +1,13 @@
 <?php
 
-namespace Tests\Wallabag\Controller\Import;
+namespace Wallabag\Tests\Controller\Import;
 
 use Craue\ConfigBundle\Util\Config;
 use Doctrine\ORM\EntityManagerInterface;
 use Predis\Client;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
-use Tests\Wallabag\WallabagTestCase;
 use Wallabag\Entity\Entry;
+use Wallabag\Tests\WallabagTestCase;
 
 class DeliciousControllerTest extends WallabagTestCase
 {

--- a/tests/Controller/Import/ElcuratorControllerTest.php
+++ b/tests/Controller/Import/ElcuratorControllerTest.php
@@ -1,13 +1,13 @@
 <?php
 
-namespace Tests\Wallabag\Controller\Import;
+namespace Wallabag\Tests\Controller\Import;
 
 use Craue\ConfigBundle\Util\Config;
 use Doctrine\ORM\EntityManagerInterface;
 use Predis\Client;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
-use Tests\Wallabag\WallabagTestCase;
 use Wallabag\Entity\Entry;
+use Wallabag\Tests\WallabagTestCase;
 
 class ElcuratorControllerTest extends WallabagTestCase
 {

--- a/tests/Controller/Import/FirefoxControllerTest.php
+++ b/tests/Controller/Import/FirefoxControllerTest.php
@@ -1,13 +1,13 @@
 <?php
 
-namespace Tests\Wallabag\Controller\Import;
+namespace Wallabag\Tests\Controller\Import;
 
 use Craue\ConfigBundle\Util\Config;
 use Doctrine\ORM\EntityManagerInterface;
 use Predis\Client;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
-use Tests\Wallabag\WallabagTestCase;
 use Wallabag\Entity\Entry;
+use Wallabag\Tests\WallabagTestCase;
 
 class FirefoxControllerTest extends WallabagTestCase
 {

--- a/tests/Controller/Import/ImportControllerTest.php
+++ b/tests/Controller/Import/ImportControllerTest.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace Tests\Wallabag\Controller\Import;
+namespace Wallabag\Tests\Controller\Import;
 
-use Tests\Wallabag\WallabagTestCase;
+use Wallabag\Tests\WallabagTestCase;
 
 class ImportControllerTest extends WallabagTestCase
 {

--- a/tests/Controller/Import/InstapaperControllerTest.php
+++ b/tests/Controller/Import/InstapaperControllerTest.php
@@ -1,13 +1,13 @@
 <?php
 
-namespace Tests\Wallabag\Controller\Import;
+namespace Wallabag\Tests\Controller\Import;
 
 use Craue\ConfigBundle\Util\Config;
 use Doctrine\ORM\EntityManagerInterface;
 use Predis\Client;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
-use Tests\Wallabag\WallabagTestCase;
 use Wallabag\Entity\Entry;
+use Wallabag\Tests\WallabagTestCase;
 
 class InstapaperControllerTest extends WallabagTestCase
 {

--- a/tests/Controller/Import/OmnivoreControllerTest.php
+++ b/tests/Controller/Import/OmnivoreControllerTest.php
@@ -1,13 +1,13 @@
 <?php
 
-namespace Tests\Wallabag\Controller\Import;
+namespace Wallabag\Tests\Controller\Import;
 
 use Craue\ConfigBundle\Util\Config;
 use Doctrine\ORM\EntityManagerInterface;
 use Predis\Client;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
-use Tests\Wallabag\WallabagTestCase;
 use Wallabag\Entity\Entry;
+use Wallabag\Tests\WallabagTestCase;
 
 class OmnivoreControllerTest extends WallabagTestCase
 {

--- a/tests/Controller/Import/PinboardControllerTest.php
+++ b/tests/Controller/Import/PinboardControllerTest.php
@@ -1,13 +1,13 @@
 <?php
 
-namespace Tests\Wallabag\Controller\Import;
+namespace Wallabag\Tests\Controller\Import;
 
 use Craue\ConfigBundle\Util\Config;
 use Doctrine\ORM\EntityManagerInterface;
 use Predis\Client;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
-use Tests\Wallabag\WallabagTestCase;
 use Wallabag\Entity\Entry;
+use Wallabag\Tests\WallabagTestCase;
 
 class PinboardControllerTest extends WallabagTestCase
 {

--- a/tests/Controller/Import/PocketControllerTest.php
+++ b/tests/Controller/Import/PocketControllerTest.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace Tests\Wallabag\Controller\Import;
+namespace Wallabag\Tests\Controller\Import;
 
 use Craue\ConfigBundle\Util\Config;
 use Symfony\Component\HttpFoundation\Session\SessionInterface;
-use Tests\Wallabag\WallabagTestCase;
 use Wallabag\Import\PocketImport;
+use Wallabag\Tests\WallabagTestCase;
 
 class PocketControllerTest extends WallabagTestCase
 {

--- a/tests/Controller/Import/PocketCsvControllerTest.php
+++ b/tests/Controller/Import/PocketCsvControllerTest.php
@@ -1,13 +1,13 @@
 <?php
 
-namespace Tests\Wallabag\Controller\Import;
+namespace Wallabag\Tests\Controller\Import;
 
 use Craue\ConfigBundle\Util\Config;
 use Doctrine\ORM\EntityManagerInterface;
 use Predis\Client;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
-use Tests\Wallabag\WallabagTestCase;
 use Wallabag\Entity\Entry;
+use Wallabag\Tests\WallabagTestCase;
 
 class PocketCsvControllerTest extends WallabagTestCase
 {

--- a/tests/Controller/Import/PocketHtmlControllerTest.php
+++ b/tests/Controller/Import/PocketHtmlControllerTest.php
@@ -1,13 +1,13 @@
 <?php
 
-namespace Tests\Wallabag\Controller\Import;
+namespace Wallabag\Tests\Controller\Import;
 
 use Craue\ConfigBundle\Util\Config;
 use Doctrine\ORM\EntityManagerInterface;
 use Predis\Client;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
-use Tests\Wallabag\WallabagTestCase;
 use Wallabag\Entity\Entry;
+use Wallabag\Tests\WallabagTestCase;
 
 class PocketHtmlControllerTest extends WallabagTestCase
 {

--- a/tests/Controller/Import/ReadabilityControllerTest.php
+++ b/tests/Controller/Import/ReadabilityControllerTest.php
@@ -1,13 +1,13 @@
 <?php
 
-namespace Tests\Wallabag\Controller\Import;
+namespace Wallabag\Tests\Controller\Import;
 
 use Craue\ConfigBundle\Util\Config;
 use Doctrine\ORM\EntityManagerInterface;
 use Predis\Client;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
-use Tests\Wallabag\WallabagTestCase;
 use Wallabag\Entity\Entry;
+use Wallabag\Tests\WallabagTestCase;
 
 class ReadabilityControllerTest extends WallabagTestCase
 {

--- a/tests/Controller/Import/ShaarliControllerTest.php
+++ b/tests/Controller/Import/ShaarliControllerTest.php
@@ -1,13 +1,13 @@
 <?php
 
-namespace Tests\Wallabag\Controller\Import;
+namespace Wallabag\Tests\Controller\Import;
 
 use Craue\ConfigBundle\Util\Config;
 use Doctrine\ORM\EntityManagerInterface;
 use Predis\Client;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
-use Tests\Wallabag\WallabagTestCase;
 use Wallabag\Entity\Entry;
+use Wallabag\Tests\WallabagTestCase;
 
 class ShaarliControllerTest extends WallabagTestCase
 {

--- a/tests/Controller/Import/WallabagV1ControllerTest.php
+++ b/tests/Controller/Import/WallabagV1ControllerTest.php
@@ -1,13 +1,13 @@
 <?php
 
-namespace Tests\Wallabag\Controller\Import;
+namespace Wallabag\Tests\Controller\Import;
 
 use Craue\ConfigBundle\Util\Config;
 use Doctrine\ORM\EntityManagerInterface;
 use Predis\Client;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
-use Tests\Wallabag\WallabagTestCase;
 use Wallabag\Entity\Entry;
+use Wallabag\Tests\WallabagTestCase;
 
 class WallabagV1ControllerTest extends WallabagTestCase
 {

--- a/tests/Controller/Import/WallabagV2ControllerTest.php
+++ b/tests/Controller/Import/WallabagV2ControllerTest.php
@@ -1,13 +1,13 @@
 <?php
 
-namespace Tests\Wallabag\Controller\Import;
+namespace Wallabag\Tests\Controller\Import;
 
 use Craue\ConfigBundle\Util\Config;
 use Doctrine\ORM\EntityManagerInterface;
 use Predis\Client;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
-use Tests\Wallabag\WallabagTestCase;
 use Wallabag\Entity\Entry;
+use Wallabag\Tests\WallabagTestCase;
 
 class WallabagV2ControllerTest extends WallabagTestCase
 {

--- a/tests/Controller/SecurityControllerTest.php
+++ b/tests/Controller/SecurityControllerTest.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace Tests\Wallabag\Controller;
+namespace Wallabag\Tests\Controller;
 
 use Doctrine\ORM\EntityManagerInterface;
-use Tests\Wallabag\WallabagTestCase;
 use Wallabag\Entity\User;
+use Wallabag\Tests\WallabagTestCase;
 
 class SecurityControllerTest extends WallabagTestCase
 {

--- a/tests/Controller/SettingsControllerTest.php
+++ b/tests/Controller/SettingsControllerTest.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace Tests\Wallabag\Controller;
+namespace Wallabag\Tests\Controller;
 
-use Tests\Wallabag\WallabagTestCase;
+use Wallabag\Tests\WallabagTestCase;
 
 /**
  * The controller `SettingsController` does not exist.

--- a/tests/Controller/SiteCredentialControllerTest.php
+++ b/tests/Controller/SiteCredentialControllerTest.php
@@ -1,12 +1,12 @@
 <?php
 
-namespace Tests\Wallabag\Controller;
+namespace Wallabag\Tests\Controller;
 
 use Craue\ConfigBundle\Util\Config;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Bundle\FrameworkBundle\KernelBrowser;
-use Tests\Wallabag\WallabagTestCase;
 use Wallabag\Entity\SiteCredential;
+use Wallabag\Tests\WallabagTestCase;
 
 class SiteCredentialControllerTest extends WallabagTestCase
 {

--- a/tests/Controller/StaticControllerTest.php
+++ b/tests/Controller/StaticControllerTest.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace Tests\Wallabag\Controller;
+namespace Wallabag\Tests\Controller;
 
-use Tests\Wallabag\WallabagTestCase;
+use Wallabag\Tests\WallabagTestCase;
 
 class StaticControllerTest extends WallabagTestCase
 {

--- a/tests/Controller/TagControllerTest.php
+++ b/tests/Controller/TagControllerTest.php
@@ -1,12 +1,12 @@
 <?php
 
-namespace Tests\Wallabag\Controller;
+namespace Wallabag\Tests\Controller;
 
 use Doctrine\ORM\EntityManagerInterface;
-use Tests\Wallabag\WallabagTestCase;
 use Wallabag\Entity\Entry;
 use Wallabag\Entity\Tag;
 use Wallabag\Entity\User;
+use Wallabag\Tests\WallabagTestCase;
 
 /**
  * @group Tag

--- a/tests/Controller/UserControllerTest.php
+++ b/tests/Controller/UserControllerTest.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace Tests\Wallabag\Controller;
+namespace Wallabag\Tests\Controller;
 
-use Tests\Wallabag\WallabagTestCase;
+use Wallabag\Tests\WallabagTestCase;
 
 class UserControllerTest extends WallabagTestCase
 {

--- a/tests/Entity/EntryTest.php
+++ b/tests/Entity/EntryTest.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace Tests\Wallabag\Entity;
+namespace Wallabag\Tests\Entity;
 
-use Tests\Wallabag\WallabagTestCase;
 use Wallabag\Entity\Entry;
+use Wallabag\Tests\WallabagTestCase;
 
 class EntryTest extends WallabagTestCase
 {

--- a/tests/Event/Listener/AuthenticationFailureListenerTest.php
+++ b/tests/Event/Listener/AuthenticationFailureListenerTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Tests\Wallabag\Event\Listener;
+namespace Wallabag\Tests\Event\Listener;
 
 use Monolog\Handler\TestHandler;
 use Monolog\Logger;

--- a/tests/Event/Listener/CreateConfigListenerTest.php
+++ b/tests/Event/Listener/CreateConfigListenerTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Tests\Wallabag\Event\Listener;
+namespace Wallabag\Tests\Event\Listener;
 
 use Doctrine\ORM\EntityManager;
 use FOS\UserBundle\Event\FilterUserResponseEvent;

--- a/tests/Event/Listener/LocaleListenerTest.php
+++ b/tests/Event/Listener/LocaleListenerTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Tests\Wallabag\Event\Listener;
+namespace Wallabag\Tests\Event\Listener;
 
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\EventDispatcher\EventDispatcher;

--- a/tests/Event/Listener/UserLocaleListenerTest.php
+++ b/tests/Event/Listener/UserLocaleListenerTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Tests\Wallabag\Event\Listener;
+namespace Wallabag\Tests\Event\Listener;
 
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\Request;

--- a/tests/Event/Subscriber/TablePrefixSubscriberTest.php
+++ b/tests/Event/Subscriber/TablePrefixSubscriberTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Tests\Wallabag\Event\Subscriber;
+namespace Wallabag\Tests\Event\Subscriber;
 
 use Doctrine\Common\EventManager;
 use Doctrine\DBAL\Platforms\MySQLPlatform;

--- a/tests/Form/DataTransformer/StringToListTransformerTest.php
+++ b/tests/Form/DataTransformer/StringToListTransformerTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Tests\Wallabag\Form\DataTransformer;
+namespace Wallabag\Tests\Form\DataTransformer;
 
 use PHPUnit\Framework\TestCase;
 use Wallabag\Form\DataTransformer\StringToListTransformer;

--- a/tests/Helper/ContentProxyTest.php
+++ b/tests/Helper/ContentProxyTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Tests\Wallabag\Helper;
+namespace Wallabag\Tests\Helper;
 
 use Graby\Graby;
 use Monolog\Handler\TestHandler;

--- a/tests/Helper/CryptoProxyTest.php
+++ b/tests/Helper/CryptoProxyTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Tests\Wallabag\Helper;
+namespace Wallabag\Tests\Helper;
 
 use Monolog\Handler\TestHandler;
 use Monolog\Logger;

--- a/tests/Helper/DownloadImagesTest.php
+++ b/tests/Helper/DownloadImagesTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Tests\Wallabag\Helper;
+namespace Wallabag\Tests\Helper;
 
 use Monolog\Handler\TestHandler;
 use Monolog\Logger;

--- a/tests/Helper/RedirectTest.php
+++ b/tests/Helper/RedirectTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Tests\Wallabag\Helper;
+namespace Wallabag\Tests\Helper;
 
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;

--- a/tests/Helper/RuleBasedIgnoreOriginProcessorTest.php
+++ b/tests/Helper/RuleBasedIgnoreOriginProcessorTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Tests\Wallabag\Helper;
+namespace Wallabag\Tests\Helper;
 
 use Monolog\Handler\TestHandler;
 use Monolog\Logger;

--- a/tests/Helper/RuleBasedTaggerTest.php
+++ b/tests/Helper/RuleBasedTaggerTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Tests\Wallabag\Helper;
+namespace Wallabag\Tests\Helper;
 
 use Doctrine\ORM\AbstractQuery;
 use Doctrine\ORM\QueryBuilder;

--- a/tests/Helper/TagsAssignerTest.php
+++ b/tests/Helper/TagsAssignerTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Tests\Wallabag\Helper;
+namespace Wallabag\Tests\Helper;
 
 use PHPUnit\Framework\TestCase;
 use Wallabag\Entity\Entry;

--- a/tests/HttpClient/AuthenticatorTest.php
+++ b/tests/HttpClient/AuthenticatorTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Tests\Wallabag\HttpClient;
+namespace Wallabag\Tests\HttpClient;
 
 use Monolog\Handler\TestHandler;
 use Monolog\Logger;

--- a/tests/Import/ChromeImportTest.php
+++ b/tests/Import/ChromeImportTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Tests\Wallabag\Import;
+namespace Wallabag\Tests\Import;
 
 use Doctrine\ORM\EntityManager;
 use M6Web\Component\RedisMock\RedisMockFactory;

--- a/tests/Import/FirefoxImportTest.php
+++ b/tests/Import/FirefoxImportTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Tests\Wallabag\Import;
+namespace Wallabag\Tests\Import;
 
 use Doctrine\ORM\EntityManager;
 use M6Web\Component\RedisMock\RedisMockFactory;

--- a/tests/Import/ImportChainTest.php
+++ b/tests/Import/ImportChainTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Tests\Wallabag\Import;
+namespace Wallabag\Tests\Import;
 
 use PHPUnit\Framework\TestCase;
 use Wallabag\Import\ImportChain;

--- a/tests/Import/ImportCompilerPassTest.php
+++ b/tests/Import/ImportCompilerPassTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Tests\Wallabag\Import;
+namespace Wallabag\Tests\Import;
 
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\DependencyInjection\ContainerBuilder;

--- a/tests/Import/InstapaperImportTest.php
+++ b/tests/Import/InstapaperImportTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Tests\Wallabag\Import;
+namespace Wallabag\Tests\Import;
 
 use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\UnitOfWork;

--- a/tests/Import/PocketCsvImportTest.php
+++ b/tests/Import/PocketCsvImportTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Tests\Wallabag\Import;
+namespace Wallabag\Tests\Import;
 
 use Doctrine\ORM\EntityManager;
 use M6Web\Component\RedisMock\RedisMockFactory;

--- a/tests/Import/PocketHtmlImportTest.php
+++ b/tests/Import/PocketHtmlImportTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Tests\Wallabag\Import;
+namespace Wallabag\Tests\Import;
 
 use Doctrine\ORM\EntityManager;
 use M6Web\Component\RedisMock\RedisMockFactory;

--- a/tests/Import/PocketImportTest.php
+++ b/tests/Import/PocketImportTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Tests\Wallabag\Import;
+namespace Wallabag\Tests\Import;
 
 use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\UnitOfWork;

--- a/tests/Import/ReadabilityImportTest.php
+++ b/tests/Import/ReadabilityImportTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Tests\Wallabag\Import;
+namespace Wallabag\Tests\Import;
 
 use Doctrine\ORM\EntityManager;
 use M6Web\Component\RedisMock\RedisMockFactory;

--- a/tests/Import/ShaarliImportTest.php
+++ b/tests/Import/ShaarliImportTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Tests\Wallabag\Import;
+namespace Wallabag\Tests\Import;
 
 use Doctrine\ORM\EntityManager;
 use M6Web\Component\RedisMock\RedisMockFactory;

--- a/tests/Import/WallabagV1ImportTest.php
+++ b/tests/Import/WallabagV1ImportTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Tests\Wallabag\Import;
+namespace Wallabag\Tests\Import;
 
 use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\UnitOfWork;

--- a/tests/Import/WallabagV2ImportTest.php
+++ b/tests/Import/WallabagV2ImportTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Tests\Wallabag\Import;
+namespace Wallabag\Tests\Import;
 
 use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\UnitOfWork;

--- a/tests/Mailer/AuthCodeMailerTest.php
+++ b/tests/Mailer/AuthCodeMailerTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Tests\Wallabag\Mailer;
+namespace Wallabag\Tests\Mailer;
 
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Mailer\MailerInterface;

--- a/tests/ParamConverter/UsernameFeedTokenConverterTest.php
+++ b/tests/ParamConverter/UsernameFeedTokenConverterTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Tests\Wallabag\ParamConverter;
+namespace Wallabag\Tests\ParamConverter;
 
 use Doctrine\Persistence\ManagerRegistry;
 use Doctrine\Persistence\Mapping\ClassMetadata;

--- a/tests/Security/Voter/AdminVoterTest.php
+++ b/tests/Security/Voter/AdminVoterTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Tests\Wallabag\Security\Voter;
+namespace Wallabag\Tests\Security\Voter;
 
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;

--- a/tests/Security/Voter/AnnotationVoterTest.php
+++ b/tests/Security/Voter/AnnotationVoterTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Tests\Wallabag\Security\Voter;
+namespace Wallabag\Tests\Security\Voter;
 
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;

--- a/tests/Security/Voter/EntryVoterTest.php
+++ b/tests/Security/Voter/EntryVoterTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Tests\Wallabag\Security\Voter;
+namespace Wallabag\Tests\Security\Voter;
 
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;

--- a/tests/Security/Voter/IgnoreOriginInstanceRuleVoterTest.php
+++ b/tests/Security/Voter/IgnoreOriginInstanceRuleVoterTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Tests\Wallabag\Security\Voter;
+namespace Wallabag\Tests\Security\Voter;
 
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;

--- a/tests/Security/Voter/IgnoreOriginUserRuleVoterTest.php
+++ b/tests/Security/Voter/IgnoreOriginUserRuleVoterTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Tests\Wallabag\Security\Voter;
+namespace Wallabag\Tests\Security\Voter;
 
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;

--- a/tests/Security/Voter/MainVoterTest.php
+++ b/tests/Security/Voter/MainVoterTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Tests\Wallabag\Security\Voter;
+namespace Wallabag\Tests\Security\Voter;
 
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;

--- a/tests/Security/Voter/SiteCredentialVoterTest.php
+++ b/tests/Security/Voter/SiteCredentialVoterTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Tests\Wallabag\Security\Voter;
+namespace Wallabag\Tests\Security\Voter;
 
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;

--- a/tests/Security/Voter/TagVoterTest.php
+++ b/tests/Security/Voter/TagVoterTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Tests\Wallabag\Security\Voter;
+namespace Wallabag\Tests\Security\Voter;
 
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;

--- a/tests/Security/Voter/TaggingRuleVoterTest.php
+++ b/tests/Security/Voter/TaggingRuleVoterTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Tests\Wallabag\Security\Voter;
+namespace Wallabag\Tests\Security\Voter;
 
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;

--- a/tests/Security/Voter/UserVoterTest.php
+++ b/tests/Security/Voter/UserVoterTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Tests\Wallabag\Security\Voter;
+namespace Wallabag\Tests\Security\Voter;
 
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;

--- a/tests/SiteConfig/ArraySiteConfigBuilderTest.php
+++ b/tests/SiteConfig/ArraySiteConfigBuilderTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Tests\Wallabag\SiteConfig;
+namespace Wallabag\Tests\SiteConfig;
 
 use PHPUnit\Framework\TestCase;
 use Wallabag\SiteConfig\ArraySiteConfigBuilder;

--- a/tests/SiteConfig/GrabySiteConfigBuilderTest.php
+++ b/tests/SiteConfig/GrabySiteConfigBuilderTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Tests\Wallabag\SiteConfig;
+namespace Wallabag\Tests\SiteConfig;
 
 use Graby\SiteConfig\ConfigBuilder;
 use Graby\SiteConfig\SiteConfig as GrabySiteConfig;
@@ -8,10 +8,10 @@ use Monolog\Handler\TestHandler;
 use Monolog\Logger;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorage;
 use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
-use Tests\Wallabag\WallabagTestCase;
 use Wallabag\Entity\User;
 use Wallabag\Repository\SiteCredentialRepository;
 use Wallabag\SiteConfig\GrabySiteConfigBuilder;
+use Wallabag\Tests\WallabagTestCase;
 
 class GrabySiteConfigBuilderTest extends WallabagTestCase
 {

--- a/tests/SiteConfig/LoginFormAuthenticatorTest.php
+++ b/tests/SiteConfig/LoginFormAuthenticatorTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Tests\Wallabag\SiteConfig;
+namespace Wallabag\Tests\SiteConfig;
 
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\BrowserKit\HttpBrowser;

--- a/tests/SiteConfig/SiteConfigTest.php
+++ b/tests/SiteConfig/SiteConfigTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Tests\Wallabag\SiteConfig;
+namespace Wallabag\Tests\SiteConfig;
 
 use PHPUnit\Framework\TestCase;
 use Wallabag\SiteConfig\SiteConfig;

--- a/tests/Tools/UtilsTest.php
+++ b/tests/Tools/UtilsTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Tests\Wallabag\Tools;
+namespace Wallabag\Tests\Tools;
 
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Finder\Finder;

--- a/tests/Twig/WallabagExtensionTest.php
+++ b/tests/Twig/WallabagExtensionTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Tests\Wallabag\Twig;
+namespace Wallabag\Tests\Twig;
 
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;

--- a/tests/WallabagTestCase.php
+++ b/tests/WallabagTestCase.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Tests\Wallabag;
+namespace Wallabag\Tests;
 
 use Doctrine\ORM\EntityManagerInterface;
 use Predis\Client;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Documentation | no
| Translation   | no
| CHANGELOG.md  | no
| License       | MIT

Rename the test suite from `Tests\Wallabag` to `Wallabag\Tests` so the dev autoload namespace matches the PSR-4 mapping for `tests/`.

This branch:
- moves `AuthenticatorTest` into the `tests/HttpClient/` path that matches its namespace
- updates `composer.json` and the test namespaces/imports to use `Wallabag\Tests`

Best reviewed commit by commit.
