### PR TITLE
Fix content and fetchedContent merging

### DIFF
--- a/src/Wallabag/CoreBundle/Helper/ContentProxy.php
+++ b/src/Wallabag/CoreBundle/Helper/ContentProxy.php
@@ -75,7 +75,7 @@ class ContentProxy
             // when content is imported, we have information in $content
             // in case fetching content goes bad, we'll keep the imported information instead of overriding them
             if ($fetchedContent['html'] !== $this->fetchingErrorMessage) {
-                $content = array_merge($fetchedContent, $content);
+                $content = array_merge(array_filter($fetchedContent), array_filter($content));
             }
         }
 

--- a/tests/Wallabag/CoreBundle/Helper/ContentProxyTest.php
+++ b/tests/Wallabag/CoreBundle/Helper/ContentProxyTest.php
@@ -185,6 +185,55 @@ class ContentProxyTest extends TestCase
         $this->assertSame('1.1.1.1', $entry->getDomainName());
     }
 
+    public function testWithContentAndEmptyProvidedContent()
+    {
+        $tagger = $this->getTaggerMock();
+        $tagger->expects($this->once())
+            ->method('tag');
+
+        $ruleBasedIgnoreOriginProcessor = $this->getRuleBasedIgnoreOriginProcessorMock();
+        $ruleBasedIgnoreOriginProcessor->expects($this->once())
+            ->method('process');
+
+        $graby = $this->getMockBuilder(Graby::class)
+            ->setMethods(['fetchContent'])
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $graby->expects($this->any())
+            ->method('fetchContent')
+            ->willReturn([
+                'html' => str_repeat('this is my content', 325),
+                'title' => 'this is my title',
+                'url' => 'http://1.1.1.1',
+                'language' => 'fr',
+                'status' => '200',
+                'description' => 'OG desc',
+                'image' => 'http://3.3.3.3/cover.jpg',
+                'headers' => [
+                    'content-type' => 'text/html',
+                ],
+            ]);
+
+        $proxy = new ContentProxy($graby, $tagger, $ruleBasedIgnoreOriginProcessor, $this->getValidator(), $this->getLogger(), $this->fetchingErrorMessage);
+        $entry = new Entry(new User());
+        // empty values provided along the import should not override the fetched content
+        $proxy->updateEntry($entry, 'http://0.0.0.0', [
+            'title' => '',
+            'language' => '',
+            'image' => '',
+        ]);
+
+        $this->assertSame('http://1.1.1.1', $entry->getUrl());
+        $this->assertSame('this is my title', $entry->getTitle());
+        $this->assertStringContainsString('content', $entry->getContent());
+        $this->assertSame('http://3.3.3.3/cover.jpg', $entry->getPreviewPicture());
+        $this->assertSame('text/html', $entry->getMimetype());
+        $this->assertSame('fr', $entry->getLanguage());
+        $this->assertSame('200', $entry->getHttpStatus());
+        $this->assertSame('1.1.1.1', $entry->getDomainName());
+    }
+
     public function testWithContentAndNoOgImage()
     {
         $tagger = $this->getTaggerMock();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Documentation | no
| Translation   | no
| CHANGELOG.md  | no
| License       | MIT

`$content` contains default empty values and the result wasn't updated because of this. Now, the final `$content` get values from both arrays.