### PR TITLE
Align config and used indent space for `package.json`

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -13,6 +13,10 @@ insert_final_newline = true
 indent_style = space
 indent_size = 2
 
+[package.json]
+indent_style = space
+indent_size = 2
+
 [*akefile]
 indent_style = tab
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Documentation | no
| Translation   | no
| CHANGELOG.md  | no
| License       | MIT

## Changes

Align config and used indent space for `package.json`: 2 spaces are used.

## Reference

fixes #8944

<!--
- Please fill in this template according to the PR you're about to submit.
- Replace this comment by a description of what your PR is solving.
-->
