### PR TITLE
Add Yassine Guedidi to maintainer references

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -1,3 +1,3 @@
-wallabag is mainly developed by [Nicolas Lœuillet](https://github.com/nicosomb), [@j0k3r](https://github.com/j0k3r), [@tcitworld](https://github.com/tcitworld) and [@Kdecherf](https://github.com/Kdecherf) under the MIT License.
+wallabag is mainly developed by [Nicolas Lœuillet](https://github.com/nicosomb), [@j0k3r](https://github.com/j0k3r), [@tcitworld](https://github.com/tcitworld), [@Kdecherf](https://github.com/Kdecherf) and Yassine Guedidi ([@yguedidi](https://github.com/yguedidi)) under the MIT License.
 
 Thank you [to others contributors](https://github.com/wallabag/wallabag/graphs/contributors).

--- a/composer.json
+++ b/composer.json
@@ -30,6 +30,12 @@
             "name": "Kevin Decherf",
             "homepage": "https://kdecherf.com/",
             "role": "Developer"
+        },
+        {
+            "name": "Yassine Guedidi",
+            "email": "yassine@guedidi.com",
+            "homepage": "https://github.com/yguedidi",
+            "role": "Developer"
         }
     ],
     "homepage": "https://github.com/wallabag/wallabag",

--- a/package.json
+++ b/package.json
@@ -34,6 +34,12 @@
       "name": "Kevin Decherf",
       "homepage": "https://kdecherf.com/",
       "role": "Developer"
+    },
+    {
+      "name": "Yassine Guedidi",
+      "email": "yassine@guedidi.com",
+      "homepage": "https://github.com/yguedidi",
+      "role": "Developer"
     }
   ],
   "license": "MIT",

--- a/templates/Static/about.html.twig
+++ b/templates/Static/about.html.twig
@@ -24,7 +24,7 @@
                         <dd>Thomas Citharel — <a href="https://tcit.fr">{{ 'about.who_behind_wallabag.website'|trans }}</a></dd>
                         <dd>Jérémy Benoist — <a href="https://www.j0k3r.net">{{ 'about.who_behind_wallabag.website'|trans }}</a></dd>
                         <dd>Kevin Decherf — <a href="https://kdecherf.com/">{{ 'about.who_behind_wallabag.website'|trans }}</a></dd>
-                        <dd>Yassine Guedidi</dd>
+                        <dd>Yassine Guedidi — <a href="https://github.com/yguedidi">{{ 'about.who_behind_wallabag.website'|trans }}</a> — <a href="mailto:yassine@guedidi.com">yassine@guedidi.com</a></dd>
                         <dt>{{ 'about.who_behind_wallabag.many_contributors'|trans|raw }}</dt>
                         <dt>{{ 'about.who_behind_wallabag.project_website'|trans }}</dt>
                         <dd><a href="https://www.wallabag.org">https://www.wallabag.org</a></dd>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Documentation | no
| Translation   | no
| CHANGELOG.md  | no
| License       | MIT

I realize this kind of change can feel a bit self-referential 😅, but the intention is simply to keep the maintainer information complete and consistent across the project.

It adds myself to the Composer and npm metadata, updates the About page entry, and adjusts the credits line to use the linked GitHub handle format.
