### PR TITLE
Make the article reporting URL configurable

### DIFF
--- a/.env
+++ b/.env
@@ -15,6 +15,7 @@ WALLABAG_USER_AGENT="Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/535.2 (KHTM
 WALLABAG_OAUTH_ACCESS_TOKEN_LIFETIME=3600
 WALLABAG_OAUTH_REFRESH_TOKEN_LIFETIME=1209600
 WALLABAG_TABLE_PREFIX=wallabag_
+WALLABAG_ARTICLE_REPORTING_URL=
 # Default: SQLite — no server required
 DATABASE_URL=sqlite:///%kernel.project_dir%/data/db/wallabag.sqlite
 # MariaDB / MySQL

--- a/.env.test
+++ b/.env.test
@@ -15,6 +15,7 @@ WALLABAG_USER_AGENT="Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/535.2 (KHTM
 WALLABAG_OAUTH_ACCESS_TOKEN_LIFETIME=3600
 WALLABAG_OAUTH_REFRESH_TOKEN_LIFETIME=1209600
 WALLABAG_TABLE_PREFIX=wallabag_
+WALLABAG_ARTICLE_REPORTING_URL=
 # Default: SQLite — no server required
 DATABASE_URL=sqlite:///%kernel.project_dir%/data/db/wallabag_test.sqlite
 # MariaDB / MySQL

--- a/app/AppKernel.php
+++ b/app/AppKernel.php
@@ -34,6 +34,7 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Kernel;
 use Symfony\WebpackEncoreBundle\WebpackEncoreBundle;
 use Twig\Extra\TwigExtraBundle\TwigExtraBundle;
+use Wallabag\DependencyInjection\Compiler\ArticleReportingUrlPass;
 use Wallabag\Import\ImportCompilerPass;
 
 class AppKernel extends Kernel
@@ -125,6 +126,7 @@ class AppKernel extends Kernel
     protected function build(ContainerBuilder $container): void
     {
         $container->addCompilerPass(new ImportCompilerPass());
+        $container->addCompilerPass(new ArticleReportingUrlPass());
     }
 
     private function triggerLegacyParametersDeprecationIfNeeded(): void

--- a/app/config/services.yml
+++ b/app/config/services.yml
@@ -18,6 +18,7 @@ services:
             $debug: '%kernel.debug%'
             $environment: '%kernel.environment%'
             $defaultLocale: '%env(DEFAULT_LOCALE)%'
+            $articleReportingUrl: '%wallabag.article_reporting_url%'
             $wallabagUrl: '%env(WALLABAG_BASE_URL)%'
             $tablePrefix: '%env(WALLABAG_TABLE_PREFIX)%'
             $encryptionKeyPath: "%wallabag.site_credentials.encryption_key_path%"

--- a/app/config/wallabag.yml
+++ b/app/config/wallabag.yml
@@ -1,4 +1,6 @@
 parameters:
+    env(WALLABAG_ARTICLE_REPORTING_URL): ''
+    wallabag.article_reporting_url: '%env(WALLABAG_ARTICLE_REPORTING_URL)%'
     wallabag.version: 2.7.0-dev
     wallabag.paypal_url: "https://liberapay.com/wallabag/donate"
     wallabag.languages:

--- a/doc/content/admin/parameters.md
+++ b/doc/content/admin/parameters.md
@@ -53,6 +53,7 @@ After changing configuration in production, clear the cache with
 | WALLABAG_OAUTH_REFRESH_TOKEN_LIFETIME | OAuth refresh-token lifetime in seconds | `1209600` |
 | WALLABAG_TABLE_PREFIX | Prefix added to wallabag database tables | `wallabag_` |
 | WALLABAG_SITE_CONFIG_FOLDERS | Optional comma-separated list of extra graby site-config folders | empty |
+| WALLABAG_ARTICLE_REPORTING_URL | Destination used to report display problems with an article | `mailto:siteconfig@wallabag.org?subject=Wrong%20display%20in%20wallabag` |
 | SENTRY_DSN | Optional Sentry DSN used to report application errors | empty |
 
 ## Service variables
@@ -64,6 +65,25 @@ After changing configuration in production, clear the cache with
 | REDIS_URL | Redis connection string used by the async import worker | `redis://127.0.0.1:6379` |
 | RABBITMQ_URL | RabbitMQ connection string used by the async import worker | `amqp://guest:guest@127.0.0.1:5672` |
 | WALLABAG_RABBITMQ_PREFETCH_COUNT | RabbitMQ consumer prefetch value | `10` |
+
+## Article problem-reporting destination
+
+`WALLABAG_ARTICLE_REPORTING_URL` accepts an absolute `https:` URL or a
+`mailto:` URI with one recipient. An unset or empty value uses the default
+address shown above. Invalid values stop the Symfony container from compiling.
+
+Query names and values in the configured URL must use RFC 3986 percent
+encoding. wallabag preserves configured query parameters, including a custom
+`subject`, but always replaces `body` with the URL of the article being
+reported. Fragments are preserved.
+
+```dotenv
+WALLABAG_ARTICLE_REPORTING_URL="https://support.example.com/issues/new?template=article"
+WALLABAG_ARTICLE_REPORTING_URL="mailto:support@example.com?subject=Article%20display%20problem"
+```
+
+Because the value is validated and stored while building the container, clear
+the application cache after changing it.
 
 ## Legacy mapping for upgraded installs
 

--- a/src/DependencyInjection/Compiler/ArticleReportingUrlPass.php
+++ b/src/DependencyInjection/Compiler/ArticleReportingUrlPass.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Wallabag\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+class ArticleReportingUrlPass implements CompilerPassInterface
+{
+    private const DEFAULT_REPORTING_URL = 'mailto:siteconfig@wallabag.org?subject=Wrong%20display%20in%20wallabag';
+    private const INVALID_REPORTING_URL_MESSAGE = 'WALLABAG_ARTICLE_REPORTING_URL must be an absolute HTTPS URL or a mailto URI with one valid recipient.';
+
+    public function process(ContainerBuilder $container): void
+    {
+        $reportingUrl = $container->getParameterBag()->unescapeValue(
+            $container->resolveEnvPlaceholders(
+                $container->getParameter('wallabag.article_reporting_url'),
+                true
+            )
+        );
+
+        if ('' === $reportingUrl) {
+            $reportingUrl = self::DEFAULT_REPORTING_URL;
+        }
+
+        $scheme = strtolower((string) parse_url($reportingUrl, \PHP_URL_SCHEME));
+        $isValid = false;
+
+        if ('https' === $scheme) {
+            $isValid = false !== filter_var($reportingUrl, \FILTER_VALIDATE_URL)
+                && '' !== (string) parse_url($reportingUrl, \PHP_URL_HOST);
+        } elseif ('mailto' === $scheme) {
+            $recipient = parse_url($reportingUrl, \PHP_URL_PATH);
+            $isValid = false !== filter_var($reportingUrl, \FILTER_VALIDATE_URL)
+                && \is_string($recipient)
+                && false !== filter_var(rawurldecode($recipient), \FILTER_VALIDATE_EMAIL);
+        }
+
+        if (!$isValid) {
+            throw new \InvalidArgumentException(self::INVALID_REPORTING_URL_MESSAGE);
+        }
+
+        $container->setParameter(
+            'wallabag.article_reporting_url',
+            $container->getParameterBag()->escapeValue($reportingUrl)
+        );
+    }
+}

--- a/src/Twig/WallabagExtension.php
+++ b/src/Twig/WallabagExtension.php
@@ -2,12 +2,15 @@
 
 namespace Wallabag\Twig;
 
+use GuzzleHttp\Psr7\Query;
+use GuzzleHttp\Psr7\Uri;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
 use Twig\Extension\AbstractExtension;
 use Twig\Extension\GlobalsInterface;
 use Twig\TwigFilter;
 use Twig\TwigFunction;
+use Wallabag\Entity\Entry;
 use Wallabag\Entity\User;
 use Wallabag\Repository\AnnotationRepository;
 use Wallabag\Repository\EntryRepository;
@@ -23,6 +26,7 @@ class WallabagExtension extends AbstractExtension implements GlobalsInterface
         private $lifeTime,
         private readonly TranslatorInterface $translator,
         private readonly string $projectDir,
+        private readonly string $articleReportingUrl,
     ) {
     }
 
@@ -48,7 +52,17 @@ class WallabagExtension extends AbstractExtension implements GlobalsInterface
             new TwigFunction('display_stats', $this->displayStats(...)),
             new TwigFunction('asset_file_exists', $this->assetFileExists(...)),
             new TwigFunction('theme_class', $this->themeClass(...)),
+            new TwigFunction('generate_article_reporting_url', $this->generateArticleReportingUrl(...)),
         ];
+    }
+
+    public function generateArticleReportingUrl(Entry $entry): string
+    {
+        $uri = new Uri($this->articleReportingUrl);
+        $query = Query::parse($uri->getQuery(), \PHP_QUERY_RFC3986);
+        $query['body'] = $entry->getUrl();
+
+        return (string) $uri->withQuery(Query::build($query, \PHP_QUERY_RFC3986));
     }
 
     public function removeWww($url)

--- a/templates/Entry/entry.html.twig
+++ b/templates/Entry/entry.html.twig
@@ -282,7 +282,7 @@
         {% endif %}
 
         <li class="bold">
-            <a class="waves-effect collapsible-header" href="mailto:siteconfig@wallabag.org?subject=Wrong%20display%20in%20wallabag&amp;body={{ entry.url|url_encode }}" title="{{ 'entry.view.left_menu.problem.description'|trans }}">
+            <a class="waves-effect collapsible-header" href="{{ generate_article_reporting_url(entry) }}" title="{{ 'entry.view.left_menu.problem.description'|trans }}">
                 <i class="material-icons small">error</i>
                 <span>{{ 'entry.view.left_menu.problem.label'|trans }}</span>
             </a>

--- a/tests/functional/Controller/EntryControllerTest.php
+++ b/tests/functional/Controller/EntryControllerTest.php
@@ -513,7 +513,7 @@ class EntryControllerTest extends WallabagTestCase
         $client = $this->getTestClient();
 
         $entry = new Entry($this->getLoggedInUser());
-        $entry->setUrl('http://example.com/foo');
+        $entry->setUrl('http://example.com/foo?bar=baz&qux=quux');
         $entry->setTitle('title foo');
         $entry->setContent('foo bar baz');
         $this->getEntityManager()->persist($entry);
@@ -524,6 +524,17 @@ class EntryControllerTest extends WallabagTestCase
         $this->assertSame(200, $client->getResponse()->getStatusCode());
         $this->assertGreaterThan(1, $body = $crawler->filter('body')->extract(['_text']));
         $this->assertStringContainsString($entry->getTitle(), $body[0]);
+
+        $reportingLink = $crawler->filter('a[href^="mailto:siteconfig@wallabag.org"]');
+        $this->assertCount(1, $reportingLink);
+        $this->assertSame(
+            'mailto:siteconfig@wallabag.org?subject=Wrong%20display%20in%20wallabag&body=http%3A%2F%2Fexample.com%2Ffoo%3Fbar%3Dbaz%26qux%3Dquux',
+            $reportingLink->attr('href')
+        );
+        $this->assertStringContainsString(
+            'href="mailto:siteconfig@wallabag.org?subject=Wrong%20display%20in%20wallabag&amp;body=http%3A%2F%2Fexample.com%2Ffoo%3Fbar%3Dbaz%26qux%3Dquux"',
+            $client->getResponse()->getContent()
+        );
     }
 
     /**

--- a/tests/unit/DependencyInjection/Compiler/ArticleReportingUrlPassTest.php
+++ b/tests/unit/DependencyInjection/Compiler/ArticleReportingUrlPassTest.php
@@ -1,0 +1,123 @@
+<?php
+
+namespace Wallabag\Tests\Unit\DependencyInjection\Compiler;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Wallabag\DependencyInjection\Compiler\ArticleReportingUrlPass;
+
+class ArticleReportingUrlPassTest extends TestCase
+{
+    private const ENV_NAME = 'WALLABAG_ARTICLE_REPORTING_URL';
+    private const DEFAULT_REPORTING_URL = 'mailto:siteconfig@wallabag.org?subject=Wrong%20display%20in%20wallabag';
+
+    private bool $hadEnvValue;
+    private bool $hadServerValue;
+    private ?string $envValue = null;
+    private ?string $serverValue = null;
+    private string|false $processEnvValue;
+
+    protected function setUp(): void
+    {
+        $this->hadEnvValue = \array_key_exists(self::ENV_NAME, $_ENV);
+        $this->hadServerValue = \array_key_exists(self::ENV_NAME, $_SERVER);
+        $this->envValue = $_ENV[self::ENV_NAME] ?? null;
+        $this->serverValue = $_SERVER[self::ENV_NAME] ?? null;
+        $this->processEnvValue = getenv(self::ENV_NAME);
+    }
+
+    protected function tearDown(): void
+    {
+        if ($this->hadEnvValue) {
+            $_ENV[self::ENV_NAME] = $this->envValue;
+        } else {
+            unset($_ENV[self::ENV_NAME]);
+        }
+
+        if ($this->hadServerValue) {
+            $_SERVER[self::ENV_NAME] = $this->serverValue;
+        } else {
+            unset($_SERVER[self::ENV_NAME]);
+        }
+
+        if (false === $this->processEnvValue) {
+            putenv(self::ENV_NAME);
+        } else {
+            putenv(self::ENV_NAME . '=' . $this->processEnvValue);
+        }
+    }
+
+    /**
+     * @dataProvider validArticleReportingUrlProvider
+     */
+    public function testProcessResolvesArticleReportingUrl(?string $configuredUrl, string $expectedUrl): void
+    {
+        $container = $this->createContainer($configuredUrl);
+
+        (new ArticleReportingUrlPass())->process($container);
+
+        $reportingUrl = $container->getParameter('wallabag.article_reporting_url');
+
+        $this->assertIsString($reportingUrl);
+        $this->assertStringNotContainsString('env_', $reportingUrl);
+        $this->assertSame($expectedUrl, $container->getParameterBag()->unescapeValue($reportingUrl));
+    }
+
+    public function validArticleReportingUrlProvider(): iterable
+    {
+        yield 'unset value uses the default' => [null, self::DEFAULT_REPORTING_URL];
+        yield 'empty value uses the default' => ['', self::DEFAULT_REPORTING_URL];
+        yield 'HTTPS URL' => ['https://support.example.com/issues/new', 'https://support.example.com/issues/new'];
+        yield 'HTTPS URL with query and fragment' => [
+            'https://support.example.com/issues/new?template=article#report',
+            'https://support.example.com/issues/new?template=article#report',
+        ];
+        yield 'mailto URI' => ['mailto:support@example.com', 'mailto:support@example.com'];
+        yield 'mailto URI with query' => [
+            'mailto:support@example.com?subject=Article%20problem',
+            'mailto:support@example.com?subject=Article%20problem',
+        ];
+    }
+
+    /**
+     * @dataProvider invalidArticleReportingUrlProvider
+     */
+    public function testProcessRejectsInvalidArticleReportingUrl(string $configuredUrl): void
+    {
+        $container = $this->createContainer($configuredUrl);
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('WALLABAG_ARTICLE_REPORTING_URL must be an absolute HTTPS URL or a mailto URI with one valid recipient.');
+
+        (new ArticleReportingUrlPass())->process($container);
+    }
+
+    public function invalidArticleReportingUrlProvider(): iterable
+    {
+        yield 'whitespace' => [' '];
+        yield 'relative URL' => ['/issues/new'];
+        yield 'HTTP URL' => ['http://support.example.com/issues/new'];
+        yield 'unsupported scheme' => ['javascript:alert(1)'];
+        yield 'malformed HTTPS URL' => ['https://'];
+        yield 'mailto without recipient' => ['mailto:'];
+        yield 'mailto with invalid recipient' => ['mailto:not-an-email'];
+    }
+
+    private function createContainer(?string $configuredUrl): ContainerBuilder
+    {
+        if (null === $configuredUrl) {
+            unset($_ENV[self::ENV_NAME], $_SERVER[self::ENV_NAME]);
+            putenv(self::ENV_NAME);
+        } else {
+            $_ENV[self::ENV_NAME] = $configuredUrl;
+            $_SERVER[self::ENV_NAME] = $configuredUrl;
+            putenv(self::ENV_NAME . '=' . $configuredUrl);
+        }
+
+        $container = new ContainerBuilder();
+        $container->setParameter('env(WALLABAG_ARTICLE_REPORTING_URL)', '');
+        $container->setParameter('wallabag.article_reporting_url', '%env(WALLABAG_ARTICLE_REPORTING_URL)%');
+
+        return $container;
+    }
+}

--- a/tests/unit/Twig/WallabagExtensionTest.php
+++ b/tests/unit/Twig/WallabagExtensionTest.php
@@ -5,6 +5,9 @@ namespace Wallabag\Tests\Unit\Twig;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
+use Twig\TwigFunction;
+use Wallabag\Entity\Entry;
+use Wallabag\Entity\User;
 use Wallabag\Repository\AnnotationRepository;
 use Wallabag\Repository\EntryRepository;
 use Wallabag\Repository\TagRepository;
@@ -44,7 +47,47 @@ class WallabagExtensionTest extends TestCase
         $this->assertSame('ftp://gist.github.com', $extension->removeSchemeAndWww('ftp://gist.github.com'));
     }
 
-    private function createExtension(): WallabagExtension
+    public function testGenerateArticleReportingUrlFunctionIsRegistered(): void
+    {
+        $functionNames = array_map(
+            static fn (TwigFunction $function): string => $function->getName(),
+            $this->createExtension()->getFunctions()
+        );
+
+        $this->assertContains('generate_article_reporting_url', $functionNames);
+    }
+
+    /**
+     * @dataProvider articleReportingUrlProvider
+     */
+    public function testGenerateArticleReportingUrl(string $reportingUrl, string $expectedUrl): void
+    {
+        $entry = new Entry(new User());
+        $entry->setUrl('https://example.com/article?id=1&lang=en');
+
+        $this->assertSame(
+            $expectedUrl,
+            $this->createExtension($reportingUrl)->generateArticleReportingUrl($entry)
+        );
+    }
+
+    public function articleReportingUrlProvider(): iterable
+    {
+        yield 'default mailto URL' => [
+            'mailto:siteconfig@wallabag.org?subject=Wrong%20display%20in%20wallabag',
+            'mailto:siteconfig@wallabag.org?subject=Wrong%20display%20in%20wallabag&body=https%3A%2F%2Fexample.com%2Farticle%3Fid%3D1%26lang%3Den',
+        ];
+        yield 'custom mailto subject' => [
+            'mailto:support@example.com?subject=Custom%20subject&priority=high',
+            'mailto:support@example.com?subject=Custom%20subject&priority=high&body=https%3A%2F%2Fexample.com%2Farticle%3Fid%3D1%26lang%3Den',
+        ];
+        yield 'HTTPS URL replaces body and preserves fragment' => [
+            'https://support.example.com/issues/new?template=article&subject=Custom%20subject&body=old#report',
+            'https://support.example.com/issues/new?template=article&subject=Custom%20subject&body=https%3A%2F%2Fexample.com%2Farticle%3Fid%3D1%26lang%3Den#report',
+        ];
+    }
+
+    private function createExtension(string $articleReportingUrl = 'mailto:support@example.com'): WallabagExtension
     {
         $entryRepository = $this->getMockBuilder(EntryRepository::class)
             ->disableOriginalConstructor()
@@ -66,6 +109,6 @@ class WallabagExtensionTest extends TestCase
             ->disableOriginalConstructor()
             ->getMock();
 
-        return new WallabagExtension($entryRepository, $annotationRepository, $tagRepository, $tokenStorage, 0, $translator, '');
+        return new WallabagExtension($entryRepository, $annotationRepository, $tagRepository, $tokenStorage, 0, $translator, '', $articleReportingUrl);
     }
 }

--- a/tests/unit/Twig/WallabagExtensionTest.php
+++ b/tests/unit/Twig/WallabagExtensionTest.php
@@ -14,27 +14,7 @@ class WallabagExtensionTest extends TestCase
 {
     public function testRemoveWww(): void
     {
-        $entryRepository = $this->getMockBuilder(EntryRepository::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-
-        $annotationRepository = $this->getMockBuilder(AnnotationRepository::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-
-        $tagRepository = $this->getMockBuilder(TagRepository::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-
-        $tokenStorage = $this->getMockBuilder(TokenStorageInterface::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-
-        $translator = $this->getMockBuilder(TranslatorInterface::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-
-        $extension = new WallabagExtension($entryRepository, $annotationRepository, $tagRepository, $tokenStorage, 0, $translator, '');
+        $extension = $this->createExtension();
 
         $this->assertSame('lemonde.fr', $extension->removeWww('www.lemonde.fr'));
         $this->assertSame('lemonde.fr', $extension->removeWww('lemonde.fr'));
@@ -43,27 +23,7 @@ class WallabagExtensionTest extends TestCase
 
     public function testRemoveScheme(): void
     {
-        $entryRepository = $this->getMockBuilder(EntryRepository::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-
-        $annotationRepository = $this->getMockBuilder(AnnotationRepository::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-
-        $tagRepository = $this->getMockBuilder(TagRepository::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-
-        $tokenStorage = $this->getMockBuilder(TokenStorageInterface::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-
-        $translator = $this->getMockBuilder(TranslatorInterface::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-
-        $extension = new WallabagExtension($entryRepository, $annotationRepository, $tagRepository, $tokenStorage, 0, $translator, '');
+        $extension = $this->createExtension();
 
         $this->assertSame('lemonde.fr', $extension->removeScheme('lemonde.fr'));
         $this->assertSame('gist.github.com', $extension->removeScheme('gist.github.com'));
@@ -73,6 +33,19 @@ class WallabagExtensionTest extends TestCase
 
     public function testRemoveSchemeAndWww(): void
     {
+        $extension = $this->createExtension();
+
+        $this->assertSame('lemonde.fr', $extension->removeSchemeAndWww('www.lemonde.fr'));
+        $this->assertSame('lemonde.fr', $extension->removeSchemeAndWww('http://www.lemonde.fr'));
+        $this->assertSame('lemonde.fr', $extension->removeSchemeAndWww('http://lemonde.fr'));
+        $this->assertSame('lemonde.fr', $extension->removeSchemeAndWww('https://www.lemonde.fr'));
+        $this->assertSame('lemonde.fr', $extension->removeSchemeAndWww('https://lemonde.fr'));
+        $this->assertSame('gist.github.com', $extension->removeSchemeAndWww('https://gist.github.com'));
+        $this->assertSame('ftp://gist.github.com', $extension->removeSchemeAndWww('ftp://gist.github.com'));
+    }
+
+    private function createExtension(): WallabagExtension
+    {
         $entryRepository = $this->getMockBuilder(EntryRepository::class)
             ->disableOriginalConstructor()
             ->getMock();
@@ -93,14 +66,6 @@ class WallabagExtensionTest extends TestCase
             ->disableOriginalConstructor()
             ->getMock();
 
-        $extension = new WallabagExtension($entryRepository, $annotationRepository, $tagRepository, $tokenStorage, 0, $translator, '');
-
-        $this->assertSame('lemonde.fr', $extension->removeSchemeAndWww('www.lemonde.fr'));
-        $this->assertSame('lemonde.fr', $extension->removeSchemeAndWww('http://www.lemonde.fr'));
-        $this->assertSame('lemonde.fr', $extension->removeSchemeAndWww('http://lemonde.fr'));
-        $this->assertSame('lemonde.fr', $extension->removeSchemeAndWww('https://www.lemonde.fr'));
-        $this->assertSame('lemonde.fr', $extension->removeSchemeAndWww('https://lemonde.fr'));
-        $this->assertSame('gist.github.com', $extension->removeSchemeAndWww('https://gist.github.com'));
-        $this->assertSame('ftp://gist.github.com', $extension->removeSchemeAndWww('ftp://gist.github.com'));
+        return new WallabagExtension($entryRepository, $annotationRepository, $tagRepository, $tokenStorage, 0, $translator, '');
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Documentation | yes
| Translation   | no
| CHANGELOG.md  | no
| License       | MIT

Fixes #8905

Make the article problem-reporting destination configurable through `WALLABAG_ARTICLE_REPORTING_URL` while preserving the existing mailto destination as the default.

- Validate and materialize HTTPS or single-recipient mailto destinations during Symfony container compilation.
- Generate entry-aware reporting links while preserving configured query parameters, including `subject`, and replacing only `body`.
- Expose `generate_article_reporting_url(entry)` in Twig and document the operator-facing configuration contract.

This pull request is easiest to review one commit at a time.
