### PR TITLE
Fix/api post empty authors

### DIFF
--- a/src/Wallabag/ApiBundle/Controller/EntryRestController.php
+++ b/src/Wallabag/ApiBundle/Controller/EntryRestController.php
@@ -1406,7 +1406,7 @@ class EntryRestController extends WallabagRestController
             'language' => $request->request->get('language'),
             'picture' => $request->request->get('preview_picture'),
             'publishedAt' => $request->request->get('published_at'),
-            'authors' => $request->request->get('authors', ''),
+            'authors' => $request->request->get('authors'),
             'origin_url' => $request->request->get('origin_url', ''),
         ];
     }

--- a/tests/Wallabag/ApiBundle/Controller/EntryRestControllerTest.php
+++ b/tests/Wallabag/ApiBundle/Controller/EntryRestControllerTest.php
@@ -547,6 +547,18 @@ class EntryRestControllerTest extends WallabagApiTestCase
         $this->assertTrue($content['is_public'], 'A public link has been generated for that entry');
     }
 
+    public function testPostEntryWithoutAuthors()
+    {
+        $this->client->request('POST', '/api/entries.json', [
+            'url' => 'https://www.lemonde.fr/pixels/article/2015/03/28/plongee-dans-l-univers-d-ingress-le-jeu-de-google-aux-frontieres-du-reel_4601155_4408996.html',
+            'title' => 'New title for my article',
+        ]);
+
+        $content = json_decode($this->client->getResponse()->getContent(), true);
+
+        $this->assertNull($content['published_by']);
+    }
+
     public function testPostSameEntry()
     {
         $em = $this->client->getContainer()->get(EntityManagerInterface::class);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Documentation | no
| Translation   | no
| CHANGELOG.md  | no
| License       | MIT

Because of that, POST on `entries.json` through the API resulted in empty authors.
