### PR TITLE
Enforce self and direct PHPUnit deprecations while surfacing indirect ones

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -21,7 +21,7 @@
     <server name="KERNEL_CLASS" value="AppKernel"/>
     <server name="APP_ENV" value="test"/>
     <server name="APP_DEBUG" value="0"/>
-    <env name="SYMFONY_DEPRECATIONS_HELPER" value="max[self]=0&amp;max[direct]=0&amp;quiet[]=indirect&amp;quiet[]=other"/>
+    <env name="SYMFONY_DEPRECATIONS_HELPER" value="max[self]=0&amp;max[direct]=0&amp;quiet[]=other"/>
   </php>
   <extensions>
     <extension class="DAMA\DoctrineTestBundle\PHPUnit\PHPUnitExtension"/>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Documentation | no
| Translation   | no
| CHANGELOG.md  | no
| License       | MIT

Tighten the PHPUnit deprecations helper configuration so `self` and `direct` notices are no longer tolerated, which makes the PHPUnit suite fail locally and in CI when new ones appear.

The branch still keeps `other` notices quiet, but now surfaces `indirect` notices so follow-up cleanup stays visible without blocking the suite yet.

Best reviewed commit by commit:
1. Surface direct and self PHPUnit deprecations.
2. Enforce zero self and direct PHPUnit deprecations.
3. Show indirect PHPUnit deprecations.

Local verification with `make test` passed after each commit.
