### PR TITLE
Move Doctrine test fixtures under tests/fixtures

### DIFF
--- a/app/config/services_test.yml
+++ b/app/config/services_test.yml
@@ -5,10 +5,10 @@ services:
             - "%kernel.cache_dir%/doctrine/metadata"
 
     # fixtures
-    Wallabag\DataFixtures\:
+    Wallabag\Tests\Fixtures\Doctrine\:
         bind:
             $defaultIgnoreOriginInstanceRules: '%wallabag.default_ignore_origin_instance_rules%'
             $defaultInternalSettings: '%wallabag.default_internal_settings%'
-        resource: '../../fixtures/*'
+        resource: '../../tests/fixtures/Doctrine/*'
         tags: ['doctrine.fixture.orm']
         autowire: true

--- a/composer-dependency-analyser.php
+++ b/composer-dependency-analyser.php
@@ -13,7 +13,6 @@ $config
     ->addPathToScan(__DIR__ . '/migrations', false)
     ->addPathToScan(__DIR__ . '/src', false)
     ->addPathToScan(__DIR__ . '/web', false)
-    ->addPathToScan(__DIR__ . '/fixtures', true)
     ->addPathToScan(__DIR__ . '/tests', true)
     ->ignoreErrorsOnPackages([
         'doctrine/common',

--- a/composer.json
+++ b/composer.json
@@ -214,7 +214,7 @@
     },
     "autoload-dev": {
         "psr-4": {
-            "Wallabag\\DataFixtures\\": "fixtures/",
+            "Wallabag\\Tests\\Fixtures\\": "tests/fixtures/",
             "Wallabag\\Tests\\Functional\\": "tests/functional/",
             "Wallabag\\Tests\\Integration\\": "tests/integration/",
             "Wallabag\\Tests\\Unit\\": "tests/unit/"

--- a/rector.php
+++ b/rector.php
@@ -8,7 +8,6 @@ use Rector\Php80\Rector\Class_\ClassPropertyAssignToConstructorPromotionRector;
 return RectorConfig::configure()
     ->withPaths([
         __DIR__ . '/app',
-        __DIR__ . '/fixtures',
         __DIR__ . '/src',
         __DIR__ . '/tests',
         __DIR__ . '/web',

--- a/tests/fixtures/Doctrine/AnnotationFixtures.php
+++ b/tests/fixtures/Doctrine/AnnotationFixtures.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Wallabag\DataFixtures;
+namespace Wallabag\Tests\Fixtures\Doctrine;
 
 use Doctrine\Bundle\FixturesBundle\Fixture;
 use Doctrine\Common\DataFixtures\DependentFixtureInterface;

--- a/tests/fixtures/Doctrine/ConfigFixtures.php
+++ b/tests/fixtures/Doctrine/ConfigFixtures.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Wallabag\DataFixtures;
+namespace Wallabag\Tests\Fixtures\Doctrine;
 
 use Doctrine\Bundle\FixturesBundle\Fixture;
 use Doctrine\Common\DataFixtures\DependentFixtureInterface;
@@ -20,7 +20,7 @@ class ConfigFixtures extends Fixture implements DependentFixtureInterface
         $adminConfig->setPocketConsumerKey('xxxxx');
         $adminConfig->setActionMarkAsRead(0);
         $adminConfig->setListMode(0);
-        $adminConfig->setDisplayThumbnails(0);
+        $adminConfig->setDisplayThumbnails(false);
 
         $manager->persist($adminConfig);
 
@@ -30,10 +30,9 @@ class ConfigFixtures extends Fixture implements DependentFixtureInterface
         $bobConfig->setItemsPerPage(10);
         $bobConfig->setReadingSpeed(200);
         $bobConfig->setLanguage('fr');
-        $bobConfig->setPocketConsumerKey(null);
         $bobConfig->setActionMarkAsRead(1);
         $bobConfig->setListMode(1);
-        $bobConfig->setDisplayThumbnails(1);
+        $bobConfig->setDisplayThumbnails(true);
 
         $manager->persist($bobConfig);
 
@@ -43,10 +42,9 @@ class ConfigFixtures extends Fixture implements DependentFixtureInterface
         $emptyConfig->setItemsPerPage(10);
         $emptyConfig->setReadingSpeed(100);
         $emptyConfig->setLanguage('en');
-        $emptyConfig->setPocketConsumerKey(null);
         $emptyConfig->setActionMarkAsRead(0);
         $emptyConfig->setListMode(0);
-        $emptyConfig->setDisplayThumbnails(0);
+        $emptyConfig->setDisplayThumbnails(false);
 
         $manager->persist($emptyConfig);
 

--- a/tests/fixtures/Doctrine/EntryFixtures.php
+++ b/tests/fixtures/Doctrine/EntryFixtures.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Wallabag\DataFixtures;
+namespace Wallabag\Tests\Fixtures\Doctrine;
 
 use Doctrine\Bundle\FixturesBundle\Fixture;
 use Doctrine\Common\DataFixtures\DependentFixtureInterface;

--- a/tests/fixtures/Doctrine/IgnoreOriginInstanceRuleFixtures.php
+++ b/tests/fixtures/Doctrine/IgnoreOriginInstanceRuleFixtures.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Wallabag\DataFixtures;
+namespace Wallabag\Tests\Fixtures\Doctrine;
 
 use Doctrine\Bundle\FixturesBundle\Fixture;
 use Doctrine\Persistence\ObjectManager;

--- a/tests/fixtures/Doctrine/IgnoreOriginUserRuleFixtures.php
+++ b/tests/fixtures/Doctrine/IgnoreOriginUserRuleFixtures.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Wallabag\DataFixtures;
+namespace Wallabag\Tests\Fixtures\Doctrine;
 
 use Doctrine\Bundle\FixturesBundle\Fixture;
 use Doctrine\Common\DataFixtures\DependentFixtureInterface;

--- a/tests/fixtures/Doctrine/InternalSettingFixtures.php
+++ b/tests/fixtures/Doctrine/InternalSettingFixtures.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Wallabag\DataFixtures;
+namespace Wallabag\Tests\Fixtures\Doctrine;
 
 use Doctrine\Bundle\FixturesBundle\Fixture;
 use Doctrine\Persistence\ObjectManager;

--- a/tests/fixtures/Doctrine/SiteCredentialFixtures.php
+++ b/tests/fixtures/Doctrine/SiteCredentialFixtures.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Wallabag\DataFixtures;
+namespace Wallabag\Tests\Fixtures\Doctrine;
 
 use Doctrine\Bundle\FixturesBundle\Fixture;
 use Doctrine\Common\DataFixtures\DependentFixtureInterface;

--- a/tests/fixtures/Doctrine/TagFixtures.php
+++ b/tests/fixtures/Doctrine/TagFixtures.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Wallabag\DataFixtures;
+namespace Wallabag\Tests\Fixtures\Doctrine;
 
 use Doctrine\Bundle\FixturesBundle\Fixture;
 use Doctrine\Persistence\ObjectManager;

--- a/tests/fixtures/Doctrine/TaggingRuleFixtures.php
+++ b/tests/fixtures/Doctrine/TaggingRuleFixtures.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Wallabag\DataFixtures;
+namespace Wallabag\Tests\Fixtures\Doctrine;
 
 use Doctrine\Bundle\FixturesBundle\Fixture;
 use Doctrine\Common\DataFixtures\DependentFixtureInterface;

--- a/tests/fixtures/Doctrine/UserFixtures.php
+++ b/tests/fixtures/Doctrine/UserFixtures.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Wallabag\DataFixtures;
+namespace Wallabag\Tests\Fixtures\Doctrine;
 
 use Doctrine\Bundle\FixturesBundle\Fixture;
 use Doctrine\Persistence\ObjectManager;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Documentation | no
| Translation   | no
| CHANGELOG.md  | no
| License       | MIT

Move the Doctrine fixture classes that are only loaded in `APP_ENV=test` out of the root `fixtures/` directory and into `tests/fixtures/Doctrine`, and retarget Composer and test service discovery to the `Wallabag\Tests\Fixtures\Doctrine` namespace.

This is preparation work for future dev-environment fixtures so local development can start from seeded data instead of an empty database, while keeping the current test-only Doctrine fixtures separate from that upcoming dev-only setup.
