### PR TITLE
Add tags to EPUB and PDF exports

### DIFF
--- a/src/Helper/EntriesExport.php
+++ b/src/Helper/EntriesExport.php
@@ -207,6 +207,8 @@ class EntriesExport
 
             $readingTime = round($entry->getReadingTime() / $user->getConfig()->getReadingSpeed() * 200);
 
+            $tagLabels = array_map(fn ($tag) => $tag->getLabel(), $entry->getTags()->toArray());
+
             $titlepage = $content_start .
                 '<h1>' . $entry->getTitle() . '</h1>' .
                 '<dl>' .
@@ -215,6 +217,7 @@ class EntriesExport
                 '<dt>' . $this->translator->trans('entry.metadata.reading_time') . '</dt><dd>' . $this->translator->trans('entry.metadata.reading_time_minutes_short', ['%readingTime%' => $readingTime]) . '</dd>' .
                 '<dt>' . $this->translator->trans('entry.metadata.added_on') . '</dt><dd>' . $entry->getCreatedAt()->format('Y-m-d') . '</dd>' .
                 '<dt>' . $this->translator->trans('entry.metadata.address') . '</dt><dd><a href="' . $entry->getUrl() . '">' . $entry->getUrl() . '</a></dd>' .
+                (!empty($tagLabels) ? '<dt>' . $this->translator->trans('entry.metadata.tags') . '</dt><dd>' . implode(', ', $tagLabels) . '</dd>' : '') .
                 '</dl>' .
                 $bookEnd;
             $book->addChapter("Entry {$i} of {$entryCount}", "{$filename}_cover.html", $titlepage, true, EPub::EXTERNAL_REF_ADD);
@@ -277,6 +280,8 @@ class EntriesExport
 
             $readingTime = $entry->getReadingTime() / $user->getConfig()->getReadingSpeed() * 200;
 
+            $tagLabels = array_map(fn ($tag) => $tag->getLabel(), $entry->getTags()->toArray());
+
             $pdf->addPage();
             $html = '<h1>' . $entry->getTitle() . '</h1>' .
                 '<dl>' .
@@ -284,6 +289,7 @@ class EntriesExport
                 '<dt>' . $this->translator->trans('entry.metadata.reading_time') . '</dt><dd>' . $this->translator->trans('entry.metadata.reading_time_minutes_short', ['%readingTime%' => $readingTime]) . '</dd>' .
                 '<dt>' . $this->translator->trans('entry.metadata.added_on') . '</dt><dd>' . $entry->getCreatedAt()->format('Y-m-d') . '</dd>' .
                 '<dt>' . $this->translator->trans('entry.metadata.address') . '</dt><dd><a href="' . $entry->getUrl() . '">' . $entry->getUrl() . '</a></dd>' .
+                (!empty($tagLabels) ? '<dt>' . $this->translator->trans('entry.metadata.tags') . '</dt><dd>' . implode(', ', $tagLabels) . '</dd>' : '') .
                 '</dl>';
             $pdf->writeHTMLCell(0, 0, null, null, $html, 0, 1);
 

--- a/src/Helper/EntriesExport.php
+++ b/src/Helper/EntriesExport.php
@@ -207,7 +207,7 @@ class EntriesExport
 
             $readingTime = round($entry->getReadingTime() / $user->getConfig()->getReadingSpeed() * 200);
 
-            $tagLabels = array_map(fn ($tag) => $tag->getLabel(), $entry->getTags()->toArray());
+            $tagLabels = array_map(static fn ($tag) => $tag->getLabel(), $entry->getTags()->toArray());
 
             $titlepage = $content_start .
                 '<h1>' . $entry->getTitle() . '</h1>' .
@@ -280,7 +280,7 @@ class EntriesExport
 
             $readingTime = $entry->getReadingTime() / $user->getConfig()->getReadingSpeed() * 200;
 
-            $tagLabels = array_map(fn ($tag) => $tag->getLabel(), $entry->getTags()->toArray());
+            $tagLabels = array_map(static fn ($tag) => $tag->getLabel(), $entry->getTags()->toArray());
 
             $pdf->addPage();
             $html = '<h1>' . $entry->getTitle() . '</h1>' .

--- a/translations/messages.be.yml
+++ b/translations/messages.be.yml
@@ -293,6 +293,7 @@ entry:
         address: Адрас
         added_on: Дададзена на
         published_on: Апублікавана на
+        tags: Тэгі
 about:
     page_title: Аб
     top_menu:

--- a/translations/messages.cs.yml
+++ b/translations/messages.cs.yml
@@ -90,6 +90,7 @@ entry:
         add_tags: Přidat štítky
     metadata:
         published_on: Zveřejněno
+        tags: Štítky
         added_on: Přidáno
         address: Adresa
         reading_time_minutes_short: '%readingTime% min'

--- a/translations/messages.de.yml
+++ b/translations/messages.de.yml
@@ -341,6 +341,7 @@ entry:
         address: Adresse
         added_on: Hinzugefügt am
         published_on: Veröffentlicht am
+        tags: Tags
 about:
     page_title: Über
     top_menu:

--- a/translations/messages.el.yml
+++ b/translations/messages.el.yml
@@ -352,6 +352,7 @@ howto:
 entry:
     metadata:
         published_on: Δημοσιεύτηκε την
+        tags: Ετικέτες
         added_on: Προστέθηκε την
         address: Διεύθυνση
         reading_time_minutes_short: '%readingTime% λεπτά'

--- a/translations/messages.en.yml
+++ b/translations/messages.en.yml
@@ -338,6 +338,7 @@ entry:
         address: Address
         added_on: Added on
         published_on: "Published on"
+        tags: Tags
 about:
     page_title: About
     top_menu:

--- a/translations/messages.es.yml
+++ b/translations/messages.es.yml
@@ -341,6 +341,7 @@ entry:
         reading_time_minutes_short: '%readingTime% min'
         reading_time: Tiempo estimado de lectura
         published_on: Publicado en
+        tags: Etiquetas
 about:
     page_title: 'Acerca de'
     top_menu:

--- a/translations/messages.fr.yml
+++ b/translations/messages.fr.yml
@@ -338,6 +338,7 @@ entry:
         address: Adresse
         added_on: Ajouté le
         published_on: Publié le
+        tags: Étiquettes
 about:
     page_title: À propos
     top_menu:

--- a/translations/messages.gl.yml
+++ b/translations/messages.gl.yml
@@ -79,6 +79,7 @@ about:
 entry:
     metadata:
         published_on: Publicado o
+        tags: Etiquetas
         added_on: Engadido o
         address: Enderezo
         reading_time_minutes_short: '%readingTime% min'

--- a/translations/messages.hr.yml
+++ b/translations/messages.hr.yml
@@ -563,6 +563,7 @@ entry:
         reading_time: Procijenjeno vrijeme čitanja
         address: Adresa
         published_on: Datum objavljivanja
+        tags: Oznake
     confirm:
         delete: Stvarno želiš ukloniti taj članak?
         delete_tag: Stvarno želiš ukloniti tu oznaku za taj članak?

--- a/translations/messages.hu.yml
+++ b/translations/messages.hu.yml
@@ -239,6 +239,7 @@ entry:
         reading_time_minutes_short: '%readingTime% perc'
         address: Cím
         added_on: Hozzáadva
+        tags: Címkék
 about:
     page_title: Névjegy
     top_menu:

--- a/translations/messages.it.yml
+++ b/translations/messages.it.yml
@@ -329,6 +329,7 @@ entry:
         address: Indirizzo
         added_on: Aggiunto il
         published_on: Pubblicato in data
+        tags: Etichette
 about:
     page_title: A proposito
     top_menu:

--- a/translations/messages.ja.yml
+++ b/translations/messages.ja.yml
@@ -331,6 +331,7 @@ entry:
         reading_time_minutes_short: '%readingTime% 分'
         reading_time: 推定読了時間
         published_on: 公開日
+        tags: タグ
     confirm:
         delete_tag: 本当にこのタグを記事から削除してよろしいですか？
         delete: 本当にこの記事を削除してよろしいですか？

--- a/translations/messages.ko.yml
+++ b/translations/messages.ko.yml
@@ -252,6 +252,7 @@ entry:
         shared_by_wallabag: 이 문서는 %username% 님이 <a href='%wallabag_instance%'>wallabag</a>와 공유했습니다
     metadata:
         published_on: 게시일
+        tags: 태그
         added_on: 추가
         address: 주소
         reading_time_minutes_short: '%readingTime% 분'

--- a/translations/messages.nb.yml
+++ b/translations/messages.nb.yml
@@ -699,6 +699,7 @@ entry:
         number_on_the_page: '{0} Det er ingen oppføringer.|{1} Det er én oppføring.|]1,Inf[ Det er %count% oppføringer.'
     metadata:
         published_on: Publisert
+        tags: Etiketter
         added_on: Lagt til
         address: Adresse
         reading_time_minutes_short: '%readingTime% min'

--- a/translations/messages.nl.yml
+++ b/translations/messages.nl.yml
@@ -657,6 +657,7 @@ entry:
         reading_time_minutes_short: '%readingTime% min'
         reading_time: Geschatte leestijd
         published_on: Gepubliceerd op
+        tags: Labels
     confirm:
         delete_tag: Weet je zeker dat je dit label wilt verwijderen van dit artikel?
         delete: Weet je zeker dat je dit artikel wilt verwijderen?

--- a/translations/messages.oc.yml
+++ b/translations/messages.oc.yml
@@ -340,6 +340,7 @@ entry:
         address: Adreça
         added_on: Apondut lo
         published_on: Publicat lo
+        tags: Etiquetas
         reading_time: Durada de lectura estimada
 about:
     page_title: A prepaus

--- a/translations/messages.pl.yml
+++ b/translations/messages.pl.yml
@@ -341,6 +341,7 @@ entry:
         address: Adres
         added_on: Dodano
         published_on: Opublikowano dnia
+        tags: Tagi
 about:
     page_title: O nas
     top_menu:

--- a/translations/messages.ru.yml
+++ b/translations/messages.ru.yml
@@ -321,6 +321,7 @@ entry:
         reading_time_minutes_short: '%readingTime% мин'
         reading_time: Приблизительное время чтения
         published_on: Опубликовано
+        tags: Теги
     confirm:
         delete_tag: Вы уверены, что хотите удалить этот тег из статьи?
         delete: Вы уверены, что хотите удалить эту статью?

--- a/translations/messages.ta.yml
+++ b/translations/messages.ta.yml
@@ -604,6 +604,7 @@ entry:
         address: முகவரி
         added_on: சேர்க்கப்பட்டது
         published_on: வெளியிடப்பட்டது
+        tags: குறிச்சொற்கள்
 howto:
     page_title: எப்படி
     tab_menu:

--- a/translations/messages.tr.yml
+++ b/translations/messages.tr.yml
@@ -341,6 +341,7 @@ entry:
         address: Adres
         added_on: Eklenme tarihi
         published_on: Yayımlanma tarihi
+        tags: Etiketler
 about:
     page_title: Hakkımızda
     top_menu:

--- a/translations/messages.uk.yml
+++ b/translations/messages.uk.yml
@@ -333,6 +333,7 @@ entry:
         address: Адреса
         added_on: Додано
         published_on: Опубліковане
+        tags: Теги
 about:
     page_title: Про wallabag
     top_menu:

--- a/translations/messages.zh.yml
+++ b/translations/messages.zh.yml
@@ -340,6 +340,7 @@ entry:
         address: "地址"
         added_on: "添加于"
         published_on: 发布于
+        tags: 标签
 about:
     page_title: '关于'
     top_menu:

--- a/translations/messages.zh_Hant.yml
+++ b/translations/messages.zh_Hant.yml
@@ -327,6 +327,7 @@ entry:
         reading_time: 閱讀約需時
         reading_time_minutes_short: '%readingTime% 分鐘'
         published_on: 發布於
+        tags: 標籤
         added_on: 添加於
         address: 地址
     default_title: 條目標題


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Documentation | no
| Translation   | no
| CHANGELOG.md  | no
| License       | MIT

Fixes #8789

It adds 1 string to the list of messages. Since the text appears multiple times in the English translation, I can update the PR to add it for the other languages too. Just let me know.