### PR TITLE
chore: remove historic internet explorer icon quirk

### DIFF
--- a/templates/base.html.twig
+++ b/templates/base.html.twig
@@ -30,7 +30,7 @@
             <link rel="apple-touch-icon" type="image/png" href="{{ asset('img/appicon/apple-touch-icon.png') }}">
             <link rel="icon" type="image/png" href="{{ asset('img/appicon/apple-touch-icon.png') }}">
 
-            <link rel="shortcut icon" type="image/x-icon" href="{{ asset('favicon.ico') }}">
+            <link rel="icon" type="image/x-icon" href="{{ asset('favicon.ico') }}">
 
             <link rel="manifest" href="{{ asset('manifest.json') }}">
 


### PR DESCRIPTION
HTML5 use "icon". "shortcut" was used by historic internet explorer. https://html.spec.whatwg.org/#rel-icon

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Documentation | no
| Translation   | no
| CHANGELOG.md  | no
| License       | MIT

<!--
Please list the issues your PR fixes using special keywords, see
https://help.github.com/articles/closing-issues-using-keywords/

Fixes #…
-->
Reference #6964
<!--
- Please fill in this template according to the PR you're about to submit.
- Replace this comment by a description of what your PR is solving.
-->
