### PR TITLE
Rename the nav panel button class

### DIFF
--- a/assets/scss/_media_queries.scss
+++ b/assets/scss/_media_queries.scss
@@ -52,7 +52,7 @@
     padding: 6px 0;
   }
 
-  .nav-panel-buttom {
+  .nav-panel-button {
     justify-content: space-between;
   }
 

--- a/assets/scss/_nav.scss
+++ b/assets/scss/_nav.scss
@@ -70,7 +70,7 @@ nav {
   display: none;
 }
 
-.nav-panel-buttom {
+.nav-panel-button {
   display: flex;
   flex-grow: 1;
   justify-content: flex-end;

--- a/templates/layout.html.twig
+++ b/templates/layout.html.twig
@@ -88,7 +88,7 @@
                         {% endblock %}
                     </h1>
                 </div>
-                <ul class="input-field nav-panel-buttom">
+                <ul class="input-field nav-panel-button">
                     <li class="bold toggle-add-url-container">
                         <a class="waves-effect toggle-add-url" data-controller="materialize--tooltip" data-materialize--tooltip-position-value="bottom" data-materialize--tooltip-enter-delay-value="50" data-tooltip="{{ 'menu.top.add_new_entry'|trans }}" href="{{ path('new') }}" data-action="topbar#showAddUrl:prevent:stop" data-shortcuts-target="showAddUrl">
                             <i class="material-icons">add</i>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Documentation | no
| Translation   | no
| CHANGELOG.md  | no
| License       | MIT

This fixes the misspelled `nav-panel-buttom` class in the main layout and the two SCSS selectors that keep the nav panel aligned across breakpoints. The change is mechanical and preserves the existing DOM structure and responsive behavior.
