### PR TITLE
Fix flaky MondeDiplo test

### DIFF
--- a/tests/functional/Controller/EntryControllerTest.php
+++ b/tests/functional/Controller/EntryControllerTest.php
@@ -1683,9 +1683,6 @@ class EntryControllerTest extends WallabagTestCase
         $this->assertSame($expectedLanguage, $content->getLanguage());
     }
 
-    /**
-     * @group NetworkCalls
-     */
     public function testRestrictedArticle(): void
     {
         $url = 'https://www.monde-diplomatique.fr/2017/05/BONNET/57476';
@@ -1706,6 +1703,21 @@ class EntryControllerTest extends WallabagTestCase
         $em->persist($credential);
         $em->flush();
 
+        $contentProxy = $this->getMockBuilder(ContentProxy::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['updateEntry'])
+            ->getMock();
+        $contentProxy->expects($this->once())
+            ->method('updateEntry')
+            ->with($this->callback(static function (Entry $entry) use ($url): bool {
+                return $url === $entry->getUrl();
+            }))
+            ->willReturnCallback(static function (Entry $entry): void {
+                $entry->setTitle('Quand Manille manœuvre');
+                $entry->setContent('<p>Article content.</p>');
+                $entry->setDomainName('monde-diplomatique.fr');
+            });
+
         $crawler = $client->request('GET', '/new');
 
         $this->assertSame(200, $client->getResponse()->getStatusCode());
@@ -1716,6 +1728,10 @@ class EntryControllerTest extends WallabagTestCase
             'entry[url]' => $url,
         ];
 
+        $cookie = $client->getCookieJar()->all();
+        $client = $this->getNewClient();
+        $client->getCookieJar()->set($cookie[0]);
+        $client->getContainer()->set(ContentProxy::class, $contentProxy);
         $client->submit($form, $data);
 
         $this->assertSame(302, $client->getResponse()->getStatusCode());

--- a/tests/unit/HttpClient/AuthenticatorTest.php
+++ b/tests/unit/HttpClient/AuthenticatorTest.php
@@ -9,6 +9,7 @@ use Symfony\Contracts\HttpClient\ResponseInterface;
 use Wallabag\HttpClient\Authenticator;
 use Wallabag\SiteConfig\ArraySiteConfigBuilder;
 use Wallabag\SiteConfig\LoginFormAuthenticator;
+use Wallabag\SiteConfig\SiteConfig;
 
 class AuthenticatorTest extends TestCase
 {
@@ -67,6 +68,39 @@ class AuthenticatorTest extends TestCase
 
         $this->assertCount(1, $records);
         $this->assertSame('loginIfRequired> user is not logged in, attach authenticator', $records[0]['message']);
+    }
+
+    public function testLoginIfRequiredLogsInWithResolvedSiteConfig(): void
+    {
+        $authenticator = $this->getMockBuilder(LoginFormAuthenticator::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $authenticator->expects($this->once())
+            ->method('isLoggedIn')
+            ->with($this->callback(static function (SiteConfig $siteConfig): bool {
+                return 'example.com' === $siteConfig->getHost()
+                    && 'http://example.com/login' === $siteConfig->getLoginUri();
+            }))
+            ->willReturn(false);
+
+        $authenticator->expects($this->once())
+            ->method('login')
+            ->with($this->callback(static function (SiteConfig $siteConfig): bool {
+                return 'example.com' === $siteConfig->getHost()
+                    && 'johndoe' === $siteConfig->getUsername()
+                    && 'unkn0wn' === $siteConfig->getPassword();
+            }));
+
+        $builder = new ArraySiteConfigBuilder(['example.com' => [
+            'requiresLogin' => true,
+            'loginUri' => 'http://example.com/login',
+            'username' => 'johndoe',
+            'password' => 'unkn0wn',
+        ]]);
+        $subscriber = new Authenticator($builder, $authenticator);
+
+        $this->assertTrue($subscriber->loginIfRequired('http://www.example.com/article'));
     }
 
     public function testLoginIfRequestedNotRequired(): void


### PR DESCRIPTION
Looks like when we fetch `monde-diplomatique.fr`, sometimes the request fails. When it fails, no title are extracted so we try to find a default title (`ContentProxy`->`setDefaultEntryTitle`) with became `57476` instead of `Quand Manille manœuvre`. See https://3v4l.org/tiUMt

To avoid that random error, we now mock the HTTP call to the website.
In addition, add a unit test login data are properly passed.