### PR TITLE
Replace JavaScript-only action links with semantic controls

### DIFF
--- a/assets/controllers/materialize/collapsible_controller.js
+++ b/assets/controllers/materialize/collapsible_controller.js
@@ -8,6 +8,13 @@ export default class extends Controller {
 
   connect() {
     this.instance = M.Collapsible.init(this.element, { accordion: this.accordionValue });
+    this.buttonHeaders = [...this.element.querySelectorAll('button.collapsible-header')];
+    // eslint-disable-next-line dot-notation
+    const keydownHandler = this.instance['_handleCollapsibleKeydownBound'];
+
+    this.buttonHeaders.forEach((header) => {
+      header.removeEventListener('keydown', keydownHandler);
+    });
   }
 
   disconnect() {

--- a/assets/scss/_dark_theme.scss
+++ b/assets/scss/_dark_theme.scss
@@ -59,6 +59,7 @@
   #article article h5,
   #article article h6,
   .dropdown-content li > a,
+  .dropdown-content li > button,
   .input-field input,
   .input-field input:focus,
   .results-item,

--- a/assets/scss/_dark_theme.scss
+++ b/assets/scss/_dark_theme.scss
@@ -80,6 +80,7 @@
   .grey-text.text-darken-4,
   .nav-panel-item .add,
   .nav-panel-item .search,
+  .nav-panels .sidenav-trigger,
   .nav-panels .close {
     color: #dfdfdf !important;
   }

--- a/assets/scss/_nav.scss
+++ b/assets/scss/_nav.scss
@@ -78,6 +78,7 @@ nav {
 
 .nav-panel-item .add,
 .nav-panel-item .search,
+.nav-panels .sidenav-trigger,
 .nav-panels .close {
   color: #444 !important;
 }

--- a/assets/scss/_nav.scss
+++ b/assets/scss/_nav.scss
@@ -161,8 +161,11 @@ nav {
   }
 }
 
-.nav-form-button,
-.nav-panel-item .close {
+.nav-panel-item .nav-panel-close {
+  padding: 0;
+}
+
+.nav-form-button {
   margin: 0 1%;
 }
 

--- a/assets/scss/_nav.scss
+++ b/assets/scss/_nav.scss
@@ -1,6 +1,8 @@
 /* ==========================================================================
    Nav
    ========================================================================== */
+@use "variables";
+
 nav {
   height: auto;
   line-height: initial;
@@ -182,11 +184,28 @@ nav {
     padding-right: 15px;
   }
 
-  li > a {
+  li > a,
+  li > button {
     display: flex;
     padding: 14px 10px;
     align-items: center;
+    width: 100%;
+    text-align: left;
     white-space: initial;
+  }
+
+  li > button {
+    color: variables.$blue-accent-color;
+    font-size: 16px;
+    line-height: 22px;
+
+    > i {
+      flex: 0 0 24px;
+      height: inherit;
+      line-height: inherit;
+      margin: 0 24px 0 0;
+      width: 24px;
+    }
   }
 }
 

--- a/assets/scss/_sidenav.scss
+++ b/assets/scss/_sidenav.scss
@@ -45,6 +45,8 @@
 
 // adapted from anchor styles from node_modules/@materializecss/materialize/sass/components/_sidenav.scss
 .sidenav li button {
+  background: none;
+  border: 0;
   color: rgba(0 0 0 / 87%);
   display: block;
   font-size: 14px;

--- a/assets/scss/_various.scss
+++ b/assets/scss/_various.scss
@@ -51,3 +51,8 @@ nav .input-field input {
     background: none;
   }
 }
+
+.config-help {
+  font: inherit;
+  line-height: inherit;
+}

--- a/templates/Config/index.html.twig
+++ b/templates/Config/index.html.twig
@@ -129,9 +129,9 @@
                                     }
                                 }) }}
                                 <div class="input-field col s1">
-                                    <a href="#" data-controller="materialize--tooltip" data-materialize--tooltip-position-value="left" data-materialize--tooltip-enter-delay-value="50" data-tooltip="{{ 'config.form_settings.help_font'|trans }}">
+                                    <button type="button" class="btn-link config-help" data-controller="materialize--tooltip" data-materialize--tooltip-position-value="left" data-materialize--tooltip-enter-delay-value="50" data-tooltip="{{ 'config.form_settings.help_font'|trans }}">
                                         <i class="material-icons">live_help</i>
-                                    </a>
+                                    </button>
                                 </div>
 
                                 <div class="input-field range-field col s5" data-controller="materialize--range">
@@ -140,9 +140,9 @@
                                     {{ form_label(form.config.lineHeight, null, {'label_attr': {'class': 'settings-range-label'}}) }}
                                 </div>
                                 <div class="input-field col s1">
-                                    <a href="#" data-controller="materialize--tooltip" data-materialize--tooltip-position-value="left" data-materialize--tooltip-enter-delay-value="50" data-tooltip="{{ 'config.form_settings.help_lineheight'|trans }}">
+                                    <button type="button" class="btn-link config-help" data-controller="materialize--tooltip" data-materialize--tooltip-position-value="left" data-materialize--tooltip-enter-delay-value="50" data-tooltip="{{ 'config.form_settings.help_lineheight'|trans }}">
                                         <i class="material-icons">live_help</i>
-                                    </a>
+                                    </button>
                                 </div>
                             </div>
 
@@ -153,9 +153,9 @@
                                     {{ form_label(form.config.fontsize, null, {'label_attr': {'class': 'settings-range-label'}}) }}
                                 </div>
                                 <div class="input-field col s1">
-                                    <a href="#" data-controller="materialize--tooltip" data-materialize--tooltip-position-value="left" data-materialize--tooltip-enter-delay-value="50" data-tooltip="{{ 'config.form_settings.help_fontsize'|trans }}">
+                                    <button type="button" class="btn-link config-help" data-controller="materialize--tooltip" data-materialize--tooltip-position-value="left" data-materialize--tooltip-enter-delay-value="50" data-tooltip="{{ 'config.form_settings.help_fontsize'|trans }}">
                                         <i class="material-icons">live_help</i>
-                                    </a>
+                                    </button>
                                 </div>
 
                                 <div class="input-field range-field col s5" data-controller="materialize--range">
@@ -164,9 +164,9 @@
                                     {{ form_label(form.config.maxWidth, null, {'label_attr': {'class': 'settings-range-label'}}) }}
                                 </div>
                                 <div class="input-field col s1">
-                                    <a href="#" data-controller="materialize--tooltip" data-materialize--tooltip-position-value="left" data-materialize--tooltip-enter-delay-value="50" data-tooltip="{{ 'config.form_settings.help_maxwidth'|trans }}">
+                                    <button type="button" class="btn-link config-help" data-controller="materialize--tooltip" data-materialize--tooltip-position-value="left" data-materialize--tooltip-enter-delay-value="50" data-tooltip="{{ 'config.form_settings.help_maxwidth'|trans }}">
                                         <i class="material-icons">live_help</i>
-                                    </a>
+                                    </button>
                                 </div>
                             </div>
 

--- a/templates/Config/index.html.twig
+++ b/templates/Config/index.html.twig
@@ -32,9 +32,9 @@
                                 {{ form_label(form.config.items_per_page) }}
                             </div>
                             <div class="input-field col s1">
-                                <a href="#" data-controller="materialize--tooltip" data-materialize--tooltip-position-value="left" data-materialize--tooltip-enter-delay-value="50" data-tooltip="{{ 'config.form_settings.help_items_per_page'|trans }}">
+                                <button type="button" class="btn-link config-help" data-controller="materialize--tooltip" data-materialize--tooltip-position-value="left" data-materialize--tooltip-enter-delay-value="50" data-tooltip="{{ 'config.form_settings.help_items_per_page'|trans }}">
                                     <i class="material-icons">live_help</i>
-                                </a>
+                                </button>
                             </div>
                         </div>
 
@@ -47,9 +47,9 @@
                                 </label>
                             </div>
                             <div class="input-field col s1">
-                                <a href="#" data-controller="materialize--tooltip" data-materialize--tooltip-position-value="left" data-materialize--tooltip-enter-delay-value="50" data-tooltip="{{ 'config.form_settings.help_display_thumbnails'|trans }}">
+                                <button type="button" class="btn-link config-help" data-controller="materialize--tooltip" data-materialize--tooltip-position-value="left" data-materialize--tooltip-enter-delay-value="50" data-tooltip="{{ 'config.form_settings.help_display_thumbnails'|trans }}">
                                     <i class="material-icons">live_help</i>
-                                </a>
+                                </button>
                             </div>
                         </div>
 
@@ -64,9 +64,9 @@
                                     </p>
                                 </div>
                                 <div class="input-field col s1">
-                                    <a href="#" data-controller="materialize--tooltip" data-materialize--tooltip-position-value="left" data-materialize--tooltip-enter-delay-value="50" data-tooltip="{{ 'config.form_settings.help_reading_speed'|trans }}">
+                                    <button type="button" class="btn-link config-help" data-controller="materialize--tooltip" data-materialize--tooltip-position-value="left" data-materialize--tooltip-enter-delay-value="50" data-tooltip="{{ 'config.form_settings.help_reading_speed'|trans }}">
                                         <i class="material-icons">live_help</i>
-                                    </a>
+                                    </button>
                                 </div>
                             </div>
 
@@ -85,9 +85,9 @@
                                     }
                                 }) }}
                                 <div class="input-field col s1">
-                                    <a href="#" data-controller="materialize--tooltip" data-materialize--tooltip-position-value="left" data-materialize--tooltip-enter-delay-value="50" data-tooltip="{{ 'config.form_settings.help_language'|trans }}">
+                                    <button type="button" class="btn-link config-help" data-controller="materialize--tooltip" data-materialize--tooltip-position-value="left" data-materialize--tooltip-enter-delay-value="50" data-tooltip="{{ 'config.form_settings.help_language'|trans }}">
                                         <i class="material-icons">live_help</i>
-                                    </a>
+                                    </button>
                                 </div>
                             </div>
 
@@ -102,9 +102,9 @@
                                     </p>
                                 </div>
                                 <div class="input-field col s1">
-                                    <a href="#" data-controller="materialize--tooltip" data-materialize--tooltip-position-value="left" data-materialize--tooltip-enter-delay-value="50" data-tooltip="{{ 'config.form_settings.help_pocket_consumer_key'|trans }}">
+                                    <button type="button" class="btn-link config-help" data-controller="materialize--tooltip" data-materialize--tooltip-position-value="left" data-materialize--tooltip-enter-delay-value="50" data-tooltip="{{ 'config.form_settings.help_pocket_consumer_key'|trans }}">
                                         <i class="material-icons">live_help</i>
-                                    </a>
+                                    </button>
                                 </div>
                             </div>
 

--- a/templates/Entry/entries.html.twig
+++ b/templates/Entry/entries.html.twig
@@ -31,16 +31,16 @@
     {% endif %}
     {% if has_filters %}
         <li class="button-filters">
-            <a class="sidenav-trigger" data-controller="materialize--tooltip" data-materialize--tooltip-position-value="bottom" data-materialize--tooltip-enter-delay-value="50" data-tooltip="{{ 'menu.top.filter_entries'|trans }}" href="#" data-target="filters">
+            <button type="button" class="sidenav-trigger" data-controller="materialize--tooltip" data-materialize--tooltip-position-value="bottom" data-materialize--tooltip-enter-delay-value="50" data-tooltip="{{ 'menu.top.filter_entries'|trans }}" data-target="filters">
                 <i class="material-icons">filter_list</i>
-            </a>
+            </button>
         </li>
     {% endif %}
     {% if has_exports %}
         <li class="button-export">
-            <a class="sidenav-trigger" data-controller="materialize--tooltip" data-materialize--tooltip-position-value="bottom" data-materialize--tooltip-enter-delay-value="50" data-tooltip="{{ 'menu.top.export'|trans }}" href="#" data-target="export">
+            <button type="button" class="sidenav-trigger" data-controller="materialize--tooltip" data-materialize--tooltip-position-value="bottom" data-materialize--tooltip-enter-delay-value="50" data-tooltip="{{ 'menu.top.export'|trans }}" data-target="export">
                 <i class="material-icons">file_download</i>
-            </a>
+            </button>
         </li>
     {% endif %}
 {% endblock %}

--- a/templates/Entry/entry.html.twig
+++ b/templates/Entry/entry.html.twig
@@ -129,10 +129,10 @@
         {% endif %}
 
         <li class="bold border-bottom">
-            <a class="waves-effect collapsible-header" id="nav-btn-add-tag" data-action="click->materialize--sidenav#close click->leftbar#toggleAddTagForm">
+            <button type="button" class="waves-effect collapsible-header" id="nav-btn-add-tag" data-action="click->materialize--sidenav#close click->leftbar#toggleAddTagForm">
                 <i class="material-icons small">label_outline</i>
                 <span>{{ 'entry.view.left_menu.add_a_tag'|trans }}</span>
-            </a>
+            </button>
             <div class="collapsible-body"></div>
         </li>
 

--- a/templates/Entry/entry.html.twig
+++ b/templates/Entry/entry.html.twig
@@ -14,9 +14,9 @@
         <div class="nav-panel-item cyan darken-1">
             <ul>
                 <li>
-                    <a href="#" data-target="slide-out" class="sidenav-trigger">
+                    <button type="button" data-target="slide-out" class="sidenav-trigger">
                         <i class="material-icons">menu</i>
-                    </a>
+                    </button>
                 </li>
                 <li>
                     <a class="waves-effect" href="{{ path('homepage') }}">

--- a/templates/Entry/entry.html.twig
+++ b/templates/Entry/entry.html.twig
@@ -143,22 +143,22 @@
             </a>
             <ul class="collapsible-body">
                 <li>
-                    <a href="#" data-action="click->dark-theme#useLight:prevent">
+                    <button type="button" data-action="click->dark-theme#useLight">
                         <i class="theme-toggle-icon material-icons tiny">brightness_high</i>
                         <span>{{ 'entry.view.left_menu.theme_toggle_light'|trans }}</span>
-                    </a>
+                    </button>
                 </li>
                 <li>
-                    <a href="#" data-action="click->dark-theme#useDark:prevent">
+                    <button type="button" data-action="click->dark-theme#useDark">
                         <i class="theme-toggle-icon material-icons tiny">brightness_low</i>
                         <span>{{ 'entry.view.left_menu.theme_toggle_dark'|trans }}</span>
-                    </a>
+                    </button>
                 </li>
                 <li>
-                    <a href="#" data-action="click->dark-theme#useAuto:prevent">
+                    <button type="button" data-action="click->dark-theme#useAuto">
                         <i class="theme-toggle-icon material-icons tiny">brightness_auto</i>
                         <span>{{ 'entry.view.left_menu.theme_toggle_auto'|trans }}</span>
-                    </a>
+                    </button>
                 </li>
             </ul>
         </li>

--- a/templates/Entry/entry.html.twig
+++ b/templates/Entry/entry.html.twig
@@ -244,10 +244,10 @@
 
         {% if craue_setting('show_printlink') %}
         <li class="bold border-bottom hide-on-med-and-down">
-            <a class="waves-effect collapsible-header" title="{{ 'entry.view.left_menu.print'|trans }}" href="javascript: window.print();">
+            <button type="button" class="waves-effect collapsible-header" title="{{ 'entry.view.left_menu.print'|trans }}" onclick="window.print();">
                 <i class="material-icons small">print</i>
                 <span>{{ 'entry.view.left_menu.print'|trans }}</span>
-            </a>
+            </button>
             <div class="collapsible-body"></div>
         </li>
         {% endif %}
@@ -263,10 +263,10 @@
 
         {% if is_granted('EXPORT', entry) %}
             <li class="bold">
-                <a class="waves-effect collapsible-header">
+                <button type="button" class="waves-effect collapsible-header">
                     <i class="material-icons small">file_download</i>
                     <span>{{ 'entry.view.left_menu.export'|trans }}</span>
-                </a>
+                </button>
                 <div class="collapsible-body">
                     <ul>
                         {% if craue_setting('export_epub') %}<li><a href="{{ path('export_entry', {entry: entry.id, 'format': 'epub'}) }}" title="Generate ePub file">EPUB</a></li>{% endif %}

--- a/templates/Entry/entry.html.twig
+++ b/templates/Entry/entry.html.twig
@@ -137,10 +137,10 @@
         </li>
 
         <li class="bold">
-            <a class="waves-effect collapsible-header">
+            <button type="button" class="waves-effect collapsible-header">
                 <i class="material-icons small">brightness_medium</i>
                 <span>{{ 'entry.view.left_menu.theme_toggle'|trans }}</span>
-            </a>
+            </button>
             <ul class="collapsible-body">
                 <li>
                     <button type="button" data-action="click->dark-theme#useLight">
@@ -164,10 +164,10 @@
         </li>
         {% if craue_setting('share_public') or craue_setting('share_twitter') or craue_setting('share_shaarli') or craue_setting('share_diaspora') or craue_setting('share_unmark') or craue_setting('share_linkding') or craue_setting('share_mail') %}
         <li class="bold">
-            <a class="waves-effect collapsible-header">
+            <button type="button" class="waves-effect collapsible-header">
                 <i class="material-icons small">share</i>
                 <span>{{ 'entry.view.left_menu.share_content'|trans }}</span>
-            </a>
+            </button>
             <div class="collapsible-body">
                 <ul>
                     {% if craue_setting('share_public') %}
@@ -371,9 +371,9 @@
         </article>
 
         <div class="fixed-action-btn hide-on-large-only" data-controller="materialize--fab" data-action="scroll@window->materialize--fab#autoDisplay click->materialize--fab#click">
-            <a class="btn-floating btn-large" data-toggle="actions">
+            <button type="button" class="btn-floating btn-large" data-toggle="actions">
               <i class="material-icons">menu</i>
-            </a>
+            </button>
             <ul>
                 {% if is_granted('ARCHIVE', entry) %}
                     <li>

--- a/templates/Entry/new_form.html.twig
+++ b/templates/Entry/new_form.html.twig
@@ -9,7 +9,7 @@
     {% endif %}
 
     {{ form_widget(form.url, {'attr': {'autocomplete': 'off', 'placeholder': 'entry.new.placeholder', 'data-topbar-target': 'addUrlInput'}}) }}
-    <i class="material-icons close" aria-label="clear" role="button" data-action="click->topbar#showActions" data-shortcuts-target="showActions"></i>
+    <button type="button" class="nav-form-button nav-panel-close" aria-label="clear" data-action="click->topbar#showActions" data-shortcuts-target="showActions"><i class="material-icons close"></i></button>
 
     {{ form_rest(form) }}
 </form>

--- a/templates/Entry/search_form.html.twig
+++ b/templates/Entry/search_form.html.twig
@@ -11,7 +11,7 @@
     <input type="hidden" name="currentRoute" value="{{ currentRoute }}" />
 
     {{ form_widget(form.term, {'attr': {'autocomplete': 'off', 'placeholder': 'entry.search.placeholder', 'data-topbar-target': 'searchInput'}}) }}
-    <i class="material-icons close" aria-label="clear" role="button" data-action="click->topbar#showActions" data-shortcuts-target="showActions"></i>
+    <button type="button" class="nav-form-button nav-panel-close" aria-label="clear" data-action="click->topbar#showActions" data-shortcuts-target="showActions"><i class="material-icons close"></i></button>
 
     {{ form_rest(form) }}
 </form>

--- a/templates/layout.html.twig
+++ b/templates/layout.html.twig
@@ -134,22 +134,22 @@
                         <li class="divider"></li>
                     {% endif %}
                     <li>
-                        <a href="#" data-action="click->dark-theme#useLight:prevent">
+                        <button type="button" data-action="click->dark-theme#useLight">
                             <i class="theme-toggle-icon material-icons tiny">brightness_high</i>
                             <span>{{ 'menu.left.theme_toggle_light'|trans }}</span>
-                        </a>
+                        </button>
                     </li>
                     <li>
-                        <a href="#" data-action="click->dark-theme#useDark:prevent">
+                        <button type="button" data-action="click->dark-theme#useDark">
                             <i class="theme-toggle-icon material-icons tiny">brightness_low</i>
                             <span>{{ 'menu.left.theme_toggle_dark'|trans }}</span>
-                        </a>
+                        </button>
                     </li>
                     <li>
-                        <a href="#" data-action="click->dark-theme#useAuto:prevent">
+                        <button type="button" data-action="click->dark-theme#useAuto">
                             <i class="theme-toggle-icon material-icons tiny">brightness_auto</i>
                             <span>{{ 'menu.left.theme_toggle_auto'|trans }}</span>
-                        </a>
+                        </button>
                     </li>
                     <li class="divider"></li>
                     <li><a href="{{ path('howto') }}"><i class="material-icons">live_help</i> {{ 'menu.left.howto'|trans }}</a></li>

--- a/templates/layout.html.twig
+++ b/templates/layout.html.twig
@@ -101,9 +101,9 @@
                     </li>
                     {% block nav_panel_extra_actions '' %}
                     <li class="bold">
-                        <a class="waves-effect dropdown-trigger" data-controller="materialize--dropdown materialize--tooltip" data-target="dropdown-account" data-materialize--tooltip-position-value="bottom" data-materialize--tooltip-enter-delay-value="50" data-tooltip="{{ 'menu.top.account'|trans }}" href="#" id="news_menu">
+                        <button type="button" class="waves-effect dropdown-trigger" data-controller="materialize--dropdown materialize--tooltip" data-target="dropdown-account" data-materialize--tooltip-position-value="bottom" data-materialize--tooltip-enter-delay-value="50" data-tooltip="{{ 'menu.top.account'|trans }}" id="news_menu">
                             <i class="material-icons" id="news_link">account_circle</i>
-                        </a>
+                        </button>
                     </li>
                 </ul>
                 <ul id="dropdown-account" class="dropdown-content">

--- a/templates/layout.html.twig
+++ b/templates/layout.html.twig
@@ -95,9 +95,9 @@
                         </a>
                     </li>
                     <li>
-                        <a class="waves-effect" data-controller="materialize--tooltip" data-materialize--tooltip-position-value="bottom" data-materialize--tooltip-enter-delay-value="50" data-tooltip="{{ 'menu.top.search'|trans }}" href="javascript: void(null);" data-action="topbar#showSearch:prevent:stop" data-shortcuts-target="showSearch">
+                        <button type="button" class="waves-effect" data-controller="materialize--tooltip" data-materialize--tooltip-position-value="bottom" data-materialize--tooltip-enter-delay-value="50" data-tooltip="{{ 'menu.top.search'|trans }}" data-action="topbar#showSearch:stop" data-shortcuts-target="showSearch">
                             <i class="material-icons">search</i>
-                        </a>
+                        </button>
                     </li>
                     {% block nav_panel_extra_actions '' %}
                     <li class="bold">

--- a/templates/layout.html.twig
+++ b/templates/layout.html.twig
@@ -82,7 +82,7 @@
         <div class="nav-panels" data-controller="topbar">
             <div class="nav-panel-item" data-topbar-target="actions">
                 <div class="nav-panel-top">
-                    <a href="#" data-target="slide-out" class="sidenav-trigger"><i class="material-icons">menu</i></a>
+                    <button type="button" data-target="slide-out" class="sidenav-trigger"><i class="material-icons">menu</i></button>
                     <h1 class="left action">
                         {% block title %}
                         {% endblock %}

--- a/tests/unit/Twig/JavaScriptOnlyLinkTest.php
+++ b/tests/unit/Twig/JavaScriptOnlyLinkTest.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Wallabag\Tests\Unit\Twig;
+
+use PHPUnit\Framework\TestCase;
+
+class JavaScriptOnlyLinkTest extends TestCase
+{
+    /**
+     * @dataProvider anchors
+     */
+    public function testTwigAnchorsHaveHref(string $path, string $anchor): void
+    {
+        self::assertMatchesRegularExpression(
+            '/\\bhref\\s*=/i',
+            $anchor,
+            \sprintf('Anchor without href in %s: %s', $path, $anchor)
+        );
+    }
+
+    public function anchors(): iterable
+    {
+        $projectDirectory = \dirname(__DIR__, 3);
+        $templates = new \RecursiveIteratorIterator(
+            new \RecursiveDirectoryIterator($projectDirectory . '/templates', \FilesystemIterator::SKIP_DOTS)
+        );
+
+        foreach ($templates as $template) {
+            if (!$template->isFile() || 'twig' !== $template->getExtension()) {
+                continue;
+            }
+
+            $path = $template->getPathname();
+            $contents = file_get_contents($path);
+
+            if (false === $contents) {
+                self::fail(\sprintf('Unable to read %s.', $path));
+            }
+
+            preg_match_all('/<a\\b[^>]*>/is', $contents, $matches);
+
+            foreach ($matches[0] as $index => $anchor) {
+                yield \sprintf('%s:%d', $path, $index + 1) => [$path, $anchor];
+            }
+        }
+    }
+}

--- a/tests/unit/Twig/JavaScriptOnlyLinkTest.php
+++ b/tests/unit/Twig/JavaScriptOnlyLinkTest.php
@@ -6,6 +6,8 @@ use PHPUnit\Framework\TestCase;
 
 class JavaScriptOnlyLinkTest extends TestCase
 {
+    private const BOOKMARKLET_TEMPLATE = 'templates/Static/_bookmarklet.html.twig';
+
     /**
      * @dataProvider anchors
      */
@@ -30,6 +32,28 @@ class JavaScriptOnlyLinkTest extends TestCase
         );
     }
 
+    /**
+     * @dataProvider anchors
+     */
+    public function testTwigAnchorsDoNotUseJavaScriptDestinations(string $path, string $anchor): void
+    {
+        if (self::BOOKMARKLET_TEMPLATE === $path) {
+            self::assertMatchesRegularExpression(
+                '/\\bhref\\s*=\\s*(["\\\'])javascript:/i',
+                $anchor,
+                \sprintf('Intentional bookmarklet JavaScript link missing in %s: %s', $path, $anchor)
+            );
+
+            return;
+        }
+
+        self::assertDoesNotMatchRegularExpression(
+            '/\\bhref\\s*=\\s*(["\\\'])javascript:/i',
+            $anchor,
+            \sprintf('JavaScript link in %s: %s', $path, $anchor)
+        );
+    }
+
     public function anchors(): iterable
     {
         $projectDirectory = \dirname(__DIR__, 3);
@@ -43,16 +67,17 @@ class JavaScriptOnlyLinkTest extends TestCase
             }
 
             $path = $template->getPathname();
+            $relativePath = str_replace('\\\\', '/', substr($path, \strlen($projectDirectory) + 1));
             $contents = file_get_contents($path);
 
             if (false === $contents) {
-                self::fail(\sprintf('Unable to read %s.', $path));
+                self::fail(\sprintf('Unable to read %s.', $relativePath));
             }
 
             preg_match_all('/<a\\b[^>]*>/is', $contents, $matches);
 
             foreach ($matches[0] as $index => $anchor) {
-                yield \sprintf('%s:%d', $path, $index + 1) => [$path, $anchor];
+                yield \sprintf('%s:%d', $relativePath, $index + 1) => [$relativePath, $anchor];
             }
         }
     }

--- a/tests/unit/Twig/JavaScriptOnlyLinkTest.php
+++ b/tests/unit/Twig/JavaScriptOnlyLinkTest.php
@@ -18,6 +18,18 @@ class JavaScriptOnlyLinkTest extends TestCase
         );
     }
 
+    /**
+     * @dataProvider anchors
+     */
+    public function testTwigAnchorsDoNotUseEmptyHashDestinations(string $path, string $anchor): void
+    {
+        self::assertDoesNotMatchRegularExpression(
+            '/\\bhref\\s*=\\s*(["\\\'])#\\1/i',
+            $anchor,
+            \sprintf('Fake fragment link in %s: %s', $path, $anchor)
+        );
+    }
+
     public function anchors(): iterable
     {
         $projectDirectory = \dirname(__DIR__, 3);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Documentation | no
| Translation   | no
| CHANGELOG.md  | no
| License       | MIT

Part of #8967.

Replace JavaScript-only action links and role=button icons with native buttons while preserving navigational anchors, Materialize hooks, and UI parity. This is the semantic-control foundation for the accessibility layer above it.

- [ ] Manual desktop and mobile browser review completed

This draft is easiest to review one commit at a time; its descriptive fixups intentionally remain visible.