### PR TITLE
Clarify SQLite support in FAQ

### DIFF
--- a/doc/content/user/faq.md
+++ b/doc/content/user/faq.md
@@ -61,13 +61,9 @@ please edit your `web/app.php` file and add this line:
 This is a Doctrine / PHP bug, nothing we can do about it.
 
 
-## Why has SQLite support been dropped?
+## Why is SQLite not recommended for production installations?
 
-Since June 2017, [SQLite support has been
-dropped](https://github.com/wallabag/wallabag/pull/3171)
-and MySQL is the default database now. SQLite support has been dropped
-because it's awful for database migrations. It's just you'll have to
-do migrations the hard way and lose data each time.
+MySQL is the default database for standard wallabag installations. SQLite is still useful for development and small/simple setups, but it is not recommended as the main production database because database migrations can be difficult to support reliably.
 
-For development purposes, SQLite is still fine though.
+For production installations, we recommend using MySQL or PostgreSQL.
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Documentation | yes
| Translation   | no
| CHANGELOG.md  | no
| License       | MIT

This PR clarifies the FAQ entry about SQLite support.

The current wording says SQLite support has been dropped, which can be confusing because SQLite is still used in some contexts such as development and simple setups. This update rephrases the section to explain that SQLite is not recommended for production installations because migrations can be difficult to support reliably.

Changes:

- Reworded the SQLite FAQ heading
- Clarified that SQLite is not recommended for production installations
- Recommended MySQL or PostgreSQL for production usage

Fixes #7779.