### PR TITLE
Allow WALLABAG_SITE_CONFIG_FOLDERS to configure an external site config folder

### DIFF
--- a/app/config/services.yml
+++ b/app/config/services.yml
@@ -5,6 +5,8 @@ imports:
 
 parameters:
     spiriit_form_filter.get_filter.doctrine_orm.class: Wallabag\Event\Subscriber\CustomDoctrineORMSubscriber
+    env(WALLABAG_SITE_CONFIG_FOLDERS): ''
+    wallabag.site_config_folders: '%env(csv:WALLABAG_SITE_CONFIG_FOLDERS)%'
 
 services:
     _defaults:
@@ -225,7 +227,7 @@ services:
 
     Graby\SiteConfig\ConfigBuilder:
         arguments:
-            $config: {}
+            $config: "@=parameter('wallabag.site_config_folders') and parameter('wallabag.site_config_folders')[0] ? {'site_config': parameter('wallabag.site_config_folders')} : {}"
 
     Wallabag\SiteConfig\GrabySiteConfigBuilder:
         tags:


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Documentation | no
| Translation   | no
| CHANGELOG.md  | no
| License       | MIT

The [wiki](https://github.com/wallabag/wallabag/wiki/Auto%E2%80%90Updating-wallabag%27s-site%E2%80%90depended-config) documents a manual process where users must edit `app/config/services.yml` to point `Graby\SiteConfig\ConfigBuilder` at an external site-config folder (typically a live clone of ftr-site-config). This PR eliminates that manual edit by introducing a `WALLABAG_SITE_CONFIG_FOLDERS` environment variable.

When the variable is unset or empty the behaviour is identical to before: Graby uses only its bundled config. When set to a directory path, that path is passed to `ConfigBuilder` as the `site_config` value — exactly as the wiki currently instructs users to do by hand.

Two Symfony DI features work together: `env(WALLABAG_SITE_CONFIG_FOLDERS): ''` in the `parameters` block provides a safe empty-string default so the variable is optional, and a `%env()%`-backed named parameter exposes it to a `@=` Expression Language expression on the `ConfigBuilder` argument. The compiled container resolves this to a `getEnv()` call at runtime, not at `cache:clear` time.
