### PR TITLE
Skip admin user creation prompt when existing schema is kept

### DIFF
--- a/src/Command/InstallCommand.php
+++ b/src/Command/InstallCommand.php
@@ -32,6 +32,7 @@ class InstallCommand extends Command
 
     private InputInterface $defaultInput;
     private SymfonyStyle $io;
+    private bool $schemaIsNew = true;
     private array $functionExists = [
         'curl_exec',
         'curl_multi_init',
@@ -239,6 +240,8 @@ class InstallCommand extends Command
 
                 $this->dropWallabagSchemaOnly();
                 $this->runCommand('doctrine:migrations:migrate', ['--no-interaction' => true]);
+            } else {
+                $this->schemaIsNew = false;
             }
         } else {
             $this->io->text('Creating schema...');
@@ -260,6 +263,12 @@ class InstallCommand extends Command
     private function setupAdmin()
     {
         $this->io->section('Step 3 of 4: Administration setup.');
+
+        if (!$this->schemaIsNew) {
+            $this->io->text('<info>Existing schema kept — skipping admin user creation.</info>');
+
+            return $this;
+        }
 
         if (!$this->io->confirm('Would you like to create a new admin user (recommended)?', true)) {
             return $this;

--- a/tests/integration/Command/InstallCommandTest.php
+++ b/tests/integration/Command/InstallCommandTest.php
@@ -223,6 +223,26 @@ class InstallCommandTest extends WallabagKernelTestCase
         }
     }
 
+    public function testRunInstallCommandSchemaExistsNotReset()
+    {
+        $this->setupDatabase();
+
+        $command = $this->getCommand();
+
+        $tester = new CommandTester($command);
+        $tester->setInputs([
+            'n', // don't want to reset the entire database
+            'n', // don't want to reset the schema
+            // no further input — admin prompt must NOT appear
+        ]);
+        $tester->execute([]);
+
+        $this->assertStringContainsString('Setting up database.', $tester->getDisplay());
+        $this->assertStringContainsString('Administration setup.', $tester->getDisplay());
+        $this->assertStringContainsString('Existing schema kept', $tester->getDisplay());
+        $this->assertStringNotContainsString('Would you like to create a new admin user', $tester->getDisplay());
+    }
+
     public function testRunInstallCommandNoInteraction()
     {
         $this->setupDatabase();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Documentation | no
| Translation   | no
| CHANGELOG.md  | no
| License       | MIT

When running `wallabag:install` against a database whose schema already exists and the user chooses not to reset it, the command was still prompting to create a new admin user. Since the schema was preserved, existing users are already in the database, making the prompt misleading. This change skips the admin creation step automatically in that case and prints an informational message instead.

A new integration test (`testRunInstallCommandSchemaExistsNotReset`) covers this path and asserts that no admin user prompt is shown.