### PR TITLE
Update gitattributes for LF and binaries

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -5,3 +5,12 @@
 /phpstan.neon export-ignore
 /phpunit.xml.dist export-ignore
 /tests export-ignore
+
+# According to .editorconfig
+* text eol=lf
+
+# mark binaries to avoid corruption
+*.png binary
+*.jpg binary
+*.jpeg binary
+*.gif binary


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Documentation | no
| Translation   | no
| CHANGELOG.md  | no
| License       | MIT

## Change

Align repository line endings with `.editorconfig` by enforcing `eol=lf` for text files, and mark common image formats as binary to prevent unintended conversion or corruption.

## Reference

fixes #8946

<!--
- Please fill in this template according to the PR you're about to submit.
- Replace this comment by a description of what your PR is solving.
-->
