### PR TITLE
Fix PHP 8.4 CSV deprecations

### DIFF
--- a/src/Helper/EntriesExport.php
+++ b/src/Helper/EntriesExport.php
@@ -326,7 +326,7 @@ class EntriesExport
         $enclosure = '"';
         $handle = fopen('php://memory', 'b+r');
 
-        fputcsv($handle, ['Title', 'URL', 'Content', 'Tags', 'MIME Type', 'Language', 'Creation date'], $delimiter, $enclosure);
+        fputcsv($handle, ['Title', 'URL', 'Content', 'Tags', 'MIME Type', 'Language', 'Creation date'], $delimiter, $enclosure, '');
 
         foreach ($this->entries as $entry) {
             fputcsv(
@@ -342,7 +342,8 @@ class EntriesExport
                     $entry->getCreatedAt()->format('d/m/Y h:i:s'),
                 ],
                 $delimiter,
-                $enclosure
+                $enclosure,
+                ''
             );
         }
 

--- a/src/Import/InstapaperImport.php
+++ b/src/Import/InstapaperImport.php
@@ -51,7 +51,7 @@ class InstapaperImport extends AbstractImport
 
         $entries = [];
         $handle = fopen($this->filepath, 'r');
-        while (false !== ($data = fgetcsv($handle, 10240))) {
+        while (false !== ($data = fgetcsv($handle, 10240, ',', '"', ''))) {
             if ('URL' === $data[0]) {
                 continue;
             }

--- a/src/Import/PocketCsvImport.php
+++ b/src/Import/PocketCsvImport.php
@@ -55,7 +55,7 @@ class PocketCsvImport extends AbstractImport
 
         $entries = [];
         $handle = fopen($this->filepath, 'r');
-        while (false !== ($data = fgetcsv($handle, 10240))) {
+        while (false !== ($data = fgetcsv($handle, 10240, ',', '"', ''))) {
             if ('title' === $data[0]) {
                 continue;
             }

--- a/tests/Controller/ExportControllerTest.php
+++ b/tests/Controller/ExportControllerTest.php
@@ -175,7 +175,7 @@ class ExportControllerTest extends WallabagTestCase
         $this->assertSame('attachment; filename="Archive articles.csv"', $headers->get('content-disposition'));
         $this->assertSame('UTF-8', $headers->get('content-transfer-encoding'));
 
-        $csv = str_getcsv((string) $client->getResponse()->getContent(), "\n");
+        $csv = str_getcsv((string) $client->getResponse()->getContent(), "\n", '"', '');
 
         $this->assertGreaterThan(1, $csv);
         // +1 for title line


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | yes
| Tests pass?   | yes
| Documentation | no
| Translation   | no
| CHANGELOG.md  | no
| License       | MIT

This updates the Pocket and Instapaper CSV imports plus CSV export parsing/writing to pass explicit empty-string escape parameters required by PHP 8.4.

`make test` passes on this branch, and the previous remaining self deprecation notices for `fgetcsv()`, `fputcsv()`, and `str_getcsv()` no longer appear in the PHPUnit summary.
