### PR TITLE
Use archive and outbox icons for read status actions

### DIFF
--- a/templates/Entry/_card_actions.html.twig
+++ b/templates/Entry/_card_actions.html.twig
@@ -21,7 +21,7 @@
                     <input type="hidden" name="token" value="{{ csrf_token('archive-entry') }}"/>
 
                     <button type="submit" class="btn-link tool grey-text" title="{{ 'entry.list.toogle_as_read'|trans }}">
-                        <i class="material-icons">{% if entry.isArchived == 0 %}done{% else %}unarchive{% endif %}</i>
+                        <i class="material-icons">{% if entry.isArchived == 0 %}archive{% else %}outbox{% endif %}</i>
                     </button>
                 </form>
             </li>

--- a/templates/Entry/_card_list.html.twig
+++ b/templates/Entry/_card_list.html.twig
@@ -26,7 +26,7 @@
                     <input type="hidden" name="token" value="{{ csrf_token('archive-entry') }}"/>
 
                     <button type="submit" class="btn-link tool grey-text" title="{{ 'entry.list.toogle_as_read'|trans }}">
-                        <i class="material-icons">{% if entry.isArchived == 0 %}done{% else %}unarchive{% endif %}</i>
+                        <i class="material-icons">{% if entry.isArchived == 0 %}archive{% else %}outbox{% endif %}</i>
                     </button>
                 </form>
             {% endif %}

--- a/templates/Entry/entries.html.twig
+++ b/templates/Entry/entries.html.twig
@@ -93,7 +93,7 @@
             <div class="mass-action">
                 <div class="mass-action-group">
                     <input type="checkbox" form="form_mass_action" class="entry-checkbox-input" data-action="batch-edit#toggleSelection" />
-                    <button class="mass-action-button btn cyan darken-1" type="submit" form="form_mass_action" name="toggle-read" title="{{ 'entry.list.toogle_as_read'|trans }}"><i class="material-icons">done</i></button>
+                    <button class="mass-action-button btn cyan darken-1" type="submit" form="form_mass_action" name="toggle-read" title="{{ 'entry.list.toogle_as_read'|trans }}"><i class="material-icons">archive</i></button>
                     <button class="mass-action-button btn cyan darken-1" type="submit" form="form_mass_action" name="toggle-star" title="{{ 'entry.list.toogle_as_star'|trans }}" ><i class="material-icons">star</i></button>
                     <button class="mass-action-button btn cyan darken-1" type="submit" form="form_mass_action" name="delete" onclick="return confirm('{{ 'entry.confirm.delete_entries'|trans|escape('js') }}')" title="{{ 'entry.list.delete'|trans }}"><i class="material-icons">delete</i></button>
                 </div>

--- a/templates/Entry/entry.html.twig
+++ b/templates/Entry/entry.html.twig
@@ -31,7 +31,7 @@
                             <input type="hidden" name="token" value="{{ csrf_token('archive-entry') }}"/>
 
                             <button type="submit" class="waves-effect" title="{{ 'entry.view.left_menu.set_as_read'|trans }}">
-                                <i class="material-icons small">{% if entry.isArchived == 0 %}done{% else %}unarchive{% endif %}</i>
+                                <i class="material-icons small">{% if entry.isArchived == 0 %}archive{% else %}outbox{% endif %}</i>
                             </button>
                         </form>
                     </li>
@@ -92,7 +92,7 @@
                     <input type="hidden" name="token" value="{{ csrf_token('archive-entry') }}"/>
 
                     <button type="submit" class="waves-effect collapsible-header" title="{{ mark_as_read_label|trans }}" data-shortcuts-target="markAsRead">
-                        <i class="material-icons small">{% if entry.isArchived == 0 %}done{% else %}unarchive{% endif %}</i>
+                        <i class="material-icons small">{% if entry.isArchived == 0 %}archive{% else %}outbox{% endif %}</i>
                         <span>{{ mark_as_read_label|trans }}</span>
                     </button>
                 </form>
@@ -381,7 +381,7 @@
                           <input type="hidden" name="token" value="{{ csrf_token('archive-entry') }}"/>
 
                           <button type="submit" class="btn-floating">
-                              <i class="material-icons">{% if entry.isArchived == 0 %}done{% else %}unarchive{% endif %}</i>
+                              <i class="material-icons">{% if entry.isArchived == 0 %}archive{% else %}outbox{% endif %}</i>
                           </button>
                       </form>
                     </li>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | focused checks, see below
| Documentation | no
| Translation   | no
| CHANGELOG.md  | no
| License       | MIT

Fixes #8322

This updates the read/unread status action icons so the controls are less likely to be confused with the bulk-select checkmark:

- unread entries now use `archive` for the action that marks them as read
- archived entries now use `outbox` for the action that sends them back to unread
- the bulk mark-as-read action also uses `archive`

This follows up on the review discussion in #8344 without copying that PR directly. #8344 changed the unread action to `archive` but kept the archived action as `unarchive`, and it also touched the tag rename icon by mistake. This PR keeps the scope to Entry templates and applies the suggested `outbox` counterpart for the archived-to-unread action.

Validation:

- Confirmed #8322 is still open, unassigned, and has no active implementation PR.
- Confirmed #8344 is closed and unmerged, with review feedback suggesting `outbox`.
- Confirmed current `master` still has the old `done` / `unarchive` icon pair.
- Confirmed `archive` and `outbox` exist in `material-design-icons-iconfont@6.7.0`.
- Ran a focused Node template assertion for the changed icon mappings.
- Ran `git diff --check`.
- Ran publication-scope leak checks; the changed files and added lines are clean. The full repository scan reports pre-existing findings outside this PR's changed files.

I could not run the full PHP/Composer/Yarn test suite in this local environment because those tools are not installed here.
