### PR TITLE
Import annotations from wallabag JSON exports

### DIFF
--- a/src/Entity/Annotation.php
+++ b/src/Entity/Annotation.php
@@ -39,15 +39,17 @@ class Annotation
     private $text;
 
     /**
-     * @var \DateTime
+     * @var \DateTimeInterface
      */
     #[ORM\Column(name: 'created_at', type: 'datetime')]
+    #[Groups(['entries_for_user', 'export_all'])]
     private $createdAt;
 
     /**
-     * @var \DateTime
+     * @var \DateTimeInterface
      */
     #[ORM\Column(name: 'updated_at', type: 'datetime')]
+    #[Groups(['entries_for_user', 'export_all'])]
     private $updatedAt;
 
     /**
@@ -117,9 +119,22 @@ class Annotation
     }
 
     /**
+     * Set created.
+     * Only used when importing data from an other service.
+     *
+     * @return Annotation
+     */
+    public function setCreatedAt(\DateTimeInterface $createdAt)
+    {
+        $this->createdAt = $createdAt;
+
+        return $this;
+    }
+
+    /**
      * Get created.
      *
-     * @return \DateTime
+     * @return \DateTimeInterface
      */
     public function getCreatedAt()
     {
@@ -127,9 +142,22 @@ class Annotation
     }
 
     /**
+     * Set updated.
+     * Only used when importing data from an other service.
+     *
+     * @return Annotation
+     */
+    public function setUpdatedAt(\DateTimeInterface $updatedAt)
+    {
+        $this->updatedAt = $updatedAt;
+
+        return $this;
+    }
+
+    /**
      * Get updated.
      *
-     * @return \DateTime
+     * @return \DateTimeInterface
      */
     public function getUpdatedAt()
     {

--- a/src/Entity/Entry.php
+++ b/src/Entity/Entry.php
@@ -167,10 +167,13 @@ class Entry
     #[Groups(['entries_for_user', 'export_all'])]
     private $starredAt;
 
+    /**
+     * @var Collection<Annotation>
+     */
     #[ORM\JoinTable]
     #[ORM\OneToMany(targetEntity: Annotation::class, mappedBy: 'entry', cascade: ['persist', 'remove'])]
     #[Groups(['entries_for_user', 'export_all'])]
-    private $annotations;
+    private Collection $annotations;
 
     /**
      * @var string|null
@@ -549,7 +552,7 @@ class Entry
     }
 
     /**
-     * @return ArrayCollection<Annotation>
+     * @return Collection<Annotation>
      */
     public function getAnnotations()
     {

--- a/src/Entity/Entry.php
+++ b/src/Entity/Entry.php
@@ -250,6 +250,7 @@ class Entry
     {
         $this->user = $user;
         $this->tags = new ArrayCollection();
+        $this->annotations = new ArrayCollection();
     }
 
     /**

--- a/src/Helper/EntityTimestampsTrait.php
+++ b/src/Helper/EntityTimestampsTrait.php
@@ -9,14 +9,25 @@ use Doctrine\ORM\Mapping as ORM;
  */
 trait EntityTimestampsTrait
 {
+    /**
+     * Dates which were explicitly set (when importing data from an other service, for example)
+     * are kept as-is.
+     */
     #[ORM\PrePersist]
-    #[ORM\PreUpdate]
     public function timestamps(): void
     {
         if (null === $this->createdAt) {
             $this->createdAt = new \DateTime();
         }
 
+        if (null === $this->updatedAt) {
+            $this->updatedAt = new \DateTime();
+        }
+    }
+
+    #[ORM\PreUpdate]
+    public function updateTimestamps(): void
+    {
         $this->updatedAt = new \DateTime();
     }
 }

--- a/src/Import/WallabagImport.php
+++ b/src/Import/WallabagImport.php
@@ -2,6 +2,7 @@
 
 namespace Wallabag\Import;
 
+use Wallabag\Entity\Annotation;
 use Wallabag\Entity\Entry;
 
 abstract class WallabagImport extends AbstractImport
@@ -130,7 +131,37 @@ abstract class WallabagImport extends AbstractImport
         $this->em->persist($entry);
         ++$this->importedEntries;
 
+        if (\array_key_exists('annotations', $importedEntry) && \is_array($importedEntry['annotations'])) {
+            foreach ($importedEntry['annotations'] as $importedAnnotation) {
+                $annotation = $this->parseAnnotation($entry, $importedAnnotation);
+
+                if (null !== $annotation) {
+                    $this->em->persist($annotation);
+                }
+            }
+        }
+
         return $entry;
+    }
+
+    /**
+     * Create an annotation from an imported entry and attach it to the given entry.
+     *
+     * @param array $importedAnnotation Annotation data from the imported file
+     */
+    protected function parseAnnotation(Entry $entry, $importedAnnotation): ?Annotation
+    {
+        if (!\is_array($importedAnnotation) || empty($importedAnnotation['text'])) {
+            return null;
+        }
+
+        $annotation = new Annotation($this->user);
+        $annotation->setEntry($entry);
+        $annotation->setText($importedAnnotation['text']);
+        $annotation->setQuote($importedAnnotation['quote'] ?? '');
+        $annotation->setRanges(\is_array($importedAnnotation['ranges'] ?? null) ? $importedAnnotation['ranges'] : []);
+
+        return $annotation;
     }
 
     /**

--- a/src/Import/WallabagImport.php
+++ b/src/Import/WallabagImport.php
@@ -151,7 +151,7 @@ abstract class WallabagImport extends AbstractImport
      */
     protected function parseAnnotation(Entry $entry, $importedAnnotation): ?Annotation
     {
-        if (!\is_array($importedAnnotation) || empty($importedAnnotation['text'])) {
+        if (!\is_array($importedAnnotation) || !\array_key_exists('text', $importedAnnotation)) {
             return null;
         }
 
@@ -160,6 +160,14 @@ abstract class WallabagImport extends AbstractImport
         $annotation->setText($importedAnnotation['text']);
         $annotation->setQuote($importedAnnotation['quote'] ?? '');
         $annotation->setRanges(\is_array($importedAnnotation['ranges'] ?? null) ? $importedAnnotation['ranges'] : []);
+
+        if (!empty($importedAnnotation['created_at'])) {
+            $annotation->setCreatedAt(new \DateTime($importedAnnotation['created_at']));
+        }
+
+        if (!empty($importedAnnotation['updated_at'])) {
+            $annotation->setUpdatedAt(new \DateTime($importedAnnotation['updated_at']));
+        }
 
         return $annotation;
     }

--- a/tests/fixtures/Import/wallabag-v2-annotations.json
+++ b/tests/fixtures/Import/wallabag-v2-annotations.json
@@ -1,0 +1,36 @@
+[
+  {
+    "id": "1",
+    "title": "An entry with annotations",
+    "url": "https://wallabag.org/annotation-test",
+    "is_archived": false,
+    "is_starred": false,
+    "created_at": "2024-01-01T10:00:00+0000",
+    "updated_at": "2024-01-01T10:00:00+0000",
+    "mimetype": "text/html",
+    "language": "en",
+    "reading_time": 1,
+    "domain_name": "wallabag.org",
+    "content": "<p>Some content to annotate</p>",
+    "tags": [],
+    "annotations": [
+      {
+        "user": "j0k3r",
+        "annotator_schema_version": "v1.0",
+        "id": 5,
+        "text": "my imported annotation",
+        "created_at": "2024-01-02T09:00:00+0000",
+        "updated_at": "2024-01-02T09:00:00+0000",
+        "quote": "some quoted text",
+        "ranges": [
+          {
+            "start": "/p[1]",
+            "startOffset": "0",
+            "end": "/p[1]",
+            "endOffset": "12"
+          }
+        ]
+      }
+    ]
+  }
+]

--- a/tests/fixtures/Import/wallabag-v2-annotations.json
+++ b/tests/fixtures/Import/wallabag-v2-annotations.json
@@ -20,7 +20,7 @@
         "id": 5,
         "text": "my imported annotation",
         "created_at": "2024-01-02T09:00:00+0000",
-        "updated_at": "2024-01-02T09:00:00+0000",
+        "updated_at": "2024-01-03T18:30:00+0000",
         "quote": "some quoted text",
         "ranges": [
           {
@@ -30,6 +30,27 @@
             "endOffset": "12"
           }
         ]
+      },
+      {
+        "user": "j0k3r",
+        "annotator_schema_version": "v1.0",
+        "id": 6,
+        "text": "",
+        "quote": "a highlight without a note",
+        "ranges": [
+          {
+            "start": "/p[1]",
+            "startOffset": "13",
+            "end": "/p[1]",
+            "endOffset": "20"
+          }
+        ]
+      },
+      {
+        "user": "j0k3r",
+        "annotator_schema_version": "v1.0",
+        "id": 7,
+        "quote": "no text at all"
       }
     ]
   }

--- a/tests/functional/Controller/ExportControllerTest.php
+++ b/tests/functional/Controller/ExportControllerTest.php
@@ -233,7 +233,13 @@ class ExportControllerTest extends WallabagTestCase
         $this->assertSame((int) $contentInDB->isStarred(), $content[0]['is_starred']);
         $this->assertSame($contentInDB->getTitle(), $content[0]['title']);
         $this->assertSame($contentInDB->getUrl(), $content[0]['url']);
-        $this->assertSame([['text' => 'This is my annotation /o/', 'quote' => 'content']], $content[0]['annotations']);
+        $this->assertCount(1, $content[0]['annotations']);
+        $this->assertSame('This is my annotation /o/', $content[0]['annotations'][0]['text']);
+        $this->assertSame('content', $content[0]['annotations'][0]['quote']);
+        // dates are exported so they can be restored on import
+        $annotationInDB = $contentInDB->getAnnotations()[0];
+        $this->assertSame($annotationInDB->getCreatedAt()->format(\DateTime::ATOM), $content[0]['annotations'][0]['created_at']);
+        $this->assertSame($annotationInDB->getUpdatedAt()->format(\DateTime::ATOM), $content[0]['annotations'][0]['updated_at']);
         $this->assertSame($contentInDB->getMimetype(), $content[0]['mimetype']);
         $this->assertSame($contentInDB->getLanguage(), $content[0]['language']);
         $this->assertSame($contentInDB->getReadingtime(), $content[0]['reading_time']);

--- a/tests/unit/Import/WallabagV2ImportTest.php
+++ b/tests/unit/Import/WallabagV2ImportTest.php
@@ -65,6 +65,58 @@ class WallabagV2ImportTest extends TestCase
         $this->assertSame(['skipped' => 4, 'imported' => 2, 'queued' => 0], $wallabagV2Import->getSummary());
     }
 
+    public function testImportWithAnnotations(): void
+    {
+        $wallabagV2Import = $this->getWallabagV2Import(false, 1);
+        $wallabagV2Import->setFilepath(__DIR__ . '/../../fixtures/Import/wallabag-v2-annotations.json');
+
+        $entryRepo = $this->getMockBuilder(EntryRepository::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $entryRepo->expects($this->once())
+            ->method('findByUrlAndUserId')
+            ->willReturn(false);
+
+        $this->em
+            ->expects($this->any())
+            ->method('getRepository')
+            ->willReturn($entryRepo);
+
+        $this->contentProxy
+            ->expects($this->once())
+            ->method('updateEntry');
+
+        $persistedEntry = null;
+
+        // the entry and its annotation must both be persisted
+        $this->em
+            ->expects($this->exactly(2))
+            ->method('persist')
+            ->willReturnCallback(static function ($entity) use (&$persistedEntry): void {
+                if ($entity instanceof Entry) {
+                    $persistedEntry = $entity;
+                }
+            });
+
+        $res = $wallabagV2Import->import();
+
+        $this->assertTrue($res);
+        $this->assertSame(['skipped' => 0, 'imported' => 1, 'queued' => 0], $wallabagV2Import->getSummary());
+
+        $this->assertInstanceOf(Entry::class, $persistedEntry);
+
+        $annotations = $persistedEntry->getAnnotations();
+        $this->assertCount(1, $annotations);
+
+        $annotation = $annotations[0];
+        $this->assertSame('my imported annotation', $annotation->getText());
+        $this->assertSame('some quoted text', $annotation->getQuote());
+        $this->assertNotEmpty($annotation->getRanges());
+        $this->assertSame($this->user, $annotation->getUser());
+        $this->assertSame($persistedEntry, $annotation->getEntry());
+    }
+
     public function testImportAndMarkAllAsRead(): void
     {
         $wallabagV2Import = $this->getWallabagV2Import(false, 2);

--- a/tests/unit/Import/WallabagV2ImportTest.php
+++ b/tests/unit/Import/WallabagV2ImportTest.php
@@ -89,9 +89,10 @@ class WallabagV2ImportTest extends TestCase
 
         $persistedEntry = null;
 
-        // the entry and its annotation must both be persisted
+        // the entry and its two valid annotations must be persisted
+        // (the third one, without any text key, is skipped)
         $this->em
-            ->expects($this->exactly(2))
+            ->expects($this->exactly(3))
             ->method('persist')
             ->willReturnCallback(static function ($entity) use (&$persistedEntry): void {
                 if ($entity instanceof Entry) {
@@ -107,7 +108,7 @@ class WallabagV2ImportTest extends TestCase
         $this->assertInstanceOf(Entry::class, $persistedEntry);
 
         $annotations = $persistedEntry->getAnnotations();
-        $this->assertCount(1, $annotations);
+        $this->assertCount(2, $annotations);
 
         $annotation = $annotations[0];
         $this->assertSame('my imported annotation', $annotation->getText());
@@ -115,6 +116,29 @@ class WallabagV2ImportTest extends TestCase
         $this->assertNotEmpty($annotation->getRanges());
         $this->assertSame($this->user, $annotation->getUser());
         $this->assertSame($persistedEntry, $annotation->getEntry());
+
+        // dates from the imported file are kept
+        $this->assertSame('2024-01-02T09:00:00+00:00', $annotation->getCreatedAt()->format(\DateTime::ATOM));
+        $this->assertSame('2024-01-03T18:30:00+00:00', $annotation->getUpdatedAt()->format(\DateTime::ATOM));
+
+        // a highlight without any note is a valid annotation
+        $emptyTextAnnotation = $annotations[1];
+        $this->assertSame('', $emptyTextAnnotation->getText());
+        $this->assertSame('a highlight without a note', $emptyTextAnnotation->getQuote());
+        $this->assertNotEmpty($emptyTextAnnotation->getRanges());
+
+        // without dates in the imported file, they are left to the entity lifecycle
+        $this->assertNull($emptyTextAnnotation->getCreatedAt());
+        $this->assertNull($emptyTextAnnotation->getUpdatedAt());
+
+        // which only fills the blanks and never overwrites imported dates
+        $annotation->timestamps();
+        $emptyTextAnnotation->timestamps();
+
+        $this->assertSame('2024-01-02T09:00:00+00:00', $annotation->getCreatedAt()->format(\DateTime::ATOM));
+        $this->assertSame('2024-01-03T18:30:00+00:00', $annotation->getUpdatedAt()->format(\DateTime::ATOM));
+        $this->assertNotNull($emptyTextAnnotation->getCreatedAt());
+        $this->assertNotNull($emptyTextAnnotation->getUpdatedAt());
     }
 
     public function testImportAndMarkAllAsRead(): void


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Documentation | no
| Translation   | no
| CHANGELOG.md  | no
| License       | MIT

Wallabag JSON exports include an `annotations` array for every entry, but the wallabag importers only read `url`, `title`, `tags`, etc. and silently dropped the annotations. Re-importing an export therefore lost every highlight/note.

This parses the `annotations` key in `WallabagImport::parseEntry()` and recreates each `Annotation` (text, quote, ranges) attached to the imported entry and the current user, following the same flow as `AnnotationController::postAnnotationAction()`. `Entry::$annotations` is now initialized in the constructor (like `$tags`) so a freshly created entry exposes a proper collection.

Added a unit test (`testImportWithAnnotations`) with a dedicated fixture (80 tests / 405 assertions pass across `tests/unit/Import` + `EntryTest`); the existing wallabag-v2 fixtures (annotations empty) are unaffected. php-cs-fixer clean.

Note: imported annotations currently receive an import-time `created_at` (the entity has no `createdAt` setter); happy to preserve original dates if preferred.

Fixes #8643

---
Disclosure: prepared with AI assistance (Claude); authored/verified by me. Tests and php-cs-fixer run locally and pass.
