### PR TITLE
Escape dynamic data in the ePub export

### DIFF
--- a/src/Wallabag/CoreBundle/Helper/EntriesExport.php
+++ b/src/Wallabag/CoreBundle/Helper/EntriesExport.php
@@ -157,7 +157,7 @@ class EntriesExport
          * Book metadata
          */
 
-        $book->setTitle($this->title);
+        $book->setTitle($this->escapeXml($this->title));
         // EPub specification requires BCP47-compliant languages, thus we replace _ with -
         $book->setLanguage(str_replace('_', '-', $this->language));
         $book->setDescription('Some articles saved on my wallabag');
@@ -168,7 +168,7 @@ class EntriesExport
         $book->setPublisher('wallabag', 'wallabag');
         // Strictly not needed as the book date defaults to time().
         $book->setDate(time());
-        $book->setSourceURL($this->wallabagUrl);
+        $book->setSourceURL($this->escapeXml($this->wallabagUrl));
 
         $book->addDublinCoreMetadata(DublinCore::CONTRIBUTOR, 'PHP');
         $book->addDublinCoreMetadata(DublinCore::CONTRIBUTOR, 'wallabag');
@@ -213,20 +213,20 @@ class EntriesExport
             $readingTime = $entry->getUserReadingTime();
 
             $titlepage = $content_start .
-                '<h1>' . $entry->getTitle() . '</h1>' .
+                '<h1>' . $this->escapeXml($entry->getTitle()) . '</h1>' .
                 '<dl>' .
-                '<dt>' . $this->translator->trans('entry.view.published_by') . '</dt><dd>' . $authors . '</dd>' .
-                '<dt>' . $this->translator->trans('entry.metadata.published_on') . '</dt><dd>' . $publishedDate . '</dd>' .
-                '<dt>' . $this->translator->trans('entry.metadata.reading_time') . '</dt><dd>' . $this->translator->trans('entry.metadata.reading_time_minutes_short', ['%readingTime%' => $readingTime]) . '</dd>' .
-                '<dt>' . $this->translator->trans('entry.metadata.added_on') . '</dt><dd>' . $entry->getCreatedAt()->format('Y-m-d') . '</dd>' .
-                '<dt>' . $this->translator->trans('entry.metadata.address') . '</dt><dd><a href="' . $entry->getUrl() . '">' . $entry->getUrl() . '</a></dd>' .
+                '<dt>' . $this->escapeXml($this->translator->trans('entry.view.published_by')) . '</dt><dd>' . $this->escapeXml($authors) . '</dd>' .
+                '<dt>' . $this->escapeXml($this->translator->trans('entry.metadata.published_on')) . '</dt><dd>' . $publishedDate . '</dd>' .
+                '<dt>' . $this->escapeXml($this->translator->trans('entry.metadata.reading_time')) . '</dt><dd>' . $this->escapeXml($this->translator->trans('entry.metadata.reading_time_minutes_short', ['%readingTime%' => $readingTime])) . '</dd>' .
+                '<dt>' . $this->escapeXml($this->translator->trans('entry.metadata.added_on')) . '</dt><dd>' . $entry->getCreatedAt()->format('Y-m-d') . '</dd>' .
+                '<dt>' . $this->escapeXml($this->translator->trans('entry.metadata.address')) . '</dt><dd><a href="' . $this->escapeXml($entry->getUrl()) . '">' . $this->escapeXml($entry->getUrl()) . '</a></dd>' .
                 '</dl>' .
                 $bookEnd;
             $book->addChapter("Entry {$i} of {$entryCount}", "{$filename}_cover.html", $titlepage, true, EPub::EXTERNAL_REF_ADD);
             $chapter = $content_start . $entry->getContent() . $bookEnd;
 
             $entryIds[] = $entry->getId();
-            $book->addChapter($entry->getTitle(), "{$filename}.html", $chapter, true, EPub::EXTERNAL_REF_ADD);
+            $book->addChapter($this->escapeXml($entry->getTitle()), "{$filename}.html", $chapter, true, EPub::EXTERNAL_REF_ADD);
         }
 
         $book->addChapter('Notices', 'Cover2.html', $content_start . $this->getExportInformation('PHPePub') . $bookEnd);
@@ -245,6 +245,11 @@ class EntriesExport
                 'Content-Transfer-Encoding' => 'binary',
             ]
         );
+    }
+
+    private function escapeXml($value)
+    {
+        return htmlspecialchars($value ?? '', \ENT_XML1 | \ENT_COMPAT, 'UTF-8', false);
     }
 
     /**

--- a/tests/Wallabag/CoreBundle/Controller/ExportControllerTest.php
+++ b/tests/Wallabag/CoreBundle/Controller/ExportControllerTest.php
@@ -5,6 +5,8 @@ namespace Tests\Wallabag\CoreBundle\Controller;
 use Doctrine\ORM\EntityManagerInterface;
 use Tests\Wallabag\CoreBundle\WallabagCoreTestCase;
 use Wallabag\CoreBundle\Entity\Entry;
+use Wallabag\CoreBundle\Helper\EntriesExport;
+use Wallabag\UserBundle\Entity\User;
 
 class ExportControllerTest extends WallabagCoreTestCase
 {
@@ -100,6 +102,60 @@ class ExportControllerTest extends WallabagCoreTestCase
         $this->assertSame('application/epub+zip', $headers->get('content-type'));
         $this->assertSame('attachment; filename="Archive articles.epub"', $headers->get('content-disposition'));
         $this->assertSame('binary', $headers->get('content-transfer-encoding'));
+    }
+
+    public function testEpubExportEscapesXmlSpecialCharacters()
+    {
+        $this->logInAs('admin');
+        $client = $this->getTestClient();
+        $em = $client->getContainer()->get(EntityManagerInterface::class);
+        $user = $em->getRepository(User::class)->findOneByUserName('admin');
+
+        $entry = new Entry($user);
+        $entry->setUrl('http://example.com/article?foo=bar&baz=qux');
+        $entry->setTitle('D&D <test> article');
+        $entry->setContent('<p>valid content</p>');
+        $entry->setLanguage('en');
+        $entry->setDomainName('example.com');
+        $entry->setMimetype('text/html');
+        $entry->setCreatedAt(new \DateTimeImmutable());
+        $em->persist($entry);
+        $em->flush();
+
+        $response = $client->getContainer()
+            ->get(EntriesExport::class)
+            ->setEntries($entry)
+            ->updateTitle('entry')
+            ->updateAuthor('entry')
+            ->exportAs('epub');
+
+        $this->assertSame(200, $response->getStatusCode());
+
+        $epubFilename = tempnam(sys_get_temp_dir(), 'wallabag-epub-');
+        file_put_contents($epubFilename, $response->getContent());
+
+        $zip = new \ZipArchive();
+        $this->assertTrue($zip->open($epubFilename));
+
+        $opf = $zip->getFromName('OEBPS/book.opf');
+        $this->assertIsString($opf);
+        $this->assertXmlStringEqualsXmlString($opf, $opf);
+        $this->assertStringContainsString('D&amp;D &lt;test&gt; article', $opf);
+
+        $cover = $zip->getFromName('OEBPS/' . sha1($entry->getUrl() . ':' . $entry->getTitle()) . '_cover.html');
+        $this->assertIsString($cover);
+        $this->assertXmlStringEqualsXmlString($cover, $cover);
+        $this->assertStringContainsString('href="http://example.com/article?foo=bar&amp;baz=qux"', $cover);
+
+        $epub3Toc = $zip->getFromName('OEBPS/epub3toc.xhtml');
+        $this->assertIsString($epub3Toc);
+        $this->assertXmlStringEqualsXmlString($epub3Toc, $epub3Toc);
+
+        $zip->close();
+        unlink($epubFilename);
+
+        $em->remove($entry);
+        $em->flush();
     }
 
     public function testMobiExport()


### PR DESCRIPTION
To avoid having bad surprise.

I started to escape only title & url but the content can also have `&` or `<` and then break the html as well.

Fix https://github.com/wallabag/wallabag/issues/8940