### PR TITLE
Add accessible state and keyboard interactions to semantic controls

### DIFF
--- a/assets/controllers/dark_theme_controller.js
+++ b/assets/controllers/dark_theme_controller.js
@@ -19,16 +19,19 @@ export default class extends Controller {
   useLight() {
     this.element.classList.remove('dark-theme');
     document.cookie = 'theme=light;samesite=Lax;path=/;max-age=31536000';
+    this.#select('light');
   }
 
   useDark() {
     this.element.classList.add('dark-theme');
     document.cookie = 'theme=dark;samesite=Lax;path=/;max-age=31536000';
+    this.#select('dark');
   }
 
   useAuto() {
     document.cookie = 'theme=auto;samesite=Lax;path=/;max-age=0';
     this.#choose();
+    this.#select('auto');
   }
 
   #choose() {

--- a/assets/controllers/dark_theme_controller.js
+++ b/assets/controllers/dark_theme_controller.js
@@ -1,12 +1,15 @@
 import { Controller } from '@hotwired/stimulus';
 
 export default class extends Controller {
+  static targets = ['light', 'dark', 'auto'];
+
   connect() {
     this.mql = window.matchMedia('(prefers-color-scheme: dark)');
     this.handleThemeChange = this.#choose.bind(this);
     this.mql.addEventListener('change', this.handleThemeChange);
 
     this.#choose();
+    this.#select(this.#currentPreference());
   }
 
   disconnect() {
@@ -40,5 +43,20 @@ export default class extends Controller {
     } else {
       this.element.classList.remove('dark-theme');
     }
+  }
+
+  #currentPreference() {
+    const themeCookie = this.element.ownerDocument.cookie
+      .split(';')
+      .map((cookie) => cookie.trim())
+      .find((cookie) => cookie.startsWith('theme='));
+
+    return themeCookie?.split('=')[1] ?? 'auto';
+  }
+
+  #select(preference) {
+    this.lightTargets.forEach((target) => target.setAttribute('aria-pressed', (preference === 'light').toString()));
+    this.darkTargets.forEach((target) => target.setAttribute('aria-pressed', (preference === 'dark').toString()));
+    this.autoTargets.forEach((target) => target.setAttribute('aria-pressed', (preference === 'auto').toString()));
   }
 }

--- a/assets/controllers/leftbar_controller.js
+++ b/assets/controllers/leftbar_controller.js
@@ -1,7 +1,10 @@
 import { Controller } from '@hotwired/stimulus';
 
 export default class extends Controller {
-  toggleAddTagForm() {
+  toggleAddTagForm({ currentTarget }) {
+    const expanded = currentTarget.getAttribute('aria-expanded') !== 'true';
+
+    currentTarget.setAttribute('aria-expanded', expanded.toString());
     this.dispatch('toggleAddTagForm');
   }
 }

--- a/assets/controllers/materialize/collapsible_controller.js
+++ b/assets/controllers/materialize/collapsible_controller.js
@@ -7,7 +7,11 @@ export default class extends Controller {
   };
 
   connect() {
-    this.instance = M.Collapsible.init(this.element, { accordion: this.accordionValue });
+    this.instance = M.Collapsible.init(this.element, {
+      accordion: this.accordionValue,
+      onOpenStart: (listItem) => this.constructor.#setExpanded(listItem, true),
+      onCloseStart: (listItem) => this.constructor.#setExpanded(listItem, false),
+    });
     this.buttonHeaders = [...this.element.querySelectorAll('button.collapsible-header')];
     // eslint-disable-next-line dot-notation
     const keydownHandler = this.instance['_handleCollapsibleKeydownBound'];
@@ -19,5 +23,11 @@ export default class extends Controller {
 
   disconnect() {
     this.instance.destroy();
+  }
+
+  static #setExpanded(listItem, expanded) {
+    const header = listItem.querySelector(':scope > .collapsible-header[aria-expanded]');
+
+    header?.setAttribute('aria-expanded', expanded.toString());
   }
 }

--- a/assets/controllers/materialize/dropdown_controller.js
+++ b/assets/controllers/materialize/dropdown_controller.js
@@ -12,9 +12,12 @@ export default class extends Controller {
       onCloseStart: () => this.element.setAttribute('aria-expanded', 'false'),
     });
     this.element.setAttribute('aria-expanded', 'false');
+    this.spaceHandler = this.constructor.#activateWithSpace;
+    this.instance.dropdownEl.addEventListener('keydown', this.spaceHandler);
   }
 
   disconnect() {
+    this.instance.dropdownEl.removeEventListener('keydown', this.spaceHandler);
     this.instance.destroy();
   }
 
@@ -22,5 +25,21 @@ export default class extends Controller {
     this.instance.dropdownEl
       .querySelector('li:not(.divider) > a, li:not(.divider) > button:not([disabled])')
       ?.focus({ preventScroll: true });
+  }
+
+  static #activateWithSpace(event) {
+    if (event.key !== ' ') {
+      return;
+    }
+
+    const action = event.target.closest('a, button')
+      ?? event.target.closest('li')?.querySelector('a, button');
+
+    if (!action) {
+      return;
+    }
+
+    event.preventDefault();
+    action.click();
   }
 }

--- a/assets/controllers/materialize/dropdown_controller.js
+++ b/assets/controllers/materialize/dropdown_controller.js
@@ -7,7 +7,10 @@ export default class extends Controller {
       hover: false,
       coverTrigger: false,
       constrainWidth: false,
+      onOpenStart: () => this.element.setAttribute('aria-expanded', 'true'),
+      onCloseStart: () => this.element.setAttribute('aria-expanded', 'false'),
     });
+    this.element.setAttribute('aria-expanded', 'false');
   }
 
   disconnect() {

--- a/assets/controllers/materialize/dropdown_controller.js
+++ b/assets/controllers/materialize/dropdown_controller.js
@@ -8,6 +8,7 @@ export default class extends Controller {
       coverTrigger: false,
       constrainWidth: false,
       onOpenStart: () => this.element.setAttribute('aria-expanded', 'true'),
+      onOpenEnd: () => this.#focusFirstAction(),
       onCloseStart: () => this.element.setAttribute('aria-expanded', 'false'),
     });
     this.element.setAttribute('aria-expanded', 'false');
@@ -15,5 +16,11 @@ export default class extends Controller {
 
   disconnect() {
     this.instance.destroy();
+  }
+
+  #focusFirstAction() {
+    this.instance.dropdownEl
+      .querySelector('li:not(.divider) > a, li:not(.divider) > button:not([disabled])')
+      ?.focus({ preventScroll: true });
   }
 }

--- a/assets/controllers/materialize/fab_controller.js
+++ b/assets/controllers/materialize/fab_controller.js
@@ -3,10 +3,12 @@ import M from '@materializecss/materialize';
 
 export default class extends Controller {
   connect() {
+    this.trigger = this.element.querySelector('[data-toggle="actions"]');
     this.instance = M.FloatingActionButton.init(this.element, {
       direction: 'left',
       hoverEnabled: false,
     });
+    this.#syncExpanded();
   }
 
   autoDisplay() {
@@ -19,13 +21,20 @@ export default class extends Controller {
       this.toggleScroll = false;
       this.instance.close();
     }
+
+    this.#syncExpanded();
   }
 
   click() {
     this.dispatch('click');
+    requestAnimationFrame(() => this.#syncExpanded());
   }
 
   disconnect() {
     this.instance.destroy();
+  }
+
+  #syncExpanded() {
+    this.trigger.setAttribute('aria-expanded', this.instance.isOpen.toString());
   }
 }

--- a/assets/controllers/materialize/sidenav_controller.js
+++ b/assets/controllers/materialize/sidenav_controller.js
@@ -9,7 +9,14 @@ export default class extends Controller {
   };
 
   connect() {
-    this.instance = M.Sidenav.init(this.element, { edge: this.edgeValue });
+    this.triggers = [...document.querySelectorAll('.sidenav-trigger')]
+      .filter((trigger) => trigger.dataset.target === this.element.id);
+    this.instance = M.Sidenav.init(this.element, {
+      edge: this.edgeValue,
+      onOpenStart: () => this.#setExpanded(true),
+      onCloseStart: () => this.#setExpanded(false),
+    });
+    this.#setExpanded(false);
   }
 
   close() {
@@ -20,5 +27,9 @@ export default class extends Controller {
 
   disconnect() {
     this.instance.destroy();
+  }
+
+  #setExpanded(expanded) {
+    this.triggers.forEach((trigger) => trigger.setAttribute('aria-expanded', expanded.toString()));
   }
 }

--- a/assets/controllers/materialize/sidenav_controller.js
+++ b/assets/controllers/materialize/sidenav_controller.js
@@ -17,6 +17,8 @@ export default class extends Controller {
       onCloseStart: () => this.#setExpanded(false),
     });
     this.#setExpanded(false);
+    this.keydownHandler = this.#handleKeydown.bind(this);
+    document.addEventListener('keydown', this.keydownHandler);
   }
 
   close() {
@@ -26,7 +28,18 @@ export default class extends Controller {
   }
 
   disconnect() {
+    document.removeEventListener('keydown', this.keydownHandler);
     this.instance.destroy();
+  }
+
+  #handleKeydown(event) {
+    if (event.key !== 'Escape' || !this.instance.isOpen || (this.instance.isFixed && window.innerWidth >= mobileMaxWidth)) {
+      return;
+    }
+
+    event.preventDefault();
+    event.stopPropagation();
+    this.instance.close();
   }
 
   #setExpanded(expanded) {

--- a/assets/controllers/materialize/sidenav_controller.js
+++ b/assets/controllers/materialize/sidenav_controller.js
@@ -2,6 +2,14 @@ import { Controller } from '@hotwired/stimulus';
 import M from '@materializecss/materialize';
 
 const mobileMaxWidth = 993;
+const focusableSelector = [
+  'a[href]',
+  'button:not([disabled])',
+  'input:not([disabled])',
+  'select:not([disabled])',
+  'textarea:not([disabled])',
+  '[tabindex]:not([tabindex="-1"])',
+].join(', ');
 
 export default class extends Controller {
   static values = {
@@ -13,8 +21,13 @@ export default class extends Controller {
       .filter((trigger) => trigger.dataset.target === this.element.id);
     this.instance = M.Sidenav.init(this.element, {
       edge: this.edgeValue,
-      onOpenStart: () => this.#setExpanded(true),
+      onOpenStart: () => {
+        this.#setExpanded(true);
+        this.#rememberInvokingTrigger();
+      },
+      onOpenEnd: () => this.#focusFirstControl(),
       onCloseStart: () => this.#setExpanded(false),
+      onCloseEnd: () => this.#restoreInvokingTrigger(),
     });
     this.#setExpanded(false);
     this.keydownHandler = this.#handleKeydown.bind(this);
@@ -33,13 +46,40 @@ export default class extends Controller {
   }
 
   #handleKeydown(event) {
-    if (event.key !== 'Escape' || !this.instance.isOpen || (this.instance.isFixed && window.innerWidth >= mobileMaxWidth)) {
+    if (event.key !== 'Escape' || !this.instance.isOpen || this.#isFixed()) {
       return;
     }
 
     event.preventDefault();
     event.stopPropagation();
     this.instance.close();
+  }
+
+  #rememberInvokingTrigger() {
+    this.invokingTrigger = this.triggers.find(
+      (trigger) => trigger === document.activeElement,
+    ) ?? this.triggers[0];
+  }
+
+  #focusFirstControl() {
+    if (this.#isFixed()) {
+      return;
+    }
+
+    const control = [...this.element.querySelectorAll(focusableSelector)]
+      .find((element) => element.getClientRects().length > 0);
+
+    control?.focus({ preventScroll: true });
+  }
+
+  #restoreInvokingTrigger() {
+    if (!this.#isFixed() && this.invokingTrigger?.isConnected) {
+      this.invokingTrigger.focus({ preventScroll: true });
+    }
+  }
+
+  #isFixed() {
+    return this.element.classList.contains('sidenav-fixed') && window.innerWidth >= mobileMaxWidth;
   }
 
   #setExpanded(expanded) {

--- a/assets/controllers/shortcuts_controller.js
+++ b/assets/controllers/shortcuts_controller.js
@@ -112,6 +112,10 @@ export default class extends Controller {
         return false;
       }
 
+      if (e.defaultPrevented || element.closest('a, button, input, select, textarea')) {
+        return true;
+      }
+
       return this.originalStopCallback(e, element);
     };
     Mousetrap.prototype.stopCallback = this.stopCallback;

--- a/assets/controllers/shortcuts_controller.js
+++ b/assets/controllers/shortcuts_controller.js
@@ -112,7 +112,7 @@ export default class extends Controller {
         return false;
       }
 
-      if (e.defaultPrevented || element.closest('a, button, input, select, textarea')) {
+      if (e.defaultPrevented || element.closest('a, button, input, select, textarea, [contenteditable="true"], .dropdown-content')) {
         return true;
       }
 

--- a/assets/controllers/topbar_controller.js
+++ b/assets/controllers/topbar_controller.js
@@ -1,7 +1,7 @@
 import { Controller } from '@hotwired/stimulus';
 
 export default class extends Controller {
-  static targets = ['addUrl', 'addUrlInput', 'search', 'searchInput', 'actions'];
+  static targets = ['addUrl', 'addUrlInput', 'addUrlTrigger', 'search', 'searchInput', 'searchTrigger', 'actions'];
 
   showAddUrl() {
     this.actionsTarget.style.display = 'none';

--- a/assets/controllers/topbar_controller.js
+++ b/assets/controllers/topbar_controller.js
@@ -3,7 +3,8 @@ import { Controller } from '@hotwired/stimulus';
 export default class extends Controller {
   static targets = ['addUrl', 'addUrlInput', 'addUrlTrigger', 'search', 'searchInput', 'searchTrigger', 'actions'];
 
-  showAddUrl() {
+  showAddUrl({ currentTarget } = {}) {
+    this.modeTrigger = currentTarget ?? this.addUrlTriggerTarget;
     this.actionsTarget.style.display = 'none';
     this.addUrlTarget.style.display = 'flex';
     this.searchTarget.style.display = 'none';
@@ -17,7 +18,8 @@ export default class extends Controller {
     this.addUrlInputTarget.blur();
   }
 
-  showSearch() {
+  showSearch({ currentTarget } = {}) {
+    this.modeTrigger = currentTarget ?? this.searchTriggerTarget;
     this.actionsTarget.style.display = 'none';
     this.addUrlTarget.style.display = 'none';
     this.searchTarget.style.display = 'flex';
@@ -30,6 +32,8 @@ export default class extends Controller {
     this.addUrlTarget.style.display = 'none';
     this.searchTarget.style.display = 'none';
     this.#setExpanded(false, false);
+    this.modeTrigger?.focus({ preventScroll: true });
+    this.modeTrigger = undefined;
   }
 
   #setExpanded(addUrl, search) {

--- a/assets/controllers/topbar_controller.js
+++ b/assets/controllers/topbar_controller.js
@@ -7,6 +7,7 @@ export default class extends Controller {
     this.actionsTarget.style.display = 'none';
     this.addUrlTarget.style.display = 'flex';
     this.searchTarget.style.display = 'none';
+    this.#setExpanded(true, false);
     this.addUrlInputTarget.focus();
   }
 
@@ -20,6 +21,7 @@ export default class extends Controller {
     this.actionsTarget.style.display = 'none';
     this.addUrlTarget.style.display = 'none';
     this.searchTarget.style.display = 'flex';
+    this.#setExpanded(false, true);
     this.searchInputTarget.focus();
   }
 
@@ -27,5 +29,11 @@ export default class extends Controller {
     this.actionsTarget.style.display = 'flex';
     this.addUrlTarget.style.display = 'none';
     this.searchTarget.style.display = 'none';
+    this.#setExpanded(false, false);
+  }
+
+  #setExpanded(addUrl, search) {
+    this.addUrlTriggerTarget.setAttribute('aria-expanded', addUrl.toString());
+    this.searchTriggerTarget.setAttribute('aria-expanded', search.toString());
   }
 }

--- a/assets/scss/_dark_theme.scss
+++ b/assets/scss/_dark_theme.scss
@@ -1,3 +1,5 @@
+@use "variables";
+
 .dark-theme {
   body {
     background-color: #101010;
@@ -68,6 +70,11 @@
   .sidenav li button,
   .sidenav li button > i.material-icons {
     color: #dfdfdf;
+  }
+
+  .dropdown-content button[data-dark-theme-target][aria-pressed="true"],
+  .sidenav button[data-dark-theme-target][aria-pressed="true"] {
+    color: variables.$blue-accent-color;
   }
 
   .cyan,

--- a/assets/scss/_various.scss
+++ b/assets/scss/_various.scss
@@ -56,3 +56,13 @@ nav .input-field input {
   font: inherit;
   line-height: inherit;
 }
+
+.dropdown-content button[data-dark-theme-target][aria-pressed="true"],
+.sidenav button[data-dark-theme-target][aria-pressed="true"] {
+  color: variables.$blue-accent-color;
+  font-weight: bold;
+
+  > i {
+    color: inherit;
+  }
+}

--- a/assets/scss/_various.scss
+++ b/assets/scss/_various.scss
@@ -56,6 +56,11 @@ button:not(:disabled, .disabled) {
   cursor: pointer;
 }
 
+button:disabled,
+button.disabled {
+  cursor: default;
+}
+
 .config-help {
   font: inherit;
   line-height: inherit;

--- a/assets/scss/_various.scss
+++ b/assets/scss/_various.scss
@@ -52,6 +52,10 @@ nav .input-field input {
   }
 }
 
+button:not(:disabled, .disabled) {
+  cursor: pointer;
+}
+
 .config-help {
   font: inherit;
   line-height: inherit;

--- a/assets/scss/_various.scss
+++ b/assets/scss/_various.scss
@@ -61,6 +61,11 @@ button.disabled {
   cursor: default;
 }
 
+button:focus-visible {
+  outline: 2px solid currentcolor;
+  outline-offset: 2px;
+}
+
 .config-help {
   font: inherit;
   line-height: inherit;

--- a/assets/scss/_various.scss
+++ b/assets/scss/_various.scss
@@ -66,6 +66,17 @@ button:focus-visible {
   outline-offset: 2px;
 }
 
+.sidenav a:focus-visible,
+.dropdown-content a:focus-visible {
+  outline: 2px solid currentcolor;
+  outline-offset: -2px;
+}
+
+.dropdown-content li:focus-visible {
+  outline: 2px solid variables.$blue-accent-color;
+  outline-offset: -2px;
+}
+
 .config-help {
   font: inherit;
   line-height: inherit;

--- a/templates/Config/index.html.twig
+++ b/templates/Config/index.html.twig
@@ -32,8 +32,8 @@
                                 {{ form_label(form.config.items_per_page) }}
                             </div>
                             <div class="input-field col s1">
-                                <button type="button" class="btn-link config-help" data-controller="materialize--tooltip" data-materialize--tooltip-position-value="left" data-materialize--tooltip-enter-delay-value="50" data-tooltip="{{ 'config.form_settings.help_items_per_page'|trans }}">
-                                    <i class="material-icons">live_help</i>
+                                <button type="button" class="btn-link config-help" data-controller="materialize--tooltip" data-materialize--tooltip-position-value="left" data-materialize--tooltip-enter-delay-value="50" data-tooltip="{{ 'config.form_settings.help_items_per_page'|trans }}" aria-label="{{ 'config.form_settings.help_items_per_page'|trans }}">
+                                    <i class="material-icons" aria-hidden="true">live_help</i>
                                 </button>
                             </div>
                         </div>
@@ -47,8 +47,8 @@
                                 </label>
                             </div>
                             <div class="input-field col s1">
-                                <button type="button" class="btn-link config-help" data-controller="materialize--tooltip" data-materialize--tooltip-position-value="left" data-materialize--tooltip-enter-delay-value="50" data-tooltip="{{ 'config.form_settings.help_display_thumbnails'|trans }}">
-                                    <i class="material-icons">live_help</i>
+                                <button type="button" class="btn-link config-help" data-controller="materialize--tooltip" data-materialize--tooltip-position-value="left" data-materialize--tooltip-enter-delay-value="50" data-tooltip="{{ 'config.form_settings.help_display_thumbnails'|trans }}" aria-label="{{ 'config.form_settings.help_display_thumbnails'|trans }}">
+                                    <i class="material-icons" aria-hidden="true">live_help</i>
                                 </button>
                             </div>
                         </div>
@@ -64,8 +64,8 @@
                                     </p>
                                 </div>
                                 <div class="input-field col s1">
-                                    <button type="button" class="btn-link config-help" data-controller="materialize--tooltip" data-materialize--tooltip-position-value="left" data-materialize--tooltip-enter-delay-value="50" data-tooltip="{{ 'config.form_settings.help_reading_speed'|trans }}">
-                                        <i class="material-icons">live_help</i>
+                                    <button type="button" class="btn-link config-help" data-controller="materialize--tooltip" data-materialize--tooltip-position-value="left" data-materialize--tooltip-enter-delay-value="50" data-tooltip="{{ 'config.form_settings.help_reading_speed'|trans }}" aria-label="{{ 'config.form_settings.help_reading_speed'|trans }}">
+                                        <i class="material-icons" aria-hidden="true">live_help</i>
                                     </button>
                                 </div>
                             </div>
@@ -85,8 +85,8 @@
                                     }
                                 }) }}
                                 <div class="input-field col s1">
-                                    <button type="button" class="btn-link config-help" data-controller="materialize--tooltip" data-materialize--tooltip-position-value="left" data-materialize--tooltip-enter-delay-value="50" data-tooltip="{{ 'config.form_settings.help_language'|trans }}">
-                                        <i class="material-icons">live_help</i>
+                                    <button type="button" class="btn-link config-help" data-controller="materialize--tooltip" data-materialize--tooltip-position-value="left" data-materialize--tooltip-enter-delay-value="50" data-tooltip="{{ 'config.form_settings.help_language'|trans }}" aria-label="{{ 'config.form_settings.help_language'|trans }}">
+                                        <i class="material-icons" aria-hidden="true">live_help</i>
                                     </button>
                                 </div>
                             </div>
@@ -102,8 +102,8 @@
                                     </p>
                                 </div>
                                 <div class="input-field col s1">
-                                    <button type="button" class="btn-link config-help" data-controller="materialize--tooltip" data-materialize--tooltip-position-value="left" data-materialize--tooltip-enter-delay-value="50" data-tooltip="{{ 'config.form_settings.help_pocket_consumer_key'|trans }}">
-                                        <i class="material-icons">live_help</i>
+                                    <button type="button" class="btn-link config-help" data-controller="materialize--tooltip" data-materialize--tooltip-position-value="left" data-materialize--tooltip-enter-delay-value="50" data-tooltip="{{ 'config.form_settings.help_pocket_consumer_key'|trans }}" aria-label="{{ 'config.form_settings.help_pocket_consumer_key'|trans }}">
+                                        <i class="material-icons" aria-hidden="true">live_help</i>
                                     </button>
                                 </div>
                             </div>
@@ -129,8 +129,8 @@
                                     }
                                 }) }}
                                 <div class="input-field col s1">
-                                    <button type="button" class="btn-link config-help" data-controller="materialize--tooltip" data-materialize--tooltip-position-value="left" data-materialize--tooltip-enter-delay-value="50" data-tooltip="{{ 'config.form_settings.help_font'|trans }}">
-                                        <i class="material-icons">live_help</i>
+                                    <button type="button" class="btn-link config-help" data-controller="materialize--tooltip" data-materialize--tooltip-position-value="left" data-materialize--tooltip-enter-delay-value="50" data-tooltip="{{ 'config.form_settings.help_font'|trans }}" aria-label="{{ 'config.form_settings.help_font'|trans }}">
+                                        <i class="material-icons" aria-hidden="true">live_help</i>
                                     </button>
                                 </div>
 
@@ -140,8 +140,8 @@
                                     {{ form_label(form.config.lineHeight, null, {'label_attr': {'class': 'settings-range-label'}}) }}
                                 </div>
                                 <div class="input-field col s1">
-                                    <button type="button" class="btn-link config-help" data-controller="materialize--tooltip" data-materialize--tooltip-position-value="left" data-materialize--tooltip-enter-delay-value="50" data-tooltip="{{ 'config.form_settings.help_lineheight'|trans }}">
-                                        <i class="material-icons">live_help</i>
+                                    <button type="button" class="btn-link config-help" data-controller="materialize--tooltip" data-materialize--tooltip-position-value="left" data-materialize--tooltip-enter-delay-value="50" data-tooltip="{{ 'config.form_settings.help_lineheight'|trans }}" aria-label="{{ 'config.form_settings.help_lineheight'|trans }}">
+                                        <i class="material-icons" aria-hidden="true">live_help</i>
                                     </button>
                                 </div>
                             </div>
@@ -153,8 +153,8 @@
                                     {{ form_label(form.config.fontsize, null, {'label_attr': {'class': 'settings-range-label'}}) }}
                                 </div>
                                 <div class="input-field col s1">
-                                    <button type="button" class="btn-link config-help" data-controller="materialize--tooltip" data-materialize--tooltip-position-value="left" data-materialize--tooltip-enter-delay-value="50" data-tooltip="{{ 'config.form_settings.help_fontsize'|trans }}">
-                                        <i class="material-icons">live_help</i>
+                                    <button type="button" class="btn-link config-help" data-controller="materialize--tooltip" data-materialize--tooltip-position-value="left" data-materialize--tooltip-enter-delay-value="50" data-tooltip="{{ 'config.form_settings.help_fontsize'|trans }}" aria-label="{{ 'config.form_settings.help_fontsize'|trans }}">
+                                        <i class="material-icons" aria-hidden="true">live_help</i>
                                     </button>
                                 </div>
 
@@ -164,8 +164,8 @@
                                     {{ form_label(form.config.maxWidth, null, {'label_attr': {'class': 'settings-range-label'}}) }}
                                 </div>
                                 <div class="input-field col s1">
-                                    <button type="button" class="btn-link config-help" data-controller="materialize--tooltip" data-materialize--tooltip-position-value="left" data-materialize--tooltip-enter-delay-value="50" data-tooltip="{{ 'config.form_settings.help_maxwidth'|trans }}">
-                                        <i class="material-icons">live_help</i>
+                                    <button type="button" class="btn-link config-help" data-controller="materialize--tooltip" data-materialize--tooltip-position-value="left" data-materialize--tooltip-enter-delay-value="50" data-tooltip="{{ 'config.form_settings.help_maxwidth'|trans }}" aria-label="{{ 'config.form_settings.help_maxwidth'|trans }}">
+                                        <i class="material-icons" aria-hidden="true">live_help</i>
                                     </button>
                                 </div>
                             </div>

--- a/templates/Entry/entries.html.twig
+++ b/templates/Entry/entries.html.twig
@@ -31,15 +31,15 @@
     {% endif %}
     {% if has_filters %}
         <li class="button-filters">
-            <button type="button" class="sidenav-trigger" data-controller="materialize--tooltip" data-materialize--tooltip-position-value="bottom" data-materialize--tooltip-enter-delay-value="50" data-tooltip="{{ 'menu.top.filter_entries'|trans }}" data-target="filters">
-                <i class="material-icons">filter_list</i>
+            <button type="button" class="sidenav-trigger" data-controller="materialize--tooltip" data-materialize--tooltip-position-value="bottom" data-materialize--tooltip-enter-delay-value="50" data-tooltip="{{ 'menu.top.filter_entries'|trans }}" data-target="filters" aria-label="{{ 'menu.top.filter_entries'|trans }}">
+                <i class="material-icons" aria-hidden="true">filter_list</i>
             </button>
         </li>
     {% endif %}
     {% if has_exports %}
         <li class="button-export">
-            <button type="button" class="sidenav-trigger" data-controller="materialize--tooltip" data-materialize--tooltip-position-value="bottom" data-materialize--tooltip-enter-delay-value="50" data-tooltip="{{ 'menu.top.export'|trans }}" data-target="export">
-                <i class="material-icons">file_download</i>
+            <button type="button" class="sidenav-trigger" data-controller="materialize--tooltip" data-materialize--tooltip-position-value="bottom" data-materialize--tooltip-enter-delay-value="50" data-tooltip="{{ 'menu.top.export'|trans }}" data-target="export" aria-label="{{ 'menu.top.export'|trans }}">
+                <i class="material-icons" aria-hidden="true">file_download</i>
             </button>
         </li>
     {% endif %}

--- a/templates/Entry/entries.html.twig
+++ b/templates/Entry/entries.html.twig
@@ -31,14 +31,14 @@
     {% endif %}
     {% if has_filters %}
         <li class="button-filters">
-            <button type="button" class="sidenav-trigger" data-controller="materialize--tooltip" data-materialize--tooltip-position-value="bottom" data-materialize--tooltip-enter-delay-value="50" data-tooltip="{{ 'menu.top.filter_entries'|trans }}" data-target="filters" aria-label="{{ 'menu.top.filter_entries'|trans }}">
+            <button type="button" class="sidenav-trigger" data-controller="materialize--tooltip" data-materialize--tooltip-position-value="bottom" data-materialize--tooltip-enter-delay-value="50" data-tooltip="{{ 'menu.top.filter_entries'|trans }}" data-target="filters" aria-label="{{ 'menu.top.filter_entries'|trans }}" aria-controls="filters" aria-expanded="false">
                 <i class="material-icons" aria-hidden="true">filter_list</i>
             </button>
         </li>
     {% endif %}
     {% if has_exports %}
         <li class="button-export">
-            <button type="button" class="sidenav-trigger" data-controller="materialize--tooltip" data-materialize--tooltip-position-value="bottom" data-materialize--tooltip-enter-delay-value="50" data-tooltip="{{ 'menu.top.export'|trans }}" data-target="export" aria-label="{{ 'menu.top.export'|trans }}">
+            <button type="button" class="sidenav-trigger" data-controller="materialize--tooltip" data-materialize--tooltip-position-value="bottom" data-materialize--tooltip-enter-delay-value="50" data-tooltip="{{ 'menu.top.export'|trans }}" data-target="export" aria-label="{{ 'menu.top.export'|trans }}" aria-controls="export" aria-expanded="false">
                 <i class="material-icons" aria-hidden="true">file_download</i>
             </button>
         </li>

--- a/templates/Entry/entry.html.twig
+++ b/templates/Entry/entry.html.twig
@@ -14,8 +14,8 @@
         <div class="nav-panel-item cyan darken-1">
             <ul>
                 <li>
-                    <button type="button" data-target="slide-out" class="sidenav-trigger">
-                        <i class="material-icons">menu</i>
+                    <button type="button" data-target="slide-out" class="sidenav-trigger" aria-label="{{ 'menu.top.open_menu'|trans }}">
+                        <i class="material-icons" aria-hidden="true">menu</i>
                     </button>
                 </li>
                 <li>

--- a/templates/Entry/entry.html.twig
+++ b/templates/Entry/entry.html.twig
@@ -14,7 +14,7 @@
         <div class="nav-panel-item cyan darken-1">
             <ul>
                 <li>
-                    <button type="button" data-target="slide-out" class="sidenav-trigger" aria-label="{{ 'menu.top.open_menu'|trans }}">
+                    <button type="button" data-target="slide-out" class="sidenav-trigger" aria-label="{{ 'menu.top.open_menu'|trans }}" aria-controls="slide-out" aria-expanded="false">
                         <i class="material-icons" aria-hidden="true">menu</i>
                     </button>
                 </li>

--- a/templates/Entry/entry.html.twig
+++ b/templates/Entry/entry.html.twig
@@ -143,19 +143,19 @@
             </button>
             <ul id="reader-theme-options" class="collapsible-body">
                 <li>
-                    <button type="button" data-action="click->dark-theme#useLight">
+                    <button type="button" data-action="click->dark-theme#useLight" data-dark-theme-target="light" aria-pressed="false">
                         <i class="theme-toggle-icon material-icons tiny" aria-hidden="true">brightness_high</i>
                         <span>{{ 'entry.view.left_menu.theme_toggle_light'|trans }}</span>
                     </button>
                 </li>
                 <li>
-                    <button type="button" data-action="click->dark-theme#useDark">
+                    <button type="button" data-action="click->dark-theme#useDark" data-dark-theme-target="dark" aria-pressed="false">
                         <i class="theme-toggle-icon material-icons tiny" aria-hidden="true">brightness_low</i>
                         <span>{{ 'entry.view.left_menu.theme_toggle_dark'|trans }}</span>
                     </button>
                 </li>
                 <li>
-                    <button type="button" data-action="click->dark-theme#useAuto">
+                    <button type="button" data-action="click->dark-theme#useAuto" data-dark-theme-target="auto" aria-pressed="false">
                         <i class="theme-toggle-icon material-icons tiny" aria-hidden="true">brightness_auto</i>
                         <span>{{ 'entry.view.left_menu.theme_toggle_auto'|trans }}</span>
                     </button>

--- a/templates/Entry/entry.html.twig
+++ b/templates/Entry/entry.html.twig
@@ -130,7 +130,7 @@
 
         <li class="bold border-bottom">
             <button type="button" class="waves-effect collapsible-header" id="nav-btn-add-tag" data-action="click->materialize--sidenav#close click->leftbar#toggleAddTagForm">
-                <i class="material-icons small">label_outline</i>
+                <i class="material-icons small" aria-hidden="true">label_outline</i>
                 <span>{{ 'entry.view.left_menu.add_a_tag'|trans }}</span>
             </button>
             <div class="collapsible-body"></div>
@@ -138,25 +138,25 @@
 
         <li class="bold">
             <button type="button" class="waves-effect collapsible-header">
-                <i class="material-icons small">brightness_medium</i>
+                <i class="material-icons small" aria-hidden="true">brightness_medium</i>
                 <span>{{ 'entry.view.left_menu.theme_toggle'|trans }}</span>
             </button>
             <ul class="collapsible-body">
                 <li>
                     <button type="button" data-action="click->dark-theme#useLight">
-                        <i class="theme-toggle-icon material-icons tiny">brightness_high</i>
+                        <i class="theme-toggle-icon material-icons tiny" aria-hidden="true">brightness_high</i>
                         <span>{{ 'entry.view.left_menu.theme_toggle_light'|trans }}</span>
                     </button>
                 </li>
                 <li>
                     <button type="button" data-action="click->dark-theme#useDark">
-                        <i class="theme-toggle-icon material-icons tiny">brightness_low</i>
+                        <i class="theme-toggle-icon material-icons tiny" aria-hidden="true">brightness_low</i>
                         <span>{{ 'entry.view.left_menu.theme_toggle_dark'|trans }}</span>
                     </button>
                 </li>
                 <li>
                     <button type="button" data-action="click->dark-theme#useAuto">
-                        <i class="theme-toggle-icon material-icons tiny">brightness_auto</i>
+                        <i class="theme-toggle-icon material-icons tiny" aria-hidden="true">brightness_auto</i>
                         <span>{{ 'entry.view.left_menu.theme_toggle_auto'|trans }}</span>
                     </button>
                 </li>
@@ -165,7 +165,7 @@
         {% if craue_setting('share_public') or craue_setting('share_twitter') or craue_setting('share_shaarli') or craue_setting('share_diaspora') or craue_setting('share_unmark') or craue_setting('share_linkding') or craue_setting('share_mail') %}
         <li class="bold">
             <button type="button" class="waves-effect collapsible-header">
-                <i class="material-icons small">share</i>
+                <i class="material-icons small" aria-hidden="true">share</i>
                 <span>{{ 'entry.view.left_menu.share_content'|trans }}</span>
             </button>
             <div class="collapsible-body">
@@ -245,7 +245,7 @@
         {% if craue_setting('show_printlink') %}
         <li class="bold border-bottom hide-on-med-and-down">
             <button type="button" class="waves-effect collapsible-header" title="{{ 'entry.view.left_menu.print'|trans }}" onclick="window.print();">
-                <i class="material-icons small">print</i>
+                <i class="material-icons small" aria-hidden="true">print</i>
                 <span>{{ 'entry.view.left_menu.print'|trans }}</span>
             </button>
             <div class="collapsible-body"></div>
@@ -264,7 +264,7 @@
         {% if is_granted('EXPORT', entry) %}
             <li class="bold">
                 <button type="button" class="waves-effect collapsible-header">
-                    <i class="material-icons small">file_download</i>
+                    <i class="material-icons small" aria-hidden="true">file_download</i>
                     <span>{{ 'entry.view.left_menu.export'|trans }}</span>
                 </button>
                 <div class="collapsible-body">
@@ -371,8 +371,8 @@
         </article>
 
         <div class="fixed-action-btn hide-on-large-only" data-controller="materialize--fab" data-action="scroll@window->materialize--fab#autoDisplay click->materialize--fab#click">
-            <button type="button" class="btn-floating btn-large" data-toggle="actions">
-              <i class="material-icons">menu</i>
+            <button type="button" class="btn-floating btn-large" data-toggle="actions" aria-label="{{ 'entry.view.left_menu.toggle_actions'|trans }}">
+              <i class="material-icons" aria-hidden="true">menu</i>
             </button>
             <ul>
                 {% if is_granted('ARCHIVE', entry) %}

--- a/templates/Entry/entry.html.twig
+++ b/templates/Entry/entry.html.twig
@@ -129,7 +129,7 @@
         {% endif %}
 
         <li class="bold border-bottom">
-            <button type="button" class="waves-effect collapsible-header" id="nav-btn-add-tag" data-action="click->materialize--sidenav#close click->leftbar#toggleAddTagForm">
+            <button type="button" class="waves-effect collapsible-header" id="nav-btn-add-tag" data-action="click->materialize--sidenav#close click->leftbar#toggleAddTagForm" aria-controls="entry-add-tag" aria-expanded="false">
                 <i class="material-icons small" aria-hidden="true">label_outline</i>
                 <span>{{ 'entry.view.left_menu.add_a_tag'|trans }}</span>
             </button>
@@ -352,7 +352,7 @@
             </div>
 
             {% if is_granted('TAG', entry) %}
-                <div class="input-field hidden" data-controller="add-tag" data-action="leftbar:toggleAddTagForm@window->add-tag#toggle">
+                <div id="entry-add-tag" class="input-field hidden" data-controller="add-tag" data-action="leftbar:toggleAddTagForm@window->add-tag#toggle">
                     {{ render(controller('Wallabag\\Controller\\TagController::addTagFormAction', {'id': entry.id})) }}
                 </div>
             {% endif %}

--- a/templates/Entry/entry.html.twig
+++ b/templates/Entry/entry.html.twig
@@ -137,11 +137,11 @@
         </li>
 
         <li class="bold">
-            <button type="button" class="waves-effect collapsible-header">
+            <button type="button" class="waves-effect collapsible-header" aria-controls="reader-theme-options" aria-expanded="false">
                 <i class="material-icons small" aria-hidden="true">brightness_medium</i>
                 <span>{{ 'entry.view.left_menu.theme_toggle'|trans }}</span>
             </button>
-            <ul class="collapsible-body">
+            <ul id="reader-theme-options" class="collapsible-body">
                 <li>
                     <button type="button" data-action="click->dark-theme#useLight">
                         <i class="theme-toggle-icon material-icons tiny" aria-hidden="true">brightness_high</i>
@@ -164,11 +164,11 @@
         </li>
         {% if craue_setting('share_public') or craue_setting('share_twitter') or craue_setting('share_shaarli') or craue_setting('share_diaspora') or craue_setting('share_unmark') or craue_setting('share_linkding') or craue_setting('share_mail') %}
         <li class="bold">
-            <button type="button" class="waves-effect collapsible-header">
+            <button type="button" class="waves-effect collapsible-header" aria-controls="reader-share-options" aria-expanded="false">
                 <i class="material-icons small" aria-hidden="true">share</i>
                 <span>{{ 'entry.view.left_menu.share_content'|trans }}</span>
             </button>
-            <div class="collapsible-body">
+            <div id="reader-share-options" class="collapsible-body">
                 <ul>
                     {% if craue_setting('share_public') %}
                         {% if is_granted('SHARE', entry) %}
@@ -263,11 +263,11 @@
 
         {% if is_granted('EXPORT', entry) %}
             <li class="bold">
-                <button type="button" class="waves-effect collapsible-header">
+                <button type="button" class="waves-effect collapsible-header" aria-controls="reader-export-options" aria-expanded="false">
                     <i class="material-icons small" aria-hidden="true">file_download</i>
                     <span>{{ 'entry.view.left_menu.export'|trans }}</span>
                 </button>
-                <div class="collapsible-body">
+                <div id="reader-export-options" class="collapsible-body">
                     <ul>
                         {% if craue_setting('export_epub') %}<li><a href="{{ path('export_entry', {entry: entry.id, 'format': 'epub'}) }}" title="Generate ePub file">EPUB</a></li>{% endif %}
                         {% if craue_setting('export_pdf') %}<li><a href="{{ path('export_entry', {entry: entry.id, 'format': 'pdf'}) }}" title="Generate PDF file">PDF</a></li>{% endif %}
@@ -371,10 +371,10 @@
         </article>
 
         <div class="fixed-action-btn hide-on-large-only" data-controller="materialize--fab" data-action="scroll@window->materialize--fab#autoDisplay click->materialize--fab#click">
-            <button type="button" class="btn-floating btn-large" data-toggle="actions" aria-label="{{ 'entry.view.left_menu.toggle_actions'|trans }}">
+            <button type="button" class="btn-floating btn-large" data-toggle="actions" aria-label="{{ 'entry.view.left_menu.toggle_actions'|trans }}" aria-controls="reader-mobile-actions" aria-expanded="false">
               <i class="material-icons" aria-hidden="true">menu</i>
             </button>
-            <ul>
+            <ul id="reader-mobile-actions">
                 {% if is_granted('ARCHIVE', entry) %}
                     <li>
                       <form action="{{ path('archive_entry', {'id': entry.id, redirect: current_path}) }}" method="post" class="inline-block">

--- a/templates/Entry/new_form.html.twig
+++ b/templates/Entry/new_form.html.twig
@@ -1,4 +1,4 @@
-<form class="input-field nav-panel-item nav-panel-add" style="display: none" name="entry" method="post" action="{{ path('new_entry') }}" data-topbar-target="addUrl" data-action="topbar#submittingUrl">
+<form id="nav-panel-add" class="input-field nav-panel-item nav-panel-add" style="display: none" name="entry" method="post" action="{{ path('new_entry') }}" data-topbar-target="addUrl" data-action="topbar#submittingUrl">
     {% if form_errors(form) %}
         <span class="black-text">{{ form_errors(form) }}</span>
     {% endif %}

--- a/templates/Entry/new_form.html.twig
+++ b/templates/Entry/new_form.html.twig
@@ -9,7 +9,7 @@
     {% endif %}
 
     {{ form_widget(form.url, {'attr': {'autocomplete': 'off', 'placeholder': 'entry.new.placeholder', 'data-topbar-target': 'addUrlInput'}}) }}
-    <button type="button" class="nav-form-button nav-panel-close" aria-label="clear" data-action="click->topbar#showActions" data-shortcuts-target="showActions"><i class="material-icons close"></i></button>
+    <button type="button" class="nav-form-button nav-panel-close" aria-label="{{ 'menu.top.close'|trans }}" data-action="click->topbar#showActions" data-shortcuts-target="showActions"><i class="material-icons close" aria-hidden="true"></i></button>
 
     {{ form_rest(form) }}
 </form>

--- a/templates/Entry/search_form.html.twig
+++ b/templates/Entry/search_form.html.twig
@@ -11,7 +11,7 @@
     <input type="hidden" name="currentRoute" value="{{ currentRoute }}" />
 
     {{ form_widget(form.term, {'attr': {'autocomplete': 'off', 'placeholder': 'entry.search.placeholder', 'data-topbar-target': 'searchInput'}}) }}
-    <button type="button" class="nav-form-button nav-panel-close" aria-label="clear" data-action="click->topbar#showActions" data-shortcuts-target="showActions"><i class="material-icons close"></i></button>
+    <button type="button" class="nav-form-button nav-panel-close" aria-label="{{ 'menu.top.close'|trans }}" data-action="click->topbar#showActions" data-shortcuts-target="showActions"><i class="material-icons close" aria-hidden="true"></i></button>
 
     {{ form_rest(form) }}
 </form>

--- a/templates/Entry/search_form.html.twig
+++ b/templates/Entry/search_form.html.twig
@@ -1,4 +1,4 @@
-<form class="input-field nav-panel-item nav-panel-search" style="display: none" name="search" method="GET" action="{{ path('search') }}" data-topbar-target="search">
+<form id="nav-panel-search" class="input-field nav-panel-item nav-panel-search" style="display: none" name="search" method="GET" action="{{ path('search') }}" data-topbar-target="search">
     {% if form_errors(form) %}
         <span class="black-text">{{ form_errors(form) }}</span>
     {% endif %}

--- a/templates/layout.html.twig
+++ b/templates/layout.html.twig
@@ -134,19 +134,19 @@
                         <li class="divider"></li>
                     {% endif %}
                     <li>
-                        <button type="button" data-action="click->dark-theme#useLight">
+                        <button type="button" data-action="click->dark-theme#useLight" data-dark-theme-target="light" aria-pressed="false">
                             <i class="theme-toggle-icon material-icons tiny" aria-hidden="true">brightness_high</i>
                             <span>{{ 'menu.left.theme_toggle_light'|trans }}</span>
                         </button>
                     </li>
                     <li>
-                        <button type="button" data-action="click->dark-theme#useDark">
+                        <button type="button" data-action="click->dark-theme#useDark" data-dark-theme-target="dark" aria-pressed="false">
                             <i class="theme-toggle-icon material-icons tiny" aria-hidden="true">brightness_low</i>
                             <span>{{ 'menu.left.theme_toggle_dark'|trans }}</span>
                         </button>
                     </li>
                     <li>
-                        <button type="button" data-action="click->dark-theme#useAuto">
+                        <button type="button" data-action="click->dark-theme#useAuto" data-dark-theme-target="auto" aria-pressed="false">
                             <i class="theme-toggle-icon material-icons tiny" aria-hidden="true">brightness_auto</i>
                             <span>{{ 'menu.left.theme_toggle_auto'|trans }}</span>
                         </button>

--- a/templates/layout.html.twig
+++ b/templates/layout.html.twig
@@ -82,7 +82,7 @@
         <div class="nav-panels" data-controller="topbar">
             <div class="nav-panel-item" data-topbar-target="actions">
                 <div class="nav-panel-top">
-                    <button type="button" data-target="slide-out" class="sidenav-trigger"><i class="material-icons">menu</i></button>
+                    <button type="button" data-target="slide-out" class="sidenav-trigger" aria-label="{{ 'menu.top.open_menu'|trans }}"><i class="material-icons" aria-hidden="true">menu</i></button>
                     <h1 class="left action">
                         {% block title %}
                         {% endblock %}

--- a/templates/layout.html.twig
+++ b/templates/layout.html.twig
@@ -135,19 +135,19 @@
                     {% endif %}
                     <li>
                         <button type="button" data-action="click->dark-theme#useLight">
-                            <i class="theme-toggle-icon material-icons tiny">brightness_high</i>
+                            <i class="theme-toggle-icon material-icons tiny" aria-hidden="true">brightness_high</i>
                             <span>{{ 'menu.left.theme_toggle_light'|trans }}</span>
                         </button>
                     </li>
                     <li>
                         <button type="button" data-action="click->dark-theme#useDark">
-                            <i class="theme-toggle-icon material-icons tiny">brightness_low</i>
+                            <i class="theme-toggle-icon material-icons tiny" aria-hidden="true">brightness_low</i>
                             <span>{{ 'menu.left.theme_toggle_dark'|trans }}</span>
                         </button>
                     </li>
                     <li>
                         <button type="button" data-action="click->dark-theme#useAuto">
-                            <i class="theme-toggle-icon material-icons tiny">brightness_auto</i>
+                            <i class="theme-toggle-icon material-icons tiny" aria-hidden="true">brightness_auto</i>
                             <span>{{ 'menu.left.theme_toggle_auto'|trans }}</span>
                         </button>
                     </li>

--- a/templates/layout.html.twig
+++ b/templates/layout.html.twig
@@ -90,12 +90,12 @@
                 </div>
                 <ul class="input-field nav-panel-button">
                     <li class="bold toggle-add-url-container">
-                        <a class="waves-effect toggle-add-url" data-controller="materialize--tooltip" data-materialize--tooltip-position-value="bottom" data-materialize--tooltip-enter-delay-value="50" data-tooltip="{{ 'menu.top.add_new_entry'|trans }}" href="{{ path('new') }}" data-action="topbar#showAddUrl:prevent:stop" data-shortcuts-target="showAddUrl">
+                        <a class="waves-effect toggle-add-url" data-controller="materialize--tooltip" data-materialize--tooltip-position-value="bottom" data-materialize--tooltip-enter-delay-value="50" data-tooltip="{{ 'menu.top.add_new_entry'|trans }}" href="{{ path('new') }}" data-action="topbar#showAddUrl:prevent:stop" data-shortcuts-target="showAddUrl" data-topbar-target="addUrlTrigger" aria-controls="nav-panel-add" aria-expanded="false">
                             <i class="material-icons">add</i>
                         </a>
                     </li>
                     <li>
-                        <button type="button" class="waves-effect" data-controller="materialize--tooltip" data-materialize--tooltip-position-value="bottom" data-materialize--tooltip-enter-delay-value="50" data-tooltip="{{ 'menu.top.search'|trans }}" data-action="topbar#showSearch:stop" data-shortcuts-target="showSearch" aria-label="{{ 'menu.top.search'|trans }}">
+                        <button type="button" class="waves-effect" data-controller="materialize--tooltip" data-materialize--tooltip-position-value="bottom" data-materialize--tooltip-enter-delay-value="50" data-tooltip="{{ 'menu.top.search'|trans }}" data-action="topbar#showSearch:stop" data-shortcuts-target="showSearch" data-topbar-target="searchTrigger" aria-label="{{ 'menu.top.search'|trans }}" aria-controls="nav-panel-search" aria-expanded="false">
                             <i class="material-icons" aria-hidden="true">search</i>
                         </button>
                     </li>

--- a/templates/layout.html.twig
+++ b/templates/layout.html.twig
@@ -82,7 +82,7 @@
         <div class="nav-panels" data-controller="topbar">
             <div class="nav-panel-item" data-topbar-target="actions">
                 <div class="nav-panel-top">
-                    <button type="button" data-target="slide-out" class="sidenav-trigger" aria-label="{{ 'menu.top.open_menu'|trans }}"><i class="material-icons" aria-hidden="true">menu</i></button>
+                    <button type="button" data-target="slide-out" class="sidenav-trigger" aria-label="{{ 'menu.top.open_menu'|trans }}" aria-controls="slide-out" aria-expanded="false"><i class="material-icons" aria-hidden="true">menu</i></button>
                     <h1 class="left action">
                         {% block title %}
                         {% endblock %}

--- a/templates/layout.html.twig
+++ b/templates/layout.html.twig
@@ -95,14 +95,14 @@
                         </a>
                     </li>
                     <li>
-                        <button type="button" class="waves-effect" data-controller="materialize--tooltip" data-materialize--tooltip-position-value="bottom" data-materialize--tooltip-enter-delay-value="50" data-tooltip="{{ 'menu.top.search'|trans }}" data-action="topbar#showSearch:stop" data-shortcuts-target="showSearch">
-                            <i class="material-icons">search</i>
+                        <button type="button" class="waves-effect" data-controller="materialize--tooltip" data-materialize--tooltip-position-value="bottom" data-materialize--tooltip-enter-delay-value="50" data-tooltip="{{ 'menu.top.search'|trans }}" data-action="topbar#showSearch:stop" data-shortcuts-target="showSearch" aria-label="{{ 'menu.top.search'|trans }}">
+                            <i class="material-icons" aria-hidden="true">search</i>
                         </button>
                     </li>
                     {% block nav_panel_extra_actions '' %}
                     <li class="bold">
-                        <button type="button" class="waves-effect dropdown-trigger" data-controller="materialize--dropdown materialize--tooltip" data-target="dropdown-account" data-materialize--tooltip-position-value="bottom" data-materialize--tooltip-enter-delay-value="50" data-tooltip="{{ 'menu.top.account'|trans }}" id="news_menu">
-                            <i class="material-icons" id="news_link">account_circle</i>
+                        <button type="button" class="waves-effect dropdown-trigger" data-controller="materialize--dropdown materialize--tooltip" data-target="dropdown-account" data-materialize--tooltip-position-value="bottom" data-materialize--tooltip-enter-delay-value="50" data-tooltip="{{ 'menu.top.account'|trans }}" id="news_menu" aria-label="{{ 'menu.top.account'|trans }}">
+                            <i class="material-icons" id="news_link" aria-hidden="true">account_circle</i>
                         </button>
                     </li>
                 </ul>

--- a/templates/layout.html.twig
+++ b/templates/layout.html.twig
@@ -101,7 +101,7 @@
                     </li>
                     {% block nav_panel_extra_actions '' %}
                     <li class="bold">
-                        <button type="button" class="waves-effect dropdown-trigger" data-controller="materialize--dropdown materialize--tooltip" data-target="dropdown-account" data-materialize--tooltip-position-value="bottom" data-materialize--tooltip-enter-delay-value="50" data-tooltip="{{ 'menu.top.account'|trans }}" id="news_menu" aria-label="{{ 'menu.top.account'|trans }}">
+                        <button type="button" class="waves-effect dropdown-trigger" data-controller="materialize--dropdown materialize--tooltip" data-target="dropdown-account" data-materialize--tooltip-position-value="bottom" data-materialize--tooltip-enter-delay-value="50" data-tooltip="{{ 'menu.top.account'|trans }}" id="news_menu" aria-label="{{ 'menu.top.account'|trans }}" aria-controls="dropdown-account" aria-expanded="false">
                             <i class="material-icons" id="news_link" aria-hidden="true">account_circle</i>
                         </button>
                     </li>

--- a/tests/unit/Twig/JavaScriptOnlyLinkTest.php
+++ b/tests/unit/Twig/JavaScriptOnlyLinkTest.php
@@ -8,6 +8,15 @@ class JavaScriptOnlyLinkTest extends TestCase
 {
     private const BOOKMARKLET_TEMPLATE = 'templates/Static/_bookmarklet.html.twig';
 
+    private const ACCESSIBLE_ICON_BUTTON_MARKERS = [
+        'templates/Config/index.html.twig' => ['config-help'],
+        'templates/Entry/entries.html.twig' => ['data-target="filters"', 'data-target="export"'],
+        'templates/Entry/entry.html.twig' => ['class="sidenav-trigger"', 'data-toggle="actions"'],
+        'templates/Entry/new_form.html.twig' => ['class="nav-form-button"'],
+        'templates/Entry/search_form.html.twig' => ['class="nav-form-button"'],
+        'templates/layout.html.twig' => ['class="sidenav-trigger"', 'data-shortcuts-target="showSearch"', 'id="news_menu"'],
+    ];
+
     /**
      * @dataProvider anchors
      */
@@ -54,6 +63,23 @@ class JavaScriptOnlyLinkTest extends TestCase
         );
     }
 
+    /**
+     * @dataProvider iconButtons
+     */
+    public function testIconOnlyTwigButtonsHaveAccessibleNames(string $path, string $button): void
+    {
+        self::assertMatchesRegularExpression(
+            '/\\baria-label\\s*=/i',
+            $button,
+            \sprintf('Icon-only button without an accessible name in %s: %s', $path, $button)
+        );
+        self::assertMatchesRegularExpression(
+            '/<i\\b[^>]*\\bclass\\s*=\\s*(["\\\'])[^"\\\']*\\bmaterial-icons\\b[^"\\\']*\\1[^>]*\\baria-hidden\\s*=\\s*(["\\\'])true\\2/i',
+            $button,
+            \sprintf('Decorative icon exposed to assistive technology in %s: %s', $path, $button)
+        );
+    }
+
     public function anchors(): iterable
     {
         $projectDirectory = \dirname(__DIR__, 3);
@@ -78,6 +104,31 @@ class JavaScriptOnlyLinkTest extends TestCase
 
             foreach ($matches[0] as $index => $anchor) {
                 yield \sprintf('%s:%d', $relativePath, $index + 1) => [$relativePath, $anchor];
+            }
+        }
+    }
+
+    public function iconButtons(): iterable
+    {
+        $projectDirectory = \dirname(__DIR__, 3);
+        foreach (self::ACCESSIBLE_ICON_BUTTON_MARKERS as $relativePath => $markers) {
+            $path = $projectDirectory . '/' . $relativePath;
+            $contents = file_get_contents($path);
+
+            if (false === $contents) {
+                self::fail(\sprintf('Unable to read %s.', $relativePath));
+            }
+
+            foreach ($markers as $marker) {
+                preg_match_all(
+                    '/<button\\b(?=[^>]*' . preg_quote($marker, '/') . ')[^>]*>.*?<\\/button>/is',
+                    $contents,
+                    $matches
+                );
+
+                foreach ($matches[0] as $index => $button) {
+                    yield \sprintf('%s:%s:%d', $relativePath, $marker, $index + 1) => [$relativePath, $button];
+                }
             }
         }
     }

--- a/translations/messages.en.yml
+++ b/translations/messages.en.yml
@@ -307,6 +307,7 @@ entry:
             theme_toggle_light: Light
             theme_toggle_dark: Dark
             theme_toggle_auto: Automatic
+            toggle_actions: Toggle actions
             problem:
                 label: Problems?
                 description: Does this article appear wrong?

--- a/translations/messages.en.yml
+++ b/translations/messages.en.yml
@@ -43,6 +43,7 @@ menu:
         theme_toggle_auto: "Automatic theme"
     top:
         add_new_entry: Add a new entry
+        close: Close
         open_menu: Open menu
         search: Search
         filter_entries: Filter entries

--- a/translations/messages.en.yml
+++ b/translations/messages.en.yml
@@ -43,6 +43,7 @@ menu:
         theme_toggle_auto: "Automatic theme"
     top:
         add_new_entry: Add a new entry
+        open_menu: Open menu
         search: Search
         filter_entries: Filter entries
         export: Export

--- a/translations/messages.fr.yml
+++ b/translations/messages.fr.yml
@@ -40,6 +40,7 @@ menu:
         theme_toggle_auto: "Thème automatique"
     top:
         add_new_entry: Sauvegarder un nouvel article
+        open_menu: Ouvrir le menu
         search: Rechercher
         filter_entries: Filtrer les articles
         random_entry: Aller à un article aléatoire de cette liste

--- a/translations/messages.fr.yml
+++ b/translations/messages.fr.yml
@@ -40,6 +40,7 @@ menu:
         theme_toggle_auto: "Thème automatique"
     top:
         add_new_entry: Sauvegarder un nouvel article
+        close: Fermer
         open_menu: Ouvrir le menu
         search: Rechercher
         filter_entries: Filtrer les articles

--- a/translations/messages.fr.yml
+++ b/translations/messages.fr.yml
@@ -304,6 +304,7 @@ entry:
             theme_toggle_light: "Clair"
             theme_toggle_dark: "Sombre"
             theme_toggle_auto: "Automatique"
+            toggle_actions: Afficher ou masquer les actions
             problem:
                 label: Un problème ?
                 description: Est-ce que cet article s’affiche mal ?


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Documentation | no
| Translation   | no
| CHANGELOG.md  | no
| License       | MIT

Part of #8967.

Build on the semantic controls with accessible names, expanded and selected state, keyboard-safe shortcuts, overlay focus behavior, and visible focus cues.

- [ ] Manual desktop and mobile browser review completed

This draft is easiest to review one commit at a time; its descriptive fixups intentionally remain visible.