### PR TITLE
Skip bundle analysis when no frontend assets changed

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -505,16 +505,31 @@ jobs:
         with:
           fetch-depth: 2
 
+      - name: "Detect changed bundle-relevant files"
+        id: changed-files
+        uses: tj-actions/changed-files@v47.0.5
+        with:
+          files: |
+            webpack.config.js
+            postcss.config.js
+            package.json
+            yarn.lock
+            .nvmrc
+            assets/**
+
       - name: "Install Node"
+        if: steps.changed-files.outputs.any_changed == 'true'
         uses: actions/setup-node@v6
         with:
           node-version-file: ".nvmrc"
           cache: 'yarn'
 
       - name: "Install dependencies with Yarn"
+        if: steps.changed-files.outputs.any_changed == 'true'
         run: yarn install
 
       - name: "Build assets and upload bundle analysis"
+        if: steps.changed-files.outputs.any_changed == 'true'
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         run: yarn build:prod


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Documentation | no
| Translation   | no
| CHANGELOG.md  | no
| License       | MIT

The bundle-analysis CI job ran on every push and pull request, even when no frontend-related files changed. This caused Codecov to post automatic bundle report comments on PRs that only touched PHP, templates, translations, or documentation — comments that were completely irrelevant to those changes.

Add a `tj-actions/changed-files` step (v47.0.5) right after checkout to detect whether any webpack-relevant paths were modified: `webpack.config.js`, `postcss.config.js`, `package.json`, `yarn.lock`, `.nvmrc`, or anything under `assets/`. The three subsequent steps (Node install, Yarn install, and the webpack build + Codecov upload) are now gated behind `any_changed == 'true'` and are skipped automatically when no relevant files changed.

See it working here: https://github.com/wallabag/wallabag/actions/runs/23205597174/job/67439968252?pr=8742
