### PR TITLE
Avoid empty array to be saved in `published_by` field

### DIFF
--- a/src/Wallabag/ApiBundle/Controller/EntryRestController.php
+++ b/src/Wallabag/ApiBundle/Controller/EntryRestController.php
@@ -1406,7 +1406,7 @@ class EntryRestController extends WallabagRestController
             'language' => $request->request->get('language'),
             'picture' => $request->request->get('preview_picture'),
             'publishedAt' => $request->request->get('published_at'),
-            'authors' => $request->request->get('authors', ''),
+            'authors' => $request->request->get('authors', []),
             'origin_url' => $request->request->get('origin_url', ''),
         ];
     }

--- a/src/Wallabag/ApiBundle/Controller/EntryRestController.php
+++ b/src/Wallabag/ApiBundle/Controller/EntryRestController.php
@@ -1406,7 +1406,7 @@ class EntryRestController extends WallabagRestController
             'language' => $request->request->get('language'),
             'picture' => $request->request->get('preview_picture'),
             'publishedAt' => $request->request->get('published_at'),
-            'authors' => $request->request->get('authors', []),
+            'authors' => $request->request->get('authors'),
             'origin_url' => $request->request->get('origin_url', ''),
         ];
     }

--- a/src/Wallabag/CoreBundle/Entity/Entry.php
+++ b/src/Wallabag/CoreBundle/Entity/Entry.php
@@ -908,7 +908,7 @@ class Entry
     }
 
     /**
-     * @return array
+     * @return array|null
      */
     public function getPublishedBy()
     {
@@ -916,13 +916,23 @@ class Entry
     }
 
     /**
-     * @param array $publishedBy
+     * @param array|null $publishedBy
      *
      * @return Entry
      */
     public function setPublishedBy($publishedBy)
     {
-        $this->publishedBy = $publishedBy;
+        if (\is_array($publishedBy)) {
+            $publishedBy = array_values(array_filter(
+                array_map(
+                    static fn ($author) => is_scalar($author) ? trim((string) $author) : '',
+                    $publishedBy
+                ),
+                static fn ($author) => '' !== $author
+            ));
+        }
+
+        $this->publishedBy = empty($publishedBy) ? null : $publishedBy;
 
         return $this;
     }

--- a/tests/Wallabag/CoreBundle/Entity/EntryTest.php
+++ b/tests/Wallabag/CoreBundle/Entity/EntryTest.php
@@ -25,4 +25,24 @@ class EntryTest extends WallabagCoreTestCase
             $this->assertSame($lang, $entry->getHTMLLanguage());
         }
     }
+
+    public function testSetPublishedByFiltersEmptyAuthors()
+    {
+        $this->logInAs('admin');
+        $entry = new Entry($this->getLoggedInUser());
+
+        $entry->setPublishedBy(['', ' bob ', '  ', 'helen']);
+
+        $this->assertSame(['bob', 'helen'], $entry->getPublishedBy());
+    }
+
+    public function testSetPublishedByStoresNullWhenOnlyEmptyAuthorsAreProvided()
+    {
+        $this->logInAs('admin');
+        $entry = new Entry($this->getLoggedInUser());
+
+        $entry->setPublishedBy(['', '  ']);
+
+        $this->assertNull($entry->getPublishedBy());
+    }
 }


### PR DESCRIPTION
Looks like a kind of empty `authors` given from the API can lead to an array of an empty value to be saved in the database. Also, the default value for the `authors` field in the API can generate that problem too.

Fix https://github.com/wallabag/wallabag/issues/8935