### PR TITLE
Add wallabag:api-client:create console command

### DIFF
--- a/doc/content/admin/console_commands.md
+++ b/doc/content/admin/console_commands.md
@@ -30,6 +30,7 @@ From Symfony:
 
 Custom to wallabag:
 
+ - `wallabag:api-client:create`: Creates an OAuth API client for an existing user.
  - `wallabag:clean-downloaded-images`: Cleans downloaded images which are no longer associated with an entry.
  - `wallabag:clean-duplicates`: Removes all entry duplicates for one user or all users.
  - `wallabag:entry:reload`: Reloads entries.
@@ -41,6 +42,46 @@ Custom to wallabag:
  - `wallabag:tag:all`: Tags all entries for a user using their tagging rules.
  - `wallabag:user:show`: Shows the details for a user.
  - `wallabag:user:list`: Lists all existing users.
+
+wallabag:api-client:create
+--------------------------
+
+This command creates an OAuth API client for an existing user. Useful for IaC
+pipelines, credential rotation, or provisioning a second client without
+recreating the user.
+
+Usage:
+
+```
+wallabag:api-client:create [--display-name DISPLAY-NAME] [--grant-types GRANT-TYPES] [--format FORMAT] <username>
+```
+
+Arguments:
+
+ - username: Owner of the client
+
+Options:
+
+ - `--display-name=DISPLAY-NAME`: Display name shown in /developer [default: "Default client"]
+ - `--grant-types=GRANT-TYPES`: Comma-separated list of allowed grant types: token, authorization_code, password, refresh_token [default: all four]
+ - `--format=FORMAT`: Output format: `text`, `env`, or `json` [default: "text"]
+
+Examples:
+
+```
+# Human-readable output
+bin/console wallabag:api-client:create alice
+
+# Machine-readable for CI / provisioning
+bin/console wallabag:api-client:create alice --display-name="ansible-bootstrap" --format=env
+
+# JSON output
+bin/console wallabag:api-client:create alice --format=json
+
+# Restrict grant types
+bin/console wallabag:api-client:create alice --grant-types=password,refresh_token
+```
+
 
 wallabag:clean-downloaded-images
 -------------------------

--- a/src/Command/CreateApiClientCommand.php
+++ b/src/Command/CreateApiClientCommand.php
@@ -1,0 +1,124 @@
+<?php
+
+namespace Wallabag\Command;
+
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\NoResultException;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+use Wallabag\Entity\Api\Client;
+use Wallabag\Repository\UserRepository;
+
+class CreateApiClientCommand extends Command
+{
+    private const ALLOWED_GRANT_TYPES = ['token', 'authorization_code', 'password', 'refresh_token'];
+    protected static $defaultName = 'wallabag:api-client:create';
+    protected static $defaultDescription = 'Create an OAuth API client for an existing user';
+
+    public function __construct(
+        private readonly UserRepository $userRepository,
+        private readonly EntityManagerInterface $entityManager,
+    ) {
+        parent::__construct();
+    }
+
+    protected function configure(): void
+    {
+        $this
+            ->setHelp('This command creates an OAuth API client for an existing user')
+            ->addArgument(
+                'username',
+                InputArgument::REQUIRED,
+                'User to create a client for'
+            )
+            ->addOption(
+                'display-name',
+                null,
+                InputOption::VALUE_REQUIRED,
+                'Display name of the client',
+                'Default client'
+            )
+            ->addOption(
+                'grant-types',
+                null,
+                InputOption::VALUE_REQUIRED,
+                'Comma-separated list of allowed grant types (' . implode(', ', self::ALLOWED_GRANT_TYPES) . ')',
+                implode(',', self::ALLOWED_GRANT_TYPES)
+            )
+            ->addOption(
+                'format',
+                null,
+                InputOption::VALUE_REQUIRED,
+                'Output format (text, env, json)',
+                'text'
+            );
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+
+        $username = $input->getArgument('username');
+
+        try {
+            $user = $this->userRepository->findOneByUserName($username);
+        } catch (NoResultException) {
+            $io->error(\sprintf('User "%s" not found.', $username));
+
+            return 1;
+        }
+
+        $format = (string) $input->getOption('format');
+        if (!\in_array($format, ['text', 'env', 'json'], true)) {
+            $io->error(\sprintf('Unknown format "%s". Use text, env, or json.', $format));
+
+            return 1;
+        }
+
+        $grantTypes = array_filter(array_map('trim', explode(',', (string) $input->getOption('grant-types'))));
+        $invalidGrantTypes = array_diff($grantTypes, self::ALLOWED_GRANT_TYPES);
+        if (!empty($invalidGrantTypes)) {
+            $io->error(\sprintf(
+                'Invalid grant type(s): %s. Allowed values are: %s.',
+                implode(', ', $invalidGrantTypes),
+                implode(', ', self::ALLOWED_GRANT_TYPES)
+            ));
+
+            return 1;
+        }
+
+        $client = new Client($user);
+        $client->setName((string) $input->getOption('display-name'));
+        $client->setAllowedGrantTypes(array_values($grantTypes));
+
+        $this->entityManager->persist($client);
+        $this->entityManager->flush();
+
+        switch ($format) {
+            case 'env':
+                $output->writeln('WALLABAG_CLIENT_ID="' . $client->getPublicId() . '"');
+                $output->writeln('WALLABAG_CLIENT_SECRET="' . $client->getSecret() . '"');
+                break;
+            case 'json':
+                $output->writeln((string) json_encode([
+                    'client_id' => $client->getPublicId(),
+                    'client_secret' => $client->getSecret(),
+                    'name' => $client->getName(),
+                ], \JSON_PRETTY_PRINT | \JSON_THROW_ON_ERROR));
+                break;
+            default:
+                $io->success('Client created');
+                $io->definitionList(
+                    ['client_id' => $client->getPublicId()],
+                    ['client_secret' => $client->getSecret()],
+                    ['name' => $client->getName()],
+                );
+        }
+
+        return 0;
+    }
+}

--- a/tests/integration/Command/CreateApiClientCommandTest.php
+++ b/tests/integration/Command/CreateApiClientCommandTest.php
@@ -1,0 +1,159 @@
+<?php
+
+namespace Wallabag\Tests\Integration\Command;
+
+use Symfony\Component\Console\Exception\RuntimeException;
+use Symfony\Component\Console\Tester\CommandTester;
+use Wallabag\Tests\Integration\WallabagKernelTestCase;
+
+class CreateApiClientCommandTest extends WallabagKernelTestCase
+{
+    public function testMissingUsername(): void
+    {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Not enough arguments');
+
+        $application = $this->createApplication();
+
+        $command = $application->find('wallabag:api-client:create');
+
+        $tester = new CommandTester($command);
+        $tester->execute([]);
+    }
+
+    public function testUnknownUser(): void
+    {
+        $application = $this->createApplication();
+
+        $command = $application->find('wallabag:api-client:create');
+
+        $tester = new CommandTester($command);
+        $tester->execute([
+            'username' => 'unknown',
+        ]);
+
+        $this->assertStringContainsString('User "unknown" not found', $tester->getDisplay());
+        $this->assertSame(1, $tester->getStatusCode());
+    }
+
+    public function testCreateClientDefaultFormat(): void
+    {
+        $application = $this->createApplication();
+
+        $command = $application->find('wallabag:api-client:create');
+
+        $tester = new CommandTester($command);
+        $tester->execute([
+            'username' => 'admin',
+        ]);
+
+        $this->assertStringContainsString('client_id', $tester->getDisplay());
+        $this->assertStringContainsString('client_secret', $tester->getDisplay());
+        $this->assertSame(0, $tester->getStatusCode());
+    }
+
+    public function testCreateClientEnvFormat(): void
+    {
+        $application = $this->createApplication();
+
+        $command = $application->find('wallabag:api-client:create');
+
+        $tester = new CommandTester($command);
+        $tester->execute([
+            'username' => 'admin',
+            '--format' => 'env',
+        ]);
+
+        $this->assertStringContainsString('WALLABAG_CLIENT_ID="', $tester->getDisplay());
+        $this->assertStringContainsString('WALLABAG_CLIENT_SECRET="', $tester->getDisplay());
+        $this->assertSame(0, $tester->getStatusCode());
+    }
+
+    public function testCreateClientJsonFormat(): void
+    {
+        $application = $this->createApplication();
+
+        $command = $application->find('wallabag:api-client:create');
+
+        $tester = new CommandTester($command);
+        $tester->execute([
+            'username' => 'admin',
+            '--format' => 'json',
+        ]);
+
+        $decoded = json_decode($tester->getDisplay(), true);
+        $this->assertIsArray($decoded);
+        $this->assertArrayHasKey('client_id', $decoded);
+        $this->assertArrayHasKey('client_secret', $decoded);
+        $this->assertArrayHasKey('name', $decoded);
+        $this->assertSame(0, $tester->getStatusCode());
+    }
+
+    public function testCreateClientWithCustomDisplayName(): void
+    {
+        $application = $this->createApplication();
+
+        $command = $application->find('wallabag:api-client:create');
+
+        $tester = new CommandTester($command);
+        $tester->execute([
+            'username' => 'admin',
+            '--display-name' => 'my-custom-client',
+        ]);
+
+        $this->assertStringContainsString('my-custom-client', $tester->getDisplay());
+        $this->assertSame(0, $tester->getStatusCode());
+    }
+
+    public function testCreateClientWithCustomGrantTypes(): void
+    {
+        $application = $this->createApplication();
+
+        $command = $application->find('wallabag:api-client:create');
+
+        $tester = new CommandTester($command);
+        $tester->execute([
+            'username' => 'admin',
+            '--grant-types' => 'password,refresh_token',
+            '--format' => 'json',
+        ]);
+
+        $this->assertSame(0, $tester->getStatusCode());
+        $decoded = json_decode($tester->getDisplay(), true);
+        $this->assertIsArray($decoded);
+        $this->assertArrayHasKey('client_id', $decoded);
+    }
+
+    public function testInvalidFormat(): void
+    {
+        $application = $this->createApplication();
+
+        $command = $application->find('wallabag:api-client:create');
+
+        $tester = new CommandTester($command);
+        $tester->execute([
+            'username' => 'admin',
+            '--format' => 'xml',
+        ]);
+
+        $this->assertStringContainsString('Unknown format "xml"', $tester->getDisplay());
+        $this->assertSame(1, $tester->getStatusCode());
+    }
+
+    public function testInvalidGrantType(): void
+    {
+        $application = $this->createApplication();
+
+        $command = $application->find('wallabag:api-client:create');
+
+        $tester = new CommandTester($command);
+        $tester->execute([
+            'username' => 'admin',
+            '--grant-types' => 'password,client_credentials',
+        ]);
+
+        $this->assertStringContainsString('Invalid grant type(s)', $tester->getDisplay());
+        $this->assertStringContainsString('client_credentials', $tester->getDisplay());
+        $this->assertSame(1, $tester->getStatusCode());
+    }
+}


### PR DESCRIPTION
## What

Adds a `wallabag:api-client:create` console command to create an OAuth API client for an existing user, closing the gap identified in #8841.

```sh
# Human-readable output (default)
bin/console wallabag:api-client:create alice

# Machine-readable for CI / provisioning
bin/console wallabag:api-client:create alice --name="ansible-bootstrap" --format=env
# WALLABAG_CLIENT_ID=…
# WALLABAG_CLIENT_SECRET=…

bin/console wallabag:api-client:create alice --format=json
# {"client_id":"…","client_secret":"…","name":"…"}

# Restrict grant types
bin/console wallabag:api-client:create alice --grant-types=password --grant-types=refresh_token
```

Exit codes: `0` success, `1` user not found or invalid `--format`.

## Options

| Option | Default | Description |
|---|---|---|
| `--name` | `Default client` | Display name shown in `/developer` |
| `--grant-types` | all 4 (`token`, `authorization_code`, `password`, `refresh_token`) | Allowed grant types (repeatable) |
| `--format` | `text` | Output format: `text`, `env`, `json` |

## Why not a security risk

- No new HTTP surface — CLI only, same posture as `wallabag:user:create`.
- Uses the exact same `Client` entity and `setAllowedGrantTypes()` call as `DeveloperController::createClientAction` — no duplicate storage path.
- The secret is printed once to stdout; the operator is responsible for redirecting it (`> .creds`, `| vault write`, etc.).

## Testing

8 new integration tests covering: missing argument, unknown user, text/env/json formats, custom name, custom grant types, and invalid format.