### PR TITLE
Fix tag chip edit input to stay within chip bounds and match chip text style

### DIFF
--- a/assets/scss/_tag_chip.scss
+++ b/assets/scss/_tag_chip.scss
@@ -44,9 +44,25 @@
   flex-grow: 1;
 }
 
+/* Materialize text input overrides for the tag chip rename form */
+.tag-chip-form {
+  input:not([type], .browser-default),
+  input[type="text"]:not(.browser-default) {
+    height: 1.8rem;
+    margin-bottom: 0;
+    font-size: 13px;
+    border-bottom: none;
+
+    &:focus:not([readonly]) {
+      border-bottom: none;
+      box-shadow: none;
+    }
+  }
+}
+
+/* Custom styles for the tag chip rename form input */
 .tag-chip-form input {
-  margin-bottom: 0;
-  height: 1.8rem;
+  color: #fff;
 }
 
 .tag-chip-action {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Documentation | no
| Translation   | no
| CHANGELOG.md  | no
| License       | MIT

When clicking the edit button on a tag chip, the rename input was overflowing outside the chip's bounds, showing dark text instead of white, and displaying Materialize's default grey bottom border and teal focus underline.

The root cause was specificity: Materialize's text input selector `input[type="text"]:not(.browser-default)` has specificity (0,2,1) and its focus rule reaches (0,4,1), both higher than the flat `.tag-chip-form input` selector at (0,1,1).

The fix restructures `assets/scss/_tag_chip.scss` into two clearly separated blocks:

- A **Materialize override block** that nests Materialize's exact input selector pattern (`input:not([type], .browser-default)` and `input[type="text"]:not(.browser-default)`) inside `.tag-chip-form`, raising specificity to (0,3,1)-(0,5,1). Overridden properties: `height` (3rem to 1.8rem), `margin-bottom` (8px to 0), `font-size` (16px to 13px to match the Materialize chip label default), `border-bottom` (removed), and focus `border-bottom`/`box-shadow` (removed).
- A **custom additions block** (`.tag-chip-form input`) that sets `color: #fff` - a property Materialize does not set on text inputs - to explicitly match the chip label's white text.

Before:
<img width="265" height="69" alt="Capture d&#39;écran 2026-03-23 152707" src="https://github.com/user-attachments/assets/ad09d363-2e6d-4a3e-87a5-63b758c7a9fb" />
<img width="264" height="62" alt="Capture d&#39;écran 2026-03-23 152723" src="https://github.com/user-attachments/assets/d3e848da-d119-44ff-9da3-0d7d63eb6930" />

After:
<img width="269" height="59" alt="Capture d&#39;écran 2026-03-23 210255" src="https://github.com/user-attachments/assets/2ab93852-af9e-4f67-a7e5-6be4364d74ab" />
<img width="273" height="62" alt="Capture d&#39;écran 2026-03-23 210239" src="https://github.com/user-attachments/assets/1f34c934-4214-445d-b4c4-3f8d22fff9c3" />
