### PR TITLE
Add parameter `detail` to the entry endpoint

### DIFF
--- a/src/Controller/Api/EntryRestController.php
+++ b/src/Controller/Api/EntryRestController.php
@@ -394,6 +394,17 @@ class EntryRestController extends WallabagRestController
      *             pattern="\w+",
      *         )
      *     ),
+     *     @OA\Parameter(
+     *         name="detail",
+     *         in="query",
+     *         description="include content field if 'full'. 'full' by default for backward compatibility.",
+     *         required=false,
+     *         @OA\Schema(
+     *             type="string",
+     *             enum={"metadata", "full"},
+     *             default="full"
+     *         )
+     *     ),
      *     @OA\Response(
      *         response="200",
      *         description="Returned when successful"
@@ -404,8 +415,18 @@ class EntryRestController extends WallabagRestController
      */
     #[Route(path: '/api/entries/{entry}.{_format}', name: 'api_get_entry', methods: ['GET'], defaults: ['_format' => 'json'])]
     #[IsGranted('VIEW', subject: 'entry')]
-    public function getEntryAction(Entry $entry)
+    public function getEntryAction(Request $request, Entry $entry)
     {
+        $detail = strtolower($request->query->get('detail', 'full'));
+
+        if (!\in_array($detail, ['full', 'metadata'], true)) {
+            throw new BadRequestHttpException('Detail "' . $detail . '" parameter is wrong, allowed: full or metadata');
+        }
+
+        if ('metadata' === $detail) {
+            $entry->setContent(null);
+        }
+
         return $this->sendResponse($entry);
     }
 

--- a/src/Entity/Entry.php
+++ b/src/Entity/Entry.php
@@ -430,7 +430,7 @@ class Entry
     /**
      * Set content.
      *
-     * @param string $content
+     * @param string|null $content
      *
      * @return Entry
      */
@@ -444,7 +444,7 @@ class Entry
     /**
      * Get content.
      *
-     * @return string
+     * @return string|null
      */
     public function getContent()
     {

--- a/tests/functional/Controller/Api/EntryRestControllerTest.php
+++ b/tests/functional/Controller/Api/EntryRestControllerTest.php
@@ -32,8 +32,48 @@ class EntryRestControllerTest extends WallabagApiTestCase
         $this->assertSame($entry->getUserName(), $content['user_name']);
         $this->assertSame($entry->getUserEmail(), $content['user_email']);
         $this->assertSame($entry->getUserId(), $content['user_id']);
+        $this->assertNotNull($content['content']);
 
         $this->assertSame('application/json', $this->client->getResponse()->headers->get('Content-Type'));
+    }
+
+    public function testGetOneEntryDetailMetadata(): void
+    {
+        $entityManager = $this->client->getContainer()
+            ->get(EntityManagerInterface::class);
+        $entry = $entityManager
+            ->getRepository(Entry::class)
+            ->findOneBy(['user' => $this->getUserId(), 'isArchived' => false]);
+
+        if (!$entry) {
+            $this->markTestSkipped('No content found in db.');
+        }
+
+        $entryId = $entry->getId();
+        $entityManager->detach($entry);
+
+        $this->client->request('GET', '/api/entries/' . $entryId . '.json?detail=metadata');
+        $this->assertSame(200, $this->client->getResponse()->getStatusCode());
+
+        $content = json_decode($this->client->getResponse()->getContent(), true);
+
+        $this->assertNull($content['content']);
+        $this->assertSame('application/json', $this->client->getResponse()->headers->get('Content-Type'));
+    }
+
+    public function testGetOneEntryWrongDetail(): void
+    {
+        $entry = $this->client->getContainer()
+            ->get(EntityManagerInterface::class)
+            ->getRepository(Entry::class)
+            ->findOneBy(['user' => $this->getUserId(), 'isArchived' => false]);
+
+        if (!$entry) {
+            $this->markTestSkipped('No content found in db.');
+        }
+
+        $this->client->request('GET', '/api/entries/' . $entry->getId() . '.json?detail=bad');
+        $this->assertSame(400, $this->client->getResponse()->getStatusCode());
     }
 
     public function testGetOneEntryWithOriginUrl(): void


### PR DESCRIPTION
Like it was done for the listing, add the parameter `detail` to the entry endpoint.

Remove the `ParamConverter` in the API `getEntryAction` so that we can actually only fetch what the client request (instead of fetching the `content` and then remove it later).

Fix #8901