### PR TITLE
ci: harden the release packaging path and the workflow actions

### DIFF
--- a/.github/workflows/coding-standards.yml
+++ b/.github/workflows/coding-standards.yml
@@ -19,10 +19,10 @@ jobs:
 
     steps:
       - name: "Checkout"
-        uses: "actions/checkout@v7"
+        uses: "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1" # v7.0.1
 
       - name: "Install PHP"
-        uses: "shivammathur/setup-php@v2"
+        uses: "shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240" # 2.37.2
         with:
           coverage: "none"
           php-version: "8.2"
@@ -33,7 +33,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: "Install Node"
-        uses: actions/setup-node@v7
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version-file: ".nvmrc"
           cache: 'yarn'
@@ -45,7 +45,7 @@ jobs:
 
       - name: "Install dependencies with Composer"
         id: composer-install
-        uses: "ramsey/composer-install@v4"
+        uses: "ramsey/composer-install@65e4f84970763564f46a70b8a54b90d033b3bdda" # 4.0.0
         with:
           composer-options: "--optimize-autoloader --prefer-dist"
 

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -48,12 +48,12 @@ jobs:
 
     steps:
       - name: "Checkout"
-        uses: "actions/checkout@v7"
+        uses: "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1" # v7.0.1
         with:
           fetch-depth: 2
 
       - name: "Install PHP"
-        uses: "shivammathur/setup-php@v2"
+        uses: "shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240" # 2.37.2
         with:
           php-version: "${{ matrix.php }}"
           coverage: pcov
@@ -62,7 +62,7 @@ jobs:
           ini-values: "date.timezone=Europe/Paris"
 
       - name: "Install Node"
-        uses: actions/setup-node@v7
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version-file: ".nvmrc"
           cache: 'yarn'
@@ -82,7 +82,7 @@ jobs:
           pg_isready -d wallabag_test -h localhost -p 5432 -U wallabag
 
       - name: "Install dependencies with Composer"
-        uses: "ramsey/composer-install@v4"
+        uses: "ramsey/composer-install@65e4f84970763564f46a70b8a54b90d033b3bdda" # 4.0.0
         with:
           composer-options: "--optimize-autoloader --prefer-dist"
 
@@ -120,7 +120,7 @@ jobs:
 
       - name: "Upload unit coverage to Codecov"
         if: ${{ !cancelled() }}
-        uses: "codecov/codecov-action@v7"
+        uses: "codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f" # v7.0.0
         continue-on-error: true
         with:
           token: "${{ secrets.CODECOV_TOKEN }}"
@@ -132,7 +132,7 @@ jobs:
 
       - name: "Upload unit test results to Codecov"
         if: ${{ !cancelled() }}
-        uses: "codecov/codecov-action@v7"
+        uses: "codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f" # v7.0.0
         continue-on-error: true
         with:
           token: "${{ secrets.CODECOV_TOKEN }}"
@@ -169,7 +169,7 @@ jobs:
 
       - name: "Upload integration coverage to Codecov"
         if: ${{ !cancelled() }}
-        uses: "codecov/codecov-action@v7"
+        uses: "codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f" # v7.0.0
         continue-on-error: true
         with:
           token: "${{ secrets.CODECOV_TOKEN }}"
@@ -181,7 +181,7 @@ jobs:
 
       - name: "Upload integration test results to Codecov"
         if: ${{ !cancelled() }}
-        uses: "codecov/codecov-action@v7"
+        uses: "codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f" # v7.0.0
         continue-on-error: true
         with:
           token: "${{ secrets.CODECOV_TOKEN }}"
@@ -218,7 +218,7 @@ jobs:
 
       - name: "Upload functional coverage to Codecov"
         if: ${{ !cancelled() }}
-        uses: "codecov/codecov-action@v7"
+        uses: "codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f" # v7.0.0
         continue-on-error: true
         with:
           token: "${{ secrets.CODECOV_TOKEN }}"
@@ -230,7 +230,7 @@ jobs:
 
       - name: "Upload functional test results to Codecov"
         if: ${{ !cancelled() }}
-        uses: "codecov/codecov-action@v7"
+        uses: "codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f" # v7.0.0
         continue-on-error: true
         with:
           token: "${{ secrets.CODECOV_TOKEN }}"
@@ -272,12 +272,12 @@ jobs:
 
     steps:
       - name: "Checkout"
-        uses: "actions/checkout@v7"
+        uses: "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1" # v7.0.1
         with:
           fetch-depth: 2
 
       - name: "Install PHP"
-        uses: "shivammathur/setup-php@v2"
+        uses: "shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240" # 2.37.2
         with:
           php-version: "${{ matrix.php }}"
           coverage: pcov
@@ -286,7 +286,7 @@ jobs:
           ini-values: "date.timezone=Europe/Paris"
 
       - name: "Install Node"
-        uses: actions/setup-node@v7
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version-file: ".nvmrc"
           cache: 'yarn'
@@ -306,7 +306,7 @@ jobs:
           pg_isready -d wallabag_test -h localhost -p 5432 -U wallabag
 
       - name: "Install dependencies with Composer"
-        uses: "ramsey/composer-install@v4"
+        uses: "ramsey/composer-install@65e4f84970763564f46a70b8a54b90d033b3bdda" # 4.0.0
         with:
           composer-options: "--optimize-autoloader --prefer-dist"
 
@@ -344,7 +344,7 @@ jobs:
 
       - name: "Upload unit coverage to Codecov"
         if: ${{ !cancelled() }}
-        uses: "codecov/codecov-action@v7"
+        uses: "codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f" # v7.0.0
         continue-on-error: true
         with:
           token: "${{ secrets.CODECOV_TOKEN }}"
@@ -356,7 +356,7 @@ jobs:
 
       - name: "Upload unit test results to Codecov"
         if: ${{ !cancelled() }}
-        uses: "codecov/codecov-action@v7"
+        uses: "codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f" # v7.0.0
         continue-on-error: true
         with:
           token: "${{ secrets.CODECOV_TOKEN }}"
@@ -393,7 +393,7 @@ jobs:
 
       - name: "Upload integration coverage to Codecov"
         if: ${{ !cancelled() }}
-        uses: "codecov/codecov-action@v7"
+        uses: "codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f" # v7.0.0
         continue-on-error: true
         with:
           token: "${{ secrets.CODECOV_TOKEN }}"
@@ -405,7 +405,7 @@ jobs:
 
       - name: "Upload integration test results to Codecov"
         if: ${{ !cancelled() }}
-        uses: "codecov/codecov-action@v7"
+        uses: "codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f" # v7.0.0
         continue-on-error: true
         with:
           token: "${{ secrets.CODECOV_TOKEN }}"
@@ -442,7 +442,7 @@ jobs:
 
       - name: "Upload functional coverage to Codecov"
         if: ${{ !cancelled() }}
-        uses: "codecov/codecov-action@v7"
+        uses: "codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f" # v7.0.0
         continue-on-error: true
         with:
           token: "${{ secrets.CODECOV_TOKEN }}"
@@ -454,7 +454,7 @@ jobs:
 
       - name: "Upload functional test results to Codecov"
         if: ${{ !cancelled() }}
-        uses: "codecov/codecov-action@v7"
+        uses: "codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f" # v7.0.0
         continue-on-error: true
         with:
           token: "${{ secrets.CODECOV_TOKEN }}"
@@ -486,12 +486,12 @@ jobs:
 
     steps:
       - name: "Checkout"
-        uses: "actions/checkout@v7"
+        uses: "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1" # v7.0.1
         with:
           fetch-depth: 2
 
       - name: "Install PHP"
-        uses: "shivammathur/setup-php@v2"
+        uses: "shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240" # 2.37.2
         with:
           php-version: "${{ matrix.php }}"
           coverage: pcov
@@ -500,7 +500,7 @@ jobs:
           ini-values: "date.timezone=Europe/Paris"
 
       - name: "Install Node"
-        uses: actions/setup-node@v7
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version-file: ".nvmrc"
           cache: 'yarn'
@@ -520,7 +520,7 @@ jobs:
           pg_isready -d wallabag_test -h localhost -p 5432 -U wallabag
 
       - name: "Install dependencies with Composer"
-        uses: "ramsey/composer-install@v4"
+        uses: "ramsey/composer-install@65e4f84970763564f46a70b8a54b90d033b3bdda" # 4.0.0
         with:
           composer-options: "--optimize-autoloader --prefer-dist"
 
@@ -558,7 +558,7 @@ jobs:
 
       - name: "Upload unit coverage to Codecov"
         if: ${{ !cancelled() }}
-        uses: "codecov/codecov-action@v7"
+        uses: "codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f" # v7.0.0
         continue-on-error: true
         with:
           token: "${{ secrets.CODECOV_TOKEN }}"
@@ -570,7 +570,7 @@ jobs:
 
       - name: "Upload unit test results to Codecov"
         if: ${{ !cancelled() }}
-        uses: "codecov/codecov-action@v7"
+        uses: "codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f" # v7.0.0
         continue-on-error: true
         with:
           token: "${{ secrets.CODECOV_TOKEN }}"
@@ -607,7 +607,7 @@ jobs:
 
       - name: "Upload integration coverage to Codecov"
         if: ${{ !cancelled() }}
-        uses: "codecov/codecov-action@v7"
+        uses: "codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f" # v7.0.0
         continue-on-error: true
         with:
           token: "${{ secrets.CODECOV_TOKEN }}"
@@ -619,7 +619,7 @@ jobs:
 
       - name: "Upload integration test results to Codecov"
         if: ${{ !cancelled() }}
-        uses: "codecov/codecov-action@v7"
+        uses: "codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f" # v7.0.0
         continue-on-error: true
         with:
           token: "${{ secrets.CODECOV_TOKEN }}"
@@ -656,7 +656,7 @@ jobs:
 
       - name: "Upload functional coverage to Codecov"
         if: ${{ !cancelled() }}
-        uses: "codecov/codecov-action@v7"
+        uses: "codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f" # v7.0.0
         continue-on-error: true
         with:
           token: "${{ secrets.CODECOV_TOKEN }}"
@@ -668,7 +668,7 @@ jobs:
 
       - name: "Upload functional test results to Codecov"
         if: ${{ !cancelled() }}
-        uses: "codecov/codecov-action@v7"
+        uses: "codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f" # v7.0.0
         continue-on-error: true
         with:
           token: "${{ secrets.CODECOV_TOKEN }}"
@@ -685,13 +685,13 @@ jobs:
 
     steps:
       - name: "Checkout"
-        uses: "actions/checkout@v7"
+        uses: "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1" # v7.0.1
         with:
           fetch-depth: 2
 
       - name: "Detect changed bundle-relevant files"
         id: changed-files
-        uses: tj-actions/changed-files@v47.0.6
+        uses: tj-actions/changed-files@9426d40962ed5378910ee2e21d5f8c6fcbf2dd96 # v47.0.6
         with:
           files: |
             webpack.config.js
@@ -703,7 +703,7 @@ jobs:
 
       - name: "Install Node"
         if: steps.changed-files.outputs.any_changed == 'true'
-        uses: actions/setup-node@v7
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version-file: ".nvmrc"
           cache: 'yarn'
@@ -729,12 +729,12 @@ jobs:
 
     steps:
       - name: "Checkout"
-        uses: "actions/checkout@v7"
+        uses: "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1" # v7.0.1
         with:
           fetch-depth: 2
 
       - name: "Send Codecov notifications"
-        uses: "codecov/codecov-action@v7"
+        uses: "codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f" # v7.0.0
         continue-on-error: true
         with:
           token: "${{ secrets.CODECOV_TOKEN }}"

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -15,6 +15,9 @@ env:
   PGPASSWORD: wallabagrocks
   COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+permissions:
+  contents: read
+
 jobs:
   phpunit:
     name: "PHP ${{ matrix.php }} using ${{ matrix.database }}"

--- a/.github/workflows/dependabot-automerge-js.yml
+++ b/.github/workflows/dependabot-automerge-js.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - name: Dependabot metadata
         id: metadata
-        uses: dependabot/fetch-metadata@v3.1.0
+        uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # v3.1.0
         with:
           github-token: '${{ secrets.GITHUB_TOKEN }}'
       - name: Approve and merge minor updates

--- a/.github/workflows/git.yml
+++ b/.github/workflows/git.yml
@@ -2,6 +2,9 @@ name: Git
 
 on: pull_request
 
+permissions:
+  contents: read
+
 jobs:
   no-fixups:
     name: No fixups

--- a/.github/workflows/git.yml
+++ b/.github/workflows/git.yml
@@ -8,4 +8,4 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check for 'amend!', 'fixup!', or 'squash!' commits
-        uses: matijs/no-fixups-action@v1.1.4
+        uses: matijs/no-fixups-action@8dfcf79304e29c3aa37e327cfc1d3685dca3c6c0 # v1.1.4

--- a/.github/workflows/translations.yml
+++ b/.github/workflows/translations.yml
@@ -22,10 +22,10 @@ jobs:
 
     steps:
       - name: "Checkout"
-        uses: "actions/checkout@v7"
+        uses: "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1" # v7.0.1
 
       - name: "Install PHP"
-        uses: "shivammathur/setup-php@v2"
+        uses: "shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240" # 2.37.2
         with:
           coverage: "none"
           php-version: "${{ matrix.php }}"
@@ -36,7 +36,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: "Install dependencies with Composer"
-        uses: "ramsey/composer-install@v4"
+        uses: "ramsey/composer-install@65e4f84970763564f46a70b8a54b90d033b3bdda" # 4.0.0
         with:
           composer-options: "--optimize-autoloader --prefer-dist"
 

--- a/.github/workflows/upload-release-package.yml
+++ b/.github/workflows/upload-release-package.yml
@@ -16,10 +16,10 @@ jobs:
 
     steps:
       - name: "Checkout"
-        uses: "actions/checkout@v7"
+        uses: "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1" # v7.0.1
 
       - name: "Install PHP"
-        uses: "shivammathur/setup-php@v2"
+        uses: "shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240" # 2.37.2
         with:
           coverage: "none"
           php-version: "${{ matrix.php }}"
@@ -30,7 +30,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: "Install Node"
-        uses: actions/setup-node@v7
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version-file: ".nvmrc"
           cache: "yarn"
@@ -39,7 +39,7 @@ jobs:
         run: make release VERSION=${{ github.event.release.tag_name }}
 
       - name: Upload the package to the release
-        uses: shogo82148/actions-upload-release-asset@v1
+        uses: shogo82148/actions-upload-release-asset@d0cb37bb764791e72e64e643cd7056f74f1e77d7 # v1.10.3
         with:
           upload_url: ${{ github.event.release.upload_url }}
           asset_path: /tmp/wllbg-release/wallabag-${{ github.event.release.tag_name }}.tar.gz

--- a/.github/workflows/upload-release-package.yml
+++ b/.github/workflows/upload-release-package.yml
@@ -33,7 +33,6 @@ jobs:
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version-file: ".nvmrc"
-          cache: "yarn"
 
       - name: Create the package
         run: make release VERSION=${{ github.event.release.tag_name }}

--- a/.github/workflows/upload-release-package.yml
+++ b/.github/workflows/upload-release-package.yml
@@ -5,6 +5,10 @@ on:
     types:
       - created
 
+permissions:
+  # The packaged tarball is uploaded to the release with this token.
+  contents: write
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Documentation | no
| Translation   | no
| CHANGELOG.md  | no
| License       | MIT

Three commits, focused on the workflow that builds the tarball users download.

**Reference every action by commit hash.** The release packaging workflow uploads the tarball to the release with a write token, and all actions were referenced by tags. A tag is a movable pointer, whoever controls an action repository can point it at different code after review, which is how the tj-actions/changed-files incident (CVE-2025-30066) leaked CI secrets at scale, and that action is in use here. A commit hash cannot be retargeted. Each pin keeps the version as a comment for review, versions stay exactly where they were (composer-install sits on its 4.0.0 release since the v4 branch floats ahead of it), and dependabot keeps bumping hash pins the same way it bumps tags today.

**Build the release package without the yarn cache.** The packaging job restored a cache populated by earlier branch builds while producing the artifact that ships to users. Anything that poisons that cache reaches the release tarball. Release builds are rare, the extra install time costs less than the exposure.

**Declare token permissions.** Only the release packaging workflow keeps `contents: write` for the upload, the test, lint and git checks drop to read only.

One heads-up: if the org ever restricts allowed actions with tag patterns like `owner/action@v2`, those stop matching hash refs and workflows fail at startup, the fix is `owner/action@*` there. Nothing to do if no such restriction is configured.

Found and fixed by [Plumber](https://github.com/getplumber/plumber)'s analysis, reviewed and submitted by me.