### PR TITLE
ci: keep the hardened workflows from drifting back

### DIFF
--- a/.github/workflows/plumber.yml
+++ b/.github/workflows/plumber.yml
@@ -1,0 +1,37 @@
+name: "Plumber"
+
+on:
+  push:
+    branches:
+      - "master"
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  plumber:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      security-events: write
+      # Needed by score-push to publish the score for the README badge.
+      id-token: write
+    steps:
+      - name: "Checkout"
+        uses: "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1" # v7.0.1
+
+      - name: "Run Plumber"
+        uses: "getplumber/plumber@e815e0bff47f9170e8e0a056df0a851124634ae2" # v0.4.51
+        with:
+          # Code scanning upload needs security-events write, which PRs
+          # from forks do not get. The report stays available as a
+          # workflow artifact there.
+          upload-sarif: ${{ github.event.pull_request.head.repo.fork != true }}
+          # Publishes the score to score.getplumber.io, which feeds the
+          # badge in the README. A failed push never fails the run.
+          score-push: true
+          # Gate at 85 points instead of the all-or-nothing default,
+          # leaves room for a small finding without blocking PRs.
+          min-points: 85

--- a/.plumber.yaml
+++ b/.plumber.yaml
@@ -1,0 +1,18 @@
+# Plumber overlay: inherits every control from the CLI's built-in
+# baseline, only the differences for this repo are written here.
+# Run 'plumber config resolve' to see the full effective config.
+extends: plumber:default
+version: '2.0'
+
+github:
+  controls:
+    githubActionMustComeFromAuthorizedSources:
+      # Keep the curated default list and trust the PHP toolchain,
+      # release and hygiene actions this repo already uses on top of it.
+      includePlumberDefaults: true
+      trustedGithubActions:
+        - matijs/no-fixups-action
+        - ramsey/composer-install
+        - shivammathur/setup-php
+        - shogo82148/actions-upload-release-asset
+        - tj-actions/changed-files

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 > The name of this project is **wallabag** — all lowercase, always. Not "Wallabag", not "WallaBag", not any other variation. Just plain, humble, all-lowercase **wallabag** 😉
 
 [![CI](https://github.com/wallabag/wallabag/actions/workflows/continuous-integration.yml/badge.svg?branch=master)](https://github.com/wallabag/wallabag/actions/workflows/continuous-integration.yml?query=branch%3Amaster)
+[![Plumber Score](https://score.getplumber.io/github.com/wallabag/wallabag.svg)](https://score.getplumber.io/github.com/wallabag/wallabag)
 [![Matrix](https://matrix.to/img/matrix-badge.svg)](https://matrix.to/#/#wallabag:matrix.org)
 [![Donation Status](https://img.shields.io/liberapay/goal/wallabag.svg?logo=liberapay)](https://liberapay.com/wallabag/donate)
 [![Translation status](https://hosted.weblate.org/widgets/wallabag/-/svg-badge.svg)](https://hosted.weblate.org/engage/wallabag/?utm_source=widget)


### PR DESCRIPTION
Follow-up to #8992, merged a couple of weeks ago.

Since you reviewed those hashes by hand, this adds the check that does it continuously: a small workflow that runs the [Plumber](https://github.com/getplumber/plumber) CLI on pushes to master and on pull requests, covering the class of findings the hardening fixed plus permissions and cache rules. It gates at 85 points instead of all-or-nothing, so one small finding never blocks anyone's PR.

The badge works like OpenSSF Scorecard's published results: every run publishes the score, the badge shows master, a failed publish never fails your CI, and no token or secret is involved. It shows gray UNKNOWN until the first run. If you want the check without the badge, removing the `score-push` line is the whole opt-out.

Same disclosure as last time: I work on Plumber. If the tool is not for you, say so and I close this, the hardening from #8992 stands on its own either way.
