### PR TITLE
doc: Replace outdated URL in errors_during_fetching.md

### DIFF
--- a/doc/content/user/errors_during_fetching.md
+++ b/doc/content/user/errors_during_fetching.md
@@ -32,7 +32,7 @@ If you already tried to re-fetch the content or to solve potential networking is
 
 Wallabag uses two systems working together to try to fetch the content of an article:
 
-- site configuration files written for each specific domain (often called _site config_, stored in `vendor/j0k3r/graby-site-config`);
+- site configuration files written for each specific domain (often called _site config_, fetched from [j0k3r/graby-site-config](https://github.com/j0k3r/graby-site-config);
 - [php-readability](https://github.com/j0k3r/php-readability), which automatically analyzes the content of a web page to determine what is more likely to be the desired content.
 
 None of these two elements are flawless and we sometimes have to help wallabag a bit! In order to help you efficiently, we will need you to gather some information beforehand, as described below. When required, you could also create (or update) the site configuration file of the website hosting the desired content.


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | no
| Documentation | yes
| Translation   | no
| CHANGELOG.md  | no
| License       | MIT

This replaces

> stored in `vendor/j0k3r/graby-site-config`

with

> fetched from [j0k3r/graby-site-config](https://github.com/j0k3r/graby-site-config)

This PR is a new version of https://github.com/wallabag/wallabag/pull/9015 which was incorrect.