### PR TITLE
Add PHP 8.5 to the CI test matrix

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -34,6 +34,7 @@ jobs:
           - "8.2"
           - "8.3"
           - "8.4"
+          - "8.5"
         database:
           - "sqlite"
           - "mysql"


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Documentation | no
| Translation   | no
| CHANGELOG.md  | no
| License       | MIT

Add PHP 8.5 to the main `phpunit` job matrix in the CI workflow. The `composer.json` constraint is already `>=8.2`, so no package changes are needed. The `phpunit_no_prefix` and `phpunit-without-rmq-redis` jobs are intentionally pinned to single PHP versions and are left unchanged.