### PR TITLE
Entry soft-deletion (part 1&2)

### DIFF
--- a/migrations/Version20260426000000.php
+++ b/migrations/Version20260426000000.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Application\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Wallabag\Doctrine\WallabagMigration;
+
+final class Version20260426000000 extends WallabagMigration
+{
+    public function up(Schema $schema): void
+    {
+        $entryTable = $schema->getTable($this->getTable('entry'));
+        $this->skipIf($entryTable->hasColumn('deleted_at'), 'Column deleted_at already exists');
+        $entryTable->addColumn('deleted_at', 'datetime', ['notnull' => false]);
+    }
+
+    public function down(Schema $schema): void
+    {
+        $entryTable = $schema->getTable($this->getTable('entry'));
+        $entryTable->dropColumn('deleted_at');
+    }
+}

--- a/src/Command/CleanDuplicatesCommand.php
+++ b/src/Command/CleanDuplicatesCommand.php
@@ -93,7 +93,7 @@ class CleanDuplicatesCommand extends Command
                 // entry deleted, dispatch event about it!
                 $this->eventDispatcher->dispatch(new EntryDeletedEvent($entryToDelete), EntryDeletedEvent::NAME);
 
-                $this->entityManager->remove($entryToDelete);
+                $entryToDelete->softDelete();
                 $this->entityManager->flush(); // Flushing at the end of the loop would require the instance not being online
             } else {
                 $urls[] = $entry['url'];

--- a/src/Command/CleanDuplicatesCommand.php
+++ b/src/Command/CleanDuplicatesCommand.php
@@ -93,7 +93,7 @@ class CleanDuplicatesCommand extends Command
                 // entry deleted, dispatch event about it!
                 $this->eventDispatcher->dispatch(new EntryDeletedEvent($entryToDelete), EntryDeletedEvent::NAME);
 
-                $entryToDelete->softDelete();
+                $entryToDelete->setContent(null)->setPreviewPicture(null)->updateDeleted(true);
                 $this->entityManager->flush(); // Flushing at the end of the loop would require the instance not being online
             } else {
                 $urls[] = $entry['url'];

--- a/src/Command/CleanDuplicatesCommand.php
+++ b/src/Command/CleanDuplicatesCommand.php
@@ -93,7 +93,7 @@ class CleanDuplicatesCommand extends Command
                 // entry deleted, dispatch event about it!
                 $this->eventDispatcher->dispatch(new EntryDeletedEvent($entryToDelete), EntryDeletedEvent::NAME);
 
-                $entryToDelete->setContent(null)->setPreviewPicture(null)->updateDeleted(true);
+                $entryToDelete->updateDeleted(true);
                 $this->entityManager->flush(); // Flushing at the end of the loop would require the instance not being online
             } else {
                 $urls[] = $entry['url'];

--- a/src/Command/CleanDuplicatesCommand.php
+++ b/src/Command/CleanDuplicatesCommand.php
@@ -93,7 +93,7 @@ class CleanDuplicatesCommand extends Command
                 // entry deleted, dispatch event about it!
                 $this->eventDispatcher->dispatch(new EntryDeletedEvent($entryToDelete), EntryDeletedEvent::NAME);
 
-                $entryToDelete->updateDeleted(true);
+                $entryToDelete->delete();
                 $this->entityManager->flush(); // Flushing at the end of the loop would require the instance not being online
             } else {
                 $urls[] = $entry['url'];

--- a/src/Controller/Api/EntryRestController.php
+++ b/src/Controller/Api/EntryRestController.php
@@ -327,7 +327,7 @@ class EntryRestController extends WallabagRestController
         $domainName = (null === $request->query->get('domain_name')) ? '' : (string) $request->query->get('domain_name');
         $httpStatus = (!\array_key_exists((int) $request->query->get('http_status'), Response::$statusTexts)) ? null : (int) $request->query->get('http_status');
         $hasAnnotations = (null === $request->query->get('annotations')) ? null : (bool) $request->query->get('annotations');
-        $includeDeleted = (bool) $request->query->get('include_deleted', false);
+        $includeDeleted = (null === $request->query->get('include_deleted')) ? false : (bool) $request->query->get('include_deleted');
 
         try {
             /** @var Pagerfanta $pager */
@@ -506,7 +506,7 @@ class EntryRestController extends WallabagRestController
                 // entry deleted, dispatch event about it!
                 $eventDispatcher->dispatch(new EntryDeletedEvent($entry), EntryDeletedEvent::NAME);
 
-                $entry->setContent(null)->setPreviewPicture(null)->updateDeleted(true);
+                $entry->updateDeleted(true);
                 $this->entityManager->flush();
             }
 
@@ -1136,7 +1136,7 @@ class EntryRestController extends WallabagRestController
         // entry deleted, dispatch event about it!
         $eventDispatcher->dispatch(new EntryDeletedEvent($entry), EntryDeletedEvent::NAME);
 
-        $entry->setContent(null)->setPreviewPicture(null)->updateDeleted(true);
+        $entry->updateDeleted(true);
         $this->entityManager->flush();
 
         return $response;

--- a/src/Controller/Api/EntryRestController.php
+++ b/src/Controller/Api/EntryRestController.php
@@ -327,6 +327,7 @@ class EntryRestController extends WallabagRestController
         $domainName = (null === $request->query->get('domain_name')) ? '' : (string) $request->query->get('domain_name');
         $httpStatus = (!\array_key_exists((int) $request->query->get('http_status'), Response::$statusTexts)) ? null : (int) $request->query->get('http_status');
         $hasAnnotations = (null === $request->query->get('annotations')) ? null : (bool) $request->query->get('annotations');
+        $includeDeleted = (bool) $request->query->get('include_deleted', false);
 
         try {
             /** @var Pagerfanta $pager */
@@ -343,7 +344,8 @@ class EntryRestController extends WallabagRestController
                 $domainName,
                 $isNotParsed,
                 $httpStatus,
-                $hasAnnotations
+                $hasAnnotations,
+                $includeDeleted
             );
         } catch (\Exception $e) {
             throw new BadRequestHttpException($e->getMessage());
@@ -406,6 +408,10 @@ class EntryRestController extends WallabagRestController
     #[IsGranted('VIEW', subject: 'entry')]
     public function getEntryAction(Entry $entry)
     {
+        if ($entry->isDeleted()) {
+            throw $this->createNotFoundException();
+        }
+
         return $this->sendResponse($entry);
     }
 
@@ -496,11 +502,11 @@ class EntryRestController extends WallabagRestController
 
             $results[$key]['url'] = $url;
 
-            if (false !== $entry && $this->authorizationChecker->isGranted('DELETE', $entry)) {
+            if (false !== $entry && !$entry->isDeleted() && $this->authorizationChecker->isGranted('DELETE', $entry)) {
                 // entry deleted, dispatch event about it!
                 $eventDispatcher->dispatch(new EntryDeletedEvent($entry), EntryDeletedEvent::NAME);
 
-                $this->entityManager->remove($entry);
+                $entry->softDelete();
                 $this->entityManager->flush();
             }
 
@@ -554,6 +560,10 @@ class EntryRestController extends WallabagRestController
                 $url,
                 $this->getUser()->getId()
             );
+
+            if ($entry instanceof Entry && $entry->isDeleted()) {
+                $entry = false;
+            }
 
             $results[$key]['url'] = $url;
 
@@ -729,6 +739,10 @@ class EntryRestController extends WallabagRestController
             $url,
             $this->getUser()->getId()
         );
+
+        if ($entry instanceof Entry && $entry->isDeleted()) {
+            $entry = false;
+        }
 
         if (false === $entry) {
             $entry = new Entry($this->getUser());
@@ -1107,6 +1121,10 @@ class EntryRestController extends WallabagRestController
     #[IsGranted('DELETE', subject: 'entry')]
     public function deleteEntriesAction(Entry $entry, Request $request, EventDispatcherInterface $eventDispatcher)
     {
+        if ($entry->isDeleted()) {
+            throw $this->createNotFoundException();
+        }
+
         $expect = $request->query->get('expect', 'entry');
         if (!\in_array($expect, ['id', 'entry'], true)) {
             throw new BadRequestHttpException(\sprintf("expect: 'id' or 'entry' expected, %s given", $expect));
@@ -1124,7 +1142,7 @@ class EntryRestController extends WallabagRestController
         // entry deleted, dispatch event about it!
         $eventDispatcher->dispatch(new EntryDeletedEvent($entry), EntryDeletedEvent::NAME);
 
-        $this->entityManager->remove($entry);
+        $entry->softDelete();
         $this->entityManager->flush();
 
         return $response;

--- a/src/Controller/Api/EntryRestController.php
+++ b/src/Controller/Api/EntryRestController.php
@@ -558,7 +558,8 @@ class EntryRestController extends WallabagRestController
         foreach ($urls as $key => $url) {
             $entry = $entryRepository->findByUrlAndUserId(
                 $url,
-                $this->getUser()->getId()
+                $this->getUser()->getId(),
+                includeDeleted: true
             );
 
             $results[$key]['url'] = $url;
@@ -735,7 +736,8 @@ class EntryRestController extends WallabagRestController
 
         $entry = $entryRepository->findByUrlAndUserId(
             $url,
-            $this->getUser()->getId()
+            $this->getUser()->getId(),
+            includeDeleted: true
         );
 
         if (false === $entry) {

--- a/src/Controller/Api/EntryRestController.php
+++ b/src/Controller/Api/EntryRestController.php
@@ -506,7 +506,7 @@ class EntryRestController extends WallabagRestController
                 // entry deleted, dispatch event about it!
                 $eventDispatcher->dispatch(new EntryDeletedEvent($entry), EntryDeletedEvent::NAME);
 
-                $entry->softDelete();
+                $entry->setContent(null)->setPreviewPicture(null)->updateDeleted(true);
                 $this->entityManager->flush();
             }
 
@@ -561,13 +561,11 @@ class EntryRestController extends WallabagRestController
                 $this->getUser()->getId()
             );
 
-            if ($entry instanceof Entry && $entry->isDeleted()) {
-                $entry = false;
-            }
-
             $results[$key]['url'] = $url;
 
-            if (false === $entry) {
+            if ($entry instanceof Entry && $entry->isDeleted()) {
+                $contentProxy->updateEntry($entry, $url);
+            } elseif (false === $entry) {
                 $entry = new Entry($this->getUser());
 
                 $contentProxy->updateEntry($entry, $url);
@@ -739,10 +737,6 @@ class EntryRestController extends WallabagRestController
             $url,
             $this->getUser()->getId()
         );
-
-        if ($entry instanceof Entry && $entry->isDeleted()) {
-            $entry = false;
-        }
 
         if (false === $entry) {
             $entry = new Entry($this->getUser());
@@ -1142,7 +1136,7 @@ class EntryRestController extends WallabagRestController
         // entry deleted, dispatch event about it!
         $eventDispatcher->dispatch(new EntryDeletedEvent($entry), EntryDeletedEvent::NAME);
 
-        $entry->softDelete();
+        $entry->setContent(null)->setPreviewPicture(null)->updateDeleted(true);
         $this->entityManager->flush();
 
         return $response;

--- a/src/Controller/Api/EntryRestController.php
+++ b/src/Controller/Api/EntryRestController.php
@@ -327,7 +327,7 @@ class EntryRestController extends WallabagRestController
         $domainName = (null === $request->query->get('domain_name')) ? '' : (string) $request->query->get('domain_name');
         $httpStatus = (!\array_key_exists((int) $request->query->get('http_status'), Response::$statusTexts)) ? null : (int) $request->query->get('http_status');
         $hasAnnotations = (null === $request->query->get('annotations')) ? null : (bool) $request->query->get('annotations');
-        $includeDeleted = (null === $request->query->get('include_deleted')) ? false : (bool) $request->query->get('include_deleted');
+        $includeDeleted = $request->query->getBoolean('include_deleted');
 
         try {
             /** @var Pagerfanta $pager */

--- a/src/Controller/Api/EntryRestController.php
+++ b/src/Controller/Api/EntryRestController.php
@@ -506,7 +506,7 @@ class EntryRestController extends WallabagRestController
                 // entry deleted, dispatch event about it!
                 $eventDispatcher->dispatch(new EntryDeletedEvent($entry), EntryDeletedEvent::NAME);
 
-                $entry->updateDeleted(true);
+                $entry->delete();
                 $this->entityManager->flush();
             }
 
@@ -1138,7 +1138,7 @@ class EntryRestController extends WallabagRestController
         // entry deleted, dispatch event about it!
         $eventDispatcher->dispatch(new EntryDeletedEvent($entry), EntryDeletedEvent::NAME);
 
-        $entry->updateDeleted(true);
+        $entry->delete();
         $this->entityManager->flush();
 
         return $response;

--- a/src/Controller/Api/EntryRestController.php
+++ b/src/Controller/Api/EntryRestController.php
@@ -327,6 +327,7 @@ class EntryRestController extends WallabagRestController
         $domainName = (null === $request->query->get('domain_name')) ? '' : (string) $request->query->get('domain_name');
         $httpStatus = (!\array_key_exists((int) $request->query->get('http_status'), Response::$statusTexts)) ? null : (int) $request->query->get('http_status');
         $hasAnnotations = (null === $request->query->get('annotations')) ? null : (bool) $request->query->get('annotations');
+        $includeDeleted = (bool) $request->query->get('include_deleted', false);
 
         try {
             /** @var Pagerfanta $pager */
@@ -343,7 +344,8 @@ class EntryRestController extends WallabagRestController
                 $domainName,
                 $isNotParsed,
                 $httpStatus,
-                $hasAnnotations
+                $hasAnnotations,
+                $includeDeleted
             );
         } catch (\Exception $e) {
             throw new BadRequestHttpException($e->getMessage());
@@ -417,6 +419,10 @@ class EntryRestController extends WallabagRestController
     #[IsGranted('VIEW', subject: 'entry')]
     public function getEntryAction(Request $request, Entry $entry)
     {
+        if ($entry->isDeleted()) {
+            throw $this->createNotFoundException();
+        }
+
         $detail = strtolower($request->query->get('detail', 'full'));
 
         if (!\in_array($detail, ['full', 'metadata'], true)) {
@@ -517,11 +523,11 @@ class EntryRestController extends WallabagRestController
 
             $results[$key]['url'] = $url;
 
-            if (false !== $entry && $this->authorizationChecker->isGranted('DELETE', $entry)) {
+            if (false !== $entry && !$entry->isDeleted() && $this->authorizationChecker->isGranted('DELETE', $entry)) {
                 // entry deleted, dispatch event about it!
                 $eventDispatcher->dispatch(new EntryDeletedEvent($entry), EntryDeletedEvent::NAME);
 
-                $this->entityManager->remove($entry);
+                $entry->softDelete();
                 $this->entityManager->flush();
             }
 
@@ -575,6 +581,10 @@ class EntryRestController extends WallabagRestController
                 $url,
                 $this->getUser()->getId()
             );
+
+            if ($entry instanceof Entry && $entry->isDeleted()) {
+                $entry = false;
+            }
 
             $results[$key]['url'] = $url;
 
@@ -750,6 +760,10 @@ class EntryRestController extends WallabagRestController
             $url,
             $this->getUser()->getId()
         );
+
+        if ($entry instanceof Entry && $entry->isDeleted()) {
+            $entry = false;
+        }
 
         if (false === $entry) {
             $entry = new Entry($this->getUser());
@@ -1128,6 +1142,10 @@ class EntryRestController extends WallabagRestController
     #[IsGranted('DELETE', subject: 'entry')]
     public function deleteEntriesAction(Entry $entry, Request $request, EventDispatcherInterface $eventDispatcher)
     {
+        if ($entry->isDeleted()) {
+            throw $this->createNotFoundException();
+        }
+
         $expect = $request->query->get('expect', 'entry');
         if (!\in_array($expect, ['id', 'entry'], true)) {
             throw new BadRequestHttpException(\sprintf("expect: 'id' or 'entry' expected, %s given", $expect));
@@ -1145,7 +1163,7 @@ class EntryRestController extends WallabagRestController
         // entry deleted, dispatch event about it!
         $eventDispatcher->dispatch(new EntryDeletedEvent($entry), EntryDeletedEvent::NAME);
 
-        $this->entityManager->remove($entry);
+        $entry->softDelete();
         $this->entityManager->flush();
 
         return $response;

--- a/src/Controller/Api/EntryRestController.php
+++ b/src/Controller/Api/EntryRestController.php
@@ -527,7 +527,7 @@ class EntryRestController extends WallabagRestController
                 // entry deleted, dispatch event about it!
                 $eventDispatcher->dispatch(new EntryDeletedEvent($entry), EntryDeletedEvent::NAME);
 
-                $entry->updateDeleted(true);
+                $entry->delete();
                 $this->entityManager->flush();
             }
 
@@ -1159,7 +1159,7 @@ class EntryRestController extends WallabagRestController
         // entry deleted, dispatch event about it!
         $eventDispatcher->dispatch(new EntryDeletedEvent($entry), EntryDeletedEvent::NAME);
 
-        $entry->updateDeleted(true);
+        $entry->delete();
         $this->entityManager->flush();
 
         return $response;

--- a/src/Controller/Api/EntryRestController.php
+++ b/src/Controller/Api/EntryRestController.php
@@ -527,7 +527,7 @@ class EntryRestController extends WallabagRestController
                 // entry deleted, dispatch event about it!
                 $eventDispatcher->dispatch(new EntryDeletedEvent($entry), EntryDeletedEvent::NAME);
 
-                $entry->softDelete();
+                $entry->setContent(null)->setPreviewPicture(null)->updateDeleted(true);
                 $this->entityManager->flush();
             }
 
@@ -582,13 +582,11 @@ class EntryRestController extends WallabagRestController
                 $this->getUser()->getId()
             );
 
-            if ($entry instanceof Entry && $entry->isDeleted()) {
-                $entry = false;
-            }
-
             $results[$key]['url'] = $url;
 
-            if (false === $entry) {
+            if ($entry instanceof Entry && $entry->isDeleted()) {
+                $contentProxy->updateEntry($entry, $url);
+            } elseif (false === $entry) {
                 $entry = new Entry($this->getUser());
 
                 $contentProxy->updateEntry($entry, $url);
@@ -760,10 +758,6 @@ class EntryRestController extends WallabagRestController
             $url,
             $this->getUser()->getId()
         );
-
-        if ($entry instanceof Entry && $entry->isDeleted()) {
-            $entry = false;
-        }
 
         if (false === $entry) {
             $entry = new Entry($this->getUser());
@@ -1163,7 +1157,7 @@ class EntryRestController extends WallabagRestController
         // entry deleted, dispatch event about it!
         $eventDispatcher->dispatch(new EntryDeletedEvent($entry), EntryDeletedEvent::NAME);
 
-        $entry->softDelete();
+        $entry->setContent(null)->setPreviewPicture(null)->updateDeleted(true);
         $this->entityManager->flush();
 
         return $response;

--- a/src/Controller/Api/EntryRestController.php
+++ b/src/Controller/Api/EntryRestController.php
@@ -579,7 +579,8 @@ class EntryRestController extends WallabagRestController
         foreach ($urls as $key => $url) {
             $entry = $entryRepository->findByUrlAndUserId(
                 $url,
-                $this->getUser()->getId()
+                $this->getUser()->getId(),
+                includeDeleted: true
             );
 
             $results[$key]['url'] = $url;
@@ -756,7 +757,8 @@ class EntryRestController extends WallabagRestController
 
         $entry = $entryRepository->findByUrlAndUserId(
             $url,
-            $this->getUser()->getId()
+            $this->getUser()->getId(),
+            includeDeleted: true
         );
 
         if (false === $entry) {

--- a/src/Controller/Api/EntryRestController.php
+++ b/src/Controller/Api/EntryRestController.php
@@ -327,7 +327,7 @@ class EntryRestController extends WallabagRestController
         $domainName = (null === $request->query->get('domain_name')) ? '' : (string) $request->query->get('domain_name');
         $httpStatus = (!\array_key_exists((int) $request->query->get('http_status'), Response::$statusTexts)) ? null : (int) $request->query->get('http_status');
         $hasAnnotations = (null === $request->query->get('annotations')) ? null : (bool) $request->query->get('annotations');
-        $includeDeleted = (bool) $request->query->get('include_deleted', false);
+        $includeDeleted = (null === $request->query->get('include_deleted')) ? false : (bool) $request->query->get('include_deleted');
 
         try {
             /** @var Pagerfanta $pager */
@@ -527,7 +527,7 @@ class EntryRestController extends WallabagRestController
                 // entry deleted, dispatch event about it!
                 $eventDispatcher->dispatch(new EntryDeletedEvent($entry), EntryDeletedEvent::NAME);
 
-                $entry->setContent(null)->setPreviewPicture(null)->updateDeleted(true);
+                $entry->updateDeleted(true);
                 $this->entityManager->flush();
             }
 
@@ -1157,7 +1157,7 @@ class EntryRestController extends WallabagRestController
         // entry deleted, dispatch event about it!
         $eventDispatcher->dispatch(new EntryDeletedEvent($entry), EntryDeletedEvent::NAME);
 
-        $entry->setContent(null)->setPreviewPicture(null)->updateDeleted(true);
+        $entry->updateDeleted(true);
         $this->entityManager->flush();
 
         return $response;

--- a/src/Controller/EntryController.php
+++ b/src/Controller/EntryController.php
@@ -734,5 +734,4 @@ class EntryController extends AbstractController
 
         $this->addFlash('notice', $message);
     }
-
 }

--- a/src/Controller/EntryController.php
+++ b/src/Controller/EntryController.php
@@ -122,7 +122,7 @@ class EntryController extends AbstractController
                     }
                 } elseif ('delete' === $action) {
                     $this->eventDispatcher->dispatch(new EntryDeletedEvent($entry), EntryDeletedEvent::NAME);
-                    $entry->setContent(null)->setPreviewPicture(null)->updateDeleted(true);
+                    $entry->updateDeleted(true);
                 }
             }
 
@@ -522,7 +522,7 @@ class EntryController extends AbstractController
         // entry deleted, dispatch event about it!
         $this->eventDispatcher->dispatch(new EntryDeletedEvent($entry), EntryDeletedEvent::NAME);
 
-        $entry->setContent(null)->setPreviewPicture(null)->updateDeleted(true);
+        $entry->updateDeleted(true);
         $this->entityManager->flush();
 
         $this->addFlash(

--- a/src/Controller/EntryController.php
+++ b/src/Controller/EntryController.php
@@ -122,7 +122,7 @@ class EntryController extends AbstractController
                     }
                 } elseif ('delete' === $action) {
                     $this->eventDispatcher->dispatch(new EntryDeletedEvent($entry), EntryDeletedEvent::NAME);
-                    $entry->softDelete();
+                    $entry->setContent(null)->setPreviewPicture(null)->updateDeleted(true);
                 }
             }
 
@@ -178,15 +178,19 @@ class EntryController extends AbstractController
         $form->handleRequest($request);
 
         if ($form->isSubmitted() && $form->isValid()) {
-            $existingEntry = $this->checkIfEntryAlreadyExists($entry);
+            $existingEntry = $this->entryRepository->findByUrlAndUserId($entry->getUrl(), $this->getUser()->getId());
 
-            if (false !== $existingEntry) {
+            if ($existingEntry instanceof Entry && !$existingEntry->isDeleted()) {
                 $this->addFlash(
                     'notice',
                     $translator->trans('flashes.entry.notice.entry_already_saved', ['%date%' => $existingEntry->getCreatedAt()->format('d-m-Y')])
                 );
 
                 return $this->redirect($this->generateUrl('view', ['id' => $existingEntry->getId()]));
+            }
+
+            if ($existingEntry instanceof Entry) {
+                $entry = $existingEntry;
             }
 
             $this->updateEntry($entry);
@@ -217,9 +221,14 @@ class EntryController extends AbstractController
         $entry = new Entry($this->getUser());
         $entry->setUrl($request->query->get('url'));
 
-        if (false === $this->checkIfEntryAlreadyExists($entry)) {
-            $this->updateEntry($entry);
+        $existingEntry = $this->entryRepository->findByUrlAndUserId($entry->getUrl(), $this->getUser()->getId());
 
+        if ($existingEntry instanceof Entry && $existingEntry->isDeleted()) {
+            $this->updateEntry($existingEntry);
+            $this->entityManager->flush();
+            $this->eventDispatcher->dispatch(new EntrySavedEvent($existingEntry), EntrySavedEvent::NAME);
+        } elseif (!$existingEntry instanceof Entry) {
+            $this->updateEntry($entry);
             $this->entityManager->persist($entry);
             $this->entityManager->flush();
 
@@ -513,7 +522,7 @@ class EntryController extends AbstractController
         // entry deleted, dispatch event about it!
         $this->eventDispatcher->dispatch(new EntryDeletedEvent($entry), EntryDeletedEvent::NAME);
 
-        $entry->softDelete();
+        $entry->setContent(null)->setPreviewPicture(null)->updateDeleted(true);
         $this->entityManager->flush();
 
         $this->addFlash(
@@ -726,18 +735,4 @@ class EntryController extends AbstractController
         $this->addFlash('notice', $message);
     }
 
-    /**
-     * Check for existing entry, if it exists, redirect to it with a message.
-     *
-     * @return Entry|bool
-     */
-    private function checkIfEntryAlreadyExists(Entry $entry)
-    {
-        $existing = $this->entryRepository->findByUrlAndUserId($entry->getUrl(), $this->getUser()->getId());
-        if ($existing instanceof Entry && $existing->isDeleted()) {
-            return false;
-        }
-
-        return $existing;
-    }
 }

--- a/src/Controller/EntryController.php
+++ b/src/Controller/EntryController.php
@@ -178,7 +178,7 @@ class EntryController extends AbstractController
         $form->handleRequest($request);
 
         if ($form->isSubmitted() && $form->isValid()) {
-            $existingEntry = $this->entryRepository->findByUrlAndUserId($entry->getUrl(), $this->getUser()->getId());
+            $existingEntry = $this->entryRepository->findByUrlAndUserId($entry->getUrl(), $this->getUser()->getId(), includeDeleted: true);
 
             if ($existingEntry instanceof Entry && !$existingEntry->isDeleted()) {
                 $this->addFlash(
@@ -221,7 +221,7 @@ class EntryController extends AbstractController
         $entry = new Entry($this->getUser());
         $entry->setUrl($request->query->get('url'));
 
-        $existingEntry = $this->entryRepository->findByUrlAndUserId($entry->getUrl(), $this->getUser()->getId());
+        $existingEntry = $this->entryRepository->findByUrlAndUserId($entry->getUrl(), $this->getUser()->getId(), includeDeleted: true);
 
         if ($existingEntry instanceof Entry && $existingEntry->isDeleted()) {
             $this->updateEntry($existingEntry);

--- a/src/Controller/EntryController.php
+++ b/src/Controller/EntryController.php
@@ -122,7 +122,7 @@ class EntryController extends AbstractController
                     }
                 } elseif ('delete' === $action) {
                     $this->eventDispatcher->dispatch(new EntryDeletedEvent($entry), EntryDeletedEvent::NAME);
-                    $this->entityManager->remove($entry);
+                    $entry->softDelete();
                 }
             }
 
@@ -513,7 +513,7 @@ class EntryController extends AbstractController
         // entry deleted, dispatch event about it!
         $this->eventDispatcher->dispatch(new EntryDeletedEvent($entry), EntryDeletedEvent::NAME);
 
-        $this->entityManager->remove($entry);
+        $entry->softDelete();
         $this->entityManager->flush();
 
         $this->addFlash(
@@ -733,6 +733,11 @@ class EntryController extends AbstractController
      */
     private function checkIfEntryAlreadyExists(Entry $entry)
     {
-        return $this->entryRepository->findByUrlAndUserId($entry->getUrl(), $this->getUser()->getId());
+        $existing = $this->entryRepository->findByUrlAndUserId($entry->getUrl(), $this->getUser()->getId());
+        if ($existing instanceof Entry && $existing->isDeleted()) {
+            return false;
+        }
+
+        return $existing;
     }
 }

--- a/src/Controller/EntryController.php
+++ b/src/Controller/EntryController.php
@@ -122,7 +122,7 @@ class EntryController extends AbstractController
                     }
                 } elseif ('delete' === $action) {
                     $this->eventDispatcher->dispatch(new EntryDeletedEvent($entry), EntryDeletedEvent::NAME);
-                    $entry->updateDeleted(true);
+                    $entry->delete();
                 }
             }
 
@@ -522,7 +522,7 @@ class EntryController extends AbstractController
         // entry deleted, dispatch event about it!
         $this->eventDispatcher->dispatch(new EntryDeletedEvent($entry), EntryDeletedEvent::NAME);
 
-        $entry->updateDeleted(true);
+        $entry->delete();
         $this->entityManager->flush();
 
         $this->addFlash(

--- a/src/Entity/Entry.php
+++ b/src/Entity/Entry.php
@@ -325,9 +325,12 @@ class Entry
         return null !== $this->deletedAt;
     }
 
-    public function updateDeleted(bool $isDeleted = false): static
+    public function updateDeleted(bool $isDeleted): static
     {
         $this->deletedAt = $isDeleted ? new \DateTimeImmutable() : null;
+        if ($isDeleted) {
+            $this->setContent(null)->setPreviewPicture(null);
+        }
 
         return $this;
     }

--- a/src/Entity/Entry.php
+++ b/src/Entity/Entry.php
@@ -167,6 +167,10 @@ class Entry
     #[Groups(['entries_for_user', 'export_all'])]
     private $starredAt;
 
+    #[ORM\Column(name: 'deleted_at', type: 'datetime', nullable: true)]
+    #[Groups(['entries_for_user', 'export_all'])]
+    private ?\DateTimeInterface $deletedAt = null;
+
     #[ORM\JoinTable]
     #[ORM\OneToMany(targetEntity: Annotation::class, mappedBy: 'entry', cascade: ['persist', 'remove'])]
     #[Groups(['entries_for_user', 'export_all'])]
@@ -361,6 +365,25 @@ class Entry
         $this->archivedAt = $archivedAt;
 
         return $this;
+    }
+
+    public function getDeletedAt(): ?\DateTimeInterface
+    {
+        return $this->deletedAt;
+    }
+
+    public function softDelete(?\DateTimeInterface $deletedAt = null): static
+    {
+        $this->deletedAt = $deletedAt ?? new \DateTimeImmutable();
+        $this->setContent(null);
+        $this->setPreviewPicture(null);
+
+        return $this;
+    }
+
+    public function isDeleted(): bool
+    {
+        return null !== $this->deletedAt;
     }
 
     /**

--- a/src/Entity/Entry.php
+++ b/src/Entity/Entry.php
@@ -329,7 +329,8 @@ class Entry
     {
         $this->deletedAt = $isDeleted ? new \DateTimeImmutable() : null;
         if ($isDeleted) {
-            $this->setContent(null)->setPreviewPicture(null);
+            $this->content = null;
+            $this->previewPicture = null;
         }
 
         return $this;
@@ -468,7 +469,7 @@ class Entry
     /**
      * Get content.
      *
-     * @return string
+     * @return string|null
      */
     public function getContent()
     {

--- a/src/Entity/Entry.php
+++ b/src/Entity/Entry.php
@@ -315,6 +315,23 @@ class Entry
         return $this->url;
     }
 
+    public function getDeletedAt(): ?\DateTimeInterface
+    {
+        return $this->deletedAt;
+    }
+
+    public function isDeleted(): bool
+    {
+        return null !== $this->deletedAt;
+    }
+
+    public function updateDeleted(bool $isDeleted = false): static
+    {
+        $this->deletedAt = $isDeleted ? new \DateTimeImmutable() : null;
+
+        return $this;
+    }
+
     /**
      * Set isArchived.
      *
@@ -365,25 +382,6 @@ class Entry
         $this->archivedAt = $archivedAt;
 
         return $this;
-    }
-
-    public function getDeletedAt(): ?\DateTimeInterface
-    {
-        return $this->deletedAt;
-    }
-
-    public function softDelete(?\DateTimeInterface $deletedAt = null): static
-    {
-        $this->deletedAt = $deletedAt ?? new \DateTimeImmutable();
-        $this->setContent(null);
-        $this->setPreviewPicture(null);
-
-        return $this;
-    }
-
-    public function isDeleted(): bool
-    {
-        return null !== $this->deletedAt;
     }
 
     /**

--- a/src/Entity/Entry.php
+++ b/src/Entity/Entry.php
@@ -325,14 +325,19 @@ class Entry
         return null !== $this->deletedAt;
     }
 
-    public function updateDeleted(bool $isDeleted): static
+    public function delete(): static
     {
-        $this->deletedAt = $isDeleted ? new \DateTimeImmutable() : null;
-        if ($isDeleted) {
-            $this->content = null;
-            $this->previewPicture = null;
-            $this->uid = null;
-        }
+        $this->deletedAt = new \DateTimeImmutable();
+        $this->content = null;
+        $this->previewPicture = null;
+        $this->uid = null;
+
+        return $this;
+    }
+
+    public function restore(): static
+    {
+        $this->deletedAt = null;
 
         return $this;
     }

--- a/src/Entity/Entry.php
+++ b/src/Entity/Entry.php
@@ -331,6 +331,7 @@ class Entry
         if ($isDeleted) {
             $this->content = null;
             $this->previewPicture = null;
+            $this->uid = null;
         }
 
         return $this;

--- a/src/Entity/Entry.php
+++ b/src/Entity/Entry.php
@@ -329,7 +329,8 @@ class Entry
     {
         $this->deletedAt = $isDeleted ? new \DateTimeImmutable() : null;
         if ($isDeleted) {
-            $this->setContent(null)->setPreviewPicture(null);
+            $this->content = null;
+            $this->previewPicture = null;
         }
 
         return $this;

--- a/src/Helper/ContentProxy.php
+++ b/src/Helper/ContentProxy.php
@@ -42,6 +42,8 @@ class ContentProxy
      */
     public function updateEntry(Entry $entry, $url, array $content = [], $disableContentUpdate = false): void
     {
+        $entry->updateDeleted(false);
+
         $this->graby->toggleImgNoReferrer(true);
         if (!empty($content['html'])) {
             $this->graby->setContentAsPrefetched($content['html']);

--- a/src/Helper/ContentProxy.php
+++ b/src/Helper/ContentProxy.php
@@ -42,6 +42,8 @@ class ContentProxy
      */
     public function updateEntry(Entry $entry, $url, array $content = [], $disableContentUpdate = false): void
     {
+        $entry->updateDeleted(false);
+
         $this->graby->toggleImgNoReferrer(true);
         if (!empty($content['html'])) {
             $content['html'] = $this->graby->cleanupHtml($content['html'], $url);

--- a/src/Helper/ContentProxy.php
+++ b/src/Helper/ContentProxy.php
@@ -42,6 +42,7 @@ class ContentProxy
      */
     public function updateEntry(Entry $entry, $url, array $content = [], $disableContentUpdate = false): void
     {
+        // no mater previous state, if an entry got updated, we restore it
         $entry->updateDeleted(false);
 
         $this->graby->toggleImgNoReferrer(true);

--- a/src/Helper/ContentProxy.php
+++ b/src/Helper/ContentProxy.php
@@ -43,7 +43,7 @@ class ContentProxy
     public function updateEntry(Entry $entry, $url, array $content = [], $disableContentUpdate = false): void
     {
         // no mater previous state, if an entry got updated, we restore it
-        $entry->updateDeleted(false);
+        $entry->restore();
 
         $this->graby->toggleImgNoReferrer(true);
         if (!empty($content['html'])) {

--- a/src/Import/BrowserImport.php
+++ b/src/Import/BrowserImport.php
@@ -94,9 +94,9 @@ abstract class BrowserImport extends AbstractImport
 
         $existingEntry = $this->em
             ->getRepository(Entry::class)
-            ->findByUrlAndUserId($url, $this->user->getId());
+            ->findByUrlAndUserId($url, $this->user->getId(), includeDeleted: true);
 
-        if (false !== $existingEntry) {
+        if ($existingEntry instanceof Entry && !$existingEntry->isDeleted()) {
             ++$this->skippedEntries;
 
             return null;
@@ -104,7 +104,7 @@ abstract class BrowserImport extends AbstractImport
 
         $data = $this->prepareEntry($importedEntry);
 
-        $entry = new Entry($this->user);
+        $entry = ($existingEntry instanceof Entry) ? $existingEntry : new Entry($this->user);
         $entry->setUrl($data['url']);
         $entry->setTitle($data['title']);
 

--- a/src/Import/DeliciousImport.php
+++ b/src/Import/DeliciousImport.php
@@ -81,9 +81,9 @@ class DeliciousImport extends AbstractImport
     {
         $existingEntry = $this->em
             ->getRepository(Entry::class)
-            ->findByUrlAndUserId($importedEntry['url'], $this->user->getId());
+            ->findByUrlAndUserId($importedEntry['url'], $this->user->getId(), includeDeleted: true);
 
-        if (false !== $existingEntry) {
+        if ($existingEntry instanceof Entry && !$existingEntry->isDeleted()) {
             ++$this->skippedEntries;
 
             return null;
@@ -98,7 +98,7 @@ class DeliciousImport extends AbstractImport
             'tags' => $importedEntry['tags'],
         ];
 
-        $entry = new Entry($this->user);
+        $entry = ($existingEntry instanceof Entry) ? $existingEntry : new Entry($this->user);
         $entry->setUrl($data['url']);
         $entry->setTitle($data['title']);
 

--- a/src/Import/HtmlImport.php
+++ b/src/Import/HtmlImport.php
@@ -75,9 +75,9 @@ abstract class HtmlImport extends AbstractImport
 
         $existingEntry = $this->em
             ->getRepository(Entry::class)
-            ->findByUrlAndUserId($url, $this->user->getId());
+            ->findByUrlAndUserId($url, $this->user->getId(), includeDeleted: true);
 
-        if (false !== $existingEntry) {
+        if ($existingEntry instanceof Entry && !$existingEntry->isDeleted()) {
             ++$this->skippedEntries;
 
             return null;
@@ -85,7 +85,7 @@ abstract class HtmlImport extends AbstractImport
 
         $data = $this->prepareEntry($importedEntry);
 
-        $entry = new Entry($this->user);
+        $entry = ($existingEntry instanceof Entry) ? $existingEntry : new Entry($this->user);
         $entry->setUrl($data['url']);
         $entry->updateArchived($data['is_archived']);
         $createdAt = new \DateTime();

--- a/src/Import/InstapaperImport.php
+++ b/src/Import/InstapaperImport.php
@@ -109,15 +109,15 @@ class InstapaperImport extends AbstractImport
     {
         $existingEntry = $this->em
             ->getRepository(Entry::class)
-            ->findByUrlAndUserId($importedEntry['url'], $this->user->getId());
+            ->findByUrlAndUserId($importedEntry['url'], $this->user->getId(), includeDeleted: true);
 
-        if (false !== $existingEntry) {
+        if ($existingEntry instanceof Entry && !$existingEntry->isDeleted()) {
             ++$this->skippedEntries;
 
             return null;
         }
 
-        $entry = new Entry($this->user);
+        $entry = ($existingEntry instanceof Entry) ? $existingEntry : new Entry($this->user);
         $entry->setUrl($importedEntry['url']);
         $entry->setTitle($importedEntry['title']);
 

--- a/src/Import/OmnivoreImport.php
+++ b/src/Import/OmnivoreImport.php
@@ -81,9 +81,9 @@ class OmnivoreImport extends AbstractImport
     {
         $existingEntry = $this->em
             ->getRepository(Entry::class)
-            ->findByUrlAndUserId($importedEntry['url'], $this->user->getId());
+            ->findByUrlAndUserId($importedEntry['url'], $this->user->getId(), includeDeleted: true);
 
-        if (false !== $existingEntry) {
+        if ($existingEntry instanceof Entry && !$existingEntry->isDeleted()) {
             ++$this->skippedEntries;
 
             return null;
@@ -101,7 +101,7 @@ class OmnivoreImport extends AbstractImport
             'preview_picture' => $importedEntry['thumbnail'],
         ];
 
-        $entry = new Entry($this->user);
+        $entry = ($existingEntry instanceof Entry) ? $existingEntry : new Entry($this->user);
         $entry->setUrl($data['url']);
         $entry->setTitle($data['title']);
 

--- a/src/Import/PinboardImport.php
+++ b/src/Import/PinboardImport.php
@@ -81,9 +81,9 @@ class PinboardImport extends AbstractImport
     {
         $existingEntry = $this->em
             ->getRepository(Entry::class)
-            ->findByUrlAndUserId($importedEntry['href'], $this->user->getId());
+            ->findByUrlAndUserId($importedEntry['href'], $this->user->getId(), includeDeleted: true);
 
-        if (false !== $existingEntry) {
+        if ($existingEntry instanceof Entry && !$existingEntry->isDeleted()) {
             ++$this->skippedEntries;
 
             return null;
@@ -98,7 +98,7 @@ class PinboardImport extends AbstractImport
             'tags' => array_filter(explode(' ', (string) $importedEntry['tags'])),
         ];
 
-        $entry = new Entry($this->user);
+        $entry = ($existingEntry instanceof Entry) ? $existingEntry : new Entry($this->user);
         $entry->setUrl($data['url']);
         $entry->setTitle($data['title']);
 

--- a/src/Import/PocketCsvImport.php
+++ b/src/Import/PocketCsvImport.php
@@ -91,15 +91,15 @@ class PocketCsvImport extends AbstractImport
     {
         $existingEntry = $this->em
             ->getRepository(Entry::class)
-            ->findByUrlAndUserId($importedEntry['url'], $this->user->getId());
+            ->findByUrlAndUserId($importedEntry['url'], $this->user->getId(), includeDeleted: true);
 
-        if (false !== $existingEntry) {
+        if ($existingEntry instanceof Entry && !$existingEntry->isDeleted()) {
             ++$this->skippedEntries;
 
             return null;
         }
 
-        $entry = new Entry($this->user);
+        $entry = ($existingEntry instanceof Entry) ? $existingEntry : new Entry($this->user);
         $entry->setUrl($importedEntry['url']);
         $entry->setTitle($importedEntry['title']);
 

--- a/src/Import/PocketImport.php
+++ b/src/Import/PocketImport.php
@@ -164,15 +164,15 @@ class PocketImport extends AbstractImport
 
         $existingEntry = $this->em
             ->getRepository(Entry::class)
-            ->findByUrlAndUserId($url, $this->user->getId());
+            ->findByUrlAndUserId($url, $this->user->getId(), includeDeleted: true);
 
-        if (false !== $existingEntry) {
+        if ($existingEntry instanceof Entry && !$existingEntry->isDeleted()) {
             ++$this->skippedEntries;
 
             return null;
         }
 
-        $entry = new Entry($this->user);
+        $entry = ($existingEntry instanceof Entry) ? $existingEntry : new Entry($this->user);
         $entry->setUrl($url);
 
         // update entry with content (in case fetching failed, the given entry will be return)

--- a/src/Import/ReadabilityImport.php
+++ b/src/Import/ReadabilityImport.php
@@ -81,9 +81,9 @@ class ReadabilityImport extends AbstractImport
     {
         $existingEntry = $this->em
             ->getRepository(Entry::class)
-            ->findByUrlAndUserId($importedEntry['article__url'], $this->user->getId());
+            ->findByUrlAndUserId($importedEntry['article__url'], $this->user->getId(), includeDeleted: true);
 
-        if (false !== $existingEntry) {
+        if ($existingEntry instanceof Entry && !$existingEntry->isDeleted()) {
             ++$this->skippedEntries;
 
             return null;
@@ -98,7 +98,7 @@ class ReadabilityImport extends AbstractImport
             'html' => false,
         ];
 
-        $entry = new Entry($this->user);
+        $entry = ($existingEntry instanceof Entry) ? $existingEntry : new Entry($this->user);
         $entry->setUrl($data['url']);
         $entry->setTitle($data['title']);
 

--- a/src/Import/WallabagImport.php
+++ b/src/Import/WallabagImport.php
@@ -87,9 +87,9 @@ abstract class WallabagImport extends AbstractImport
     {
         $existingEntry = $this->em
             ->getRepository(Entry::class)
-            ->findByUrlAndUserId($importedEntry['url'], $this->user->getId());
+            ->findByUrlAndUserId($importedEntry['url'], $this->user->getId(), includeDeleted: true);
 
-        if (false !== $existingEntry) {
+        if ($existingEntry instanceof Entry && !$existingEntry->isDeleted()) {
             ++$this->skippedEntries;
 
             return null;
@@ -97,7 +97,7 @@ abstract class WallabagImport extends AbstractImport
 
         $data = $this->prepareEntry($importedEntry);
 
-        $entry = new Entry($this->user);
+        $entry = ($existingEntry instanceof Entry) ? $existingEntry : new Entry($this->user);
         $entry->setUrl($data['url']);
         $entry->setTitle($data['title']);
 

--- a/src/Repository/AnnotationRepository.php
+++ b/src/Repository/AnnotationRepository.php
@@ -144,6 +144,7 @@ class AnnotationRepository extends ServiceEntityRepository
             ->leftJoin('a.entry', 'e')
             ->where('a.user = :userid')->setParameter(':userid', $userId)
             ->andWhere('e.isArchived = true')
+            ->andWhere('e.deletedAt IS NULL')
             ->getQuery()
             ->getResult();
     }

--- a/src/Repository/EntryRepository.php
+++ b/src/Repository/EntryRepository.php
@@ -503,11 +503,12 @@ class EntryRepository extends ServiceEntityRepository
      *
      * @return Entry|false
      */
-    public function findByUrlAndUserId($url, $userId)
+    public function findByUrlAndUserId($url, $userId, bool $includeDeleted = false)
     {
         return $this->findByHashedUrlAndUserId(
             UrlHasher::hashUrl($url),
-            $userId
+            $userId,
+            $includeDeleted
         );
     }
 
@@ -536,25 +537,33 @@ class EntryRepository extends ServiceEntityRepository
      *
      * @return Entry|false
      */
-    public function findByHashedUrlAndUserId($hashedUrl, $userId)
+    public function findByHashedUrlAndUserId($hashedUrl, $userId, bool $includeDeleted = false)
     {
         // try first using hashed_url (to use the database index)
-        $res = $this->createQueryBuilder('e')
+        $qb = $this->createQueryBuilder('e')
             ->where('e.hashedUrl = :hashed_url')->setParameter('hashed_url', $hashedUrl)
-            ->andWhere('e.user = :user_id')->setParameter('user_id', $userId)
-            ->getQuery()
-            ->getResult();
+            ->andWhere('e.user = :user_id')->setParameter('user_id', $userId);
+
+        if (!$includeDeleted) {
+            $qb->andWhere('e.deletedAt IS NULL');
+        }
+
+        $res = $qb->getQuery()->getResult();
 
         if (\count($res)) {
             return current($res);
         }
 
         // then try using hashed_given_url (to use the database index)
-        $res = $this->createQueryBuilder('e')
+        $qb = $this->createQueryBuilder('e')
             ->where('e.hashedGivenUrl = :hashed_given_url')->setParameter('hashed_given_url', $hashedUrl)
-            ->andWhere('e.user = :user_id')->setParameter('user_id', $userId)
-            ->getQuery()
-            ->getResult();
+            ->andWhere('e.user = :user_id')->setParameter('user_id', $userId);
+
+        if (!$includeDeleted) {
+            $qb->andWhere('e.deletedAt IS NULL');
+        }
+
+        $res = $qb->getQuery()->getResult();
 
         if (\count($res)) {
             return current($res);
@@ -567,6 +576,7 @@ class EntryRepository extends ServiceEntityRepository
     {
         $qb = $this->createQueryBuilder('e')->select(['e.id', 'e.hashedUrl', 'e.hashedGivenUrl']);
         $res = $qb->where('e.user = :user_id')->setParameter('user_id', $userId)
+                    ->andWhere('e.deletedAt IS NULL')
                     ->andWhere(
                         $qb->expr()->orX(
                             $qb->expr()->in('e.hashedUrl', $hashedUrls),

--- a/src/Repository/EntryRepository.php
+++ b/src/Repository/EntryRepository.php
@@ -279,7 +279,7 @@ class EntryRepository extends ServiceEntityRepository
      *
      * @return Pagerfanta
      */
-    public function findEntries($userId, $isArchived = null, $isStarred = null, $isPublic = null, $sort = 'created', $order = 'asc', $since = 0, $tags = '', $detail = 'full', $domainName = '', $isNotParsed = null, $httpStatus = null, $hasAnnotations = null)
+    public function findEntries($userId, $isArchived = null, $isStarred = null, $isPublic = null, $sort = 'created', $order = 'asc', $since = 0, $tags = '', $detail = 'full', $domainName = '', $isNotParsed = null, $httpStatus = null, $hasAnnotations = null, $includeDeleted = false)
     {
         if (!\in_array(strtolower($detail), ['full', 'metadata'], true)) {
             throw new \Exception('Detail "' . $detail . '" parameter is wrong, allowed: full or metadata');
@@ -288,6 +288,10 @@ class EntryRepository extends ServiceEntityRepository
         $qb = $this->createQueryBuilder('e')
             ->leftJoin('e.tags', 't')
             ->where('e.user = :userId')->setParameter('userId', $userId);
+
+        if (!$includeDeleted) {
+            $qb->andWhere('e.deletedAt IS NULL');
+        }
 
         if ('metadata' === $detail) {
             $fieldNames = $this->getClassMetadata()->getFieldNames();
@@ -587,6 +591,7 @@ class EntryRepository extends ServiceEntityRepository
         $qb = $this->createQueryBuilder('e')
             ->select('count(e)')
             ->where('e.user = :userId')->setParameter('userId', $userId)
+            ->andWhere('e.deletedAt IS NULL')
         ;
 
         return (int) $qb->getQuery()->getSingleScalarResult();
@@ -601,16 +606,18 @@ class EntryRepository extends ServiceEntityRepository
     public function removeAllByUserId($userId): void
     {
         $this->getEntityManager()
-            ->createQuery('DELETE FROM Wallabag\Entity\Entry e WHERE e.user = :userId')
+            ->createQuery('UPDATE Wallabag\Entity\Entry e SET e.deletedAt = :now, e.content = null, e.previewPicture = null WHERE e.user = :userId AND e.deletedAt IS NULL')
             ->setParameter('userId', $userId)
+            ->setParameter('now', new \DateTimeImmutable())
             ->execute();
     }
 
     public function removeArchivedByUserId($userId): void
     {
         $this->getEntityManager()
-            ->createQuery('DELETE FROM Wallabag\Entity\Entry e WHERE e.user = :userId AND e.isArchived = TRUE')
+            ->createQuery('UPDATE Wallabag\Entity\Entry e SET e.deletedAt = :now, e.content = null, e.previewPicture = null WHERE e.user = :userId AND e.isArchived = TRUE AND e.deletedAt IS NULL')
             ->setParameter('userId', $userId)
+            ->setParameter('now', new \DateTimeImmutable())
             ->execute();
     }
 
@@ -692,6 +699,7 @@ class EntryRepository extends ServiceEntityRepository
         return $this->createQueryBuilder('e')
             ->where('e.url = :url')->setParameter('url', urldecode($url))
             ->andWhere('e.user = :user_id')->setParameter('user_id', $userId)
+            ->andWhere('e.deletedAt IS NULL')
             ->getQuery()
             ->getResult();
     }
@@ -753,7 +761,8 @@ class EntryRepository extends ServiceEntityRepository
     private function getQueryBuilderByUser($userId)
     {
         return $this->createQueryBuilder('e')
-            ->andWhere('e.user = :userId')->setParameter('userId', $userId);
+            ->andWhere('e.user = :userId')->setParameter('userId', $userId)
+            ->andWhere('e.deletedAt IS NULL');
     }
 
     /**

--- a/src/Repository/EntryRepository.php
+++ b/src/Repository/EntryRepository.php
@@ -606,18 +606,16 @@ class EntryRepository extends ServiceEntityRepository
     public function removeAllByUserId($userId): void
     {
         $this->getEntityManager()
-            ->createQuery('UPDATE Wallabag\Entity\Entry e SET e.deletedAt = :now, e.content = null, e.previewPicture = null WHERE e.user = :userId AND e.deletedAt IS NULL')
+            ->createQuery('DELETE FROM Wallabag\Entity\Entry e WHERE e.user = :userId')
             ->setParameter('userId', $userId)
-            ->setParameter('now', new \DateTimeImmutable())
             ->execute();
     }
 
     public function removeArchivedByUserId($userId): void
     {
         $this->getEntityManager()
-            ->createQuery('UPDATE Wallabag\Entity\Entry e SET e.deletedAt = :now, e.content = null, e.previewPicture = null WHERE e.user = :userId AND e.isArchived = TRUE AND e.deletedAt IS NULL')
+            ->createQuery('DELETE FROM Wallabag\Entity\Entry e WHERE e.user = :userId AND e.isArchived = TRUE')
             ->setParameter('userId', $userId)
-            ->setParameter('now', new \DateTimeImmutable())
             ->execute();
     }
 

--- a/src/Repository/EntryRepository.php
+++ b/src/Repository/EntryRepository.php
@@ -637,7 +637,8 @@ class EntryRepository extends ServiceEntityRepository
     {
         $qb = $this->createQueryBuilder('e')
             ->select('e.id, e.url')
-            ->where('e.user = :userid')->setParameter(':userid', $userId);
+            ->where('e.user = :userid')->setParameter(':userid', $userId)
+            ->andWhere('e.deletedAt IS NULL');
 
         return $qb->getQuery()->getArrayResult();
     }

--- a/src/Repository/TagRepository.php
+++ b/src/Repository/TagRepository.php
@@ -107,7 +107,7 @@ class TagRepository extends ServiceEntityRepository
             FROM {$this->tablePrefix}tag t
             LEFT JOIN {$this->tablePrefix}entry_tag et ON et.tag_id = t.id
             JOIN {$this->tablePrefix}entry e ON e.id = et.entry_id
-            WHERE e.user_id = :userId
+            WHERE e.user_id = :userId AND e.deleted_at IS NULL
             GROUP BY t.id
             ORDER BY t.label
         SQL;
@@ -179,6 +179,7 @@ class TagRepository extends ServiceEntityRepository
         return $this->createQueryBuilder('t')
             ->leftJoin('t.entries', 'e')
             ->where('e.user = :userId')->setParameter('userId', $userId)
+            ->andWhere('e.deletedAt IS NULL')
             ->groupBy('t.id')
             ->orderBy('t.slug');
     }

--- a/tests/functional/Controller/Api/EntryRestControllerTest.php
+++ b/tests/functional/Controller/Api/EntryRestControllerTest.php
@@ -387,6 +387,30 @@ class EntryRestControllerTest extends WallabagApiTestCase
         $this->assertSame('application/json', $this->client->getResponse()->headers->get('Content-Type'));
     }
 
+    public function testGetEntriesIncludeDeleted(): void
+    {
+        $em = $this->client->getContainer()->get(EntityManagerInterface::class);
+        $entry = (new Entry($this->user))->setUrl('http://0.0.0.0/include-deleted-test');
+        $entry->updateDeleted(true);
+        $em->persist($entry);
+        $em->flush();
+
+        // deleted entry is hidden by default
+        $this->client->request('GET', '/api/entries');
+        $this->assertSame(200, $this->client->getResponse()->getStatusCode());
+        $content = json_decode($this->client->getResponse()->getContent(), true);
+        $urls = array_column($content['_embedded']['items'], 'url');
+        $this->assertNotContains('http://0.0.0.0/include-deleted-test', $urls);
+
+        // deleted entry appears with include_deleted=1
+        $this->client = $this->createAuthorizedClient();
+        $this->client->request('GET', '/api/entries', ['include_deleted' => 1]);
+        $this->assertSame(200, $this->client->getResponse()->getStatusCode());
+        $content = json_decode($this->client->getResponse()->getContent(), true);
+        $urls = array_column($content['_embedded']['items'], 'url');
+        $this->assertContains('http://0.0.0.0/include-deleted-test', $urls);
+    }
+
     public function testGetEntriesOnPageTwo(): void
     {
         $this->client->request('GET', '/api/entries', [

--- a/tests/functional/Controller/Api/EntryRestControllerTest.php
+++ b/tests/functional/Controller/Api/EntryRestControllerTest.php
@@ -640,6 +640,14 @@ class EntryRestControllerTest extends WallabagApiTestCase
         $this->assertSame($e['url'], $content['url']);
         $this->assertSame($e['id'], $content['id']);
 
+        // Verify soft delete persisted state
+        $entry = $em->find(Entry::class, $e['id']);
+
+        $this->assertTrue($entry->isDeleted());
+        $this->assertInstanceOf(\DateTimeInterface::class, $entry->getDeletedAt());
+        $this->assertNull($entry->getContent());
+        $this->assertNull($entry->getPreviewPicture());
+
         // We'll try to delete this entry again
         $client = $this->createAuthorizedClient();
         $client->request('DELETE', '/api/entries/' . $e['id'] . '.json');

--- a/tests/functional/Controller/Api/EntryRestControllerTest.php
+++ b/tests/functional/Controller/Api/EntryRestControllerTest.php
@@ -1513,6 +1513,57 @@ class EntryRestControllerTest extends WallabagApiTestCase
         $this->assertEmpty($content);
     }
 
+    public function testPostDeletedEntryIsRestored(): void
+    {
+        $em = $this->client->getContainer()->get(EntityManagerInterface::class);
+        $entry = (new Entry($this->user))->setUrl('http://0.0.0.0/deleted-entry-restore');
+        $entry->updateDeleted(true);
+        $em->persist($entry);
+        $em->flush();
+        $deletedId = $entry->getId();
+
+        $this->client = $this->createAuthorizedClient();
+
+        $this->client->request('POST', '/api/entries.json', [
+            'url' => 'http://0.0.0.0/deleted-entry-restore',
+        ]);
+
+        $this->assertSame(200, $this->client->getResponse()->getStatusCode());
+
+        $content = json_decode($this->client->getResponse()->getContent(), true);
+
+        $this->assertSame($deletedId, $content['id']);
+        $this->assertNull($content['deleted_at']);
+
+        $restored = $em->getRepository(Entry::class)->find($deletedId);
+        $this->assertNull($restored->getDeletedAt());
+    }
+
+    public function testPostEntriesListWithDeletedEntry(): void
+    {
+        $em = $this->client->getContainer()->get(EntityManagerInterface::class);
+        $entry = (new Entry($this->user))->setUrl('http://0.0.0.0/deleted-list-entry-restore');
+        $entry->updateDeleted(true);
+        $em->persist($entry);
+        $em->flush();
+        $deletedId = $entry->getId();
+
+        $this->client = $this->createAuthorizedClient();
+
+        $list = ['http://0.0.0.0/deleted-list-entry-restore'];
+
+        $this->client->request('POST', '/api/entries/lists?urls=' . json_encode($list));
+
+        $this->assertSame(200, $this->client->getResponse()->getStatusCode());
+
+        $content = json_decode($this->client->getResponse()->getContent(), true);
+
+        $this->assertSame($deletedId, $content[0]['entry']);
+
+        $restored = $em->getRepository(Entry::class)->find($deletedId);
+        $this->assertNull($restored->getDeletedAt());
+    }
+
     public function testDeleteEntriesListAction(): void
     {
         $em = $this->client->getContainer()->get(EntityManagerInterface::class);

--- a/tests/functional/Controller/Api/EntryRestControllerTest.php
+++ b/tests/functional/Controller/Api/EntryRestControllerTest.php
@@ -391,7 +391,7 @@ class EntryRestControllerTest extends WallabagApiTestCase
     {
         $em = $this->client->getContainer()->get(EntityManagerInterface::class);
         $entry = (new Entry($this->user))->setUrl('http://0.0.0.0/include-deleted-test');
-        $entry->updateDeleted(true);
+        $entry->delete();
         $em->persist($entry);
         $em->flush();
 
@@ -1541,7 +1541,7 @@ class EntryRestControllerTest extends WallabagApiTestCase
     {
         $em = $this->client->getContainer()->get(EntityManagerInterface::class);
         $entry = (new Entry($this->user))->setUrl('http://0.0.0.0/deleted-entry-restore');
-        $entry->updateDeleted(true);
+        $entry->delete();
         $em->persist($entry);
         $em->flush();
         $deletedId = $entry->getId();
@@ -1567,7 +1567,7 @@ class EntryRestControllerTest extends WallabagApiTestCase
     {
         $em = $this->client->getContainer()->get(EntityManagerInterface::class);
         $entry = (new Entry($this->user))->setUrl('http://0.0.0.0/deleted-list-entry-restore');
-        $entry->updateDeleted(true);
+        $entry->delete();
         $em->persist($entry);
         $em->flush();
         $deletedId = $entry->getId();

--- a/tests/functional/Controller/Api/EntryRestControllerTest.php
+++ b/tests/functional/Controller/Api/EntryRestControllerTest.php
@@ -427,6 +427,30 @@ class EntryRestControllerTest extends WallabagApiTestCase
         $this->assertSame('application/json', $this->client->getResponse()->headers->get('Content-Type'));
     }
 
+    public function testGetEntriesIncludeDeleted(): void
+    {
+        $em = $this->client->getContainer()->get(EntityManagerInterface::class);
+        $entry = (new Entry($this->user))->setUrl('http://0.0.0.0/include-deleted-test');
+        $entry->updateDeleted(true);
+        $em->persist($entry);
+        $em->flush();
+
+        // deleted entry is hidden by default
+        $this->client->request('GET', '/api/entries');
+        $this->assertSame(200, $this->client->getResponse()->getStatusCode());
+        $content = json_decode($this->client->getResponse()->getContent(), true);
+        $urls = array_column($content['_embedded']['items'], 'url');
+        $this->assertNotContains('http://0.0.0.0/include-deleted-test', $urls);
+
+        // deleted entry appears with include_deleted=1
+        $this->client = $this->createAuthorizedClient();
+        $this->client->request('GET', '/api/entries', ['include_deleted' => 1]);
+        $this->assertSame(200, $this->client->getResponse()->getStatusCode());
+        $content = json_decode($this->client->getResponse()->getContent(), true);
+        $urls = array_column($content['_embedded']['items'], 'url');
+        $this->assertContains('http://0.0.0.0/include-deleted-test', $urls);
+    }
+
     public function testGetEntriesOnPageTwo(): void
     {
         $this->client->request('GET', '/api/entries', [

--- a/tests/functional/Controller/Api/EntryRestControllerTest.php
+++ b/tests/functional/Controller/Api/EntryRestControllerTest.php
@@ -680,6 +680,14 @@ class EntryRestControllerTest extends WallabagApiTestCase
         $this->assertSame($e['url'], $content['url']);
         $this->assertSame($e['id'], $content['id']);
 
+        // Verify soft delete persisted state
+        $entry = $em->find(Entry::class, $e['id']);
+
+        $this->assertTrue($entry->isDeleted());
+        $this->assertInstanceOf(\DateTimeInterface::class, $entry->getDeletedAt());
+        $this->assertNull($entry->getContent());
+        $this->assertNull($entry->getPreviewPicture());
+
         // We'll try to delete this entry again
         $client = $this->createAuthorizedClient();
         $client->request('DELETE', '/api/entries/' . $e['id'] . '.json');

--- a/tests/functional/Controller/Api/EntryRestControllerTest.php
+++ b/tests/functional/Controller/Api/EntryRestControllerTest.php
@@ -431,7 +431,7 @@ class EntryRestControllerTest extends WallabagApiTestCase
     {
         $em = $this->client->getContainer()->get(EntityManagerInterface::class);
         $entry = (new Entry($this->user))->setUrl('http://0.0.0.0/include-deleted-test');
-        $entry->updateDeleted(true);
+        $entry->delete();
         $em->persist($entry);
         $em->flush();
 
@@ -1581,7 +1581,7 @@ class EntryRestControllerTest extends WallabagApiTestCase
     {
         $em = $this->client->getContainer()->get(EntityManagerInterface::class);
         $entry = (new Entry($this->user))->setUrl('http://0.0.0.0/deleted-entry-restore');
-        $entry->updateDeleted(true);
+        $entry->delete();
         $em->persist($entry);
         $em->flush();
         $deletedId = $entry->getId();
@@ -1607,7 +1607,7 @@ class EntryRestControllerTest extends WallabagApiTestCase
     {
         $em = $this->client->getContainer()->get(EntityManagerInterface::class);
         $entry = (new Entry($this->user))->setUrl('http://0.0.0.0/deleted-list-entry-restore');
-        $entry->updateDeleted(true);
+        $entry->delete();
         $em->persist($entry);
         $em->flush();
         $deletedId = $entry->getId();

--- a/tests/functional/Controller/Api/EntryRestControllerTest.php
+++ b/tests/functional/Controller/Api/EntryRestControllerTest.php
@@ -1553,6 +1553,57 @@ class EntryRestControllerTest extends WallabagApiTestCase
         $this->assertEmpty($content);
     }
 
+    public function testPostDeletedEntryIsRestored(): void
+    {
+        $em = $this->client->getContainer()->get(EntityManagerInterface::class);
+        $entry = (new Entry($this->user))->setUrl('http://0.0.0.0/deleted-entry-restore');
+        $entry->updateDeleted(true);
+        $em->persist($entry);
+        $em->flush();
+        $deletedId = $entry->getId();
+
+        $this->client = $this->createAuthorizedClient();
+
+        $this->client->request('POST', '/api/entries.json', [
+            'url' => 'http://0.0.0.0/deleted-entry-restore',
+        ]);
+
+        $this->assertSame(200, $this->client->getResponse()->getStatusCode());
+
+        $content = json_decode($this->client->getResponse()->getContent(), true);
+
+        $this->assertSame($deletedId, $content['id']);
+        $this->assertNull($content['deleted_at']);
+
+        $restored = $em->getRepository(Entry::class)->find($deletedId);
+        $this->assertNull($restored->getDeletedAt());
+    }
+
+    public function testPostEntriesListWithDeletedEntry(): void
+    {
+        $em = $this->client->getContainer()->get(EntityManagerInterface::class);
+        $entry = (new Entry($this->user))->setUrl('http://0.0.0.0/deleted-list-entry-restore');
+        $entry->updateDeleted(true);
+        $em->persist($entry);
+        $em->flush();
+        $deletedId = $entry->getId();
+
+        $this->client = $this->createAuthorizedClient();
+
+        $list = ['http://0.0.0.0/deleted-list-entry-restore'];
+
+        $this->client->request('POST', '/api/entries/lists?urls=' . json_encode($list));
+
+        $this->assertSame(200, $this->client->getResponse()->getStatusCode());
+
+        $content = json_decode($this->client->getResponse()->getContent(), true);
+
+        $this->assertSame($deletedId, $content[0]['entry']);
+
+        $restored = $em->getRepository(Entry::class)->find($deletedId);
+        $this->assertNull($restored->getDeletedAt());
+    }
+
     public function testDeleteEntriesListAction(): void
     {
         $em = $this->client->getContainer()->get(EntityManagerInterface::class);

--- a/tests/functional/Controller/EntryControllerTest.php
+++ b/tests/functional/Controller/EntryControllerTest.php
@@ -1950,19 +1950,21 @@ class EntryControllerTest extends WallabagTestCase
             'entry-checkbox' => $entries,
         ]);
 
+        $client->getContainer()->get(EntityManagerInterface::class)->clear();
+
         $res = $client->getContainer()
             ->get(EntityManagerInterface::class)
             ->getRepository(Entry::class)
             ->find($entry1Id);
 
-        $this->assertNull($res);
+        $this->assertNotNull($res->getDeletedAt());
 
         $res = $client->getContainer()
             ->get(EntityManagerInterface::class)
             ->getRepository(Entry::class)
             ->find($entry2Id);
 
-        $this->assertNull($res);
+        $this->assertNotNull($res->getDeletedAt());
     }
 
     public function testGetSameDomainEntries(): void

--- a/tests/functional/Controller/EntryControllerTest.php
+++ b/tests/functional/Controller/EntryControllerTest.php
@@ -1982,4 +1982,30 @@ class EntryControllerTest extends WallabagTestCase
         $this->assertSame(200, $client->getResponse()->getStatusCode());
         $this->assertCount(4, $crawler->filter('ol.entries > li'));
     }
+
+    public function testAddViaFormRestoresDeletedEntry(): void
+    {
+        $this->logInAs('admin');
+        $client = $this->getTestClient();
+
+        $em = $client->getContainer()->get(EntityManagerInterface::class);
+        $user = $this->getLoggedInUser();
+        $entry = (new Entry($user))->setUrl('http://0.0.0.0/deleted-form-restore');
+        $entry->updateDeleted(true);
+        $em->persist($entry);
+        $em->flush();
+        $deletedId = $entry->getId();
+
+        $crawler = $client->request('GET', '/new');
+        $this->assertSame(200, $client->getResponse()->getStatusCode());
+
+        $form = $crawler->filter('form[name=entry]')->form();
+        $client->submit($form, ['entry[url]' => 'http://0.0.0.0/deleted-form-restore']);
+
+        $this->assertSame(302, $client->getResponse()->getStatusCode());
+
+        $em->clear();
+        $restored = $em->getRepository(Entry::class)->find($deletedId);
+        $this->assertNull($restored->getDeletedAt());
+    }
 }

--- a/tests/functional/Controller/EntryControllerTest.php
+++ b/tests/functional/Controller/EntryControllerTest.php
@@ -1265,6 +1265,38 @@ class EntryControllerTest extends WallabagTestCase
         $client->getContainer()->get(Config::class)->set('share_public', 0);
     }
 
+    public function testDeletedEntryUidIsNulledAndShareUrlIsGone(): void
+    {
+        $this->logInAs('admin');
+        $client = $this->getTestClient();
+
+        $client->getContainer()->get(Config::class)->set('share_public', 1);
+
+        $content = new Entry($this->getLoggedInUser());
+        $content->setUrl($this->url);
+        $this->getEntityManager()->persist($content);
+        $this->getEntityManager()->flush();
+
+        $crawler = $client->request('GET', '/view/' . $content->getId());
+        $client->submit($crawler->filter('.left-bar')->selectButton('entry.view.left_menu.public_link')->form());
+        $shareUrl = $client->getResponse()->getTargetUrl();
+
+        $client->request('GET', $shareUrl);
+        $this->assertSame(200, $client->getResponse()->getStatusCode());
+
+        $crawler = $client->request('GET', '/view/' . $content->getId());
+        $client->submit($crawler->filter('.left-bar')->selectButton('entry.view.left_menu.delete')->form());
+        $this->assertSame(302, $client->getResponse()->getStatusCode());
+
+        $entry = $this->getEntityManager()->getRepository(Entry::class)->find($content->getId());
+        $this->assertNull($entry->getUid());
+
+        $client->request('GET', $shareUrl);
+        $this->assertSame(404, $client->getResponse()->getStatusCode());
+
+        $client->getContainer()->get(Config::class)->set('share_public', 0);
+    }
+
     /**
      * @group NetworkCalls
      */
@@ -1991,7 +2023,7 @@ class EntryControllerTest extends WallabagTestCase
         $em = $client->getContainer()->get(EntityManagerInterface::class);
         $user = $this->getLoggedInUser();
         $entry = (new Entry($user))->setUrl('http://0.0.0.0/deleted-form-restore');
-        $entry->updateDeleted(true);
+        $entry->delete();
         $em->persist($entry);
         $em->flush();
         $deletedId = $entry->getId();

--- a/tests/functional/Controller/EntryControllerTest.php
+++ b/tests/functional/Controller/EntryControllerTest.php
@@ -1276,6 +1276,38 @@ class EntryControllerTest extends WallabagTestCase
         $client->getContainer()->get(Config::class)->set('share_public', 0);
     }
 
+    public function testDeletedEntryUidIsNulledAndShareUrlIsGone(): void
+    {
+        $this->logInAs('admin');
+        $client = $this->getTestClient();
+
+        $client->getContainer()->get(Config::class)->set('share_public', 1);
+
+        $content = new Entry($this->getLoggedInUser());
+        $content->setUrl($this->url);
+        $this->getEntityManager()->persist($content);
+        $this->getEntityManager()->flush();
+
+        $crawler = $client->request('GET', '/view/' . $content->getId());
+        $client->submit($crawler->filter('.left-bar')->selectButton('entry.view.left_menu.public_link')->form());
+        $shareUrl = $client->getResponse()->getTargetUrl();
+
+        $client->request('GET', $shareUrl);
+        $this->assertSame(200, $client->getResponse()->getStatusCode());
+
+        $crawler = $client->request('GET', '/view/' . $content->getId());
+        $client->submit($crawler->filter('.left-bar')->selectButton('entry.view.left_menu.delete')->form());
+        $this->assertSame(302, $client->getResponse()->getStatusCode());
+
+        $entry = $this->getEntityManager()->getRepository(Entry::class)->find($content->getId());
+        $this->assertNull($entry->getUid());
+
+        $client->request('GET', $shareUrl);
+        $this->assertSame(404, $client->getResponse()->getStatusCode());
+
+        $client->getContainer()->get(Config::class)->set('share_public', 0);
+    }
+
     /**
      * @group NetworkCalls
      */
@@ -2018,7 +2050,7 @@ class EntryControllerTest extends WallabagTestCase
         $em = $client->getContainer()->get(EntityManagerInterface::class);
         $user = $this->getLoggedInUser();
         $entry = (new Entry($user))->setUrl('http://0.0.0.0/deleted-form-restore');
-        $entry->updateDeleted(true);
+        $entry->delete();
         $em->persist($entry);
         $em->flush();
         $deletedId = $entry->getId();

--- a/tests/functional/Controller/EntryControllerTest.php
+++ b/tests/functional/Controller/EntryControllerTest.php
@@ -1977,19 +1977,21 @@ class EntryControllerTest extends WallabagTestCase
             'entry-checkbox' => $entries,
         ]);
 
+        $client->getContainer()->get(EntityManagerInterface::class)->clear();
+
         $res = $client->getContainer()
             ->get(EntityManagerInterface::class)
             ->getRepository(Entry::class)
             ->find($entry1Id);
 
-        $this->assertNull($res);
+        $this->assertNotNull($res->getDeletedAt());
 
         $res = $client->getContainer()
             ->get(EntityManagerInterface::class)
             ->getRepository(Entry::class)
             ->find($entry2Id);
 
-        $this->assertNull($res);
+        $this->assertNotNull($res->getDeletedAt());
     }
 
     public function testGetSameDomainEntries(): void

--- a/tests/functional/Controller/EntryControllerTest.php
+++ b/tests/functional/Controller/EntryControllerTest.php
@@ -2009,4 +2009,30 @@ class EntryControllerTest extends WallabagTestCase
         $this->assertSame(200, $client->getResponse()->getStatusCode());
         $this->assertCount(4, $crawler->filter('ol.entries > li'));
     }
+
+    public function testAddViaFormRestoresDeletedEntry(): void
+    {
+        $this->logInAs('admin');
+        $client = $this->getTestClient();
+
+        $em = $client->getContainer()->get(EntityManagerInterface::class);
+        $user = $this->getLoggedInUser();
+        $entry = (new Entry($user))->setUrl('http://0.0.0.0/deleted-form-restore');
+        $entry->updateDeleted(true);
+        $em->persist($entry);
+        $em->flush();
+        $deletedId = $entry->getId();
+
+        $crawler = $client->request('GET', '/new');
+        $this->assertSame(200, $client->getResponse()->getStatusCode());
+
+        $form = $crawler->filter('form[name=entry]')->form();
+        $client->submit($form, ['entry[url]' => 'http://0.0.0.0/deleted-form-restore']);
+
+        $this->assertSame(302, $client->getResponse()->getStatusCode());
+
+        $em->clear();
+        $restored = $em->getRepository(Entry::class)->find($deletedId);
+        $this->assertNull($restored->getDeletedAt());
+    }
 }

--- a/tests/integration/Command/CleanDuplicatesCommandTest.php
+++ b/tests/integration/Command/CleanDuplicatesCommandTest.php
@@ -103,7 +103,7 @@ class CleanDuplicatesCommandTest extends WallabagKernelTestCase
 
         $entryDeletedBefore = new Entry($user);
         $entryDeletedBefore->setUrl($url);
-        $entryDeletedBefore->updateDeleted(true);
+        $entryDeletedBefore->delete();
         $deletedAtBefore = $entryDeletedBefore->getDeletedAt()->format('U');
 
         $entryLive = new Entry($user);
@@ -111,7 +111,7 @@ class CleanDuplicatesCommandTest extends WallabagKernelTestCase
 
         $entryDeletedAfter = new Entry($user);
         $entryDeletedAfter->setUrl($url);
-        $entryDeletedAfter->updateDeleted(true);
+        $entryDeletedAfter->delete();
         $deletedAtAfter = $entryDeletedAfter->getDeletedAt()->format('U');
 
         $em->persist($entryDeletedBefore);

--- a/tests/integration/Command/CleanDuplicatesCommandTest.php
+++ b/tests/integration/Command/CleanDuplicatesCommandTest.php
@@ -91,4 +91,57 @@ class CleanDuplicatesCommandTest extends WallabagKernelTestCase
         $query->setParameter('url', $url);
         $query->execute();
     }
+
+    public function testDuplicateSkipsAlreadyDeletedEntry(): void
+    {
+        $url = 'https://www.lemonde.fr/sport/visuel/2017/05/05/rondelle-prison-blanchissage-comprendre-le-hockey-sur-glace_5122587_3242.html';
+        $em = $this->getEntityManager();
+        $user = $this->getUser('admin');
+
+        // Deletion and restoration can combine in a lot of different ways so any order is possible.
+        // This case covers most of the edge cases: deleted / live / deleted.
+
+        $entryDeletedBefore = new Entry($user);
+        $entryDeletedBefore->setUrl($url);
+        $entryDeletedBefore->updateDeleted(true);
+        $deletedAtBefore = $entryDeletedBefore->getDeletedAt()->format('U');
+
+        $entryLive = new Entry($user);
+        $entryLive->setUrl($url);
+
+        $entryDeletedAfter = new Entry($user);
+        $entryDeletedAfter->setUrl($url);
+        $entryDeletedAfter->updateDeleted(true);
+        $deletedAtAfter = $entryDeletedAfter->getDeletedAt()->format('U');
+
+        $em->persist($entryDeletedBefore);
+        $em->persist($entryLive);
+        $em->persist($entryDeletedAfter);
+
+        $em->flush();
+
+        $application = $this->createApplication();
+
+        $command = $application->find('wallabag:clean-duplicates');
+
+        $tester = new CommandTester($command);
+        $tester->execute([
+            'username' => 'admin',
+        ]);
+
+        $this->assertStringContainsString('Cleaned 0 duplicates for user admin', $tester->getDisplay());
+
+        $em->refresh($entryDeletedBefore);
+        $this->assertSame($deletedAtBefore, $entryDeletedBefore->getDeletedAt()->format('U'));
+
+        $em->refresh($entryDeletedAfter);
+        $this->assertSame($deletedAtAfter, $entryDeletedAfter->getDeletedAt()->format('U'));
+
+        $em->refresh($entryLive);
+        $this->assertFalse($entryLive->isDeleted());
+
+        $query = $em->createQuery('DELETE FROM Wallabag\Entity\Entry e WHERE e.url = :url');
+        $query->setParameter('url', $url);
+        $query->execute();
+    }
 }

--- a/tests/unit/Import/FirefoxImportTest.php
+++ b/tests/unit/Import/FirefoxImportTest.php
@@ -76,9 +76,12 @@ class FirefoxImportTest extends TestCase
             ->disableOriginalConstructor()
             ->getMock();
 
+        $existingEntry = $this->createMock(Entry::class);
+        $existingEntry->method('isDeleted')->willReturn(false);
+
         $entryRepo->expects($this->exactly(2))
             ->method('findByUrlAndUserId')
-            ->will($this->onConsecutiveCalls(false, true));
+            ->will($this->onConsecutiveCalls(false, $existingEntry));
 
         $this->em
             ->expects($this->any())

--- a/tests/unit/Import/InstapaperImportTest.php
+++ b/tests/unit/Import/InstapaperImportTest.php
@@ -78,9 +78,12 @@ class InstapaperImportTest extends TestCase
             ->disableOriginalConstructor()
             ->getMock();
 
+        $existingEntry = $this->createMock(Entry::class);
+        $existingEntry->method('isDeleted')->willReturn(false);
+
         $entryRepo->expects($this->exactly(4))
             ->method('findByUrlAndUserId')
-            ->will($this->onConsecutiveCalls(false, true, true, true));
+            ->will($this->onConsecutiveCalls(false, $existingEntry, $existingEntry, $existingEntry));
 
         $this->em
             ->expects($this->any())

--- a/tests/unit/Import/PocketCsvImportTest.php
+++ b/tests/unit/Import/PocketCsvImportTest.php
@@ -76,9 +76,12 @@ class PocketCsvImportTest extends TestCase
             ->disableOriginalConstructor()
             ->getMock();
 
+        $existingEntry = $this->createMock(Entry::class);
+        $existingEntry->method('isDeleted')->willReturn(false);
+
         $entryRepo->expects($this->exactly(7))
             ->method('findByUrlAndUserId')
-            ->will($this->onConsecutiveCalls(false, true));
+            ->will($this->onConsecutiveCalls(false, $existingEntry, $existingEntry, $existingEntry, $existingEntry, $existingEntry, $existingEntry));
 
         $this->em
             ->expects($this->any())

--- a/tests/unit/Import/PocketHtmlImportTest.php
+++ b/tests/unit/Import/PocketHtmlImportTest.php
@@ -76,9 +76,12 @@ class PocketHtmlImportTest extends TestCase
             ->disableOriginalConstructor()
             ->getMock();
 
+        $existingEntry = $this->createMock(Entry::class);
+        $existingEntry->method('isDeleted')->willReturn(false);
+
         $entryRepo->expects($this->exactly(2))
             ->method('findByUrlAndUserId')
-            ->will($this->onConsecutiveCalls(false, true));
+            ->will($this->onConsecutiveCalls(false, $existingEntry));
 
         $this->em
             ->expects($this->any())

--- a/tests/unit/Import/PocketImportTest.php
+++ b/tests/unit/Import/PocketImportTest.php
@@ -194,9 +194,12 @@ JSON, ['response_headers' => ['Content-Type: application/json']]),
             ->disableOriginalConstructor()
             ->getMock();
 
+        $existingEntry = $this->createMock(Entry::class);
+        $existingEntry->method('isDeleted')->willReturn(false);
+
         $entryRepo->expects($this->exactly(2))
             ->method('findByUrlAndUserId')
-            ->will($this->onConsecutiveCalls(false, true));
+            ->will($this->onConsecutiveCalls(false, $existingEntry));
 
         $this->em
             ->expects($this->exactly(2))

--- a/tests/unit/Import/ReadabilityImportTest.php
+++ b/tests/unit/Import/ReadabilityImportTest.php
@@ -76,9 +76,12 @@ class ReadabilityImportTest extends TestCase
             ->disableOriginalConstructor()
             ->getMock();
 
+        $existingEntry = $this->createMock(Entry::class);
+        $existingEntry->method('isDeleted')->willReturn(false);
+
         $entryRepo->expects($this->exactly(2))
             ->method('findByUrlAndUserId')
-            ->will($this->onConsecutiveCalls(false, true));
+            ->will($this->onConsecutiveCalls(false, $existingEntry));
 
         $this->em
             ->expects($this->any())

--- a/tests/unit/Import/ShaarliImportTest.php
+++ b/tests/unit/Import/ShaarliImportTest.php
@@ -76,9 +76,12 @@ class ShaarliImportTest extends TestCase
             ->disableOriginalConstructor()
             ->getMock();
 
+        $existingEntry = $this->createMock(Entry::class);
+        $existingEntry->method('isDeleted')->willReturn(false);
+
         $entryRepo->expects($this->exactly(2))
             ->method('findByUrlAndUserId')
-            ->will($this->onConsecutiveCalls(false, true));
+            ->will($this->onConsecutiveCalls(false, $existingEntry));
 
         $this->em
             ->expects($this->any())

--- a/tests/unit/Import/WallabagV1ImportTest.php
+++ b/tests/unit/Import/WallabagV1ImportTest.php
@@ -48,9 +48,12 @@ class WallabagV1ImportTest extends TestCase
             ->disableOriginalConstructor()
             ->getMock();
 
+        $existingEntry = $this->createMock(Entry::class);
+        $existingEntry->method('isDeleted')->willReturn(false);
+
         $entryRepo->expects($this->exactly(2))
             ->method('findByUrlAndUserId')
-            ->will($this->onConsecutiveCalls(false, true, false, false));
+            ->will($this->onConsecutiveCalls(false, $existingEntry, false, false));
 
         $this->em
             ->expects($this->any())

--- a/tests/unit/Import/WallabagV2ImportTest.php
+++ b/tests/unit/Import/WallabagV2ImportTest.php
@@ -46,9 +46,12 @@ class WallabagV2ImportTest extends TestCase
             ->disableOriginalConstructor()
             ->getMock();
 
+        $existingEntry = $this->createMock(Entry::class);
+        $existingEntry->method('isDeleted')->willReturn(false);
+
         $entryRepo->expects($this->exactly(6))
             ->method('findByUrlAndUserId')
-            ->will($this->onConsecutiveCalls(false, true, false));
+            ->will($this->onConsecutiveCalls(false, $existingEntry, false, $existingEntry, $existingEntry, $existingEntry));
 
         $this->em
             ->expects($this->any())
@@ -220,9 +223,12 @@ class WallabagV2ImportTest extends TestCase
             ->disableOriginalConstructor()
             ->getMock();
 
+        $existingEntry = $this->createMock(Entry::class);
+        $existingEntry->method('isDeleted')->willReturn(false);
+
         $entryRepo->expects($this->exactly(6))
             ->method('findByUrlAndUserId')
-            ->will($this->onConsecutiveCalls(false, true, false));
+            ->will($this->onConsecutiveCalls(false, $existingEntry, false, $existingEntry, $existingEntry, $existingEntry));
 
         $this->em
             ->expects($this->any())


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | yes
| Deprecations? | no
| Tests pass?   | yes
| Documentation | no
| Translation   | no
| CHANGELOG.md  | no
| License       | MIT

First parts of #8752. I originally intended to follow the 3 PR plan from the issue but as implementation went it felt wrong to separate the deletion and the restoration. See details in the parent issue.

The gist of the changes are the new methods on the Entry entity: `isDeleted()` and `updateDeleted(bool)`. There is a lot of mechanical changes in the tests to adapt them to the new behavior.
I took into consideration the webapp, the API and the different importers. It should cover all the way to save an entry.

I wasn't sure about what fields to strip on deletion and where. I went for the pragmatic approach: `content` to optimize storage, `pictureUrl` to help me visualize state during my tests, in `updateDeleted(bool)` for a unique logic. That's easy to change. 

Another PR will follow soon with the expiration limit setting and purge command.
