### PR TITLE
Enable Twig debug and strict_variables in test environment

### DIFF
--- a/app/config/config_test.yml
+++ b/app/config/config_test.yml
@@ -39,3 +39,7 @@ dama_doctrine_test:
     enable_static_connection: true
     enable_static_meta_data_cache: true
     enable_static_query_cache: true
+
+twig:
+    debug: true
+    strict_variables: true


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Documentation | no
| Translation   | no
| CHANGELOG.md  | no
| License       | MIT

Both `twig.debug` and `twig.strict_variables` in `app/config/config.yml` are tied to
`%kernel.debug%`. Because `phpunit.xml.dist` sets `APP_DEBUG=0`, both flags are off
during tests, and undefined Twig variables silently render as empty strings instead of
raising an error. This allows template bugs to go undetected by the test suite.

This commit adds explicit `twig: { debug: true, strict_variables: true }` overrides in
`app/config/config_test.yml` so that any undefined variable reference in a template
causes a test failure regardless of the `APP_DEBUG` setting.