### PR TITLE
Add Git workflow with No fixups job

### DIFF
--- a/.github/workflows/git.yml
+++ b/.github/workflows/git.yml
@@ -1,0 +1,11 @@
+name: Git
+
+on: pull_request
+
+jobs:
+  no-fixups:
+    name: No fixups
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check for 'amend!', 'fixup!', or 'squash!' commits
+        uses: matijs/no-fixups-action@v1.1.4


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Documentation | no
| Translation   | no
| CHANGELOG.md  | no
| License       | MIT

Add a new `Git` GitHub Actions workflow that runs on pull requests and
blocks merging when any commit has a `fixup!`, `amend!`, or `squash!`
prefix, using `matijs/no-fixups-action@v1.1.4`.