### PR TITLE
Document the correct all-lowercase spelling of "wallabag" in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # wallabag
 
+> [!IMPORTANT]
+> The name of this project is **wallabag** — all lowercase, always. Not "Wallabag", not "WallaBag", not any other variation. Just plain, humble, all-lowercase **wallabag** 😉
+
 [![CI](https://github.com/wallabag/wallabag/actions/workflows/continuous-integration.yml/badge.svg?branch=master)](https://github.com/wallabag/wallabag/actions/workflows/continuous-integration.yml?query=branch%3Amaster)
 [![Matrix](https://matrix.to/img/matrix-badge.svg)](https://matrix.to/#/#wallabag:matrix.org)
 [![Donation Status](https://img.shields.io/liberapay/goal/wallabag.svg?logo=liberapay)](https://liberapay.com/wallabag/donate)


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Documentation | yes
| Translation   | no
| CHANGELOG.md  | no
| License       | MIT

The project name is always **wallabag** — all lowercase, always. Contributors and users occasionally capitalize it as "Wallabag" or "WallaBag". This PR adds a prominent GitHub `[!IMPORTANT]` callout at the top of `README.md` to set expectations clearly and in a friendly way for anyone reading the file.
